### PR TITLE
Fix/type checkers 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,5 +56,3 @@ gcp_credentials.json
 
 /pipelex.toml
 settings.local.json
-
-.pipelex/observer/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [v0.10.3] - 2025-09-26
+## [Unreleased] - 2025-09-26
 
 ### Highlights
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -633,7 +633,7 @@ Simplified input memory:
 
 ### Changed
 
-- **Refactored Cognitive Workers**: The abstraction for `LLM`, `Imgg`, and `Ocr` workers has been elegantly simplified. The old decorator-based approach (`..._job_func`) has been replaced with a more robust pattern: a public base method now handles pre- and post-execution logic while calling a private abstract method that each worker implements.
+- **Refactored Cognitive Workers**: The abstraction for `LLM`, `ImgGen`, and `Ocr` workers has been elegantly simplified. The old decorator-based approach (`..._job_func`) has been replaced with a more robust pattern: a public base method now handles pre- and post-execution logic while calling a private abstract method that each worker implements.
 - The `b64_image_bytes` field in `PromptImageBytes` was renamed to `base_64` for better consistency.
 
 ### Fixed
@@ -729,15 +729,15 @@ is_reporting_enabled = true
 ### Tests
 
 - TestTemplatePreprocessor
-- TestImggByOpenAIGpt
+- TestImgGenByOpenAIGpt
 - TestImageGeneration
-- TestPipeImgg
+- TestPipeImgGen
 
 
 ## [v0.2.9] - 2025-05-30
 
 - Include `pyproject.toml` inside the project build.
-- Fix `ImggEngineFactory`: image generation (imgg) handle required format is `platform/model_name`
+- Fix `ImgGenEngineFactory`: image generation (imgg) handle required format is `platform/model_name`
 - pipelex cli: Added `list-pipes` method that can list all the available pipes along with their descriptions.
 - Use a minimum version for `uv` instead of a fixed version
 - Implement `AGENTS.md` for Codex

--- a/Makefile
+++ b/Makefile
@@ -389,7 +389,7 @@ mypy: env
 
 pylint: env
 	$(call PRINT_TITLE,"Linting with pylint")
-	$(VENV_PYLINT) --rcfile pyproject.toml pipelex
+	$(VENV_PYLINT) --rcfile pyproject.toml pipelex tests
 
 
 ##########################################################################################

--- a/Makefile
+++ b/Makefile
@@ -389,7 +389,7 @@ mypy: env
 
 pylint: env
 	$(call PRINT_TITLE,"Linting with pylint")
-	$(VENV_PYLINT) --rcfile pyproject.toml .
+	$(VENV_PYLINT) --rcfile pyproject.toml pipelex
 
 
 ##########################################################################################

--- a/pipelex/client/api_serializer.py
+++ b/pipelex/client/api_serializer.py
@@ -87,17 +87,18 @@ class ApiSerializer:
                     continue
                 cleaned[key] = cls._clean_and_format_content(content_dict[key])
             return cleaned
-        if isinstance(content, list):
+        elif isinstance(content, list):
             cleaned_list: list[Any] = []
             content_list = cast("list[Any]", content)
             cleaned_list.extend(cls._clean_and_format_content(content_list[idx]) for idx in range(len(content_list)))
             return cleaned_list
-        if isinstance(content, datetime):
+        elif isinstance(content, datetime):
             return content.strftime(cls.API_DATETIME_FORMAT)
-        if isinstance(content, Enum):
+        elif isinstance(content, Enum):
             return content.value  # Convert enum to its value
-        if isinstance(content, Decimal):
+        elif isinstance(content, Decimal):
             return float(content)  # Convert Decimal to float for JSON compatibility
-        if isinstance(content, Path):
+        elif isinstance(content, Path):
             return str(content)  # Convert Path to string representation
-        return content
+        else:
+            return content

