### PR TITLE
Be more lax on having domain definition: it's now Optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,20 @@
 # Changelog
 
-## [v0.3.0] - 2025-06-10
+## [v0.3.1] - 2025-06-10
+
+### Added
+- New pytest marker `dry_runnable` for tests that can run without inference.
+- Enhanced `make` targets with dry-run capabilities for improved test coverage:
+  - `make test-xdist` (or `make t`): Runs all non-inference tests **plus inference tests** that support dry-runs - fast and resource-efficient
+  - `make test-inference` (or `make ti`): Runs tests requiring actual inference, with actual inference (slow and costly)
+- Parallel test execution using `pytest-xdist` (`-n auto`) enabled for:
+  - GitHub Actions workflows
+  - Codex test targets
+  
+### Changed
+- Domain validation is now less restrictive in pipeline TOML: the `definition` attribute is now `Optional`
+
+## [v0.3.0] - 2025-06-09
 
 ### Highlights
 

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ VENV_PIPELEX := $(VIRTUAL_ENV)/bin/pipelex
 
 UV_MIN_VERSION = $(shell grep -m1 'required-version' pyproject.toml | sed -E 's/.*= *"([^<>=, ]+).*/\1/')
 
-USUAL_PYTEST_MARKERS := "(dry_runable or not (inference or llm or imgg or ocr)) and not (needs_output or pipelex_api)"
+USUAL_PYTEST_MARKERS := "(dry_runnable or not (inference or llm or imgg or ocr)) and not (needs_output or pipelex_api)"
 
 define PRINT_TITLE
     $(eval PROJECT_PART := [$(PROJECT_NAME)])
@@ -205,12 +205,12 @@ cleanall: cleanderived cleanenv cleanlibraries
 codex-tests: env
 	$(call PRINT_TITLE,"Unit testing for Codex")
 	@echo "• Running unit tests for Codex (excluding inference and codex_disabled)"
-	$(VENV_PYTEST) -n auto --exitfirst --quiet -m "(dry_runable or not inference) and not (needs_output or pipelex_api)" || [ $$? = 5 ]
+	$(VENV_PYTEST) -n auto --exitfirst --quiet -m "(dry_runnable or not inference) and not (needs_output or pipelex_api)" || [ $$? = 5 ]
 
 gha-tests: env
 	$(call PRINT_TITLE,"Unit testing for github actions")
 	@echo "• Running unit tests for github actions (excluding inference and gha_disabled)"
-	$(VENV_PYTEST) -n auto --exitfirst --quiet -m "(dry_runable or not inference) and not (gha_disabled or pipelex_api)" || [ $$? = 5 ]
+	$(VENV_PYTEST) -n auto --exitfirst --quiet -m "(dry_runnable or not inference) and not (gha_disabled or pipelex_api)" || [ $$? = 5 ]
 
 run-all-tests: env
 	$(call PRINT_TITLE,"Running all unit tests")

--- a/pipelex/core/domain.py
+++ b/pipelex/core/domain.py
@@ -13,7 +13,7 @@ class SpecialDomain(StrEnum):
 
 class Domain(BaseModel):
     code: str
-    definition: str
+    definition: Optional[str] = None
     system_prompt: Optional[str] = None
     system_prompt_to_structure: Optional[str] = None
     prompt_template_to_structure: Optional[str] = None
@@ -24,4 +24,4 @@ class Domain(BaseModel):
 
     @classmethod
     def make_default(cls) -> Self:
-        return cls(code=SpecialDomain.NATIVE, definition="")
+        return cls(code=SpecialDomain.NATIVE)

--- a/pipelex/libraries/library_manager.py
+++ b/pipelex/libraries/library_manager.py
@@ -128,7 +128,10 @@ class LibraryManager:
             library_name = toml_path.stem
             domain_code = library_dict.get("domain")
             if domain_code is None:
-                raise LibraryParsingError(f"Error loafing library '{library_name}' which has no domain set at '{toml_path}'")
+                raise LibraryParsingError(
+                    f"Error loading library '{library_name}' which has no domain set at '{toml_path}'. "
+                    "Just write 'domain = \"my_domain\"' at the top of the file."
+                )
             domain_definition = library_dict.get("definition")
             if domain_definition is None:
                 # we skip the domain without definition, it must be defined one and only one time in the domain library
