### PR TITLE
feature/make-from-str-default-native-text

### DIFF
--- a/pipelex/core/stuff_factory.py
+++ b/pipelex/core/stuff_factory.py
@@ -7,7 +7,6 @@ from pydantic import BaseModel, Field
 from pipelex.config import get_config
 from pipelex.core.concept import Concept
 from pipelex.core.concept_native import NativeConcept
-from pipelex.core.domain import SpecialDomain
 from pipelex.core.stuff import Stuff, StuffCreationRecord
 from pipelex.core.stuff_content import StuffContent, StuffContentInitableFromStr
 from pipelex.exceptions import PipelexError

--- a/pipelex/core/stuff_factory.py
+++ b/pipelex/core/stuff_factory.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, Field
 from pipelex.config import get_config
 from pipelex.core.concept import Concept
 from pipelex.core.concept_native import NativeConcept
+from pipelex.core.domain import SpecialDomain
 from pipelex.core.stuff import Stuff, StuffCreationRecord
 from pipelex.core.stuff_content import StuffContent, StuffContentInitableFromStr
 from pipelex.exceptions import PipelexError
@@ -95,11 +96,13 @@ class StuffFactory:
     @classmethod
     def make_from_str(
         cls,
-        concept_code: str,
         str_value: str,
+        concept_code: Optional[str] = None,
         name: Optional[str] = None,
         pipelex_session_id: Optional[str] = None,
     ) -> Stuff:
+        if not concept_code:
+            concept_code = NativeConcept.TEXT.code
         if not Concept.concept_str_contains_domain(concept_code):
             raise StuffFactoryError(f"Concept '{concept_code}' does not contain a domain")
         the_concept = get_required_concept(concept_code=concept_code)

--- a/pipelex/pipe_operators/pipe_llm_prompt.py
+++ b/pipelex/pipe_operators/pipe_llm_prompt.py
@@ -234,6 +234,7 @@ class PipeLLMPrompt(PipeOperator):
             "You do NOT need to output a formatted JSON object, another LLM will take care of that. "
             "If you cannot find a value that is Optional, output None for that field."
             "However, you MUST clearly output the values for each of these fields in your response.\n---\n"
+            "DO NOT create information. If the information is not present, output None."
         )
         return output_structure_prompt
 

--- a/pipelex/tools/typing/type_inspector.py
+++ b/pipelex/tools/typing/type_inspector.py
@@ -120,12 +120,18 @@ def get_type_structure(
                 for arg in non_none:
                     if isinstance(arg, type):
                         collect_types(arg)
+                    elif hasattr(arg, "__origin__"):  # Handle nested generics
+                        collect_types(arg)
             elif origin in (list, List):
                 if isinstance(args[0], type):
+                    collect_types(args[0])
+                elif hasattr(args[0], "__origin__"):  # Handle nested generics
                     collect_types(args[0])
             elif origin in (dict, Dict):
                 for arg in args:
                     if isinstance(arg, type):
+                        collect_types(arg)
+                    elif hasattr(arg, "__origin__"):  # Handle nested generics
                         collect_types(arg)
             return
 


### PR DESCRIPTION
### 🔗 Related Issues

### 📝 Description

- When using StuffFactory.make_from_str, I should just have to put the string in question and a name. I should'nt have to specify that its a text.. That is the purpose of the function "make_from_str"

- Added nested and generic models inside the get_structure method

### 🔄 Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🧹 Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update

### 🧪 Tests

### 📋 Checklist

- [ ] Linting / type-checking / unit tests pass locally with my changes
- [ ] I've added tests that prove my fix is effective or that my feature works
- [ ] My code follows the style guidelines of this project
- [ ] I've made corresponding changes to the documentation
- [ ] My changes generate no new warnings
