### PR TITLE
Release/v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [v0.5.1] - 2025-07-09
+
+## Fixed
+
+- Fixed the `ConceptFactory.make_from_blueprint` method: Concepts defined in single-line format no longer automatically refine `TextContent` when a structure class with the same name exists
+- `ConceptFactory.make_concept_from_definition` is now `ConceptFactory.make_concept_from_definition_str`
+
+## Added
+
+- Bumped `kajson` to `v0.3.0`: Introducing `MetaSingleton` for better singleton management
+- Unit tests for `ConceptLibrary.is_compatible_by_concept_code`
+
 ## [v0.5.0] - 2025-07-01
 
 ### Highlight: Vibe Coding an AI workflow becomes a reality

--- a/pipelex/core/concept.py
+++ b/pipelex/core/concept.py
@@ -106,7 +106,7 @@ class Concept(BaseModel):
         if "." in concept_str:
             domain_code, concept_code = concept_str.split(".")
             return domain_code, concept_code
-        raise ConceptError(f"No extraction of domain and concept from concept code '{concept_str}'")
+        raise ConceptError(f"Could not extract domain and concept from concept code '{concept_str}'")
 
     @classmethod
     def extract_concept_name_from_str(cls, concept_str: str) -> str:

--- a/pipelex/core/concept_factory.py
+++ b/pipelex/core/concept_factory.py
@@ -82,26 +82,33 @@ class ConceptFactory:
         return the_concept
 
     @classmethod