@@ -177,10 +180,6 @@ class LibraryManager:
 
     def _load_library_dict(self, library_name: str, library_dict: Dict[str, Any], component_type: LibraryComponent):
         if domain_code := library_dict.pop("domain", None):
-            if not self.domain_library.get_domain(domain_code=domain_code):
-                raise LibraryParsingError(
-                    f"Domain '{domain_code}' is has not been defined in the domain libraryn make sure it has exactlyone definition"
-                )
             # domain is set at the root of the library
             self._load_library_components_from_recursive_dict(
                 domain_code=domain_code,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -208,7 +208,7 @@ markers = [
     "ocr: slow and costly due to ocr inference calls",
     "gha_disabled: tests that should not run in GitHub Actions",
     "codex_disabled: tests that should not run in Codex",
-    "dry_runable: tests that can be run in dry-run mode",
+    "dry_runnable: tests that can be run in dry-run mode",
 ]
 minversion = "8.0"
 

--- a/tests/pipelex/pipelex_asynch/test_pipe_batch.py
+++ b/tests/pipelex/pipelex_asynch/test_pipe_batch.py
@@ -10,7 +10,7 @@ from pipelex.core.working_memory_factory import WorkingMemoryFactory
 from pipelex.hub import get_pipe_router, get_pipeline_tracker, get_report_delegate
 
 
-@pytest.mark.dry_runable
+@pytest.mark.dry_runnable
 @pytest.mark.llm
 @pytest.mark.inference
 @pytest.mark.asyncio(loop_scope="class")

--- a/tests/pipelex/pipelex_asynch/test_pipe_imgg.py
+++ b/tests/pipelex/pipelex_asynch/test_pipe_imgg.py
@@ -11,7 +11,7 @@ from pipelex.pipe_works.pipe_job_factory import PipeJobFactory
 from tests.pipelex.test_data import IMGGTestCases
 
 
-@pytest.mark.dry_runable
+@pytest.mark.dry_runnable
 @pytest.mark.imgg
 @pytest.mark.inference
 @pytest.mark.asyncio(loop_scope="class")

--- a/tests/pipelex/pipelex_asynch/test_pipe_llm.py
+++ b/tests/pipelex/pipelex_asynch/test_pipe_llm.py
@@ -16,7 +16,7 @@ from pipelex.pipe_works.pipe_job_factory import PipeJobFactory
 from tests.pipelex.test_data import PipeTestCases
 
 
-@pytest.mark.dry_runable
+@pytest.mark.dry_runnable
 @pytest.mark.llm
 @pytest.mark.inference
 @pytest.mark.asyncio(loop_scope="class")

--- a/tests/pipelex/pipelex_asynch/test_pipe_ocr.py
+++ b/tests/pipelex/pipelex_asynch/test_pipe_ocr.py
@@ -13,7 +13,7 @@ from pipelex.pipe_works.pipe_job_factory import PipeJobFactory
 from tests.pipelex.test_data import PipeOcrTestCases
 
 
-@pytest.mark.dry_runable
+@pytest.mark.dry_runnable
 @pytest.mark.ocr
 @pytest.mark.inference
 @pytest.mark.asyncio(loop_scope="class")

--- a/tests/pipelex/pipelex_asynch/test_pipe_running_variants.py
+++ b/tests/pipelex/pipelex_asynch/test_pipe_running_variants.py
@@ -17,7 +17,7 @@ from pipelex.pipeline.job_metadata import JobMetadata
 from tests.pipelex.test_data import PipeTestCases
 
 
-@pytest.mark.dry_runable
+@pytest.mark.dry_runnable
 @pytest.mark.llm
 @pytest.mark.ocr
 @pytest.mark.inference

--- a/tests/test_pipelines/failure_modes.toml
+++ b/tests/test_pipelines/failure_modes.toml
@@ -1,7 +1,6 @@
 
 
 domain = "failure_modes"
-definition = "This domain is for testing failure modes"
 
 [concept]
 


### PR DESCRIPTION
### 📝 Description

* Be more lax on having domain definition: it's now Optional

### 🔄 Type of Change
- [ ] 🐛 Bug fix
- [X] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🧹 Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update

### 🧪 Tests

* tests/test_pipelines/failure_modes.toml has no domain definition set, and it's OK
