### PR TITLE
Feature/support claude 4.5

### DIFF
--- a/.pipelex/inference/backends/anthropic.toml
+++ b/.pipelex/inference/backends/anthropic.toml
@@ -43,23 +43,6 @@ outputs = ["text", "structured"]
 max_prompt_images = 100
 costs = { input = 15.0, output = 75.0 }
 
-# --- Claude 3.5 Series --------------------------------------------------------
-["claude-3.5-sonnet"]
-model_id = "claude-3-5-sonnet-20240620"
-max_tokens = 8192
-inputs = ["text", "images"]
-outputs = ["text", "structured"]
-max_prompt_images = 100
-costs = { input = 3.0, output = 15.0 }
-
-["claude-3.5-sonnet-v2"]
-model_id = "claude-3-5-sonnet-20241022"
-max_tokens = 8192
-inputs = ["text", "images"]
-outputs = ["text", "structured"]
-max_prompt_images = 100
-costs = { input = 3.0, output = 15.0 }
-
 # --- Claude 3.7 Series --------------------------------------------------------
 ["claude-3.7-sonnet"]
 model_id = "claude-3-7-sonnet-20250219"
@@ -97,7 +80,7 @@ costs = { input = 3.0, output = 15.0 }
 
 # --- Claude 4.5 Series --------------------------------------------------------
 ["claude-4.5-sonnet"]
-model_id = "claude-sonnet-4-5-20250919"
+model_id = "claude-sonnet-4-5-20250929"
 max_tokens = 64000
 inputs = ["text", "images"]
 outputs = ["text", "structured"]

--- a/.pipelex/inference/backends/anthropic.toml
+++ b/.pipelex/inference/backends/anthropic.toml
@@ -95,3 +95,11 @@ outputs = ["text", "structured"]
 max_prompt_images = 100
 costs = { input = 3.0, output = 15.0 }
 
+# --- Claude 4.5 Series --------------------------------------------------------
+["claude-4.5-sonnet"]
+model_id = "claude-sonnet-4-5-20250919"
+max_tokens = 64000
+inputs = ["text", "images"]
+outputs = ["text", "structured"]
+max_prompt_images = 100
+costs = { input = 3.0, output = 15.0 }

--- a/.pipelex/inference/backends/bedrock.toml
+++ b/.pipelex/inference/backends/bedrock.toml
@@ -53,24 +53,6 @@ outputs = ["text"]
 costs = { input = 3.0, output = 15.0 }
 
 # --- Claude LLMs --------------------------------------------------------------
-["claude-3.5-sonnet"]
-sdk = "bedrock_anthropic"
-model_id = "us.anthropic.claude-3-5-sonnet-20240620-v1:0"
-max_tokens = 8192
-inputs = ["text", "images"]
-outputs = ["text", "structured"]
-max_prompt_images = 100
-costs = { input = 3.0, output = 15.0 }
-
-["claude-3.5-sonnet-v2"]
-sdk = "bedrock_anthropic"
-model_id = "anthropic.claude-3-5-sonnet-20241022-v2:0"
-max_tokens = 8192
-inputs = ["text", "images"]
-outputs = ["text", "structured"]
-max_prompt_images = 100
-costs = { input = 3.0, output = 15.0 }
-
 ["claude-3.7-sonnet"]
 sdk = "bedrock_anthropic"
 model_id = "us.anthropic.claude-3-7-sonnet-20250219-v1:0"
@@ -107,3 +89,13 @@ outputs = ["text", "structured"]
 max_prompt_images = 100
 costs = { input = 3.0, output = 15.0 }
 
+# anthropic.claude-sonnet-4-5-20250929-v1:0,Anthropic,arn:aws:bedrock:us-west-2::foundation-model/anthropic.claude-sonnet-4-5-20250929-v1:0,
+
+["claude-4.5-sonnet"]
+sdk = "bedrock_anthropic"
+model_id = "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
+max_tokens = 8192
+inputs = ["text", "images"]
+outputs = ["text", "structured"]
+max_prompt_images = 100
+costs = { input = 3.0, output = 15.0 }

--- a/.pipelex/inference/backends/pipelex_inference.toml
+++ b/.pipelex/inference/backends/pipelex_inference.toml
@@ -88,6 +88,12 @@ inputs = ["text", "images"]
 outputs = ["text", "structured"]
 costs = { input = 15, output = 75 }
 
+["claude-4.5-sonnet"]
+model_id = "pipelex/claude-4.5-sonnet"
+inputs = ["text", "images"]
+outputs = ["text", "structured"]
+costs = { input = 3, output = 15 }
+
 # --- Gemini LLMs --------------------------------------------------------------
 ["gemini-2.0-flash"]
 model_id = "gemini/gemini-2.0-flash"
@@ -127,4 +133,3 @@ costs = { input = 0.3, output = 0.5 }
 
 # We are still working in giving you acces to OCR and image generation models
 # and to the best models from Mistral through the Pipelex Inference backend.
-

--- a/.pipelex/inference/routing_profiles.toml
+++ b/.pipelex/inference/routing_profiles.toml
@@ -37,6 +37,10 @@ default = "pipelex_inference"
 "gpt-image-1" = "openai"
 "mistral-ocr" = "mistral"
 
+[profiles.all_bedrock]
+description = "Use Bedrock backend for all its supported models"
+default = "bedrock"
+
 [profiles.all_anthropic]
 description = "Use Anthropic backend for all its supported models"
 default = "anthropic"
@@ -73,8 +77,6 @@ description = "Route models to various backends"
 "gpt-5-chat" = "azure_openai"
 
 "claude-4-sonnet" = "pipelex_inference"
-"claude-3.5-sonnet" = "bedrock"
-"claude-3.5-sonnet-v2" = "anthropic"
 "claude-3.7-sonnet" = "blackboxai"
 
 "gemini-2.5-flash-lite" = "pipelex_inference"
@@ -99,4 +101,3 @@ description = "Route models to various backends"
 # - Exact names: "gpt-4o-mini"
 # - Wildcards: "claude-*" (matches all models starting with claude-)
 # - Partial wildcards: "*-sonnet" (matches all sonnet variants)
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
  - Added new observer system to log events and metrics from pipe runs: Added an extract point before running a pipe, and after running a pipe. Added a local observer that dumps the payload to a local JSONL file.
  - Added new test cases for environment variable functions
  - Added new documentation for `PipeFunc` on how to register functions.
+ - Added `claude-4.5-sonnet` to the model deck.
+ - Added `pipelex show models [BACKEND_NAME]` command to list models for a specific backend.
 
 ### Changed 
  - Renamed `llm_deck` terminology to `model_deck` throughout codebase and documentation
@@ -38,6 +40,7 @@
  - Removed function `run_pipe_code` in pipe router because it was not relevant (used mostly in tests)
  - Remove the use of `PipeCompose` in `PipeCondition`, to only use jinja2 with the `ContentGenerator`
  - Remove the template libraries from the pipelex libraries.
+ - Removed `claude-3.5-sonnet` and `claude-3.5-sonnet-v2` from the model deck.
 
 ## [v0.10.2] - 2025-09-18
 

--- a/pipelex/cli/commands/show_cmd.py
+++ b/pipelex/cli/commands/show_cmd.py
@@ -1,28 +1,15 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import UTC, datetime
-from typing import Annotated, Any
+from typing import Annotated
 
 import typer
-from anthropic import AuthenticationError
-from rich import box
-from rich.console import Console
-from rich.table import Table
 
 from pipelex import pretty_print
-from pipelex.cogt.exceptions import MissingDependencyError
-from pipelex.cogt.model_backends.model_lists import do_show_models
-from pipelex.config import get_config
+from pipelex.cogt.model_backends.model_lists import ModelLister
 from pipelex.exceptions import PipelexCLIError, PipelexConfigError
-from pipelex.hub import get_models_manager, get_pipe_provider, get_required_pipe
+from pipelex.hub import get_pipe_provider, get_required_pipe
 from pipelex.pipelex import Pipelex