-    def make_concept_from_definition(
+    def make_concept_from_definition_str(
         cls,
         domain_code: str,
-        code: str,
+        concept_str: str,
         definition: str,
     ) -> Concept:
         structure_class_name: str
-        if Concept.is_valid_structure_class(structure_class_name=code):
+        refines: List[str]
+        if Concept.concept_str_contains_domain(concept_str=concept_str):
+            concept_name = Concept.extract_concept_name_from_str(concept_str=concept_str)
+        else:
+            concept_name = concept_str
+        if Concept.is_valid_structure_class(structure_class_name=concept_name):
             # structure is set implicitly, by the concept's code
-            structure_class_name = code
+            structure_class_name = concept_name
+            refines = []
         else:
             structure_class_name = TextContent.__name__
+            refines = [NativeConcept.TEXT.code]
 
         try:
             the_concept = Concept(
-                code=ConceptCodeFactory.make_concept_code(domain_code, code),
+                code=ConceptCodeFactory.make_concept_code(domain_code, concept_name),
                 domain=domain_code,
                 definition=definition,
                 structure_class_name=structure_class_name,
-                refines=[NativeConcept.TEXT.code],
+                refines=refines,
             )
             return Concept.model_validate(the_concept)
         except ValidationError as e:

--- a/pipelex/core/concept_library.py
+++ b/pipelex/core/concept_library.py
@@ -106,13 +106,22 @@ class ConceptLibrary(RootModel[ConceptLibraryRoot], ConceptProviderAbstract):
     @override
     def is_compatible_by_concept_code(self, tested_concept_code: str, wanted_concept_code: str) -> bool:
         if wanted_concept_code == NativeConcept.ANYTHING.code:
+            log.debug(
+                f"Concept '{tested_concept_code}' is compatible with '{wanted_concept_code}' "
+                f"because '{wanted_concept_code}' is '{NativeConcept.ANYTHING.code}'"
+            )
             return True
         tested_concept = self.get_required_concept(concept_code=tested_concept_code)
         wanted_concept = self.get_required_concept(concept_code=wanted_concept_code)
         if tested_concept.code == wanted_concept.code:
+            log.debug(f"Concept '{tested_concept_code}' is compatible with '{wanted_concept_code}' because they have the same code")
             return True
         for inherited_concept_code in tested_concept.refines:
             if self.is_compatible_by_concept_code(inherited_concept_code, wanted_concept_code):
+                log.debug(
+                    f"Concept '{tested_concept_code}' is compatible with '{wanted_concept_code}' "
+                    f"because '{tested_concept_code}' refines '{inherited_concept_code}' which is compatible with '{wanted_concept_code}'"
+                )
                 return True
         return False
 
@@ -134,9 +143,9 @@ class ConceptLibrary(RootModel[ConceptLibraryRoot], ConceptProviderAbstract):
             if self.is_concept_implicit(concept_code=concept_code):
                 # The implicit concept is obviously coming with a domain (the one it is used in)
                 # TODO: replace this with a concept factory method make_implicit_concept
-                return ConceptFactory.make_concept_from_definition(
+                return ConceptFactory.make_concept_from_definition_str(
                     domain_code="implicit",
-                    code=Concept.extract_domain_and_concept_from_str(concept_str=concept_code)[1],
+                    concept_str=Concept.extract_domain_and_concept_from_str(concept_str=concept_code)[1],
                     definition=concept_code,
                 )
             else:

--- a/pipelex/libraries/library_manager.py
+++ b/pipelex/libraries/library_manager.py
@@ -256,24 +256,29 @@ class LibraryManager(LibraryManagerAbstract):
                 continue
 
     def _load_concepts(self, domain_code: str, obj_dict: Dict[str, Any]):
-        for concept_code, concept_obj in obj_dict.items():
+        for concept_str, concept_obj in obj_dict.items():
             if isinstance(concept_obj, str):
                 # we only have a definition
-                concept_from_def = ConceptFactory.make_concept_from_definition(domain_code=domain_code, code=concept_code, definition=concept_obj)
+                definition = concept_obj
+                concept_from_def = ConceptFactory.make_concept_from_definition_str(
+                    domain_code=domain_code,
+                    concept_str=concept_str,
+                    definition=definition,
+                )
                 self.concept_library.add_new_concept(concept=concept_from_def)
             elif isinstance(concept_obj, dict):
                 # blueprint dict definition
                 concept_obj_dict: Dict[str, Any] = concept_obj
                 try:
                     concept_from_dict = ConceptFactory.make_from_details_dict(
-                        domain_code=domain_code, code=concept_code, details_dict=concept_obj_dict
+                        domain_code=domain_code, code=concept_str, details_dict=concept_obj_dict
                     )
                 except ValidationError as exc:
                     error_msg = format_pydantic_validation_error(exc)
-                    raise ConceptLibraryError(f"Error loading concept '{concept_code}' because of: {error_msg}") from exc
+                    raise ConceptLibraryError(f"Error loading concept '{concept_str}' because of: {error_msg}") from exc
                 self.concept_library.add_new_concept(concept=concept_from_dict)
             else:
-                raise ConceptLibraryError(f"Unexpected type for concept_code '{concept_code}' in domain '{domain_code}': {type(concept_obj)}")
+                raise ConceptLibraryError(f"Unexpected type for concept_code '{concept_str}' in domain '{domain_code}': {type(concept_obj)}")
 
     def _load_pipes(self, domain_code: str, obj_dict: Dict[str, Any]):
         for pipe_code, pipe_obj in obj_dict.items():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pipelex"
-version = "0.5.0"
+version = "0.5.1"
 description = "Pipelex is an open-source dev tool based on a simple declarative language that lets you define replicable, structured, composable LLM pipelines."
 authors = [{ name = "Evotis S.A.S.", email = "evotis@pipelex.com" }]
 maintainers = [{ name = "Pipelex staff", email = "oss@pipelex.com" }]
@@ -24,7 +24,7 @@ dependencies = [
     "instructor>=1.8.3",
     "jinja2>=3.1.4",
     "json2html>=1.3.0",
-    "kajson==0.2.3",
+    "kajson==0.3.0",
     "markdown>=3.6",
     "networkx>=3.4.2",
     "openai>=1.60.1",
@@ -284,3 +284,6 @@ packages = ["pipelex"]
 
 [tool.hatch.build.targets.sdist.force-include]
 "pyproject.toml" = "pipelex/pyproject.toml"
+
+[tool.hatch.metadata]
+allow-direct-references = true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,8 @@ import pipelex.config
 import pipelex.pipelex
 from pipelex import log
 from pipelex.config import get_config
+from pipelex.core.concept_provider_abstract import ConceptProviderAbstract
+from pipelex.hub import get_concept_provider
 from tests.cases.registry import Fruit
 
 pytest_plugins = [
@@ -66,3 +68,9 @@ def cherry() -> Fruit:
 def blueberry() -> Fruit:
     """Blueberry fruit fixture."""
     return Fruit(name="blueberry", color="blue")
+
+
+@pytest.fixture(scope="module")
+def concept_provider() -> ConceptProviderAbstract:
+    """Concept provider fixture for testing concept compatibility."""
+    return get_concept_provider()

--- a/tests/test_pipelines/concept_library/is_compatible_concept_code.py
+++ b/tests/test_pipelines/concept_library/is_compatible_concept_code.py
@@ -1,0 +1,45 @@
+from typing import Dict, List, Optional
+
+from pydantic import Field
+
+from pipelex.core.stuff_content import StructuredContent
+
+
+class FundamentalsDoc(StructuredContent):
+    project_overview: Optional[str] = Field(
+        None,
+        description="Mission, key features, architecture diagram, demo links",
+    )
+    core_concepts: Optional[Dict[str, str]] = Field(
+        None,
+        description=(
+            "Names and definitions for project-specific terms, acronyms, data model names, background knowledge, business rules, domain entities"
+        ),
+    )
+    repository_map: Optional[str] = Field(
+        None,
+        description="Directory layout explanation and purpose of each folder",
+    )
+
+
+class DocumentationConcept(StructuredContent):
+    """A specialized documentation concept that extends FundamentalsDoc."""
+
+    title: str = Field(..., description="Title of the documentation")
+    sections: List[str] = Field(default_factory=list, description="List of section names")
+    last_updated: Optional[str] = Field(None, description="Last update timestamp")
+
+
+class MultiMediaConcept(StructuredContent):
+    """A concept that combines text and images."""
+
+    text_content: str = Field(..., description="The text content")
+    image_urls: List[str] = Field(default_factory=list, description="List of image URLs")
+    caption: Optional[str] = Field(None, description="Optional caption for the content")
+
+
+class IndependentConcept(StructuredContent):
+    """An independent concept with its own structure."""
+
+    unique_field: str = Field(..., description="A unique field for this concept")
+    metadata: Dict[str, str] = Field(default_factory=dict, description="Metadata dictionary")

--- a/tests/test_pipelines/concept_library/is_compatible_concept_code.toml
+++ b/tests/test_pipelines/concept_library/is_compatible_concept_code.toml
@@ -1,0 +1,46 @@
+domain = "concept_library_tests"
+
+[concept]
+# Simple concept with no structure - should default to Text
+SimpleTextConcept = "A simple concept that should default to Text"
+
+# Concept with explicit structure class
+FundamentalsDoc = "A comprehensive overview of the fundamental concepts and principles of software engineering."
+
+# Concept that explicitly refines Text
+[concept.ExplicitTextConcept]
+Concept = "A concept that explicitly refines Text"
+refines = ["Text"]
+
+# Concept that refines Image
+[concept.ImageBasedConcept]
+Concept = "A concept based on images"
+refines = ["Image"]
+
+# Concept that refines FundamentalsDoc
+[concept.DocumentationConcept]
+Concept = "A specialized documentation concept"
+structure = "DocumentationConcept"
+refines = ["FundamentalsDoc"]
+
+# Concept that refines both Text and Image (multiple inheritance)
+[concept.MultiMediaConcept]
+Concept = "A concept that combines text and images"
+structure = "MultiMediaConcept"
+refines = ["Text", "Image"]
+
+# Concept with custom structure that doesn't refine anything
+[concept.IndependentConcept]
+Concept = "An independent concept with custom structure"
+structure = "IndependentConcept"
+
+# Concept that refines a non-native concept
+[concept.SpecializedDoc]
+Concept = "A specialized document that builds on FundamentalsDoc"
+refines = ["FundamentalsDoc"]
+
+# Chain of inheritance: Text -> ExplicitTextConcept -> DerivedTextConcept
+[concept.DerivedTextConcept]
+Concept = "A concept derived from ExplicitTextConcept"
+refines = ["ExplicitTextConcept"]
+

--- a/tests/unit/pipelex/core/test_concept_library.py
+++ b/tests/unit/pipelex/core/test_concept_library.py
@@ -1,5 +1,6 @@
 from pipelex.core.concept import Concept
 from pipelex.core.concept_native import NativeConcept
+from pipelex.core.concept_provider_abstract import ConceptProviderAbstract
 
 
 class Testget_concept_providerIsNativeConcept:
@@ -128,3 +129,103 @@ class Testget_concept_providerIsNativeConcept:
 
             # And they should also work with the explicit "native." prefix
             assert Concept.is_native_concept(f"native.{concept_name}") is True, f"'native.{concept_name}' should also be recognized as native concept"
+
+
+class TestConceptLibraryCompatibility:
+    """Test ConceptLibrary compatibility methods."""
+
+    def test_is_compatible_by_concept_code_simple_text_concept_vs_text(self, concept_provider: ConceptProviderAbstract):
+        """Test that SimpleTextConcept (no structure) is compatible with native Text."""
+        # Test: SimpleTextConcept should be compatible with native Text (defaults to Text)
+        result = concept_provider.is_compatible_by_concept_code(
+            tested_concept_code="concept_library_tests.SimpleTextConcept", wanted_concept_code="native.Text"
+        )
+        assert result is True, "SimpleTextConcept should be compatible with native Text"
+
+    def test_is_compatible_by_concept_code_fundamentals_doc_vs_text(self, concept_provider: ConceptProviderAbstract):
+        """Test that FundamentalsDoc (custom structure) is not compatible with native Text."""
+        # Test: FundamentalsDoc should NOT be compatible with native Text (has custom structure)
+        result = concept_provider.is_compatible_by_concept_code(
+            tested_concept_code="concept_library_tests.FundamentalsDoc", wanted_concept_code="native.Text"
+        )
+        assert result is False, "FundamentalsDoc should not be compatible with native Text"
+
+    def test_is_compatible_by_concept_code_explicit_text_concept_vs_text(self, concept_provider: ConceptProviderAbstract):
+        """Test that ExplicitTextConcept (explicitly refines Text) is compatible with native Text."""
+        # Test: ExplicitTextConcept should be compatible with native Text
+        result = concept_provider.is_compatible_by_concept_code(
+            tested_concept_code="concept_library_tests.ExplicitTextConcept", wanted_concept_code="native.Text"
+        )
+        assert result is True, "ExplicitTextConcept should be compatible with native Text"
+
+    def test_is_compatible_by_concept_code_image_based_concept_vs_image(self, concept_provider: ConceptProviderAbstract):
+        """Test that ImageBasedConcept is compatible with native Image."""
+        # Test: ImageBasedConcept should be compatible with native Image
+        result = concept_provider.is_compatible_by_concept_code(
+            tested_concept_code="concept_library_tests.ImageBasedConcept", wanted_concept_code="native.Image"
+        )
+        assert result is True, "ImageBasedConcept should be compatible with native Image"
+
+    def test_is_compatible_by_concept_code_image_based_concept_vs_text(self, concept_provider: ConceptProviderAbstract):
+        """Test that ImageBasedConcept is not compatible with native Text."""
+        # Test: ImageBasedConcept should NOT be compatible with native Text
+        result = concept_provider.is_compatible_by_concept_code(
+            tested_concept_code="concept_library_tests.ImageBasedConcept", wanted_concept_code="native.Text"
+        )
+        assert result is False, "ImageBasedConcept should not be compatible with native Text"
+
+    def test_is_compatible_by_concept_code_documentation_concept_vs_fundamentals_doc(self, concept_provider: ConceptProviderAbstract):
+        """Test that DocumentationConcept is compatible with FundamentalsDoc."""
+        # Test: DocumentationConcept should be compatible with FundamentalsDoc
+        result = concept_provider.is_compatible_by_concept_code(
+            tested_concept_code="concept_library_tests.DocumentationConcept", wanted_concept_code="concept_library_tests.FundamentalsDoc"
+        )
+        assert result is True, "DocumentationConcept should be compatible with FundamentalsDoc"
+
+    def test_is_compatible_by_concept_code_specialized_doc_vs_fundamentals_doc(self, concept_provider: ConceptProviderAbstract):
+        """Test that SpecializedDoc is compatible with FundamentalsDoc."""
+        # Test: SpecializedDoc should be compatible with FundamentalsDoc
+        result = concept_provider.is_compatible_by_concept_code(
+            tested_concept_code="concept_library_tests.SpecializedDoc", wanted_concept_code="concept_library_tests.FundamentalsDoc"
+        )
+        assert result is True, "SpecializedDoc should be compatible with FundamentalsDoc"
+
+    def test_is_compatible_by_concept_code_multimedia_concept_vs_text(self, concept_provider: ConceptProviderAbstract):
+        """Test that MultiMediaConcept is compatible with Text (multiple inheritance)."""
+        # Test: MultiMediaConcept should be compatible with Text
+        result = concept_provider.is_compatible_by_concept_code(
+            tested_concept_code="concept_library_tests.MultiMediaConcept", wanted_concept_code="native.Text"
+        )
+        assert result is True, "MultiMediaConcept should be compatible with Text"
+
+    def test_is_compatible_by_concept_code_multimedia_concept_vs_image(self, concept_provider: ConceptProviderAbstract):
+        """Test that MultiMediaConcept is compatible with Image (multiple inheritance)."""
+        # Test: MultiMediaConcept should be compatible with Image
+        result = concept_provider.is_compatible_by_concept_code(
+            tested_concept_code="concept_library_tests.MultiMediaConcept", wanted_concept_code="native.Image"
+        )
+        assert result is True, "MultiMediaConcept should be compatible with Image"
+
+    def test_is_compatible_by_concept_code_independent_concept_vs_text(self, concept_provider: ConceptProviderAbstract):
+        """Test that IndependentConcept is not compatible with Text."""
+        # Test: IndependentConcept should NOT be compatible with Text (no refines)
+        result = concept_provider.is_compatible_by_concept_code(
+            tested_concept_code="concept_library_tests.IndependentConcept", wanted_concept_code="native.Text"
+        )
+        assert result is False, "IndependentConcept should not be compatible with Text"
+
+    def test_is_compatible_by_concept_code_derived_text_concept_vs_text(self, concept_provider: ConceptProviderAbstract):
+        """Test that DerivedTextConcept is compatible with Text (inheritance chain)."""
+        # Test: DerivedTextConcept should be compatible with Text (through ExplicitTextConcept)
+        result = concept_provider.is_compatible_by_concept_code(
+            tested_concept_code="concept_library_tests.DerivedTextConcept", wanted_concept_code="native.Text"
+        )
+        assert result is True, "DerivedTextConcept should be compatible with Text through inheritance chain"
+
+    def test_is_compatible_by_concept_code_derived_text_concept_vs_explicit_text(self, concept_provider: ConceptProviderAbstract):
+        """Test that DerivedTextConcept is compatible with ExplicitTextConcept (direct inheritance)."""
+        # Test: DerivedTextConcept should be compatible with ExplicitTextConcept
+        result = concept_provider.is_compatible_by_concept_code(
+            tested_concept_code="concept_library_tests.DerivedTextConcept", wanted_concept_code="concept_library_tests.ExplicitTextConcept"
+        )
+        assert result is True, "DerivedTextConcept should be compatible with ExplicitTextConcept"

--- a/uv.lock
+++ b/uv.lock
@@ -889,14 +889,14 @@ wheels = [
 
 [[package]]
 name = "kajson"
-version = "0.2.3"
+version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/70/8f/72a203f9aabb272091ce078e52a127d064ed89c7b5aba098f3210d4f6ffc/kajson-0.2.3.tar.gz", hash = "sha256:45a18d298d3b193dc904a53493a20069aefba68fe93432455a01cdd92c8dcaf4", size = 20134, upload-time = "2025-06-26T13:52:05.208Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b3/51/83d17d4fc6db6b9d497f91c6cbdf7c5677116797a44d0ad65960f1b66c90/kajson-0.3.0.tar.gz", hash = "sha256:5ea8e164cd7fc96877bf4038cf64c286ac4606814146c24dc9ecc4a2c6ac047d", size = 20271, upload-time = "2025-07-09T09:52:33.851Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b3/8e/798196dd104b3d02779cdb1627f10c704780f6b279124cf2e4633cc69da5/kajson-0.2.3-py3-none-any.whl", hash = "sha256:4df631383e898f30c8f13f49b1c58cc2d69e2629bb828728817c3edb675da065", size = 26240, upload-time = "2025-06-26T13:52:03.962Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/d5/4a7974d072c5eb6565e5abe3d52b13f662491934dac4b9ea15836fa2da69/kajson-0.3.0-py3-none-any.whl", hash = "sha256:d8cc72875ebef6ea44c06c96fe63accf5b0721ca24ea1e593814dd45fd25bf15", size = 26711, upload-time = "2025-07-09T09:52:32.639Z" },
 ]
 
 [[package]]
@@ -1619,7 +1619,7 @@ wheels = [
 
 [[package]]
 name = "pipelex"
-version = "0.4.12"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },
@@ -1713,7 +1713,7 @@ requires-dist = [
     { name = "instructor", specifier = ">=1.8.3" },
     { name = "jinja2", specifier = ">=3.1.4" },
     { name = "json2html", specifier = ">=1.3.0" },
-    { name = "kajson", specifier = "==0.2.3" },
+    { name = "kajson", specifier = "==0.3.0" },
     { name = "markdown", specifier = ">=3.6" },
     { name = "mistralai", marker = "extra == 'mistralai'", specifier = "==1.5.2" },
     { name = "mkdocs", marker = "extra == 'docs'", specifier = "==1.6.1" },


### PR DESCRIPTION
## [v0.5.1] - 2025-07-09

## Fixed

- Fixed the `ConceptFactory.make_from_blueprint` method: Concepts defined in single-line format no longer automatically refine `TextContent` when a structure class with the same name exists
- `ConceptFactory.make_concept_from_definition` is now `ConceptFactory.make_concept_from_definition_str`

## Added

- Bumped `kajson` to `v0.3.0`: Introducing `MetaSingleton` for better singleton management
- Unit tests for `ConceptLibrary.is_compatible_by_concept_code`
