### PR TITLE
Add comprehensive pydantic utils tests

### DIFF
--- a/tests/tools/typing/test_pydantic_utils.py
+++ b/tests/tools/typing/test_pydantic_utils.py
@@ -1,8 +1,17 @@
+from enum import StrEnum
 from typing import Any, Dict, cast
 
-from pydantic import BaseModel, Field
+import pytest
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
-from pipelex.tools.typing.pydantic_utils import ExtraFieldAttribute, serialize_model
+from pipelex.tools.typing.pydantic_utils import (
+    CustomBaseModel,
+    ExtraFieldAttribute,
+    clean_model_to_dict,
+    convert_strenum_to_str,
+    format_pydantic_validation_error,
+    serialize_model,
+)
 
 
 class ChildModel(BaseModel):
@@ -34,3 +43,69 @@ def test_serialize_model_with_hidden_fields():
     child_serialized = cast(Dict[str, Any], serialized_result["child"])
     assert "child_secret" not in child_serialized
     assert serialized_result == {"parent_name": "bar", "child": {"child_name": "foo"}}
+
+
+class SimpleEnum(StrEnum):
+    FIRST = "first"
+    SECOND = "second"
+
+    def display_name(self) -> str:  # pragma: no cover - simple helper
+        return self.value.upper()
+
+
+class ModelWithEnum(BaseModel):
+    name: str
+    enum_val: SimpleEnum
+    secret: str = Field(
+        "hidden",
+        json_schema_extra={ExtraFieldAttribute.IS_HIDDEN: True},
+    )
+
+
+def test_clean_model_to_dict_stringifies_enums_and_hides_fields() -> None:
+    model = ModelWithEnum(name="foo", enum_val=SimpleEnum.FIRST, secret="hidden")
+    result = clean_model_to_dict(model)
+    assert result == {"name": "foo", "enum_val": "FIRST"}
+
+
+def test_convert_strenum_to_str_recursive() -> None:
+    data = {
+        "enum": SimpleEnum.SECOND,
+        "nested": [SimpleEnum.FIRST, {"e": SimpleEnum.SECOND}],
+    }
+    converted = convert_strenum_to_str(data)
+    assert converted == {
+        "enum": "SECOND",
+        "nested": ["FIRST", {"e": "SECOND"}],
+    }
+
+
+def test_format_pydantic_validation_error() -> None:
+    class Validated(BaseModel):
+        model_config = ConfigDict(extra="forbid")
+        a: int
+        b: str
+
+    with pytest.raises(ValidationError) as exc:
+        Validated.model_validate({"a": "not_int", "c": 1})
+
+    formatted = format_pydantic_validation_error(exc.value)
+    assert "Missing required fields: ['b']" in formatted
+    assert "Extra forbidden fields: ['c: 1']" in formatted
+
+
+def test_custom_base_model_truncates_repr() -> None:
+    class TestModel(CustomBaseModel):
+        base_64: str
+        url: str
+        other: str
+
+    TestModel.truncate_length = 10
+    model = TestModel(
+        base_64="b" * 20,
+        url="data:image/png;base64," + "x" * 20,
+        other="val",
+    )
+    repr_str = repr(model)
+    assert "bbbbbbbbbb…" in repr_str
+    assert "data:image…" in repr_str


### PR DESCRIPTION
## Summary
- expand `test_pydantic_utils` to cover enum conversion, cleaning and formatting helpers
- check CustomBaseModel truncation behaviour

## Testing
- `make format`
- `make lint`
- `make pyright`
- `make mypy`
- `make codex-tests`
- `.venv/bin/pipelex validate`