-from pipelex.plugins.anthropic.anthropic_exceptions import AnthropicSDKUnsupportedError
-from pipelex.plugins.anthropic.anthropic_llms import anthropic_list_available_models
-from pipelex.plugins.mistral.mistral_llms import mistral_list_available_models
-from pipelex.plugins.openai.openai_llms import openai_list_available_models
-from pipelex.plugins.plugin_sdk_registry import Plugin
-from pipelex.tools.aws.aws_config import AwsCredentialsError
 from pipelex.tools.config.manager import config_manager
 
 
@@ -100,7 +87,7 @@ def show_models_cmd(
     ] = False,
 ) -> None:
     asyncio.run(
-        do_show_models(
+        ModelLister.list_models(
             backend_name=backend_name,
             relative_config_folder_path=relative_config_folder_path,
             flat=flat,

--- a/pipelex/cli/commands/show_cmd.py
+++ b/pipelex/cli/commands/show_cmd.py
@@ -1,13 +1,28 @@
 from __future__ import annotations
 
-from typing import Annotated
+import asyncio
+from datetime import UTC, datetime
+from typing import Annotated, Any
 
 import typer
+from anthropic import AuthenticationError
+from rich import box
+from rich.console import Console
+from rich.table import Table
 
 from pipelex import pretty_print
+from pipelex.cogt.exceptions import MissingDependencyError
+from pipelex.cogt.model_backends.model_lists import do_show_models
+from pipelex.config import get_config
 from pipelex.exceptions import PipelexCLIError, PipelexConfigError
-from pipelex.hub import get_pipe_provider, get_required_pipe
+from pipelex.hub import get_models_manager, get_pipe_provider, get_required_pipe
 from pipelex.pipelex import Pipelex
+from pipelex.plugins.anthropic.anthropic_exceptions import AnthropicSDKUnsupportedError
+from pipelex.plugins.anthropic.anthropic_llms import anthropic_list_available_models
+from pipelex.plugins.mistral.mistral_llms import mistral_list_available_models
+from pipelex.plugins.openai.openai_llms import openai_list_available_models
+from pipelex.plugins.plugin_sdk_registry import Plugin
+from pipelex.tools.aws.aws_config import AwsCredentialsError
 from pipelex.tools.config.manager import config_manager
 
 
@@ -70,3 +85,24 @@ def show_pipe_cmd(
     ] = "./pipelex_libraries",
 ) -> None:
     do_show_pipe(pipe_code=pipe_code, relative_config_folder_path=relative_config_folder_path)
+
+
+@show_app.command("models")
+def show_models_cmd(
+    backend_name: Annotated[str, typer.Argument(help="Backend name to list models for")],
+    relative_config_folder_path: Annotated[
+        str,
+        typer.Option("--config-folder-path", "-c", help="Relative path to the config folder path"),
+    ] = "./pipelex_libraries",
+    flat: Annotated[
+        bool,
+        typer.Option("--flat", "-f", help="Output in flat CSV format for easy copy-pasting"),
+    ] = False,
+) -> None:
+    asyncio.run(
+        do_show_models(
+            backend_name=backend_name,
+            relative_config_folder_path=relative_config_folder_path,
+            flat=flat,
+        )
+    )

--- a/pipelex/cogt/llm/llm_worker_factory.py
+++ b/pipelex/cogt/llm/llm_worker_factory.py
@@ -1,3 +1,5 @@
+import importlib.util
+
 from pipelex.cogt.exceptions import MissingDependencyError
 from pipelex.cogt.llm.llm_worker_internal_abstract import LLMWorkerInternalAbstract
 from pipelex.cogt.llm.structured_output import StructureMethod
@@ -43,9 +45,7 @@ class LLMWorkerFactory:
                     reporting_delegate=reporting_delegate,
                 )
             case "anthropic" | "bedrock_anthropic":
-                try:
-                    import anthropic  # noqa: PLC0415
-                except ImportError as exc:
+                if importlib.util.find_spec("anthropic") is None:
                     lib_name = "anthropic"
                     lib_extra_name = "anthropic"
                     msg = (
@@ -57,7 +57,7 @@ class LLMWorkerFactory:
                         lib_name,
                         lib_extra_name,
                         msg,
-                    ) from exc
+                    )
 
                 from pipelex.plugins.anthropic.anthropic_factory import AnthropicFactory  # noqa: PLC0415
                 from pipelex.plugins.anthropic.anthropic_llm_worker import AnthropicLLMWorker  # noqa: PLC0415
@@ -75,9 +75,7 @@ class LLMWorkerFactory:
                     reporting_delegate=reporting_delegate,
                 )
             case "mistral":
-                try:
-                    import mistralai  # noqa: PLC0415
-                except ImportError as exc:
+                if importlib.util.find_spec("mistralai") is None:
                     lib_name = "mistralai"
                     lib_extra_name = "mistral"
                     msg = (
@@ -89,7 +87,7 @@ class LLMWorkerFactory:
                         lib_name,
                         lib_extra_name,
                         msg,
-                    ) from exc
+                    )
 
                 from pipelex.plugins.mistral.mistral_factory import MistralFactory  # noqa: PLC0415
                 from pipelex.plugins.mistral.mistral_llm_worker import MistralLLMWorker  # noqa: PLC0415
@@ -106,10 +104,7 @@ class LLMWorkerFactory:
                     reporting_delegate=reporting_delegate,
                 )
             case "bedrock_boto3" | "bedrock_aioboto3":
-                try:
-                    import aioboto3  # noqa: PLC0415
-                    import boto3  # noqa: PLC0415
-                except ImportError as exc:
+                if importlib.util.find_spec("boto3") is None or importlib.util.find_spec("aioboto3") is None:
                     lib_name = "boto3,aioboto3"
                     lib_extra_name = "bedrock"
                     msg = "The boto3 and aioboto3 SDKs are required to use Bedrock models."
@@ -117,7 +112,7 @@ class LLMWorkerFactory:
                         lib_name,
                         lib_extra_name,
                         msg,
-                    ) from exc
+                    )
 
                 from pipelex.plugins.bedrock.bedrock_factory import BedrockFactory  # noqa: PLC0415
                 from pipelex.plugins.bedrock.bedrock_llm_worker import BedrockLLMWorker  # noqa: PLC0415
@@ -133,9 +128,7 @@ class LLMWorkerFactory:
                     reporting_delegate=reporting_delegate,
                 )
             case "google":
-                try:
-                    import google.genai  # noqa: PLC0415
-                except ImportError as exc:
+                if importlib.util.find_spec("google.genai") is None:
                     lib_name = "google-genai"
                     lib_extra_name = "google"
                     msg = "The google-genai SDK is required to use Google Gemini API directly. You can install it with 'pip install google-genai'."
@@ -143,7 +136,7 @@ class LLMWorkerFactory:
                         lib_name,
                         lib_extra_name,
                         msg,
-                    ) from exc
+                    )
 
                 from pipelex.plugins.google.google_factory import GoogleFactory  # noqa: PLC0415
                 from pipelex.plugins.google.google_llm_worker import GoogleLLMWorker  # noqa: PLC0415

--- a/pipelex/cogt/llm/llm_worker_factory.py
+++ b/pipelex/cogt/llm/llm_worker_factory.py
@@ -44,7 +44,7 @@ class LLMWorkerFactory:
                 )
             case "anthropic" | "bedrock_anthropic":
                 try:
-                    import anthropic  # noqa: PLC0415,F401
+                    import anthropic  # noqa: PLC0415
                 except ImportError as exc:
                     lib_name = "anthropic"
                     lib_extra_name = "anthropic"
@@ -76,7 +76,7 @@ class LLMWorkerFactory:
                 )
             case "mistral":
                 try:
-                    import mistralai  # noqa: PLC0415,F401
+                    import mistralai  # noqa: PLC0415
                 except ImportError as exc:
                     lib_name = "mistralai"
                     lib_extra_name = "mistral"
@@ -107,8 +107,8 @@ class LLMWorkerFactory:
                 )
             case "bedrock_boto3" | "bedrock_aioboto3":
                 try:
-                    import aioboto3  # noqa: PLC0415,F401
-                    import boto3  # noqa: PLC0415,F401
+                    import aioboto3  # noqa: PLC0415
+                    import boto3  # noqa: PLC0415
                 except ImportError as exc:
                     lib_name = "boto3,aioboto3"
                     lib_extra_name = "bedrock"
@@ -134,7 +134,7 @@ class LLMWorkerFactory:
                 )
             case "google":
                 try:
