### PR TITLE
Fix PipeLLM with preliminary text

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,17 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "Debug check",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${workspaceFolder}/.venv/bin/pipelex",
+            "args": [
+                "--help",
+            ],
+            "console": "integratedTerminal",
+            "justMyCode": false
+        },
+        {
             "name": "Debug tests",
             "type": "debugpy",
             "request": "launch",
@@ -18,27 +29,16 @@
             "console": "integratedTerminal"
         },
         {
-            "name": "Debug legacy check",
+            "name": "Debug Validate Pipe",
             "type": "debugpy",
             "request": "launch",
-            "module": "pipelex.cli._cli",
+            "program": "${workspaceFolder}/.venv/bin/pipelex",
             "args": [
-                "check",
-            ],
-            "console": "integratedTerminal",
-            "justMyCode": true
-        },
-        {
-            "name": "Debug Expense Report",
-            "type": "debugpy",
-            "request": "launch",
-            "module": "pipelex.cli",
-            "args": [
-                "expense",
-                "--pipe",
-                "process_expense_report",
-                "--expense-report",
-                "expense_report_diner"
+                "validate",
+                "pipe",
+                "describe_image",
+                "-c",
+                "pipelex/libraries",
             ],
             "console": "integratedTerminal",
             "justMyCode": false

--- a/pipelex/cogt/content_generation/jinja2_generate.py
+++ b/pipelex/cogt/content_generation/jinja2_generate.py
@@ -5,6 +5,13 @@ from pipelex.tools.templating.jinja2_rendering import render_jinja2
 
 # TODO: get rid of this intermediate call which seems useless, or explain why it stays
 async def jinja2_gen_text(jinja2_assignment: Jinja2Assignment) -> str:
+    from pipelex.tools.templating.jinja2_parsing import check_jinja2_parsing
+    from pipelex.tools.templating.template_preprocessor import preprocess_template
+
+    if jinja2_assignment.jinja2:
+        jinja2_assignment.jinja2 = preprocess_template(template=jinja2_assignment.jinja2)
+        check_jinja2_parsing(jinja2_assignment.jinja2)
+
     jinja2_text: str = await render_jinja2(
         template_category=jinja2_assignment.template_category,
         template_provider=get_template_provider(),

--- a/pipelex/cogt/llm/llm_prompt_spec.py
+++ b/pipelex/cogt/llm/llm_prompt_spec.py
@@ -12,8 +12,6 @@ from pipelex.core.stuffs.stuff_content import ImageContent
 from pipelex.hub import get_content_generator, get_template
 from pipelex.tools.misc.context_provider_abstract import ContextProviderAbstract, ContextProviderException
 from pipelex.tools.templating.jinja2_blueprint import Jinja2Blueprint
-from pipelex.tools.templating.jinja2_parsing import check_jinja2_parsing
-from pipelex.tools.templating.template_preprocessor import preprocess_template
 from pipelex.tools.templating.templating_models import PromptingStyle
 from pipelex.tools.typing.validation_utils import has_exactly_one_among_attributes_from_list, has_more_than_one_among_attributes_from_list
 

--- a/pipelex/pipe_operators/pipe_jinja2_factory.py
+++ b/pipelex/pipe_operators/pipe_jinja2_factory.py
@@ -2,7 +2,6 @@ from typing import List, Literal, Optional
 
 from typing_extensions import override
 
-from pipelex.config import get_config
 from pipelex.core.concepts.concept_factory import ConceptFactory
 from pipelex.core.pipes.pipe_blueprint import PipeBlueprint
 from pipelex.core.pipes.pipe_factory import PipeFactoryProtocol
@@ -15,7 +14,6 @@ from pipelex.tools.templating.jinja2_blueprint import Jinja2Blueprint
 from pipelex.tools.templating.jinja2_parsing import check_jinja2_parsing
 from pipelex.tools.templating.jinja2_template_category import Jinja2TemplateCategory
 from pipelex.tools.templating.template_preprocessor import preprocess_template
-from pipelex.tools.templating.templating_models import PromptingStyle
 
 
 class PipeJinja2Blueprint(PipeBlueprint, Jinja2Blueprint):
@@ -93,18 +91,3 @@ class PipeJinja2Factory(PipeFactoryProtocol[PipeJinja2Blueprint, PipeJinja2]):
             )
         else:
             raise PipeDefinitionError("Either template_str or template_name must be provided to make_pipe_jinja2_from_template_str")
-
-    @classmethod
-    def make_pipe_jinja2_to_structure(
-        cls,
-        domain: str,
-        prompt_template_to_structure: Optional[str],
-    ) -> PipeJinja2:
-        jinja2_name = prompt_template_to_structure or get_config().pipelex.generic_template_names.structure_from_preliminary_text_user
-        prompting_style = PromptingStyle.make_default_prompting_style()
-        return PipeJinja2(
-            domain=domain,
-            code="adhoc_pipe_jinja2_to_structure",
-            jinja2_name=jinja2_name,
-            prompting_style=prompting_style,
-        )

--- a/pipelex/pipe_operators/pipe_llm.py
+++ b/pipelex/pipe_operators/pipe_llm.py
@@ -48,7 +48,6 @@ from pipelex.hub import (
 )
 from pipelex.pipe_operators.pipe_operator import PipeOperator
 from pipelex.pipeline.job_metadata import JobMetadata
-from pipelex.tools.templating.jinja2_blueprint import Jinja2Blueprint
 from pipelex.tools.typing.type_inspector import get_type_structure
 from pipelex.types import StrEnum
 
@@ -322,7 +321,10 @@ class PipeLLM(PipeOperator):
                 text=generated_text,
             )
         else:
