### PR TITLE
Release/v0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [v0.4.3] - 2025-06-19
+
+### Fixed
+- **Removed deprecated Gemini 1.5 models**: Removed `gemini-1.5-flash` and `gemini-1.5-pro` from the VertexAI integration as they are no longer supported
+- Fixed multiple import statements across the codebase
+
+### Documentation
+- **Enhanced MkDocs search**: Added search functionality to the documentation site
+- **Proofreading improvements**: Fixed various typos and improved clarity across documentation
+
+### Refactor
+- Mini refactor: changed kajson dependency to `kajson==0.1.5` (instead of `>=`) to tolerate temporary breaking changes from kajson
+
 ## [v0.4.2] - 2025-06-17
 
 - Fixed the inheritance config manager method (Undocumented feature, soon to be removed)

--- a/docs/pages/configuration/config-technical/cogt-config.md
+++ b/docs/pages/configuration/config-technical/cogt-config.md
@@ -26,7 +26,7 @@ is_auto_setup_preset_ocr = true
 
 ## LLM Configuration
 
-Configuration for Language Model interactions:
+Configuration for all Language Model interactions:
 
 ```toml
 [pipelex.cogt.llm_config]
@@ -70,7 +70,7 @@ is_sync_mode = true
 # Default parameters for image generation
 [pipelex.cogt.imgg_config.imgg_param_defaults]
 aspect_ratio = "square"  # Options: square, landscape_4_3, landscape_3_2, landscape_16_9, landscape_21_9,
-                        #         portrait_4_3, portrait_2_3, portrait_9_16, portrait_9_21
+                         # portrait_4_3, portrait_2_3, portrait_9_16, portrait_9_21
 background = "auto"     # Options: transparent, opaque, auto
 quality = "high"        # Options: low, medium, high
 nb_steps = 50          # Number of diffusion steps

--- a/docs/pages/configuration/index.md
+++ b/docs/pages/configuration/index.md
@@ -38,7 +38,7 @@ The exact loading sequence is:
    - Example environments: dev, staging, prod -> based on the environment variable `ENV` in your .env file
 5. Run mode overrides (`pipelex_{run_mode}.toml`)
    - Example run modes: normal, unit_test
-6. Super user overrides (`pipelex_super.toml`) (recommanded to put in .gitignore)
+6. Super user overrides (`pipelex_super.toml`) (recommended to put in .gitignore)
 
 Each subsequent configuration file in this sequence can override settings from the previous ones. This means:
 - Settings in `pipelex_local.toml` override the base configuration

--- a/docs/pages/cookbook-examples/extract-dpe.md
+++ b/docs/pages/cookbook-examples/extract-dpe.md
@@ -66,7 +66,7 @@ output = "Dpe" # The output is structured as a Dpe object
 images = ["page_content.page_view"]
 llm = "llm_for_img_to_text"
 structuring_method = "preliminary_text"
-system_prompt = """You are a multimodal LLM, expert at converting images into perfect markdown."""
+system_prompt = """You are a multimodal LLM, expert in converting images into perfect markdown."""
 prompt_template = """
 You are given an image of a French 'Diagnostic de Performance Energetique'.
 Your role is to convert the image into perfect markdown.

--- a/docs/pages/cookbook-examples/hello-world.md
+++ b/docs/pages/cookbook-examples/hello-world.md
@@ -1,6 +1,6 @@
 # Example: Hello World
 
-This is the "Hello World" of Pipelex. A simple pipeline that demonstrates the basic concepts of Pipelex.
+This is the "Hello World" of Pipelex, a simple pipeline that demonstrates the basic concepts of Pipelex.
 
 It's the perfect starting point to verify your installation and get a first taste of how Pipelex works.
 

--- a/docs/pages/cookbook-examples/write-screenplay.md
+++ b/docs/pages/cookbook-examples/write-screenplay.md
@@ -4,7 +4,7 @@ This example demonstrates how to use Pipelex for creative text generation. It ta
 
 ## Get the code
 
-[**➡️ View on GitHub: examples/wip/write_screen_play.py**](https://github.com/Pipelex/pipelex-cookbook/blob/main/examples/wip/write_screen_play.py)
+[**➡️ View on GitHub: examples/wip/write_screenplay.py**](https://github.com/Pipelex/pipelex-cookbook/blob/main/examples/wip/write_screenplay.py)
 
 ## The Pipeline Explained
 
@@ -109,4 +109,5 @@ steps = [
     { pipe = "create_scene_sequence", batch_over = "initial_scenes", batch_as = "scene", result = "developed_scenes" }
 ]
 ```