-                    import google.genai  # noqa: PLC0415,F401
+                    import google.genai  # noqa: PLC0415
                 except ImportError as exc:
                     lib_name = "google-genai"
                     lib_extra_name = "google"

--- a/pipelex/cogt/model_backends/model_lists.py
+++ b/pipelex/cogt/model_backends/model_lists.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timezone
 from typing import TYPE_CHECKING, Any
 
 from anthropic import AuthenticationError
@@ -303,7 +303,7 @@ class ModelLister:
         for model in models:
             # Convert Unix timestamp to formatted date
             if hasattr(model, "created") and model.created:
-                created = datetime.fromtimestamp(model.created, tz=UTC).strftime("%Y-%m-%d")
+                created = datetime.fromtimestamp(model.created, tz=timezone.utc).strftime("%Y-%m-%d")  # noqa: UP017 # Python 3.10 compatibility
             else:
                 created = "N/A"
             owned_by = model.owned_by if hasattr(model, "owned_by") else "N/A"

--- a/pipelex/cogt/model_backends/model_lists.py
+++ b/pipelex/cogt/model_backends/model_lists.py
@@ -1,285 +1,489 @@
 from __future__ import annotations
 
-import asyncio
 from datetime import UTC, datetime
-from typing import Annotated, Any
+from typing import TYPE_CHECKING, Any
 
-import typer
 from anthropic import AuthenticationError
 from rich import box
 from rich.console import Console
 from rich.table import Table
 
-from pipelex import pretty_print
-from pipelex.cogt.exceptions import MissingDependencyError
 from pipelex.config import get_config
-from pipelex.exceptions import PipelexCLIError, PipelexConfigError
-from pipelex.hub import get_models_manager, get_pipe_provider, get_required_pipe
+
+if TYPE_CHECKING:
+    from anthropic.types import ModelInfo
+    from openai.types import Model
+
+    from pipelex.cogt.model_backends.backend import InferenceBackend
+from pipelex.exceptions import PipelexCLIError
+from pipelex.hub import get_models_manager
 from pipelex.pipelex import Pipelex
 from pipelex.plugins.anthropic.anthropic_exceptions import AnthropicSDKUnsupportedError
 from pipelex.plugins.anthropic.anthropic_llms import anthropic_list_available_models
+from pipelex.plugins.bedrock.bedrock_llms import bedrock_list_available_models
 from pipelex.plugins.mistral.mistral_llms import mistral_list_available_models
 from pipelex.plugins.openai.openai_llms import openai_list_available_models
 from pipelex.plugins.plugin_sdk_registry import Plugin
 from pipelex.tools.aws.aws_config import AwsCredentialsError
-from pipelex.tools.config.manager import config_manager
-
-# Check if boto3 is available for Bedrock support
-try:
-    import boto3
-
-    _has_boto3 = True
-except ImportError:
-    _has_boto3 = False
 
 
-async def do_show_models(
-    backend_name: str,
-    relative_config_folder_path: str = "./pipelex_libraries",
-    flat: bool = False,
-) -> None:
-    """List available models for a specific backend."""
-    Pipelex.make(relative_config_folder_path=relative_config_folder_path, from_file=False)
+class ModelLister:
+    """Handles listing available models for different SDK backends."""
 
-    try:
-        backend = get_models_manager().get_required_inference_backend(backend_name)
-    except Exception as exc:
-        msg = f"Backend '{backend_name}' not found: {exc}"
-        raise PipelexCLIError(msg) from exc
+    @classmethod
+    async def list_models(
+        cls,
+        backend_name: str,
+        relative_config_folder_path: str = "./pipelex_libraries",
+        flat: bool = False,
+    ) -> None:
+        """List available models for a specific backend.
 
-    console = Console()
+        Args:
+            backend_name: Name of the backend to list models for
+            relative_config_folder_path: Path to pipelex libraries config
+            flat: Whether to output in flat CSV format
+        """
+        Pipelex.make(relative_config_folder_path=relative_config_folder_path, from_file=False)
 
-    # Determine which SDKs are used in this backend
-    # A backend can have models using different SDKs
-    if not backend.model_specs:
-        msg = f"Backend '{backend_name}' has no model specifications"
-        raise PipelexCLIError(msg)
-
-    # Group models by SDK
-    models_by_sdk: dict[str, list[str]] = {}
-    for model_name, model_spec in backend.model_specs.items():
-        sdk = model_spec.sdk
-        if sdk not in models_by_sdk:
-            models_by_sdk[sdk] = []
-        models_by_sdk[sdk].append(model_name)
-
-    # Process each SDK separately
-    any_listed = False
-    unsupported_sdks: list[str] = []
-
-    for sdk in models_by_sdk:
         try:
-            match sdk:
-                case "openai" | "azure_openai":
-                    plugin = Plugin(sdk=sdk, backend=backend_name)
-                    openai_models = await openai_list_available_models(
-                        plugin=plugin,
-                        backend=backend,
-                    )
+            backend = get_models_manager().get_required_inference_backend(backend_name)
+        except Exception as exc:
+            msg = f"Backend '{backend_name}' not found: {exc}"
+            raise PipelexCLIError(msg) from exc
 
-                    if flat:
-                        # CSV output
-                        if not any_listed:
-                            console.print("model_id,created,owned_by,sdk,backend")
-                        for model in openai_models:
-                            # Convert Unix timestamp to formatted date
-                            if hasattr(model, "created") and model.created:
-                                created = datetime.fromtimestamp(model.created, tz=UTC).strftime("%Y-%m-%d")
-                            else:
-                                created = "N/A"
-                            owned_by = model.owned_by if hasattr(model, "owned_by") else "N/A"
-                            console.print(f"{model.id},{created},{owned_by},{sdk},{backend_name}")
-                    else:
-                        # Create and display table
-                        table = Table(
-                            title=f"Available Models for Backend '{backend_name}' (SDK: {sdk})",
-                            show_header=True,
-                            header_style="bold cyan",
-                            box=box.SQUARE_DOUBLE_HEAD,
-                        )
-                        table.add_column("Model ID", style="green")
-                        table.add_column("Created", style="yellow")
-                        table.add_column("Owned By", style="blue")
+        console = Console()
 
-                        for model in openai_models:
-                            # Convert Unix timestamp to formatted date
-                            if hasattr(model, "created") and model.created:
-                                created = datetime.fromtimestamp(model.created, tz=UTC).strftime("%Y-%m-%d")
-                            else:
-                                created = "N/A"
-                            owned_by = model.owned_by if hasattr(model, "owned_by") else "N/A"
-                            table.add_row(model.id, created, owned_by)
+        # Determine which SDKs are used in this backend
+        if not backend.model_specs:
+            msg = f"Backend '{backend_name}' has no model specifications"
+            raise PipelexCLIError(msg)
 
-                        console.print("\n")
-                        console.print(table)
-                        console.print("\n")
-                    any_listed = True
+        # Group models by SDK
+        models_by_sdk: dict[str, list[str]] = {}
+        for model_name, model_spec in backend.model_specs.items():
+            sdk = model_spec.sdk
+            if sdk not in models_by_sdk:
+                models_by_sdk[sdk] = []
+            models_by_sdk[sdk].append(model_name)
 
