### PR TITLE
Replace remaining wikipedia URLs (used for tests) by URLs on AWS Clou…

### DIFF
--- a/tests/cases/urls.py
+++ b/tests/cases/urls.py
@@ -7,9 +7,9 @@ class TestURLs:
     """Test URL constants."""
 
     GCP_PUBLIC = "https://storage.googleapis.com/public_test_files_7fa6_4277_9ab/diagrams/gantt_tree_house.png"
-    WIKIPEDIA = "https://upload.wikimedia.org/wikipedia/commons/thumb/e/ec/Olympic_rings_on_the_Eiffel_Tower_2024_%2819%29.jpg/440px-Olympic_rings_on_the_Eiffel_Tower_2024_%2819%29.jpg"
+    AWS_CLOUDFRONT = "https://d2cinlfp2qnig1.cloudfront.net/tests/eiffel_tower.jpg"
 
     PUBLIC_URLS: ClassVar[list[str]] = [
         GCP_PUBLIC,
-        WIKIPEDIA,
+        AWS_CLOUDFRONT,
     ]

--- a/tests/integration/pipelex/cogt/test_data.py
+++ b/tests/integration/pipelex/cogt/test_data.py
@@ -45,7 +45,7 @@ class LLMVisionTestCases:
     VISION_USER_TEXT_2 = "What is this image about?"
     VISION_IMAGES_COMPARE_PROMPT = "Compare these two images"
 
-    URL_WIKIPEDIA_ALAN_TURING = "https://upload.wikimedia.org/wikipedia/commons/thumb/4/40/Alan_Turing_%281912-1954%29_in_1936_at_Princeton_University_%28cropped%29.jpg/440px-Alan_Turing_%281912-1954%29_in_1936_at_Princeton_University_%28cropped%29.jpg"
+    URL_CLOUDFRONT_ALAN_TURING = "https://d2cinlfp2qnig1.cloudfront.net/tests/alan_turing.jpg"
 
     TEST_IMAGE_DIRECTORY = "tests/data/images"
 
@@ -73,7 +73,7 @@ class LLMVisionTestCases:
     IMAGE_URLS: ClassVar[list[tuple[str, str]]] = [  # topic, image_uri
         (
             "Alan Turing",
-            URL_WIKIPEDIA_ALAN_TURING,
+            URL_CLOUDFRONT_ALAN_TURING,
         ),
         (
             "Gantt chart",


### PR DESCRIPTION
- Replace remaining wikipedia URLs (used for tests) by URLs on AWS Cloudfront