--- a/pipelex/client/pipeline_response_factory.py
+++ b/pipelex/client/pipeline_response_factory.py
@@ -61,4 +61,4 @@ class PipelineResponseFactory:
             PipelineResponse instance created from the response data
 
         """
-        return PipelineResponse(**response)
+        return PipelineResponse.model_validate(response)

--- a/pipelex/cogt/image/prompt_image_factory.py
+++ b/pipelex/cogt/image/prompt_image_factory.py
@@ -19,12 +19,13 @@ class PromptImageFactory:
     ) -> PromptImage:
         if file_path:
             return PromptImagePath(file_path=file_path)
-        if url:
+        elif url:
             return PromptImageUrl(url=url)
-        if base_64:
+        elif base_64:
             return PromptImageBase64(base_64=base_64)
-        msg = "PromptImageFactory requires one of file_path, url, or image_bytes"
-        raise PromptImageFactoryError(msg)
+        else:
+            msg = "PromptImageFactory requires one of file_path, url, or image_bytes"
+            raise PromptImageFactoryError(msg)
 
     @classmethod
     def make_prompt_image_from_uri(

--- a/pipelex/cogt/inference/inference_manager.py
+++ b/pipelex/cogt/inference/inference_manager.py
@@ -112,7 +112,7 @@ class InferenceManager(InferenceManagerProtocol):
         img_gen_worker = self.img_gen_workers.get(img_gen_handle)
         if img_gen_worker is None:
             if not get_config().cogt.inference_manager_config.is_auto_setup_preset_img_gen:
-                msg = f"Found no Imgg worker for '{img_gen_handle}', set it up or enable cogt.inference_manager_config.is_auto_setup_preset_img_gen"
+                msg = f"Found no ImgGen worker for '{img_gen_handle}', set it up or enable cogt.inference_manager_config.is_auto_setup_preset_img_gen"
                 raise InferenceManagerWorkerSetupError(msg)
 
             img_gen_worker = self._setup_one_img_gen_worker(img_gen_handle=img_gen_handle)

--- a/pipelex/cogt/usage/costs_per_token.py
+++ b/pipelex/cogt/usage/costs_per_token.py
@@ -8,10 +8,11 @@ def model_cost_per_token(costs: CostsByCategoryDict, cost_category: CostCategory
         case CostCategory.INPUT_CACHED:
             if cost_per_million_tokens := costs.get(CostCategory.INPUT_CACHED):
                 return cost_per_million_tokens / 1000000
-            if cost_per_million_tokens := costs.get(CostCategory.INPUT):
+            elif cost_per_million_tokens := costs.get(CostCategory.INPUT):
                 # according to openai docs, cached input tokens are discounted 50%
                 return 0.5 * cost_per_million_tokens / 1000000
-            return 0.0
+            else:
+                return 0.0
         case CostCategory.INPUT_NON_CACHED:
             return model_cost_per_token(costs=costs, cost_category=CostCategory.INPUT)
         case (
@@ -26,4 +27,5 @@ def model_cost_per_token(costs: CostsByCategoryDict, cost_category: CostCategory
         ):
             if cost_per_million_tokens := costs.get(cost_category):
                 return cost_per_million_tokens / 1000000
-            return 0.0
+            else:
+                return 0.0

--- a/pipelex/cogt/usage/costs_per_token.py
+++ b/pipelex/cogt/usage/costs_per_token.py
@@ -4,15 +4,26 @@ from pipelex.cogt.usage.cost_category import CostCategory, CostsByCategoryDict
 def model_cost_per_token(costs: CostsByCategoryDict, cost_category: CostCategory) -> float:
     # cost_per_million_tokens_usd should be missing only for models that we run on our own GPUs
     # all token types are not used for all models
-    if cost_category == CostCategory.INPUT_CACHED:
-        if cost_per_million_tokens := costs.get(CostCategory.INPUT_CACHED):
-            return cost_per_million_tokens / 1000000
-        if cost_per_million_tokens := costs.get(CostCategory.INPUT):
-            # according to openai docs, cached input tokens are discounted 50%
-            return 0.5 * cost_per_million_tokens / 1000000
-        return 0.0
-    if cost_category == CostCategory.INPUT_NON_CACHED:
-        return model_cost_per_token(costs=costs, cost_category=CostCategory.INPUT)
-    if cost_per_million_tokens := costs.get(cost_category):
-        return cost_per_million_tokens / 1000000
-    return 0.0
+    match cost_category:
+        case CostCategory.INPUT_CACHED:
+            if cost_per_million_tokens := costs.get(CostCategory.INPUT_CACHED):
+                return cost_per_million_tokens / 1000000
+            if cost_per_million_tokens := costs.get(CostCategory.INPUT):
+                # according to openai docs, cached input tokens are discounted 50%
+                return 0.5 * cost_per_million_tokens / 1000000
+            return 0.0
+        case CostCategory.INPUT_NON_CACHED:
+            return model_cost_per_token(costs=costs, cost_category=CostCategory.INPUT)
+        case (
+            CostCategory.INPUT
+            | CostCategory.INPUT_JOINED
+            | CostCategory.INPUT_AUDIO
+            | CostCategory.OUTPUT
+            | CostCategory.OUTPUT_AUDIO
+            | CostCategory.OUTPUT_REASONING
+            | CostCategory.OUTPUT_ACCEPTED_PREDICTION
+            | CostCategory.OUTPUT_REJECTED_PREDICTION
+        ):
+            if cost_per_million_tokens := costs.get(cost_category):
+                return cost_per_million_tokens / 1000000
+            return 0.0

--- a/pipelex/core/interpreter.py
+++ b/pipelex/core/interpreter.py
@@ -277,25 +277,26 @@ class PipelexInterpreter(BaseModel):
         """Convert a single pipe blueprint to PLX string."""
         if isinstance(blueprint, PipeLLMBlueprint):
             return PipelexInterpreter.llm_pipe_to_plx_string(pipe_name, blueprint)
-        if isinstance(blueprint, PipeSequenceBlueprint):
+        elif isinstance(blueprint, PipeSequenceBlueprint):
             return PipelexInterpreter.sequence_pipe_to_plx_string(pipe_name, blueprint)
-        if isinstance(blueprint, PipeOcrBlueprint):
+        elif isinstance(blueprint, PipeOcrBlueprint):
             return PipelexInterpreter.ocr_pipe_to_plx_string(pipe_name, blueprint)
-        if isinstance(blueprint, PipeFuncBlueprint):
+        elif isinstance(blueprint, PipeFuncBlueprint):
             return PipelexInterpreter.func_pipe_to_plx_string(pipe_name, blueprint)
-        if isinstance(blueprint, PipeImgGenBlueprint):
+        elif isinstance(blueprint, PipeImgGenBlueprint):
             return PipelexInterpreter.img_gen_pipe_to_plx_string(pipe_name, blueprint)
-        if isinstance(blueprint, PipeJinja2Blueprint):
+        elif isinstance(blueprint, PipeJinja2Blueprint):
             return PipelexInterpreter.jinja2_pipe_to_plx_string(pipe_name, blueprint)
-        if isinstance(blueprint, PipeConditionBlueprint):
+        elif isinstance(blueprint, PipeConditionBlueprint):
             return PipelexInterpreter.condition_pipe_to_plx_string(pipe_name, blueprint)
-        if isinstance(blueprint, PipeParallelBlueprint):
+        elif isinstance(blueprint, PipeParallelBlueprint):
             return PipelexInterpreter.parallel_pipe_to_plx_string(pipe_name, blueprint)
-        if isinstance(blueprint, PipeBatchBlueprint):
+        elif isinstance(blueprint, PipeBatchBlueprint):
             return PipelexInterpreter.batch_pipe_to_plx_string(pipe_name, blueprint)
-        # Fallback to old dict approach for unknown pipe types
-        pipe_dict = PipelexInterpreter.serialize_pipe(blueprint)
-        return f"[pipe.{pipe_name}]\n" + "\n".join([f'{k} = "{v}"' if isinstance(v, str) else f"{k} = {v}" for k, v in pipe_dict.items()])
+        else:
+            # Fallback to old dict approach for unknown pipe types
+            pipe_dict = PipelexInterpreter.serialize_pipe(blueprint)
+            return f"[pipe.{pipe_name}]\n" + "\n".join([f'{k} = "{v}"' if isinstance(v, str) else f"{k} = {v}" for k, v in pipe_dict.items()])
 
     @staticmethod
     def llm_pipe_to_plx_string(pipe_name: str, pipe: PipeLLMBlueprint) -> str:
@@ -585,24 +586,25 @@ class PipelexInterpreter(BaseModel):
     def serialize_pipe(blueprint: Any) -> dict[str, Any]:
         if isinstance(blueprint, PipeLLMBlueprint):
             return PipelexInterpreter.serialize_llm_pipe(blueprint)
-        if isinstance(blueprint, PipeOcrBlueprint):
+        elif isinstance(blueprint, PipeOcrBlueprint):
             return PipelexInterpreter.serialize_ocr_pipe(blueprint)
-        if isinstance(blueprint, PipeFuncBlueprint):
+        elif isinstance(blueprint, PipeFuncBlueprint):
             return PipelexInterpreter._serialize_func_pipe(blueprint)
-        if isinstance(blueprint, PipeImgGenBlueprint):
+        elif isinstance(blueprint, PipeImgGenBlueprint):
             return PipelexInterpreter._serialize_img_gen_pipe(blueprint)
-        if isinstance(blueprint, PipeJinja2Blueprint):
+        elif isinstance(blueprint, PipeJinja2Blueprint):
             return PipelexInterpreter.serialize_jinja2_pipe(blueprint)
-        if isinstance(blueprint, PipeSequenceBlueprint):
+        elif isinstance(blueprint, PipeSequenceBlueprint):
             return PipelexInterpreter.serialize_sequence_pipe(blueprint)
-        if isinstance(blueprint, PipeConditionBlueprint):
+        elif isinstance(blueprint, PipeConditionBlueprint):
             return PipelexInterpreter._serialize_condition_pipe(blueprint)
-        if isinstance(blueprint, PipeParallelBlueprint):
+        elif isinstance(blueprint, PipeParallelBlueprint):
             return PipelexInterpreter._serialize_parallel_pipe(blueprint)
-        if isinstance(blueprint, PipeBatchBlueprint):
+        elif isinstance(blueprint, PipeBatchBlueprint):
             return PipelexInterpreter._serialize_batch_pipe(blueprint)
-        msg = f"Unknown pipe blueprint type: {type(blueprint)}"
-        raise PipelexUnknownPipeError(msg)
+        else:
+            msg = f"Unknown pipe blueprint type: {type(blueprint)}"
+            raise PipelexUnknownPipeError(msg)
 
     @staticmethod
     def serialize_llm_pipe(pipe: PipeLLMBlueprint) -> dict[str, Any]:

--- a/pipelex/core/memory/working_memory_factory.py
+++ b/pipelex/core/memory/working_memory_factory.py
@@ -164,7 +164,7 @@ class WorkingMemoryFactory(BaseModel):
         """Helper method to create mock content for a requirement."""
         if requirement.structure_class:
             # Create mock object using polyfactory
-            class MockFactory(ModelFactory[requirement.structure_class]):  # type: ignore[requirement,name-defined]
+            class MockFactory(ModelFactory[requirement.structure_class]):  # type: ignore[name-defined]
                 __model__ = requirement.structure_class
                 __check_model__ = True
                 __use_examples__ = True

--- a/pipelex/core/pipes/pipe_run_params.py
+++ b/pipelex/core/pipes/pipe_run_params.py
@@ -128,18 +128,19 @@ def output_multiplicity_to_apply(
                 enable_multiple_outputs=base_multiplicity,
                 specific_output_count=None,
             )
-        if isinstance(base_multiplicity, int):
+        elif isinstance(base_multiplicity, int):
             log.debug("base_multiplicity is int")
             return OutputMultiplicityResolution(
                 resolved_multiplicity=base_multiplicity,
                 enable_multiple_outputs=True,
                 specific_output_count=base_multiplicity,
             )
-        log.debug("base_multiplicity is None")
-        return OutputMultiplicityResolution(resolved_multiplicity=base_multiplicity, enable_multiple_outputs=False, specific_output_count=None)
+        else:
+            log.debug("base_multiplicity is None")
+            return OutputMultiplicityResolution(resolved_multiplicity=base_multiplicity, enable_multiple_outputs=False, specific_output_count=None)
 
     # Case 2: Override is a boolean
-    if isinstance(override_multiplicity, bool):
+    elif isinstance(override_multiplicity, bool):
         log.debug("override_multiplicity is bool")
 
         if override_multiplicity:
@@ -148,22 +149,25 @@ def output_multiplicity_to_apply(
             if isinstance(base_multiplicity, bool):
                 log.debug("base_multiplicity is bool - disregarding base, using True")
                 return OutputMultiplicityResolution(resolved_multiplicity=True, enable_multiple_outputs=True, specific_output_count=None)
-            log.debug("base_multiplicity is int or None - preserving base value")
-            return OutputMultiplicityResolution(
-                resolved_multiplicity=base_multiplicity,
-                enable_multiple_outputs=True,
-                specific_output_count=base_multiplicity if isinstance(base_multiplicity, int) else None,
-            )
-        log.debug("override_multiplicity is False - forcing single output")
-        return OutputMultiplicityResolution(resolved_multiplicity=False, enable_multiple_outputs=False, specific_output_count=None)
+            else:
+                log.debug("base_multiplicity is int or None - preserving base value")
+                return OutputMultiplicityResolution(
+                    resolved_multiplicity=base_multiplicity,
+                    enable_multiple_outputs=True,
+                    specific_output_count=base_multiplicity if isinstance(base_multiplicity, int) else None,
+                )
+        else:
+            log.debug("override_multiplicity is False - forcing single output")
+            return OutputMultiplicityResolution(resolved_multiplicity=False, enable_multiple_outputs=False, specific_output_count=None)
 
-    # Case 3: Override is an integer
-    log.debug("override_multiplicity is int - using override value")
-    return OutputMultiplicityResolution(
-        resolved_multiplicity=override_multiplicity,
-        enable_multiple_outputs=True,
-        specific_output_count=override_multiplicity,
-    )
+    else:
+        # Case 3: Override is an integer
+        log.debug("override_multiplicity is int - using override value")
+        return OutputMultiplicityResolution(
+            resolved_multiplicity=override_multiplicity,
+            enable_multiple_outputs=True,
+            specific_output_count=override_multiplicity,
+        )
 
 
 class BatchParams(BaseModel):

--- a/pipelex/core/stuffs/stuff.py
+++ b/pipelex/core/stuffs/stuff.py
@@ -62,11 +62,13 @@ Forbidden fields are: 'stuff_name', 'content_class', 'concept_code', 'stuff_code
         concept_display = Concept.sentence_from_concept(concept=self.concept)
         if self.is_list:
             return f"List of [{concept_display}]"
-        if self.stuff_name:
+        elif self.stuff_name:
             if self.stuff_name == name_from_concept:
                 return concept_display
-            return f"{self.stuff_name} (a {concept_display})"
-        return concept_display
+            else:
+                return f"{self.stuff_name} (a {concept_display})"
+        else:
+            return concept_display
 
     @property
     def short_desc(self) -> str:

--- a/pipelex/core/stuffs/stuff_content.py
+++ b/pipelex/core/stuffs/stuff_content.py
@@ -243,7 +243,7 @@ class ImageContent(StuffContentInitableFromStr):
                     parts = self.url.rsplit(".", 1)
                     base_name = parts[0]
                     extension = parts[1]
-                case _:
+                case InterpretedPathOrUrl.FILE_PATH | InterpretedPathOrUrl.FILE_URI | InterpretedPathOrUrl.URL | InterpretedPathOrUrl.BASE_64:
                     file_type = detect_file_type_from_base64(b64=base_64)
                     base_name = base_name or "img"
                     extension = file_type.extension

--- a/pipelex/core/stuffs/stuff_content.py
+++ b/pipelex/core/stuffs/stuff_content.py
@@ -431,7 +431,8 @@ class ListContent(StuffContent, Generic[StuffContentType]):
         nb_classes = len(item_classes_set)
         if nb_classes == 1:
             return item_classes[0]
-        return None
+        else:
+            return None
 
     @override
     def model_dump(self, *args: Any, **kwargs: Any):

--- a/pipelex/core/stuffs/stuff_content.py
+++ b/pipelex/core/stuffs/stuff_content.py
@@ -420,9 +420,10 @@ class ListContent(StuffContent, Generic[StuffContentType]):
         nb_classes = len(item_classes_set)
         if nb_classes == 1:
             return f"list of {len(self.items)} {item_classes[0]}s"
-        if nb_items == nb_classes:
+        elif nb_items == nb_classes:
             return f"list of {len(self.items)} items of different types"
-        return f"list of {len(self.items)} items of {nb_classes} different types"
+        else:
+            return f"list of {len(self.items)} items of {nb_classes} different types"
 
     @property
     def _single_class_name(self) -> str | None:

--- a/pipelex/libraries/pipelines/builder/builder.py
+++ b/pipelex/libraries/pipelines/builder/builder.py
@@ -198,6 +198,7 @@ async def compile_in_pipelex_bundle_spec(working_memory: WorkingMemory) -> Pipel
     )
 
 
+# TODO: rename or merge with PipeDry.DryRunStatus
 class DryRunStatus(StrEnum):
     SUCCESS = "SUCCESS"
     FAILURE = "FAILURE"
@@ -248,7 +249,7 @@ async def validate_dry_run(working_memory: WorkingMemory) -> ListContent[PipeFai
 
     failed_pipes: list[PipeFailure] = []
     for pipe_code, dry_run_output in dry_run_result.items():
-        if dry_run_output.status == DryRunStatus.FAILURE and pipelex_bundle_spec.pipe and pipe_code in pipelex_bundle_spec.pipe:
+        if dry_run_output.status.is_failure and pipelex_bundle_spec.pipe and pipe_code in pipelex_bundle_spec.pipe:
             pipe_spec = pipelex_bundle_spec.pipe[pipe_code]
             spec_class = pipe_type_to_spec_class.get(pipe_spec.type)
             if not spec_class:

--- a/pipelex/pipe_operators/img_gen/pipe_img_gen.py
+++ b/pipelex/pipe_operators/img_gen/pipe_img_gen.py
@@ -263,7 +263,7 @@ class PipeImgGen(PipeOperator[PipeImgGenOutput]):
         else:
             seed = seed_setting
 
-        # Build ImggJobParams from ImgGenSetting + one-time settings
+        # Build ImgGenJobParams from ImgGenSetting + one-time settings
         img_gen_job_params = ImgGenJobParams(
             aspect_ratio=self.aspect_ratio or img_gen_param_defaults.aspect_ratio,
             background=self.background or img_gen_param_defaults.background,

--- a/pipelex/pipe_operators/jinja2/pipe_jinja2.py
+++ b/pipelex/pipe_operators/jinja2/pipe_jinja2.py
@@ -101,9 +101,10 @@ class PipeJinja2(PipeOperator[PipeJinja2Output]):
     def desc(self) -> str:
         if self.jinja2:
             return f"Jinja2 included template, prompting style {self.prompting_style}"
-        if jinja2_name := self.jinja2_name:
+        elif jinja2_name := self.jinja2_name:
             return f"Jinja2 template '{jinja2_name}', prompting style {self.prompting_style}"
-        return "Jinja2 template not defined"
+        else:
+            return "Jinja2 template not defined"
 
     @override
     def required_variables(self) -> set[str]:

--- a/pipelex/pipe_works/pipe_dry.py
+++ b/pipelex/pipe_works/pipe_dry.py
@@ -27,6 +27,16 @@ class DryRunStatus(StrEnum):
     FAILURE = "FAILURE"
     WARNING = "WARNING"
 
+    @property
+    def is_failure(self) -> bool:
+        match self:
+            case DryRunStatus.FAILURE:
+                return True
+            case DryRunStatus.SUCCESS:
+                return False
+            case DryRunStatus.WARNING:
+                return False
+
 
 class DryRunOutput(BaseModel):
     pipe_code: str

--- a/pipelex/plugins/anthropic/anthropic_llm_worker.py
+++ b/pipelex/plugins/anthropic/anthropic_llm_worker.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 import instructor
-from anthropic import NOT_GIVEN, AsyncAnthropic, AsyncAnthropicBedrock
+from anthropic import AsyncAnthropic, AsyncAnthropicBedrock, omit
 from typing_extensions import override
 
 from pipelex import log
@@ -100,7 +100,7 @@ class AnthropicLLMWorker(LLMWorkerInternalAbstract):
         max_tokens = self._adapt_max_tokens(max_tokens=llm_job.job_params.max_tokens)
         response = await self.anthropic_async_client.messages.create(
             messages=[message],
-            system=llm_job.llm_prompt.system_text or NOT_GIVEN,
+            system=llm_job.llm_prompt.system_text or omit,
             model=self.inference_model.model_id,
             temperature=llm_job.job_params.temperature,
             max_tokens=max_tokens,

--- a/pipelex/plugins/fal/fal_img_gen_worker.py
+++ b/pipelex/plugins/fal/fal_img_gen_worker.py
@@ -23,7 +23,7 @@ class FalImgGenWorker(ImgGenWorkerAbstract):
         super().__init__(inference_model=inference_model, reporting_delegate=reporting_delegate)
 
         if not isinstance(sdk_instance, AsyncClient):
-            msg = f"Provided Imgg sdk_instance is not of type fal_client.AsyncClient: it's a '{type(sdk_instance)}'"
+            msg = f"Provided ImgGen sdk_instance is not of type fal_client.AsyncClient: it's a '{type(sdk_instance)}'"
             raise SdkTypeError(msg)
 
         self.fal_async_client = sdk_instance

--- a/pipelex/plugins/openai/openai_img_gen_worker.py
+++ b/pipelex/plugins/openai/openai_img_gen_worker.py
@@ -29,7 +29,7 @@ class OpenAIImgGenWorker(ImgGenWorkerAbstract):
         super().__init__(inference_model=inference_model, reporting_delegate=reporting_delegate)
 
         if not isinstance(sdk_instance, openai.AsyncOpenAI):
-            msg = f"Provided Imgg sdk_instance is not of type openai.AsyncOpenAI: it's a '{type(sdk_instance)}'"
+            msg = f"Provided ImgGen sdk_instance is not of type openai.AsyncOpenAI: it's a '{type(sdk_instance)}'"
             raise SdkTypeError(msg)
 
         self.openai_client = sdk_instance

--- a/pipelex/tools/log/log_formatter.py
+++ b/pipelex/tools/log/log_formatter.py
@@ -18,21 +18,22 @@ def emoji_for_channel(channel_name: str) -> str | None:
     if emoji == "":
         # blank emoji is OK
         return emoji
-    if emoji:
+    elif emoji:
         return emoji
-    if channel_name.startswith("google"):
+    elif channel_name.startswith("google"):
         return "🌀"
-    if channel_name.startswith("openai"):
+    elif channel_name.startswith("openai"):
         return "⚪️"
-    if channel_name.startswith("kajson"):
+    elif channel_name.startswith("kajson"):
         # space added to make it look better
         return "*️⃣ "
-    if channel_name.startswith("#poor-log"):
+    elif channel_name.startswith("#poor-log"):
         # space added to make it look better
         return "🧿 "
-    if channel_name.startswith("pipelex"):
+    elif channel_name.startswith("pipelex"):
         return "🧠"
-    return None
+    else:
+        return None
 
 
 class EmojiLogFormatter(logging.Formatter):

--- a/pipelex/tools/log/log_levels.py
+++ b/pipelex/tools/log/log_levels.py
@@ -47,8 +47,9 @@ class LogLevel(StrEnum):
     def from_int(logging_level: int) -> "LogLevel":
         if logging_level == LOGGING_LEVEL_VERBOSE:
             return LogLevel.VERBOSE
-        if logging_level == LOGGING_LEVEL_DEV:
+        elif logging_level == LOGGING_LEVEL_DEV:
             return LogLevel.DEV
-        if logging_level == LOGGING_LEVEL_OFF or logging_level > logging.CRITICAL:
+        elif logging_level == LOGGING_LEVEL_OFF or logging_level > logging.CRITICAL:
             return LogLevel.OFF
-        return LogLevel(logging.getLevelName(logging_level))
+        else:
+            return LogLevel(logging.getLevelName(logging_level))

--- a/pipelex/tools/misc/json_utils.py
+++ b/pipelex/tools/misc/json_utils.py
@@ -220,10 +220,11 @@ def remove_none_values(json_content: JsonContent | Any) -> JsonContent | Any:
             if value is not None:
                 cleaned_dict[key] = remove_none_values(json_content=value)
         return cleaned_dict
-    if isinstance(json_content, list):
+    elif isinstance(json_content, list):
         json_content = cast("list[Any]", json_content)  # pyright: ignore[reportUnnecessaryCast]
         return [remove_none_values(item) for item in json_content]
-    return json_content
+    else:
+        return json_content
 
 
 def remove_none_values_from_dict(data: Mapping[str, Any]) -> dict[str, Any]:

--- a/pipelex/tools/misc/markdown_utils.py
+++ b/pipelex/tools/misc/markdown_utils.py
@@ -28,7 +28,7 @@ def convert_to_markdown(data: Any, level: int = 1, is_pretty: bool = False, key:
                 dict_result_lines.append(f"{converted_line}: {converted_value}")
         return "\n\n".join(line for line in dict_result_lines if line.strip())
 
-    if isinstance(data, list):
+    elif isinstance(data, list):
         # Treat lists as bullet lists. If list items are complex,
         # they get recursively converted. If they are simple strings,
         # they become list items.
@@ -48,7 +48,7 @@ def convert_to_markdown(data: Any, level: int = 1, is_pretty: bool = False, key:
             list_result_lines.extend(subsequent_lines)
         return "\n".join(list_result_lines)
 
-    if isinstance(data, (str, int, float, bool)):
+    elif isinstance(data, (str, int, float, bool)):
         # Simple scalar types become paragraphs (strings) or inline text
         # If it's a string with multiple lines, just output them as-is.
         str_value = str(data)
@@ -56,9 +56,10 @@ def convert_to_markdown(data: Any, level: int = 1, is_pretty: bool = False, key:
             return str(AttributePolisher.get_truncated_value(name=key, value=str_value))
         return str_value
 
-    if data is None:
+    elif data is None:
         # No value
         return "None"
 
-    pure_dict, _ = purify_json_dict(data, is_warning_enabled=False)
-    return convert_to_markdown(pure_dict, level=level)
+    else:
+        pure_dict, _ = purify_json_dict(data, is_warning_enabled=False)
+        return convert_to_markdown(pure_dict, level=level)

--- a/pipelex/tools/misc/path_utils.py
+++ b/pipelex/tools/misc/path_utils.py
@@ -57,11 +57,12 @@ def interpret_path_or_url(path_or_uri: str) -> InterpretedPathOrUrl:
     """
     if path_or_uri.startswith("file://"):
         return InterpretedPathOrUrl.FILE_URI