-            log.debug(f"PipeLLM generating {fixed_nb_output} output(s)" if fixed_nb_output else "PipeLLM generating a list of output(s)")
+            if is_multiple_output:
+                log.debug(f"PipeLLM generating {fixed_nb_output} output(s)" if fixed_nb_output else "PipeLLM generating a list of output(s)")
+            else:
+                log.debug("PipeLLM generating a single output")
 
             # TODO: we need a better solution for structuring_method (text then object), meanwhile,
             # we acknowledge the code here with llm_prompt_1 and llm_prompt_2 is overly complex and should be refactored.
@@ -338,19 +340,10 @@ class PipeLLM(PipeOperator):
                         # TODO: run_pipe() could get the domain at the same time as the pip_code
                         domain = get_required_domain(domain=pipe.domain)
                         prompt_template_to_structure = self.prompt_template_to_structure or domain.prompt_template_to_structure
-                        user_text_jinja2_blueprint = Jinja2Blueprint(
-                            jinja2_name=prompt_template_to_structure,
-                        )
                         system_prompt = self.system_prompt_to_structure or domain.system_prompt
-                        llm_prompt_2_blueprint = LLMPromptSpec(
-                            user_text_jinja2_blueprint=user_text_jinja2_blueprint,
-                            system_prompt=system_prompt,
-                        )
-                        llm_prompt_2_proto = await llm_prompt_2_blueprint.make_llm_prompt(
-                            output_concept_string=output_concept.concept_string,
-                            context_provider=working_memory,
-                            output_structure_prompt=output_structure_prompt,
-                            extra_params=llm_prompt_run_params.params,
+                        llm_prompt_2_proto = LLMPrompt(
+                            system_text=system_prompt,
+                            user_text=prompt_template_to_structure,
                         )
                         llm_prompt_2_factory = LLMPromptTemplate(
                             proto_prompt=llm_prompt_2_proto,
@@ -363,23 +356,15 @@ class PipeLLM(PipeOperator):
                 else:
                     domain = Domain.make_default()
                 prompt_template_to_structure = self.prompt_template_to_structure or domain.prompt_template_to_structure
-                user_text_jinja2_blueprint = Jinja2Blueprint(
-                    jinja2_name=prompt_template_to_structure,
-                )
                 system_prompt = self.system_prompt_to_structure or domain.system_prompt
-                llm_prompt_2_blueprint = LLMPromptSpec(
-                    user_text_jinja2_blueprint=user_text_jinja2_blueprint,
-                    system_prompt=system_prompt,
-                )
-                llm_prompt_2_proto = await llm_prompt_2_blueprint.make_llm_prompt(
-                    output_concept_string=output_concept.concept_string,
-                    context_provider=working_memory,
-                    output_structure_prompt=output_structure_prompt,
-                    extra_params=llm_prompt_run_params.params,
+                llm_prompt_2_proto = LLMPrompt(
+                    system_text=system_prompt,
+                    user_text=prompt_template_to_structure,
                 )
                 llm_prompt_2_factory = LLMPromptTemplate(
                     proto_prompt=llm_prompt_2_proto,
                 )
+                log.debug(llm_prompt_2_factory, title="llm_prompt_2_factory")
             else:
                 llm_prompt_2_factory = None
 

--- a/uv.lock
+++ b/uv.lock
@@ -1865,7 +1865,7 @@ wheels = [
 
 [[package]]
 name = "pipelex"
-version = "0.8.0"
+version = "0.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
### 📝 Description

- In case of structuring with preliminary text, make the prompt 2 template (factory to make the prompt after the preliminary text has been generated) from a straightforward simple LLMPrompt proto instead of rendering the prompt with jinja2 (at this stage the preliminary text doesn't exist yet)

### 🔄 Type of Change
- [X] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🧹 Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