-This modular, step-by-step process, guided by the structured data models, allows Pipelex to generate a complete, well-structured screenplay from a single, simple pitch. It's a powerful demonstration of building complex, creative AI agents. 
+
+This modular, step-by-step process, guided by the structured data models, allows Pipelex to generate a complete, well-structured screenplay from a single, simple pitch. It's a powerful demonstration of building complex, creative AI agents.

--- a/docs/pages/installation/index.md
+++ b/docs/pages/installation/index.md
@@ -6,7 +6,7 @@ Pipelex requires `python` version `3.10` or above, and access to an LLM, via an 
 
 ## Getting Started
 
-Along with [our Documentation](../quick-start/index.md), we recommend you review it before any further usage: [Cookbook](https://github.com/Pipelex/pipelex-cookbook).
+Along with our [Quick Start Guide](../quick-start/index.md), we recommend you check out our [Cookbook](https://github.com/Pipelex/pipelex-cookbook) for practical examples.
 
 - **Create a virtual environment** (recommended)
 

--- a/docs/pages/pipelex-paradigm-for-repeatable-ai-workflows/index.md
+++ b/docs/pages/pipelex-paradigm-for-repeatable-ai-workflows/index.md
@@ -12,7 +12,9 @@ Pipelex introduces **knowledge pipelines**: a way to capture these workflow step
 
 Knowledge refers to information you input from various data sources such as documents, PDFs, images, or information output by our pipes. There are different kinds of knowledge.
 
-In traditional programming, we work with data types: strings, integers, booleans (true/false), etc. But **knowledge work operates at a higher level.** Take for instance a *"non-compete clause from a contract"* and a *"description of a flower"*: they're both text, both are stored as strings, but they represent fundamentally different concepts. You can ask AI to extract the duration in months from a non-compete clause. You can ask AI to render a flower description as a Monet-style painting. But if you try the reverse, it doesn't make sense.
+### From Data Types to Concepts
+
+In traditional programming, we work with data types: strings, integers, booleans (true/false), etc. But **knowledge work operates at a higher level.** Take for instance a *"non-compete clause from a contract"* and a *"description of a flower"*: they're both text, both are stored as strings, but they represent fundamentally different concepts. You can ask an AI to extract the duration in months from a non-compete clause. You can ask an AI to render a flower description as a Monet-style painting. But if you try the reverse, it doesn't make sense.
 
 This is why Pipelex introduces **Concepts: typing with meaning attached.**
 
@@ -22,20 +24,20 @@ This is why Pipelex introduces **Concepts: typing with meaning attached.**
 
 Concretely, in Pipelex, a piece of knowledge is an object in the working memory. It could be anything, so we call that "stuff", and our Python class for it is `Stuff`.
 
-Stuff can be pretty basic, like plain text or an image, but it can also be structured with attributes, comprise lists, include other nested stuff, you get it... it's content is actually a `Pydantic BaseModel`. Also, each Stuff knows what concept it belongs to, e.g., `Text` or `NonCompeteClause` or `FlowerDescription`.
+Stuff can be pretty basic, like plain text or an image, but it can also be structured with attributes, comprise lists, include other nested stuff, you get it... the stuff's content is actually a `Pydantic BaseModel`. Also, each Stuff knows what concept it belongs to, e.g., `Text` or `NonCompeteClause` or `FlowerDescription`.
 
 And with that we are fully equipped for Lego-style plug-n-play:
 
 - Each pipe declares what inputs it uses, indicating the expected concept(s)
 - Each pipe also declares what it outputs
 
-So when you connect two pipes, Pipelex systematically checks that they are compatible. Actually it's even more powerful than that: imagine you have a sequence of 5 pipes, maybe pipe #4 takes two inputs, one given from the output of previous pipe #3 and the other one from the output of pipe #1. Pipelex checks that running the previous steps will have generated the required stuff and with the required concepts.
+So when you connect two pipes, Pipelex systematically checks that they are compatible. Actually, it's even more powerful than that: imagine you have a sequence of 5 pipes, maybe pipe #4 takes two inputs, one given from the output of previous pipe #3 and the other one from the output of pipe #1. Pipelex checks that running the previous steps will have generated the required stuff and with the required concepts.
 
 What if you have a pipe that requires a `Text` input, to translate it to Spanish for instance, then it should also accept a `FlowerDescription`, right? Yes, the greater includes the lesser. This is expressed in Pipelex by indicating that concept `FlowerDescription` **refines** concept `Text`.
 
 One problem that developers face when working with LLMs is that LLMs always try to answer your queries, and it pushes them to hallucinate. For instance, if you're trying to extract structured purchase details from an invoice, and there's a bug in your system so instead of receiving an invoice as input, the LLM received a picture of a flower, or nothing at all, there's a good chance it will generate a 100% hallucinated mock invoice. Pipelex prevents this kind of bugs, first by making sure the pipeline makes sense a priori, but it can also check any input for compatibility with the expected concept.
 
-**By letting you clearly assign concepts to the input and output stuff of your pipes, Pipelex makes sure that your pipeline makes sense, that it works in theory and detects any failure of meaning at the earliest stage possible in practice.**
+**By letting you clearly assign concepts to the input and output stuff of your pipes, Pipelex makes sure that your pipeline makes sense, that it works in theory, and detects any failure of meaning at the earliest stage possible in practice.**
 
 ## Who Defines the Concepts?
 

--- a/docs/pages/quick-start/index.md
+++ b/docs/pages/quick-start/index.md
@@ -13,7 +13,7 @@ For illustration purposes, let's build **a character generator**. Each example r
 
 ### Write your first pipeline
 
-You have to create a `.toml` library file in the `pipelex_libraries/pipelines` directory that will store your pipe definition.
+First, create a `.toml` library file in the `pipelex_libraries/pipelines` directory to store your pipe definition.
 Run `pipelex init-libraries` to create this directory if it doesn't exist. For now, keep all your pipeline definitions inside that folder only.
 
 `character.toml`
@@ -30,7 +30,7 @@ Think of it and then output the character description."""
 
 ### Run your first Pipelex script
 
-You have to create a `.py` python file to run your script. You can save it anywhere in your repository.
+Now, create a `.py` python file to run your script. You can save it anywhere in your repository.
 
 `character.py`
 ```python
@@ -100,7 +100,7 @@ Let's say that we no longer want plain text as output but a rigorously structure
 
 ### Define the model
 
-Using the [Pydantic Basemodel](https://docs.pydantic.dev/latest/) syntax, define your object structure as a Python class, in the `pipelex_libraries/pipelines` directory:
+Using the [Pydantic BaseModel](https://docs.pydantic.dev/latest/) syntax, define your object structure as a Python class, in the `pipelex_libraries/pipelines` directory:
 
 `pipelex_libraries/pipelines/characters.py`
 ```python
@@ -179,7 +179,7 @@ class CharacterMetadata(StructuredContent):
 
 ### **Let's use a template to fill prompts with data**
 
-💡 Our template syntax is based on [Jinja2 syntax](https://jinja.palletsprojects.com/en/stable/). You can include a variable using the **classic** `{{ double.curly.braces }}` and, to make it simpler, we've added the possibility to just prefix your variable with the `@` symbol (recommended). Pipes now declare their required inputs explicitly with the `inputs` table:
+💡 Our template syntax is based on [Jinja2 syntax](https://jinja.palletsprojects.com/en/stable/). You can include a variable using the **classic** `{{ double.curly.braces }}`, and to make it simpler, we've added the possibility to just prefix your variable with the `@` symbol (recommended). Pipes declare their required inputs explicitly with the `inputs` table:
 
 ```toml
 [concept]

--- a/docs/pages/tools/logging.md
+++ b/docs/pages/tools/logging.md
@@ -36,7 +36,6 @@ Built-in emoji indicators for different components:
 - ⚪️ OpenAI-related logs
 - 🌀 Google-related logs
 - ⚡️ Network connections
-- 📡 Web server (Werkzeug)
 - *️⃣ JSON processing
 - 🧿 Sandbox operations
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,7 @@ extra:
   generator: false
 
 plugins:
+  - search
   - meta-manager
   - glightbox:
       touchNavigation: true

--- a/pipelex/cogt/content_generation/assignment_models.py
+++ b/pipelex/cogt/content_generation/assignment_models.py
@@ -17,7 +17,7 @@ from pipelex.cogt.ocr.ocr_handle import OcrHandle
 from pipelex.cogt.ocr.ocr_input import OcrInput
 from pipelex.cogt.ocr.ocr_job_components import OcrJobConfig, OcrJobParams
 from pipelex.pipeline.job_metadata import JobMetadata
-from pipelex.tools.templating.jinja2_environment import Jinja2TemplateCategory
+from pipelex.tools.templating.jinja2_template_category import Jinja2TemplateCategory
 from pipelex.tools.templating.templating_models import PromptingStyle
 
 

--- a/pipelex/cogt/content_generation/content_generator.py
+++ b/pipelex/cogt/content_generation/content_generator.py
@@ -31,7 +31,7 @@ from pipelex.cogt.ocr.ocr_job_components import OcrJobConfig, OcrJobParams
 from pipelex.cogt.ocr.ocr_output import OcrOutput
 from pipelex.config import get_config
 from pipelex.pipeline.job_metadata import JobMetadata
-from pipelex.tools.templating.jinja2_environment import Jinja2TemplateCategory
+from pipelex.tools.templating.jinja2_template_category import Jinja2TemplateCategory
 from pipelex.tools.templating.templating_models import PromptingStyle
 from pipelex.tools.typing.pydantic_utils import BaseModelTypeVar
 

--- a/pipelex/cogt/content_generation/content_generator_dry.py
+++ b/pipelex/cogt/content_generation/content_generator_dry.py
@@ -18,7 +18,7 @@ from pipelex.cogt.ocr.ocr_job_components import OcrJobConfig, OcrJobParams
 from pipelex.cogt.ocr.ocr_output import ExtractedImageFromPage, OcrOutput, Page
 from pipelex.config import get_config
 from pipelex.pipeline.job_metadata import JobMetadata
-from pipelex.tools.templating.jinja2_environment import Jinja2TemplateCategory
+from pipelex.tools.templating.jinja2_template_category import Jinja2TemplateCategory
 from pipelex.tools.templating.templating_models import PromptingStyle
 from pipelex.tools.typing.pydantic_utils import BaseModelTypeVar
 

--- a/pipelex/cogt/content_generation/content_generator_protocol.py
+++ b/pipelex/cogt/content_generation/content_generator_protocol.py
@@ -13,7 +13,7 @@ from pipelex.cogt.ocr.ocr_input import OcrInput
 from pipelex.cogt.ocr.ocr_job_components import OcrJobConfig, OcrJobParams
 from pipelex.cogt.ocr.ocr_output import OcrOutput
 from pipelex.pipeline.job_metadata import JobMetadata
-from pipelex.tools.templating.jinja2_environment import Jinja2TemplateCategory
+from pipelex.tools.templating.jinja2_template_category import Jinja2TemplateCategory
 from pipelex.tools.templating.templating_models import PromptingStyle
 from pipelex.tools.typing.pydantic_utils import BaseModelTypeVar
 

--- a/pipelex/core/stuff_artefact.py
+++ b/pipelex/core/stuff_artefact.py
@@ -6,8 +6,7 @@ from typing_extensions import override
 
 from pipelex.core.stuff_content import StuffContent
 from pipelex.exceptions import StuffArtefactError
-from pipelex.tools.templating.jinja2_models import Jinja2TaggableAbstract
-from pipelex.tools.templating.jinja2_rendering import Jinja2ContextKey
+from pipelex.tools.templating.jinja2_models import Jinja2ContextKey, Jinja2TaggableAbstract
 from pipelex.tools.templating.templating_models import TextFormat
 
 

--- a/pipelex/core/stuff_factory.py
+++ b/pipelex/core/stuff_factory.py
@@ -5,12 +5,12 @@ from kajson.class_registry import class_registry
 from pydantic import BaseModel, Field
 
 from pipelex.config import get_config
-from pipelex.core.concept import Concept, ConceptError
+from pipelex.core.concept import Concept
 from pipelex.core.concept_code_factory import ConceptCodeFactory
 from pipelex.core.concept_native import NativeConcept
 from pipelex.core.stuff import Stuff, StuffCreationRecord
 from pipelex.core.stuff_content import StuffContent, StuffContentInitableFromStr
-from pipelex.exceptions import PipelexError
+from pipelex.exceptions import ConceptError, PipelexError
 from pipelex.hub import get_required_concept
 
 

--- a/pipelex/libraries/llm_integrations/vertexai.toml
+++ b/pipelex/libraries/llm_integrations/vertexai.toml
@@ -1,19 +1,3 @@
-
-
-[gemini."gemini-1.5-flash".latest]
-is_gen_object_supported = true
-is_vision_supported = true
-max_prompt_images = 3000
-cost_per_million_tokens_usd = { input = 0.075, output = 0.3 }
-platform_llm_id = { vertexai = "google/gemini-1.5-flash" }
-
-[gemini."gemini-1.5-pro".latest]
-is_gen_object_supported = true
-is_vision_supported = true
-max_prompt_images = 3000
-cost_per_million_tokens_usd = { input = 1.25, output = 5.0 }
-platform_llm_id = { vertexai = "google/gemini-1.5-pro" }
-
 [gemini."gemini-2.0-flash".latest]
 is_gen_object_supported = true
 is_vision_supported = true

--- a/pipelex/pipe_controllers/pipe_batch.py
+++ b/pipelex/pipe_controllers/pipe_batch.py
@@ -11,8 +11,8 @@ from pipelex.core.pipe_run_params import BatchParams, PipeRunParams
 from pipelex.core.stuff import Stuff
 from pipelex.core.stuff_content import ListContent, StuffContent
 from pipelex.core.stuff_factory import StuffFactory
-from pipelex.core.working_memory import MAIN_STUFF_NAME, WorkingMemory, WorkingMemoryStuffNotFoundError
-from pipelex.exceptions import PipeInputError, PipeInputNotFoundError
+from pipelex.core.working_memory import MAIN_STUFF_NAME, WorkingMemory
+from pipelex.exceptions import PipeInputError, PipeInputNotFoundError, WorkingMemoryStuffNotFoundError
 from pipelex.hub import get_pipe_router, get_pipeline_tracker, get_required_pipe
 from pipelex.pipe_controllers.pipe_controller import PipeController
 from pipelex.pipeline.job_metadata import JobMetadata

--- a/pipelex/pipe_operators/pipe_img_gen.py
+++ b/pipelex/pipe_operators/pipe_img_gen.py
@@ -9,7 +9,7 @@ from pipelex.cogt.content_generation.content_generator_protocol import ContentGe
 from pipelex.cogt.imgg.imgg_handle import ImggHandle
 from pipelex.cogt.imgg.imgg_job_components import AspectRatio, Background, ImggJobParams, Quality
 from pipelex.cogt.imgg.imgg_prompt import ImggPrompt
-from pipelex.config import StaticValidationErrorType, StaticValidationReaction, get_config
+from pipelex.config import StaticValidationReaction, get_config
 from pipelex.core.concept_native import NativeConcept
 from pipelex.core.pipe_output import PipeOutput
 from pipelex.core.pipe_run_params import PipeOutputMultiplicity, PipeRunParams, output_multiplicity_to_apply
@@ -21,6 +21,7 @@ from pipelex.exceptions import (
     PipeInputError,
     PipeRunParamsError,
     StaticValidationError,
+    StaticValidationErrorType,
     UnexpectedPipeDefinitionError,
     WorkingMemoryStuffNotFoundError,
 )

--- a/pipelex/pipe_operators/pipe_jinja2_factory.py
+++ b/pipelex/pipe_operators/pipe_jinja2_factory.py
@@ -7,8 +7,8 @@ from pipelex.core.pipe_blueprint import PipeBlueprint, PipeSpecificFactoryProtoc
 from pipelex.core.pipe_input_spec import PipeInputSpec
 from pipelex.exceptions import PipeDefinitionError
 from pipelex.pipe_operators.pipe_jinja2 import PipeJinja2
-from pipelex.tools.templating.jinja2_environment import Jinja2TemplateCategory
 from pipelex.tools.templating.jinja2_parsing import check_jinja2_parsing
+from pipelex.tools.templating.jinja2_template_category import Jinja2TemplateCategory
 from pipelex.tools.templating.template_preprocessor import preprocess_template
 from pipelex.tools.templating.templating_models import PromptingStyle
 

--- a/pipelex/pipe_operators/pipe_llm.py
+++ b/pipelex/pipe_operators/pipe_llm.py
@@ -7,9 +7,8 @@ from typing_extensions import Self, override
 from pipelex import log
 from pipelex.cogt.content_generation.content_generator_dry import ContentGeneratorDry
 from pipelex.cogt.content_generation.content_generator_protocol import ContentGeneratorProtocol
-from pipelex.cogt.llm.llm_models.llm_deck import LLMSettingChoices
 from pipelex.cogt.llm.llm_models.llm_deck_check import check_llm_setting_with_deck
-from pipelex.cogt.llm.llm_models.llm_setting import LLMSetting
+from pipelex.cogt.llm.llm_models.llm_setting import LLMSetting, LLMSettingChoices
 from pipelex.cogt.llm.llm_prompt import LLMPrompt
 from pipelex.cogt.llm.llm_prompt_factory_abstract import LLMPromptFactoryAbstract
 from pipelex.config import StaticValidationReaction, get_config

--- a/pipelex/pipe_operators/pipe_llm_factory.py
+++ b/pipelex/pipe_operators/pipe_llm_factory.py
@@ -3,8 +3,7 @@ from typing import Any, Dict, List, Optional
 from pydantic import model_validator
 from typing_extensions import Self, override
 
-from pipelex.cogt.llm.llm_models.llm_deck import LLMSettingChoices
-from pipelex.cogt.llm.llm_models.llm_setting import LLMSettingOrPresetId
+from pipelex.cogt.llm.llm_models.llm_setting import LLMSettingChoices, LLMSettingOrPresetId
 from pipelex.core.pipe_blueprint import PipeBlueprint, PipeSpecificFactoryProtocol
 from pipelex.core.pipe_input_spec import PipeInputSpec
 from pipelex.core.pipe_run_params import make_output_multiplicity

--- a/pipelex/pipe_operators/pipe_ocr_factory.py
+++ b/pipelex/pipe_operators/pipe_ocr_factory.py
@@ -2,8 +2,9 @@ from typing import Any, Dict, Optional
 
 from typing_extensions import override
 
-from pipelex.cogt.ocr.ocr_engine_factory import OcrEngineFactory, OcrPlatform
+from pipelex.cogt.ocr.ocr_engine_factory import OcrEngineFactory
 from pipelex.cogt.ocr.ocr_handle import OcrHandle
+from pipelex.cogt.ocr.ocr_platform import OcrPlatform
 from pipelex.config import get_config
 from pipelex.core.pipe_blueprint import PipeBlueprint, PipeSpecificFactoryProtocol
 from pipelex.core.pipe_input_spec import PipeInputSpec

--- a/pipelex/pipe_works/pipe_router.py
+++ b/pipelex/pipe_works/pipe_router.py
@@ -7,8 +7,9 @@ from pipelex.core.pipe_output import PipeOutputType
 from pipelex.core.pipe_run_params import PipeRunParams
 from pipelex.core.working_memory import WorkingMemory
 from pipelex.hub import get_required_pipe
+from pipelex.pipe_works.pipe_job import PipeJob
 from pipelex.pipe_works.pipe_job_factory import PipeJobFactory
-from pipelex.pipe_works.pipe_router_protocol import PipeJob, PipeRouterProtocol
+from pipelex.pipe_works.pipe_router_protocol import PipeRouterProtocol
 from pipelex.pipeline.job_metadata import JobMetadata
 
 

--- a/pipelex/pipeline/activity/activity_handler.py
+++ b/pipelex/pipeline/activity/activity_handler.py
@@ -3,7 +3,7 @@ from typing import Set, cast
 
 from pipelex import log
 from pipelex.config import get_config
-from pipelex.core.stuff import Stuff, StuffContent
+from pipelex.core.stuff import Stuff
 from pipelex.core.stuff_content import (
     HtmlContent,
     ImageContent,
@@ -11,6 +11,7 @@ from pipelex.core.stuff_content import (
     MermaidContent,
     NumberContent,
     StructuredContent,
+    StuffContent,
     TextContent,
 )
 from pipelex.pipeline.activity.activity_models import ActivityReport

--- a/pipelex/tools/log/log.py
+++ b/pipelex/tools/log/log.py
@@ -1,13 +1,10 @@
 import logging
 from typing import Any, Dict, Optional, Union
 
-from pipelex.tools.log.log_config import (
-    LogConfig,
-    LogLevel,
-)
+from pipelex.tools.log.log_config import LogConfig
 from pipelex.tools.log.log_dispatch import LogDispatch
 from pipelex.tools.log.log_formatter import EmojiLogFormatter, LevelAndEmojiLogFormatter
-from pipelex.tools.log.log_levels import LOGGING_LEVEL_DEV, LOGGING_LEVEL_OFF, LOGGING_LEVEL_VERBOSE
+from pipelex.tools.log.log_levels import LOGGING_LEVEL_DEV, LOGGING_LEVEL_OFF, LOGGING_LEVEL_VERBOSE, LogLevel
 
 
 class Log:

--- a/pipelex/tools/templating/jinja2_rendering.py
+++ b/pipelex/tools/templating/jinja2_rendering.py
@@ -8,6 +8,7 @@ from jinja2.exceptions import (
 )
 
 from pipelex import log
+from pipelex.tools.templating.jinja2_environment import make_jinja2_env_from_template_provider
 from pipelex.tools.templating.jinja2_errors import (
     Jinja2ContextError,
     Jinja2RenderError,
@@ -15,7 +16,6 @@ from pipelex.tools.templating.jinja2_errors import (
     make_jinja2_error_explanation,
 )
 from pipelex.tools.templating.jinja2_models import Jinja2ContextKey
-from pipelex.tools.templating.jinja2_required_variables import make_jinja2_env_from_template_provider
 from pipelex.tools.templating.jinja2_template_category import Jinja2TemplateCategory
 from pipelex.tools.templating.template_provider_abstract import TemplateProviderAbstract
 from pipelex.tools.templating.templating_models import PromptingStyle

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pipelex"
-version = "0.4.2"
+version = "0.4.3"
 description = "Pipelex is an open-source dev tool based on a simple declarative language that lets you define replicable, structured, composable LLM pipelines."
 authors = [{ name = "Evotis S.A.S.", email = "evotis@pipelex.com" }]
 maintainers = [{ name = "Pipelex staff", email = "oss@pipelex.com" }]
@@ -24,7 +24,7 @@ dependencies = [
     "instructor>=1.8.3",
     "jinja2>=3.1.4",
     "json2html>=1.3.0",
-    "kajson>=0.1.5",
+    "kajson==0.1.5",
     "markdown>=3.6",
     "networkx>=3.4.2",
     "openai>=1.60.1",

--- a/uv.lock
+++ b/uv.lock
@@ -1712,7 +1712,7 @@ requires-dist = [
     { name = "instructor", specifier = ">=1.8.3" },
     { name = "jinja2", specifier = ">=3.1.4" },
     { name = "json2html", specifier = ">=1.3.0" },
-    { name = "kajson", specifier = ">=0.1.5" },
+    { name = "kajson", specifier = "==0.1.5" },
     { name = "markdown", specifier = ">=3.6" },
     { name = "mistralai", marker = "extra == 'mistralai'", specifier = "==1.5.2" },
     { name = "mkdocs", marker = "extra == 'docs'", specifier = "==1.6.1" },


### PR DESCRIPTION
### Fixed
- **Removed deprecated Gemini 1.5 models**: Removed `gemini-1.5-flash` and `gemini-1.5-pro` from the VertexAI integration as they are no longer supported
- Fixed multiple import statements across the codebase

### Documentation
- **Enhanced MkDocs search**: Added search functionality to the documentation site
- **Proofreading improvements**: Fixed various typos and improved clarity across documentation

### Refactor
- Mini refactor: changed kajson dependency to `kajson==0.1.5` (instead of `>=`) to tolerate temporary breaking changes from kajson

### 🔄 Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [X] 📚 Documentation update
- [X] 🧹 Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