-                case "anthropic" | "bedrock_anthropic":
-                    plugin = Plugin(sdk=sdk, backend=backend_name)
-                    try:
-                        anthropic_models = await anthropic_list_available_models(
-                            plugin=plugin,
+        # Process each SDK separately
+        any_listed = False
+        unsupported_sdks: list[str] = []
+
+        for sdk in models_by_sdk:
+            try:
+                match sdk:
+                    case "openai" | "azure_openai":
+                        await cls._list_openai_models(
+                            sdk=sdk,
+                            backend_name=backend_name,
                             backend=backend,
+                            console=console,
+                            flat=flat,
+                            any_listed=any_listed,
                         )
-
-                        if flat:
-                            # CSV output
-                            if not any_listed:
-                                console.print("model_id,display_name,created_at,sdk,backend")
-                            for anthropic_model in anthropic_models:
-                                created_date = anthropic_model.created_at.strftime("%Y-%m-%d") if anthropic_model.created_at else "N/A"
-                                display_name = anthropic_model.display_name.replace(",", ";") if anthropic_model.display_name else "N/A"
-                                console.print(f"{anthropic_model.id},{display_name},{created_date},{sdk},{backend_name}")
-                        else:
-                            # Create and display table
-                            table = Table(
-                                title=f"Available Models for Backend '{backend_name}' (SDK: {sdk})",
-                                show_header=True,
-                                header_style="bold cyan",
-                                box=box.SQUARE_DOUBLE_HEAD,
-                            )
-                            table.add_column("Model ID", style="green")
-                            table.add_column("Display Name", style="blue")
-                            table.add_column("Created At", style="yellow")
-
-                            for anthropic_model in anthropic_models:
-                                created_date = anthropic_model.created_at.strftime("%Y-%m-%d") if anthropic_model.created_at else "N/A"
-                                table.add_row(anthropic_model.id, anthropic_model.display_name, created_date)
-
-                            console.print("\n")
-                            console.print(table)
-                            console.print("\n")
                         any_listed = True
-                    except AuthenticationError as auth_exc:
-                        msg = f"Authentication error for SDK '{sdk}' in backend '{backend_name}': {auth_exc}"
-                        raise PipelexCLIError(msg) from auth_exc
-                    except AnthropicSDKUnsupportedError:
+
+                    case "anthropic" | "bedrock_anthropic":
+                        try:
+                            await cls._list_anthropic_models(
+                                sdk=sdk,
+                                backend_name=backend_name,
+                                backend=backend,
+                                console=console,
+                                flat=flat,
+                                any_listed=any_listed,
+                            )
+                            any_listed = True
+                        except AnthropicSDKUnsupportedError:
+                            unsupported_sdks.append(sdk)
+                            continue
+
+                    case "mistral":
+                        cls._list_mistral_models(
+                            sdk=sdk,
+                            backend_name=backend_name,
+                            console=console,
+                            flat=flat,
+                            any_listed=any_listed,
+                        )
+                        any_listed = True
+
+                    case "bedrock" | "bedrock_aioboto3":
+                        await cls._list_bedrock_models(
+                            sdk=sdk,
+                            backend_name=backend_name,
+                            backend=backend,
+                            console=console,
+                            flat=flat,
+                            any_listed=any_listed,
+                        )
+                        any_listed = True
+
+                    case _:
+                        # SDK doesn't support listing
                         unsupported_sdks.append(sdk)
                         continue
 
-                case "mistral":
-                    mistral_models = mistral_list_available_models()
+            except PipelexCLIError:
+                raise
+            except Exception as exc:
+                msg = f"Error listing models for SDK '{sdk}' in backend '{backend_name}': {exc}"
+                raise PipelexCLIError(msg) from exc
 
-                    if flat:
-                        # CSV output
-                        if not any_listed:
-                            console.print("model_id,max_context_length,sdk,backend")
-                        for mistral_model in mistral_models:
-                            max_ctx = str(mistral_model.max_context_length) if mistral_model.max_context_length else "N/A"
-                            console.print(f"{mistral_model.id},{max_ctx},{sdk},{backend_name}")
-                    else:
-                        # Create and display table
-                        table = Table(
-                            title=f"Available Models for Backend '{backend_name}' (SDK: {sdk})",
-                            show_header=True,
-                            header_style="bold cyan",
-                            box=box.SQUARE_DOUBLE_HEAD,
-                        )
-                        table.add_column("Model ID", style="green")
-                        table.add_column("Max Context Length", style="yellow")
+        # After all SDKs have been processed
+        cls._display_unsupported_sdks_message(
+            any_listed=any_listed,
+            unsupported_sdks=unsupported_sdks,
+            backend_name=backend_name,
+            models_by_sdk=models_by_sdk,
+            console=console,
+            flat=flat,
+        )
 
-                        for mistral_model in mistral_models:
-                            max_ctx = str(mistral_model.max_context_length) if mistral_model.max_context_length else "N/A"
-                            table.add_row(mistral_model.id, max_ctx)
+    @classmethod
+    async def _list_openai_models(
+        cls,
+        sdk: str,
+        backend_name: str,
+        backend: InferenceBackend,
+        console: Console,
+        flat: bool,
+        any_listed: bool,
+    ) -> None:
+        """List OpenAI models."""
+        plugin = Plugin(sdk=sdk, backend=backend_name)
+        openai_models = await openai_list_available_models(
+            plugin=plugin,
+            backend=backend,
+        )
 
-                        console.print("\n")
-                        console.print(table)
-                        console.print("\n")
-                    any_listed = True
+        if flat:
+            cls._display_openai_models_flat(
+                models=openai_models,
+                sdk=sdk,
+                backend_name=backend_name,
+                console=console,
+                any_listed=any_listed,
+            )
+        else:
+            cls._display_openai_models_table(
+                models=openai_models,
+                sdk=sdk,
+                backend_name=backend_name,
+                console=console,
+            )
 
-                case "bedrock" | "bedrock_aioboto3":
-                    if not _has_boto3:
-                        msg = "boto3 is required to list Bedrock models. Please install it with: pip install boto3"
-                        raise PipelexCLIError(msg)
+    @classmethod
+    async def _list_anthropic_models(
+        cls,
+        sdk: str,
+        backend_name: str,
+        backend: InferenceBackend,
+        console: Console,
+        flat: bool,
+        any_listed: bool,
+    ) -> None:
+        """List Anthropic models."""
+        plugin = Plugin(sdk=sdk, backend=backend_name)
+        try:
+            anthropic_models = await anthropic_list_available_models(
+                plugin=plugin,
+                backend=backend,
+            )
 
-                    try:
-                        aws_config = get_config().pipelex.aws_config
-                        aws_access_key_id, aws_secret_access_key, aws_region = aws_config.get_aws_access_keys()
-                    except AwsCredentialsError as exc:
-                        msg = f"Error getting AWS credentials for Bedrock: {exc}"
-                        raise PipelexCLIError(msg) from exc
+            if flat:
+                cls._display_anthropic_models_flat(
+                    models=anthropic_models,
+                    sdk=sdk,
+                    backend_name=backend_name,
+                    console=console,
+                    any_listed=any_listed,
+                )
+            else:
+                cls._display_anthropic_models_table(
+                    models=anthropic_models,
+                    sdk=sdk,
+                    backend_name=backend_name,
+                    console=console,
+                )
+        except AuthenticationError as auth_exc:
+            msg = f"Authentication error for SDK '{sdk}' in backend '{backend_name}': {auth_exc}"
+            raise PipelexCLIError(msg) from auth_exc
 
-                    try:
-                        import aioboto3  # noqa: PLC0415
-                        import boto3  # noqa: PLC0415
-                    except ImportError as exc:
-                        lib_name = "boto3,aioboto3"
-                        lib_extra_name = "bedrock"
-                        msg = "The boto3 and aioboto3 SDKs are required to use Bedrock models."
-                        raise MissingDependencyError(
-                            lib_name,
-                            lib_extra_name,
-                            msg,
-                        ) from exc
+    @classmethod
+    def _list_mistral_models(
+        cls,
+        sdk: str,
+        backend_name: str,
+        console: Console,
+        flat: bool,
+        any_listed: bool,
+    ) -> None:
+        """List Mistral models."""
+        mistral_models = mistral_list_available_models()
 
-                    try:
-                        # Create bedrock client
-                        bedrock_client = boto3.client(  # pyright: ignore[reportUnknownVariableType, reportUnknownMemberType]
-                            "bedrock",
-                            region_name=aws_region,
-                            aws_access_key_id=aws_access_key_id,
-                            aws_secret_access_key=aws_secret_access_key,
-                        )
+        if flat:
+            cls._display_mistral_models_flat(
+                models=mistral_models,
+                sdk=sdk,
+                backend_name=backend_name,
+                console=console,
+                any_listed=any_listed,
+            )
+        else:
+            cls._display_mistral_models_table(
+                models=mistral_models,
+                sdk=sdk,
+                backend_name=backend_name,
+                console=console,
+            )
 
-                        # List foundation models
-                        response: dict[str, Any] = bedrock_client.list_foundation_models()  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
-                        bedrock_models_list: list[dict[str, Any]] = response["modelSummaries"]  # pyright: ignore[reportUnknownVariableType]
+    @classmethod
+    async def _list_bedrock_models(
+        cls,
+        sdk: str,
+        backend_name: str,
+        backend: InferenceBackend,
+        console: Console,
+        flat: bool,
+        any_listed: bool,
+    ) -> None:
+        """List Bedrock models."""
+        plugin = Plugin(sdk=sdk, backend=backend_name)
 
-                        if flat:
-                            # CSV output
-                            if not any_listed:
-                                console.print("model_id,provider,model_arn,sdk,backend,region")
-                            for bedrock_model in bedrock_models_list:  # pyright: ignore[reportUnknownVariableType]
-                                model_id = bedrock_model.get("modelId", "N/A")  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
-                                provider = bedrock_model.get("providerName", "N/A")  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
-                                model_arn = bedrock_model.get("modelArn", "N/A")  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
-                                console.print(f"{model_id},{provider},{model_arn},{sdk},{backend_name},{aws_region}")  # pyright: ignore[reportUnknownArgumentType]
-                        else:
-                            # Create and display table
-                            table = Table(
-                                title=f"Available Bedrock Models in {aws_region} (SDK: {sdk})",
-                                show_header=True,
-                                header_style="bold cyan",
-                                box=box.SQUARE_DOUBLE_HEAD,
-                            )
-                            table.add_column("Model ID", style="green")
-                            table.add_column("Provider", style="blue")
-                            table.add_column("Model ARN", style="yellow")
-
-                            for bedrock_model in bedrock_models_list:  # pyright: ignore[reportUnknownVariableType]
-                                model_id = bedrock_model.get("modelId", "N/A")  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
-                                provider = bedrock_model.get("providerName", "N/A")  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
-                                model_arn = bedrock_model.get("modelArn", "N/A")  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
-                                table.add_row(model_id, provider, model_arn)  # pyright: ignore[reportUnknownArgumentType]
-
-                            console.print("\n")
-                            console.print(table)
-                            console.print("\n")
-                        any_listed = True
-
-                    except Exception as exc:
-                        msg = f"Error listing Bedrock models: {exc}"
-                        raise PipelexCLIError(msg) from exc
-
-                case _:
-                    # SDK doesn't support listing
-                    unsupported_sdks.append(sdk)
-                    continue
-
-        except PipelexCLIError:
-            raise
-        except Exception as exc:
-            msg = f"Error listing models for SDK '{sdk}' in backend '{backend_name}': {exc}"
+        try:
+            # Get AWS region for display
+            aws_config = get_config().pipelex.aws_config
+            _, _, aws_region = aws_config.get_aws_access_keys()
+        except AwsCredentialsError as exc:
+            msg = f"Error getting AWS credentials for Bedrock: {exc}"
             raise PipelexCLIError(msg) from exc
 
-    # After all SDKs have been processed
-    if not any_listed and unsupported_sdks:
-        if not flat:
-            console.print(f"\n[yellow]Note: Backend '{backend_name}' has models using SDKs that don't support remote listing:[/yellow]")
-            for sdk in unsupported_sdks:
-                console.print(f"  • {sdk} ({len(models_by_sdk[sdk])} configured model(s))")
-            console.print("\n[dim]Configured models are still available for use in pipelines.[/dim]\n")
-        else:
-            # In flat mode, just print a simple comment
-            console.print(f"# Note: Backend '{backend_name}' has {len(unsupported_sdks)} SDK(s) that don't support remote listing")
+        try:
+            # List available models using the plugin-specific function
+            bedrock_models_list = await bedrock_list_available_models(
+                plugin=plugin,
+                backend=backend,
+            )
+
+            if flat:
+                cls._display_bedrock_models_flat(
+                    models=bedrock_models_list,
+                    sdk=sdk,
+                    backend_name=backend_name,
+                    aws_region=aws_region,
+                    console=console,
+                    any_listed=any_listed,
+                )
+            else:
+                cls._display_bedrock_models_table(
+                    models=bedrock_models_list,
+                    sdk=sdk,
+                    aws_region=aws_region,
+                    console=console,
+                )
+
+        except Exception as exc:
+            msg = f"Error listing Bedrock models: {exc}"
+            raise PipelexCLIError(msg) from exc
+
+    @staticmethod
+    def _display_openai_models_flat(
+        models: list[Model],
+        sdk: str,
+        backend_name: str,
+        console: Console,
+        any_listed: bool,
+    ) -> None:
+        """Display OpenAI models in CSV format."""
+        if not any_listed:
+            console.print("model_id,created,owned_by,sdk,backend")
+        for model in models:
+            # Convert Unix timestamp to formatted date
+            if hasattr(model, "created") and model.created:
+                created = datetime.fromtimestamp(model.created, tz=UTC).strftime("%Y-%m-%d")
+            else:
+                created = "N/A"
+            owned_by = model.owned_by if hasattr(model, "owned_by") else "N/A"
+            console.print(f"{model.id},{created},{owned_by},{sdk},{backend_name}")
+
+    @staticmethod
+    def _display_openai_models_table(
+        models: list[Model],
+        sdk: str,
+        backend_name: str,
+        console: Console,
+    ) -> None:
+        """Display OpenAI models in table format."""
+        table = Table(
+            title=f"Available Models for Backend '{backend_name}' (SDK: {sdk})",
+            show_header=True,
+            header_style="bold cyan",
+            box=box.SQUARE_DOUBLE_HEAD,
+        )
+        table.add_column("Model ID", style="green")
+        table.add_column("Created", style="yellow")
+        table.add_column("Owned By", style="blue")
+
+        for model in models:
+            # Convert Unix timestamp to formatted date
+            if hasattr(model, "created") and model.created:
+                created = datetime.fromtimestamp(model.created, tz=UTC).strftime("%Y-%m-%d")
+            else:
+                created = "N/A"
+            owned_by = model.owned_by if hasattr(model, "owned_by") else "N/A"
+            table.add_row(model.id, created, owned_by)
+
+        console.print("\n")
+        console.print(table)
+        console.print("\n")
+
+    @staticmethod
+    def _display_anthropic_models_flat(
+        models: list[ModelInfo],
+        sdk: str,
+        backend_name: str,
+        console: Console,
+        any_listed: bool,
+    ) -> None:
+        """Display Anthropic models in CSV format."""
+        if not any_listed:
+            console.print("model_id,display_name,created_at,sdk,backend")
+        for anthropic_model in models:
+            created_date = anthropic_model.created_at.strftime("%Y-%m-%d") if anthropic_model.created_at else "N/A"
+            display_name = anthropic_model.display_name.replace(",", ";") if anthropic_model.display_name else "N/A"
+            console.print(f"{anthropic_model.id},{display_name},{created_date},{sdk},{backend_name}")
+
+    @staticmethod
+    def _display_anthropic_models_table(
+        models: list[ModelInfo],
+        sdk: str,
+        backend_name: str,
+        console: Console,
+    ) -> None:
+        """Display Anthropic models in table format."""
+        table = Table(
+            title=f"Available Models for Backend '{backend_name}' (SDK: {sdk})",
+            show_header=True,
+            header_style="bold cyan",
+            box=box.SQUARE_DOUBLE_HEAD,
+        )
+        table.add_column("Model ID", style="green")
+        table.add_column("Display Name", style="blue")
+        table.add_column("Created At", style="yellow")
+
+        for anthropic_model in models:
+            created_date = anthropic_model.created_at.strftime("%Y-%m-%d") if anthropic_model.created_at else "N/A"
+            table.add_row(anthropic_model.id, anthropic_model.display_name, created_date)
+
+        console.print("\n")
+        console.print(table)
+        console.print("\n")
+
+    @staticmethod
+    def _display_mistral_models_flat(
+        models: list[Any],
+        sdk: str,
+        backend_name: str,
+        console: Console,
+        any_listed: bool,
+    ) -> None:
+        """Display Mistral models in CSV format."""
+        if not any_listed:
+            console.print("model_id,max_context_length,sdk,backend")
+        for mistral_model in models:
+            max_ctx = str(mistral_model.max_context_length) if mistral_model.max_context_length else "N/A"
+            console.print(f"{mistral_model.id},{max_ctx},{sdk},{backend_name}")
+
+    @staticmethod
+    def _display_mistral_models_table(
+        models: list[Any],
+        sdk: str,
+        backend_name: str,
+        console: Console,
+    ) -> None:
+        """Display Mistral models in table format."""
+        table = Table(
+            title=f"Available Models for Backend '{backend_name}' (SDK: {sdk})",
+            show_header=True,
+            header_style="bold cyan",
+            box=box.SQUARE_DOUBLE_HEAD,
+        )
+        table.add_column("Model ID", style="green")
+        table.add_column("Max Context Length", style="yellow")
+
+        for mistral_model in models:
+            max_ctx = str(mistral_model.max_context_length) if mistral_model.max_context_length else "N/A"
+            table.add_row(mistral_model.id, max_ctx)
+
+        console.print("\n")
+        console.print(table)
+        console.print("\n")
+
+    @staticmethod
+    def _display_bedrock_models_flat(
+        models: list[dict[str, Any]],
+        sdk: str,
+        backend_name: str,
+        aws_region: str,
+        console: Console,
+        any_listed: bool,
+    ) -> None:
+        """Display Bedrock models in CSV format."""
+        if not any_listed:
+            console.print("model_id,provider,model_arn,sdk,backend,region")
+        for bedrock_model in models:  # pyright: ignore[reportUnknownVariableType]
+            model_id = bedrock_model.get("modelId", "N/A")  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
+            provider = bedrock_model.get("providerName", "N/A")  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
+            model_arn = bedrock_model.get("modelArn", "N/A")  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
+            console.print(f"{model_id},{provider},{model_arn},{sdk},{backend_name},{aws_region}")  # pyright: ignore[reportUnknownArgumentType]
+
+    @staticmethod
+    def _display_bedrock_models_table(
+        models: list[dict[str, Any]],
+        sdk: str,
+        aws_region: str,
+        console: Console,
+    ) -> None:
+        """Display Bedrock models in table format."""
+        table = Table(
+            title=f"Available Bedrock Models in {aws_region} (SDK: {sdk})",
+            show_header=True,
+            header_style="bold cyan",
+            box=box.SQUARE_DOUBLE_HEAD,
+        )
+        table.add_column("Model ID", style="green")
+        table.add_column("Provider", style="blue")
+        table.add_column("Model ARN", style="yellow")
+
+        for bedrock_model in models:  # pyright: ignore[reportUnknownVariableType]
+            model_id = bedrock_model.get("modelId", "N/A")  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
+            provider = bedrock_model.get("providerName", "N/A")  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
+            model_arn = bedrock_model.get("modelArn", "N/A")  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
+            table.add_row(model_id, provider, model_arn)  # pyright: ignore[reportUnknownArgumentType]
+
+        console.print("\n")
+        console.print(table)
+        console.print("\n")
+
+    @staticmethod
+    def _display_unsupported_sdks_message(
+        any_listed: bool,
+        unsupported_sdks: list[str],
+        backend_name: str,
+        models_by_sdk: dict[str, list[str]],
+        console: Console,
+        flat: bool,
+    ) -> None:
+        """Display message about unsupported SDKs."""
+        if not any_listed and unsupported_sdks:
+            if not flat:
+                console.print(f"\n[yellow]Note: Backend '{backend_name}' has models using SDKs that don't support remote listing:[/yellow]")
+                for sdk in unsupported_sdks:
+                    console.print(f"  • {sdk} ({len(models_by_sdk[sdk])} configured model(s))")
+                console.print("\n[dim]Configured models are still available for use in pipelines.[/dim]\n")
+            else:
+                # In flat mode, just print a simple comment
+                console.print(f"# Note: Backend '{backend_name}' has {len(unsupported_sdks)} SDK(s) that don't support remote listing")

--- a/pipelex/cogt/model_backends/model_lists.py
+++ b/pipelex/cogt/model_backends/model_lists.py
@@ -1,0 +1,285 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from typing import Annotated, Any
+
+import typer
+from anthropic import AuthenticationError
+from rich import box
+from rich.console import Console
+from rich.table import Table
+
+from pipelex import pretty_print
+from pipelex.cogt.exceptions import MissingDependencyError
+from pipelex.config import get_config
+from pipelex.exceptions import PipelexCLIError, PipelexConfigError
+from pipelex.hub import get_models_manager, get_pipe_provider, get_required_pipe
+from pipelex.pipelex import Pipelex
+from pipelex.plugins.anthropic.anthropic_exceptions import AnthropicSDKUnsupportedError
+from pipelex.plugins.anthropic.anthropic_llms import anthropic_list_available_models
+from pipelex.plugins.mistral.mistral_llms import mistral_list_available_models
+from pipelex.plugins.openai.openai_llms import openai_list_available_models
+from pipelex.plugins.plugin_sdk_registry import Plugin
+from pipelex.tools.aws.aws_config import AwsCredentialsError
+from pipelex.tools.config.manager import config_manager
+
+# Check if boto3 is available for Bedrock support
+try:
+    import boto3
+
+    _has_boto3 = True
+except ImportError:
+    _has_boto3 = False
+
+
+async def do_show_models(
+    backend_name: str,
+    relative_config_folder_path: str = "./pipelex_libraries",
+    flat: bool = False,
+) -> None:
+    """List available models for a specific backend."""
+    Pipelex.make(relative_config_folder_path=relative_config_folder_path, from_file=False)
+
+    try:
+        backend = get_models_manager().get_required_inference_backend(backend_name)
+    except Exception as exc:
+        msg = f"Backend '{backend_name}' not found: {exc}"
+        raise PipelexCLIError(msg) from exc
+
+    console = Console()
+
+    # Determine which SDKs are used in this backend
+    # A backend can have models using different SDKs
+    if not backend.model_specs:
+        msg = f"Backend '{backend_name}' has no model specifications"
+        raise PipelexCLIError(msg)
+
+    # Group models by SDK
+    models_by_sdk: dict[str, list[str]] = {}
+    for model_name, model_spec in backend.model_specs.items():
+        sdk = model_spec.sdk
+        if sdk not in models_by_sdk:
+            models_by_sdk[sdk] = []
+        models_by_sdk[sdk].append(model_name)
+
+    # Process each SDK separately
+    any_listed = False
+    unsupported_sdks: list[str] = []
+
+    for sdk in models_by_sdk:
+        try:
+            match sdk:
+                case "openai" | "azure_openai":
+                    plugin = Plugin(sdk=sdk, backend=backend_name)
+                    openai_models = await openai_list_available_models(
+                        plugin=plugin,
+                        backend=backend,
+                    )
+
+                    if flat:
+                        # CSV output
+                        if not any_listed:
+                            console.print("model_id,created,owned_by,sdk,backend")
+                        for model in openai_models:
+                            # Convert Unix timestamp to formatted date
+                            if hasattr(model, "created") and model.created:
+                                created = datetime.fromtimestamp(model.created, tz=UTC).strftime("%Y-%m-%d")
+                            else:
+                                created = "N/A"
+                            owned_by = model.owned_by if hasattr(model, "owned_by") else "N/A"
+                            console.print(f"{model.id},{created},{owned_by},{sdk},{backend_name}")
+                    else:
+                        # Create and display table
+                        table = Table(
+                            title=f"Available Models for Backend '{backend_name}' (SDK: {sdk})",
+                            show_header=True,
+                            header_style="bold cyan",
+                            box=box.SQUARE_DOUBLE_HEAD,
+                        )
+                        table.add_column("Model ID", style="green")
+                        table.add_column("Created", style="yellow")
+                        table.add_column("Owned By", style="blue")
+
+                        for model in openai_models:
+                            # Convert Unix timestamp to formatted date
+                            if hasattr(model, "created") and model.created:
+                                created = datetime.fromtimestamp(model.created, tz=UTC).strftime("%Y-%m-%d")
+                            else:
+                                created = "N/A"
+                            owned_by = model.owned_by if hasattr(model, "owned_by") else "N/A"
+                            table.add_row(model.id, created, owned_by)
+
+                        console.print("\n")
+                        console.print(table)
+                        console.print("\n")
+                    any_listed = True
+
+                case "anthropic" | "bedrock_anthropic":
+                    plugin = Plugin(sdk=sdk, backend=backend_name)
+                    try:
+                        anthropic_models = await anthropic_list_available_models(
+                            plugin=plugin,
+                            backend=backend,
+                        )
+
+                        if flat:
+                            # CSV output
+                            if not any_listed:
+                                console.print("model_id,display_name,created_at,sdk,backend")
+                            for anthropic_model in anthropic_models:
+                                created_date = anthropic_model.created_at.strftime("%Y-%m-%d") if anthropic_model.created_at else "N/A"
+                                display_name = anthropic_model.display_name.replace(",", ";") if anthropic_model.display_name else "N/A"
+                                console.print(f"{anthropic_model.id},{display_name},{created_date},{sdk},{backend_name}")
+                        else:
+                            # Create and display table
+                            table = Table(
+                                title=f"Available Models for Backend '{backend_name}' (SDK: {sdk})",
+                                show_header=True,
+                                header_style="bold cyan",
+                                box=box.SQUARE_DOUBLE_HEAD,
+                            )
+                            table.add_column("Model ID", style="green")
+                            table.add_column("Display Name", style="blue")
+                            table.add_column("Created At", style="yellow")
+
+                            for anthropic_model in anthropic_models:
+                                created_date = anthropic_model.created_at.strftime("%Y-%m-%d") if anthropic_model.created_at else "N/A"
+                                table.add_row(anthropic_model.id, anthropic_model.display_name, created_date)
+
+                            console.print("\n")
+                            console.print(table)
+                            console.print("\n")
+                        any_listed = True
+                    except AuthenticationError as auth_exc:
+                        msg = f"Authentication error for SDK '{sdk}' in backend '{backend_name}': {auth_exc}"
+                        raise PipelexCLIError(msg) from auth_exc
+                    except AnthropicSDKUnsupportedError:
+                        unsupported_sdks.append(sdk)
+                        continue
+
+                case "mistral":
+                    mistral_models = mistral_list_available_models()
+
+                    if flat:
+                        # CSV output
+                        if not any_listed:
+                            console.print("model_id,max_context_length,sdk,backend")
+                        for mistral_model in mistral_models:
+                            max_ctx = str(mistral_model.max_context_length) if mistral_model.max_context_length else "N/A"
+                            console.print(f"{mistral_model.id},{max_ctx},{sdk},{backend_name}")
+                    else:
+                        # Create and display table
+                        table = Table(
+                            title=f"Available Models for Backend '{backend_name}' (SDK: {sdk})",
+                            show_header=True,
+                            header_style="bold cyan",
+                            box=box.SQUARE_DOUBLE_HEAD,
+                        )
+                        table.add_column("Model ID", style="green")
+                        table.add_column("Max Context Length", style="yellow")
+
+                        for mistral_model in mistral_models:
+                            max_ctx = str(mistral_model.max_context_length) if mistral_model.max_context_length else "N/A"
+                            table.add_row(mistral_model.id, max_ctx)
+
+                        console.print("\n")
+                        console.print(table)
+                        console.print("\n")
+                    any_listed = True
+
+                case "bedrock" | "bedrock_aioboto3":
+                    if not _has_boto3:
+                        msg = "boto3 is required to list Bedrock models. Please install it with: pip install boto3"
+                        raise PipelexCLIError(msg)
+
+                    try:
+                        aws_config = get_config().pipelex.aws_config
+                        aws_access_key_id, aws_secret_access_key, aws_region = aws_config.get_aws_access_keys()
+                    except AwsCredentialsError as exc:
+                        msg = f"Error getting AWS credentials for Bedrock: {exc}"
+                        raise PipelexCLIError(msg) from exc
+
+                    try:
+                        import aioboto3  # noqa: PLC0415
+                        import boto3  # noqa: PLC0415
+                    except ImportError as exc:
+                        lib_name = "boto3,aioboto3"
+                        lib_extra_name = "bedrock"
+                        msg = "The boto3 and aioboto3 SDKs are required to use Bedrock models."
+                        raise MissingDependencyError(
+                            lib_name,
+                            lib_extra_name,
+                            msg,
+                        ) from exc
+
+                    try:
+                        # Create bedrock client
+                        bedrock_client = boto3.client(  # pyright: ignore[reportUnknownVariableType, reportUnknownMemberType]
+                            "bedrock",
+                            region_name=aws_region,
+                            aws_access_key_id=aws_access_key_id,
+                            aws_secret_access_key=aws_secret_access_key,
+                        )
+
+                        # List foundation models
+                        response: dict[str, Any] = bedrock_client.list_foundation_models()  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
+                        bedrock_models_list: list[dict[str, Any]] = response["modelSummaries"]  # pyright: ignore[reportUnknownVariableType]
+
+                        if flat:
+                            # CSV output
+                            if not any_listed:
+                                console.print("model_id,provider,model_arn,sdk,backend,region")
+                            for bedrock_model in bedrock_models_list:  # pyright: ignore[reportUnknownVariableType]
+                                model_id = bedrock_model.get("modelId", "N/A")  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
+                                provider = bedrock_model.get("providerName", "N/A")  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
+                                model_arn = bedrock_model.get("modelArn", "N/A")  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
+                                console.print(f"{model_id},{provider},{model_arn},{sdk},{backend_name},{aws_region}")  # pyright: ignore[reportUnknownArgumentType]
+                        else:
+                            # Create and display table
+                            table = Table(
+                                title=f"Available Bedrock Models in {aws_region} (SDK: {sdk})",
+                                show_header=True,
+                                header_style="bold cyan",
+                                box=box.SQUARE_DOUBLE_HEAD,
+                            )
+                            table.add_column("Model ID", style="green")
+                            table.add_column("Provider", style="blue")
+                            table.add_column("Model ARN", style="yellow")
+
+                            for bedrock_model in bedrock_models_list:  # pyright: ignore[reportUnknownVariableType]
+                                model_id = bedrock_model.get("modelId", "N/A")  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
+                                provider = bedrock_model.get("providerName", "N/A")  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
+                                model_arn = bedrock_model.get("modelArn", "N/A")  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
+                                table.add_row(model_id, provider, model_arn)  # pyright: ignore[reportUnknownArgumentType]
+
+                            console.print("\n")
+                            console.print(table)
+                            console.print("\n")
+                        any_listed = True
+
+                    except Exception as exc:
+                        msg = f"Error listing Bedrock models: {exc}"
+                        raise PipelexCLIError(msg) from exc
+
+                case _:
+                    # SDK doesn't support listing
+                    unsupported_sdks.append(sdk)
+                    continue
+
+        except PipelexCLIError:
+            raise
+        except Exception as exc:
+            msg = f"Error listing models for SDK '{sdk}' in backend '{backend_name}': {exc}"
+            raise PipelexCLIError(msg) from exc
+
+    # After all SDKs have been processed
+    if not any_listed and unsupported_sdks:
+        if not flat:
+            console.print(f"\n[yellow]Note: Backend '{backend_name}' has models using SDKs that don't support remote listing:[/yellow]")
+            for sdk in unsupported_sdks:
+                console.print(f"  • {sdk} ({len(models_by_sdk[sdk])} configured model(s))")
+            console.print("\n[dim]Configured models are still available for use in pipelines.[/dim]\n")
+        else:
+            # In flat mode, just print a simple comment
+            console.print(f"# Note: Backend '{backend_name}' has {len(unsupported_sdks)} SDK(s) that don't support remote listing")

--- a/pipelex/cogt/model_backends/model_lists.py
+++ b/pipelex/cogt/model_backends/model_lists.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import UTC, datetime, timezone
+from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 from anthropic import AuthenticationError
@@ -303,7 +303,7 @@ class ModelLister:
         for model in models:
             # Convert Unix timestamp to formatted date
             if hasattr(model, "created") and model.created:
-                created = datetime.fromtimestamp(model.created, tz=timezone.utc).strftime("%Y-%m-%d")  # noqa: UP017 # Python 3.10 compatibility
+                created = datetime.fromtimestamp(model.created).strftime("%Y-%m-%d")  # noqa: DTZ006
             else:
                 created = "N/A"
             owned_by = model.owned_by if hasattr(model, "owned_by") else "N/A"
@@ -330,7 +330,7 @@ class ModelLister:
         for model in models:
             # Convert Unix timestamp to formatted date
             if hasattr(model, "created") and model.created:
-                created = datetime.fromtimestamp(model.created, tz=UTC).strftime("%Y-%m-%d")
+                created = datetime.fromtimestamp(model.created).strftime("%Y-%m-%d")  # noqa: DTZ006
             else:
                 created = "N/A"
             owned_by = model.owned_by if hasattr(model, "owned_by") else "N/A"

--- a/pipelex/plugins/anthropic/anthropic_llms.py
+++ b/pipelex/plugins/anthropic/anthropic_llms.py
@@ -7,7 +7,7 @@ from pipelex.plugins.anthropic.anthropic_factory import AnthropicFactory
 from pipelex.plugins.plugin_sdk_registry import Plugin
 
 
-async def anthropic_list_anthropic_models(plugin: Plugin, backend: InferenceBackend) -> list[ModelInfo]:
+async def anthropic_list_available_models(plugin: Plugin, backend: InferenceBackend) -> list[ModelInfo]:
     """List available Anthropic models.
 
     Returns:

--- a/pipelex/plugins/bedrock/bedrock_llms.py
+++ b/pipelex/plugins/bedrock/bedrock_llms.py
@@ -1,0 +1,57 @@
+from typing import Any, cast
+
+from pipelex.cogt.exceptions import MissingDependencyError
+from pipelex.cogt.model_backends.backend import InferenceBackend
+from pipelex.config import get_config
+from pipelex.plugins.plugin_sdk_registry import Plugin
+from pipelex.tools.aws.aws_config import AwsCredentialsError
+
+
+async def bedrock_list_available_models(
+    plugin: Plugin,  # noqa: ARG001
+    backend: InferenceBackend,  # noqa: ARG001
+) -> list[dict[str, Any]]:
+    """List available Bedrock foundation models.
+
+    Args:
+        plugin: The plugin configuration (unused, kept for interface consistency)
+        backend: The inference backend configuration (unused, kept for interface consistency)
+
+    Returns:
+        List of model summaries from Bedrock
+
+    Raises:
+        AwsCredentialsError: If AWS credentials cannot be retrieved
+        MissingDependencyError: If boto3 is not installed
+    """
+    try:
+        aws_config = get_config().pipelex.aws_config
+        aws_access_key_id, aws_secret_access_key, aws_region = aws_config.get_aws_access_keys()
+    except AwsCredentialsError as exc:
+        msg = f"Error getting AWS credentials for Bedrock: {exc}"
+        raise AwsCredentialsError(msg) from exc
+
+    try:
+        import boto3  # noqa: PLC0415
+    except ImportError as exc:
+        lib_name = "boto3,aioboto3"
+        lib_extra_name = "bedrock"
+        msg = "The boto3 and aioboto3 SDKs are required to use Bedrock models."
+        raise MissingDependencyError(
+            lib_name,
+            lib_extra_name,
+            msg,
+        ) from exc
+
+    # Create bedrock client
+    bedrock_client: Any = boto3.client(  # pyright: ignore[reportUnknownVariableType, reportUnknownMemberType]
+        "bedrock",
+        region_name=aws_region,
+        aws_access_key_id=aws_access_key_id,
+        aws_secret_access_key=aws_secret_access_key,
+    )
+
+    # List foundation models
+    response: dict[str, Any] = bedrock_client.list_foundation_models()  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
+
+    return cast("list[dict[str, Any]]", response.get("modelSummaries", []))  # pyright: ignore[reportUnknownArgumentType,reportUnknownMemberType]

--- a/pipelex/plugins/mistral/mistral_llms.py
+++ b/pipelex/plugins/mistral/mistral_llms.py
@@ -5,7 +5,7 @@ from pipelex.plugins.mistral.mistral_exceptions import MistralModelListingError
 from pipelex.plugins.mistral.mistral_factory import MistralFactory
 
 
-def list_mistral_models() -> list[Data]:
+def mistral_list_available_models() -> list[Data]:
     backend = get_models_manager().get_required_inference_backend("mistral")
     mistral_client = MistralFactory.make_mistral_client(backend=backend)
     models_list_response = mistral_client.models.list()

--- a/tests/integration/pipelex/conftest.py
+++ b/tests/integration/pipelex/conftest.py
@@ -26,9 +26,6 @@ def llm_preset_id(request: pytest.FixtureRequest) -> str:
         # "o3-mini",
         # "gpt-5-mini", # TODO: fix this
         # "gpt-5-nano", # TODO: fix this
-        # "claude-3-haiku",
-        # "claude-3-5-sonnet",
-        # "claude-3-7-sonnet",
         # "mistral-large",
         # "ministral-3b",
         # "ministral-8b",
@@ -50,11 +47,9 @@ def llm_preset_id(request: pytest.FixtureRequest) -> str:
         # "gpt-4o-mini",
         # "gpt-5-mini",
         # "gpt-5-chat",
-        "claude-4-sonnet",
+        # "claude-4-sonnet",
         # "claude-4.1-opus",
-        # "claude-3.5-sonnet",
-        # "claude-3.5-sonnet-v2"
-        # "claude-3.7-sonnet",
+        "claude-4.5-sonnet",
         # "grok-3",
         # "grok-3-mini",
         # "base-claude",

--- a/tests/integration/pipelex/plugins/test_anthropic.py
+++ b/tests/integration/pipelex/plugins/test_anthropic.py
@@ -6,7 +6,7 @@ from rich.table import Table
 
 from pipelex.hub import get_models_manager
 from pipelex.plugins.anthropic.anthropic_exceptions import AnthropicSDKUnsupportedError
-from pipelex.plugins.anthropic.anthropic_llms import anthropic_list_anthropic_models
+from pipelex.plugins.anthropic.anthropic_llms import anthropic_list_available_models
 from pipelex.plugins.plugin_sdk_registry import Plugin
 from pipelex.tools.environment import all_env_vars_are_set, any_env_var_is_placeholder
 
@@ -32,7 +32,7 @@ class TestAnthropic:
             pytest.skip(f"Some key(s) among {REQUIRED_ENV_VARS} are a placeholder, can't be used to test listing models")
         try:
             backend = get_models_manager().get_required_inference_backend("anthropic")
-            anthropic_models_list = await anthropic_list_anthropic_models(
+            anthropic_models_list = await anthropic_list_available_models(
                 plugin=plugin_for_anthropic,
                 backend=backend,
             )

--- a/tests/integration/pipelex/plugins/test_mistral.py
+++ b/tests/integration/pipelex/plugins/test_mistral.py
@@ -4,7 +4,7 @@ from rich.console import Console
 from rich.table import Table
 
 from pipelex import pretty_print
-from pipelex.plugins.mistral.mistral_llms import list_mistral_models
+from pipelex.plugins.mistral.mistral_llms import mistral_list_available_models
 from pipelex.tools.environment import all_env_vars_are_set, any_env_var_is_placeholder
 
 REQUIRED_ENV_VARS = ["MISTRAL_API_KEY"]
@@ -21,7 +21,7 @@ class TestMistral:
             pytest.skip(f"Some key(s) missing amongst {REQUIRED_ENV_VARS}")
         if any_env_var_is_placeholder(REQUIRED_ENV_VARS):
             pytest.skip(f"Some key(s) among {REQUIRED_ENV_VARS} are a placeholder, can't be used to test listing models")
-        mistral_models_list = list_mistral_models()
+        mistral_models_list = mistral_list_available_models()
         if pytestconfig.get_verbosity() >= 2:
             # Create and configure the table
             console = Console()
@@ -53,7 +53,7 @@ class TestMistral:
             pytest.skip(f"Some key(s) missing amongst {REQUIRED_ENV_VARS}")
         if any_env_var_is_placeholder(REQUIRED_ENV_VARS):
             pytest.skip(f"Some key(s) among {REQUIRED_ENV_VARS} are a placeholder, can't be used to test listing models")
-        mistral_models_list = list_mistral_models()
+        mistral_models_list = mistral_list_available_models()
         mistral_model_ids = [{"id": model.id, "aliases": model.aliases} for model in mistral_models_list]
         if pytestconfig.get_verbosity() >= 2:
             pretty_print(mistral_model_ids)


### PR DESCRIPTION

 - Added `claude-4.5-sonnet` to the model deck.
 - Added `pipelex show models [BACKEND_NAME]` command to list models for a specific backend.
 - Removed `claude-3.5-sonnet` and `claude-3.5-sonnet-v2` from the model deck.