-    if path_or_uri.startswith("http"):
+    elif path_or_uri.startswith("http"):
         return InterpretedPathOrUrl.URL
-    if os.sep in path_or_uri:
+    elif os.sep in path_or_uri:
         return InterpretedPathOrUrl.FILE_PATH
-    return InterpretedPathOrUrl.FILE_NAME
+    else:
+        return InterpretedPathOrUrl.FILE_NAME
 
 
 def clarify_path_or_url(path_or_uri: str) -> tuple[str | None, str | None]:

--- a/pipelex/tools/misc/string_utils.py
+++ b/pipelex/tools/misc/string_utils.py
@@ -234,18 +234,18 @@ def matches_wildcard_pattern(text: str, pattern: str) -> bool:
     """
     if pattern == "*":
         return True
-
-    if pattern.startswith("*") and pattern.endswith("*"):
+    elif pattern.startswith("*") and pattern.endswith("*"):
         # Pattern like "*sonnet*"
         middle = pattern[1:-1]
         return middle in text
-    if pattern.startswith("*"):
+    elif pattern.startswith("*"):
         # Pattern like "*sonnet"
         suffix = pattern[1:]
         return text.endswith(suffix)
-    if pattern.endswith("*"):
+    elif pattern.endswith("*"):
         # Pattern like "claude-*"
         prefix = pattern[:-1]
         return text.startswith(prefix)
-    # Exact match
-    return text == pattern
+    else:
+        # Exact match
+        return text == pattern

--- a/pipelex/tools/typing/pydantic_utils.py
+++ b/pipelex/tools/typing/pydantic_utils.py
@@ -79,14 +79,16 @@ def convert_strenum_to_str(
     if isinstance(obj, dict):
         obj_dict = cast("dict[str, Any]", obj)
         return {str(key): convert_strenum_to_str(value) for key, value in obj_dict.items()}
-    if isinstance(obj, list):
+    elif isinstance(obj, list):
         obj_list = cast("list[Any]", obj)
         return [convert_strenum_to_str(item) for item in obj_list]
-    if isinstance(obj, StrEnum):
+    elif isinstance(obj, StrEnum):
         if hasattr(obj, "display_name"):
             return obj.display_name()  # pyright: ignore[reportUnknownVariableType, reportUnknownMemberType, reportAttributeAccessIssue]
-        return str(obj)
-    return obj
+        else:
+            return str(obj)
+    else:
+        return obj
 
 
 class ExtraFieldAttribute(StrEnum):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,7 @@ module = ["filetype", "json2html", "pypdfium2", "pypdfium2.raw"]
 [tool.pyright]
 pythonVersion = "3.11"
 include = ["pipelex", "tests"]
-exclude = ["**/node_modules", "**/__pycache__", ".venv", ".git", "build", "dist", "node_modules", "**/__init__.py", "tests"]
+exclude = ["**/__pycache__", ".venv", ".git", "build", "dist", "tests"]
 analyzeUnannotatedFunctions = true
 deprecateTypingAliases = false
 disableBytesTypePromotions = true
@@ -242,7 +242,7 @@ exclude_lines = [
 
 [tool.ruff]
 exclude = [
-    "tests", # TO REMOVE
+    "tests",            # TO REMOVE
     ".cursor",
     ".git",
     ".github",
@@ -258,16 +258,16 @@ target-version = "py311"
 [tool.ruff.format]
 
 [tool.ruff.lint]
-select = ["ALL"] 
+select = ["ALL"]
 ignore = [
-    "ANN201", # Missing return type annotation for public function `my_func`
-    "ANN202", # Missing return type annotation for private function `my_func`
-    "ANN204", # Missing return type annotation for special method `my_func`
-    "ANN206", #  Missing return type annotation for classmethod `my_func`
-    "ANN401", # Dynamically typed expressions (typing.Any) are disallowed in `...`
+    "ANN201",   # Missing return type annotation for public function `my_func`
+    "ANN202",   # Missing return type annotation for private function `my_func`
+    "ANN204",   # Missing return type annotation for special method `my_func`
+    "ANN206",   #  Missing return type annotation for classmethod `my_func`
+    "ANN401",   # Dynamically typed expressions (typing.Any) are disallowed in `...`
     "ASYNC230", # Async functions should not open files with blocking methods like `open`
 
-    "C901", # Is to complex
+    "C901",   # Is to complex
     "COM812", # Checks for the absence of trailing commas.
 
     "D100", # Missing docstring in public module
@@ -284,7 +284,7 @@ ignore = [
     "D415", # First line should end with a period, question mark, or exclamation point
 
     "DTZ005", # `datetime.datetime.now()` called without a `tz` argument
-   
+
     "ERA001", # Found commented-out code
 
     "FBT001", # Boolean-typed positional argument in function definition
@@ -302,7 +302,7 @@ ignore = [
     "PLR2004", # Magic value used in comparison, consider replacing `2` with a constant variable
 
     "PT013", # Incorrect import of `pytest`; use `import pytest` instead
-    
+
     "PTH100", # `os.path.abspath()` should be replaced by `Path.resolve()`
     "PTH103", # `os.makedirs()` should be replaced by `Path.mkdir(parents=True)`
     "PTH109", # `os.getcwd()` should be replaced by `Path.cwd()`
@@ -332,20 +332,20 @@ ignore = [
 
     "T201", # `print` found
 
-    # TO REMOVE:
-    "BLE001", # Do not catch blind exception: `Exception`
-    "B027", # Checks for empty methods in abstract base classes without an abstract decorator.
-    "UP007", # Use `X | Y` for type annotations
-    "UP036", # Version block is outdated for minimum Python version
-    "SIM102", # Use a single `if` statement instead of nested `if` statements
-    "S701", # Using jinja2 templates with `autoescape=False` is dangerous and can lead to XSS. Ensure `autoescape=True` or use the `select_autoescape` function.
-    "N818", # Exception name `RootException` should be named with an Error suffix
-    "TRY301", # Abstract `raise` to an inner function
+    # TODO: stop ignoring these rules
+    "BLE001",  # Do not catch blind exception: `Exception`
+    "B027",    # Checks for empty methods in abstract base classes without an abstract decorator.
+    "UP007",   # Use `X | Y` for type annotations
+    "UP036",   # Version block is outdated for minimum Python version
+    "SIM102",  # Use a single `if` statement instead of nested `if` statements
+    "S701",    # Using jinja2 templates with `autoescape=False` is dangerous and can lead to XSS. Ensure `autoescape=True` or use the `select_autoescape` function.
+    "N818",    # Exception name `RootException` should be named with an Error suffix
+    "TRY301",  # Abstract `raise` to an inner function
     "PERF401", # Use a list comprehension to create a transformed list
     "PLW2901", # `for` loop variable `line` overwritten by assignment target
-    "TRY300", # Consider moving this statement to an `else` block
-    "UP035", # `typing.List` is deprecated, use `list` instead
-    "RET503", # Missing explicit `return` at the end of function able to return non-`None` value
+    "TRY300",  # Consider moving this statement to an `else` block
+    "UP035",   # `typing.List` is deprecated, use `list` instead
+    "RET503",  # Missing explicit `return` at the end of function able to return non-`None` value
 ]
 
 [tool.ruff.lint.pydocstyle]
@@ -383,4 +383,4 @@ disable = ["all"]
 enable = [
     "W0101", # Unreachable code: Used when there is some code behind a "return" or "raise" statement, which will never be accessed.
 ]
-ignore = [".venv", "__pycache__", "build", "dist", "node_modules", ".git"]
+ignore = [".venv", "__pycache__", "build", "dist", ".git"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pipelex"
-version = "0.10.3"
+version = "0.10.2"
 description = "Pipelex is an open-source dev tool based on a simple declarative language that lets you define replicable, structured, composable LLM pipelines."
 authors = [{ name = "Evotis S.A.S.", email = "evotis@pipelex.com" }]
 maintainers = [{ name = "Pipelex staff", email = "oss@pipelex.com" }]
@@ -315,6 +315,8 @@ ignore = [
     "PTH208", # Use `pathlib.Path.iterdir()` instead.
 
     "PYI051", # `Literal["auto"]` is redundant in a union with `str`
+
+    "RET505", # superfluous-else-return
 
     "RUF001", # String contains ambiguous `′` (PRIME). Did you mean ``` (GRAVE ACCENT)?
     "RUF003", # Comment contains ambiguous `’` (RIGHT SINGLE QUOTATION MARK). Did you mean ``` (GRAVE ACCENT)?

--- a/tests/integration/pipelex/plugins/test_openai_image_gen.py
+++ b/tests/integration/pipelex/plugins/test_openai_image_gen.py
@@ -13,7 +13,7 @@ from tests.integration.pipelex.test_data import ImageGenTestCases
 @pytest.mark.img_gen
 @pytest.mark.inference
 @pytest.mark.asyncio(loop_scope="class")
-class TestImggByOpenAIGpt:
+class TestImgGenByOpenAIGpt:
     @pytest.mark.parametrize("topic, image_desc", ImageGenTestCases.IMAGE_DESC)
     async def test_gpt_image_generation(self, topic: str, image_desc: str):
         backend = get_models_manager().get_required_inference_backend("openai")

--- a/uv.lock
+++ b/uv.lock
@@ -2002,7 +2002,7 @@ wheels = [
 
 [[package]]
 name = "pipelex"
-version = "0.10.3"
+version = "0.10.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },

--- a/uv.lock
+++ b/uv.lock
@@ -182,7 +182,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.68.0"
+version = "0.68.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -194,9 +194,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/64/46/da44bf087ddaf3f7dbe4808c00c7cde466fe68c4fc9fbebdfc231f4ea205/anthropic-0.68.0.tar.gz", hash = "sha256:507e9b5f627d1b249128ff15b21855e718fa4ed8dabc787d0e68860a4b32a7a8", size = 471584, upload-time = "2025-09-17T15:20:19.509Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/b9/5e736a924dabe0473b212597ae83a124e09818fac672998bb5960a64e9b1/anthropic-0.68.1.tar.gz", hash = "sha256:5fc01019dfffbc39e87a24f4d7cfe34e83dda4fff7b5371f33639f982f0c8dba", size = 471965, upload-time = "2025-09-26T16:27:30.547Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/60/32/2d7553184b05bdbec61dd600014a55b9028408aee6128b25cb6f20e3002c/anthropic-0.68.0-py3-none-any.whl", hash = "sha256:ac579ea5eca22a7165b1042e6af57c4bf556e51afae3ca80e24768d4756b78c0", size = 325199, upload-time = "2025-09-17T15:20:17.452Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/5c/e871e40ba11338502569a3f5cb176650f99f7b4ecf915f4d38fe2b8cff37/anthropic-0.68.1-py3-none-any.whl", hash = "sha256:40fc545c4781ebc45d8e7849240c4001f40d61d18a17e5363c0acb10afefc33b", size = 325214, upload-time = "2025-09-26T16:27:29.049Z" },
 ]
 
 [[package]]
@@ -301,16 +301,16 @@ wheels = [
 
 [[package]]
 name = "boto3-stubs"
-version = "1.40.39"
+version = "1.40.40"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore-stubs" },
     { name = "types-s3transfer" },
     { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ad/17/ec5698d04ea4d4a285d581c0d9b0152c6f1cd89e335b211a372bef659b0e/boto3_stubs-1.40.39.tar.gz", hash = "sha256:320315400d9a1e717014b30362b8453f0957a09dc331c5aec6128c32313ca8e2", size = 100837, upload-time = "2025-09-25T19:26:03.075Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/09/598565add9282520403e74bcc385301fa3dd3eacbc6e14a5b5b43d641fb6/boto3_stubs-1.40.40.tar.gz", hash = "sha256:68a49cb1d11280b9b0443766af32c5aa7f71d1ef4ddff8dfdbf6fd64c12283bf", size = 100830, upload-time = "2025-09-26T19:29:55.021Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/36/620718640c7e28645da3059348800e1185485597661d10095f6624dad836/boto3_stubs-1.40.39-py3-none-any.whl", hash = "sha256:1f5319c486f792ff869efb255cd43b61c072c7d478e9025e08b8f98e6e16c1e4", size = 69687, upload-time = "2025-09-25T19:25:53.38Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/d7/f263878305e43adaa5de36f7cc49a9b4cf3c1d2142613651f3d7e3023f41/boto3_stubs-1.40.40-py3-none-any.whl", hash = "sha256:b52d9491a0f701c60d6d54ba310019d4293afc5929710e4c9d69c11d02a01344", size = 69690, upload-time = "2025-09-26T19:29:49.296Z" },
 ]
 
 [[package]]
@@ -962,7 +962,7 @@ wheels = [
 
 [[package]]
 name = "google-genai"
-version = "1.39.0"
+version = "1.39.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -974,9 +974,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ee/30/eda6ec8d47946ddf25fc193d8a9be6f29296f6659ab4a482607a2cf32552/google_genai-1.39.0.tar.gz", hash = "sha256:995fbe76f3f094ed3a4122f5e5f34e3601b774aa025110a2b013a9a493eb2f81", size = 244435, upload-time = "2025-09-25T21:18:49.286Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/3e/25b88bda07ca237043f1be45d13c49ffbc73f9edf45d3232345802f67197/google_genai-1.39.1.tar.gz", hash = "sha256:4721704b43d170fc3f1b1cb5494bee1a7f7aae20de3a5383cdf6a129139df80b", size = 244631, upload-time = "2025-09-26T20:56:19.5Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c8/93/781ea98fd1dbf8ffaf78c494e59b6364b086e6cbc7dfbc1b750d92fbbe9e/google_genai-1.39.0-py3-none-any.whl", hash = "sha256:eaba325728ea8b90d6111ff009954f526ee10091badfabc31b84dbfcecdf2d02", size = 244544, upload-time = "2025-09-25T21:18:47.508Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/c3/12c1f386184d2fcd694b73adeabc3714a5ed65c01cc183b4e3727a26b9d1/google_genai-1.39.1-py3-none-any.whl", hash = "sha256:6ca36c7e40db6fcba7049dfdd102c86da326804f34403bd7d90fa613a45e5a78", size = 244681, upload-time = "2025-09-26T20:56:17.527Z" },
 ]
 
 [[package]]
@@ -1877,16 +1877,16 @@ wheels = [
 
 [[package]]
 name = "pandas-stubs"
-version = "2.3.2.250827"
+version = "2.3.2.250926"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "types-pytz" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/03/7b/8d2076a76ddf35806319798037056e4bbdcacdc832fb7c95b517f4c03fb2/pandas_stubs-2.3.2.250827.tar.gz", hash = "sha256:bcc2d49a2766325e4a1a492c3eeda879e9521bb5e26e69e2bbf13e80e7ef569a", size = 100032, upload-time = "2025-08-27T23:18:12.802Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/3b/32be58a125db39d0b5f62cc93795f32b5bb2915bd5c4a46f0e35171985e2/pandas_stubs-2.3.2.250926.tar.gz", hash = "sha256:c64b9932760ceefb96a3222b953e6a251321a9832a28548be6506df473a66406", size = 102147, upload-time = "2025-09-26T19:50:39.522Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a1/b8/dc820157be5aa9527f1f7ffe81737ee4d1cf0924081e1bfbd680530dde41/pandas_stubs-2.3.2.250827-py3-none-any.whl", hash = "sha256:3d613013b4189147a9a6bb18d8bec1e5b137de091496e9b9ff9f137ec3e223a9", size = 157775, upload-time = "2025-08-27T23:18:11.083Z" },
+    { url = "https://files.pythonhosted.org/packages/40/96/1e4a035eaf4dce9610aac6e43026d0c6baa05773daf6d21e635a4fe19e21/pandas_stubs-2.3.2.250926-py3-none-any.whl", hash = "sha256:81121818453dcfe00f45c852f4dceee043640b813830f6e7bd084a4ef7ff7270", size = 159995, upload-time = "2025-09-26T19:50:38.241Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### 📝 Description

- Tweaks and rollbacks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes control-flow with elif/else across modules, renames Imgg→ImgGen, switches API response creation to Pydantic model_validate, adds DryRunStatus.is_failure, refactors token cost matching, and updates tooling/config (pylint target, pyright/ruff settings, .gitignore), with version rollback.
> 
> - **Core/Client**:
>   - Pipeline responses now built via `PipelineResponse.model_validate()` instead of `**kwargs`.
>   - Widespread control-flow normalization: replace sequential `if` with `elif/else` across `client`, `core`, `tools`, etc. for clearer paths.
>   - Token cost computation refactored with `match` and explicit categories in `cogt/usage/costs_per_token.py`.
>   - Add `DryRunStatus.is_failure` and use it in builder dry-run validation.
> - **ImgGen/Naming**:
>   - Consistent rename `Imgg` → `ImgGen` in logs/messages and tests; minor message tweaks in inference/workers.
> - **Pipes/Operators**:
>   - Minor logic clarifications in `PipeImgGen`, `PipeJinja2`, and interpreter serialization (explicit else branches).
> - **Tooling/Config**:
>   - Makefile: `pylint` targets `pipelex tests` only; merge-check targets adjusted.
>   - `.gitignore`: ignore `.pipelex/observer/`.
>   - Pyproject/linters: pyright/ruff/pylint excludes/ignores cleaned; comments aligned.
>   - Version set to `0.10.2`; lockfile and a few deps updated (e.g., `anthropic`, `google-genai`, stubs).
> - **Docs/Changelog**:
>   - Changelog header to `[Unreleased]`; minor wording fixes (e.g., `ImgGen`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d3be1096ae8be7f9e7fc6c233cbe9132036c631. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->