### PR TITLE
Rename SDK for Azure Img Gen & fixes

### DIFF
--- a/.pipelex/inference/backends/azure_openai.toml
+++ b/.pipelex/inference/backends/azure_openai.toml
@@ -122,6 +122,7 @@ costs = { input = 1.25, output = 10.0 }
 
 # --- OpenAI Image Generation --------------------------------------------------
 [gpt-image-1]
+sdk = "azure_rest"
 model_type = "img_gen"
 model_id = "gpt-image-1-2025-04-15"
 inputs = ["text"]

--- a/pipelex/cogt/img_gen/img_gen_worker_factory.py
+++ b/pipelex/cogt/img_gen/img_gen_worker_factory.py
@@ -88,7 +88,7 @@ class ImgGenWorkerFactory:
                     inference_model=inference_model,
                     reporting_delegate=reporting_delegate,
                 )
-            case "azure_openai":
+            case "azure_rest":
                 from pipelex.plugins.azure_rest.azure_img_gen_worker import AzureImgGenWorker  # noqa: PLC0415
 
                 img_gen_worker = AzureImgGenWorker(

--- a/pipelex/cogt/models/model_manager.py
+++ b/pipelex/cogt/models/model_manager.py
@@ -79,7 +79,7 @@ class ModelManager(ModelManagerAbstract):
         all_models_and_possible_backends = self.inference_backend_library.get_all_models_and_possible_backends()
         inference_models: dict[str, InferenceModelSpec] = {}
 
-        for model_name, available_backends in all_models_and_possible_backends.items():
+        for model_name in all_models_and_possible_backends:
             backend_match_for_model = self.routing_profile.get_backend_match_for_model(
                 enabled_backends=enabled_backends,
                 model_name=model_name,
@@ -107,15 +107,15 @@ class ModelManager(ModelManagerAbstract):
                     case BackendMatchingMethod.DEFAULT:
                         # We could not find the model spec, but it was a default match,
                         # so we can look for it in the other available backends
-                        # Use fallback_order if specified, then try remaining enabled backends
+                        # Use fallback_order if specified (fallback is opt-in)
                         if backend_match_for_model.fallback_order:
                             # Try fallback_order first, then any enabled backends not in fallback_order
                             backends_to_try = backend_match_for_model.fallback_order + [
                                 b for b in enabled_backends if b not in backend_match_for_model.fallback_order
                             ]
                         else:
-                            # No fallback_order specified, use all available_backends
-                            backends_to_try = available_backends
+                            # No fallback_order specified, skip this model (fallback is opt-in)
+                            continue
 
                         for available_backend in backends_to_try:
                             if available_backend == matched_backend_name:

--- a/pipelex/kit/configs/inference/backends/azure_openai.toml
+++ b/pipelex/kit/configs/inference/backends/azure_openai.toml
@@ -122,6 +122,7 @@ costs = { input = 1.25, output = 10.0 }
 
 # --- OpenAI Image Generation --------------------------------------------------
 [gpt-image-1]
+sdk = "azure_rest"
 model_type = "img_gen"
 model_id = "gpt-image-1-2025-04-15"
 inputs = ["text"]

--- a/pipelex/plugins/azure_rest/azure_img_gen_worker.py
+++ b/pipelex/plugins/azure_rest/azure_img_gen_worker.py
@@ -30,7 +30,7 @@ class AzureImgGenWorker(ImgGenWorkerAbstract):
     ):
         super().__init__(inference_model=inference_model, reporting_delegate=reporting_delegate)
 
-        if plugin.sdk != "azure_openai":
+        if plugin.sdk != "azure_rest":
             msg = f"Plugin '{plugin}' is not supported for image generation"
             raise NotImplementedError(msg)
         self.plugin = plugin

--- a/pipelex/system/configuration/config_loader.py
+++ b/pipelex/system/configuration/config_loader.py
@@ -5,7 +5,7 @@ from pipelex.system.configuration.config_root import (
     CONFIG_BASE_OVERRIDES_AFTER_ENV,
     CONFIG_BASE_OVERRIDES_BEFORE_ENV,
 )
-from pipelex.system.runtime import runtime_manager
+from pipelex.system.runtime import RunMode, runtime_manager
 from pipelex.tools.misc.json_utils import deep_update
 from pipelex.tools.misc.toml_utils import load_toml_from_path, load_toml_from_path_if_exists
 
@@ -96,20 +96,23 @@ class ConfigLoader:
                 deep_update(pipelex_config, local_config)
 
         #################### 3. Load overrides for the current project ####################
-        list_of_overrides = [
+        list_of_overrides: list[str] = [
             *CONFIG_BASE_OVERRIDES_BEFORE_ENV,
             runtime_manager.environment,
             runtime_manager.run_mode,
             *CONFIG_BASE_OVERRIDES_AFTER_ENV,
         ]
         for override in list_of_overrides:
-            if override:
-                if override == runtime_manager.run_mode.UNIT_TEST:
-                    override_path = os.path.join(os.getcwd(), "tests", f"pipelex_{override}.toml")
-                else:
-                    override_path = os.path.join(os.getcwd(), "pipelex" if self.is_in_pipelex_config else "", f"pipelex_{override}.toml")
-                if override_dict := load_toml_from_path_if_exists(override_path):
-                    deep_update(pipelex_config, override_dict)
+            if override == runtime_manager.run_mode:
+                match runtime_manager.run_mode:
+                    case RunMode.NORMAL:
+                        continue
+                    case RunMode.UNIT_TEST | RunMode.CI_TEST:
+                        override_path = os.path.join(os.getcwd(), "tests", f"pipelex_{override}.toml")
+            else:
+                override_path = os.path.join(os.getcwd(), "pipelex" if self.is_in_pipelex_config else "", f"pipelex_{override}.toml")
+            if override_dict := load_toml_from_path_if_exists(override_path):
+                deep_update(pipelex_config, override_dict)
 
         return pipelex_config
 

--- a/tests/pipelex_unit_test.toml
+++ b/tests/pipelex_unit_test.toml
@@ -1,4 +1,7 @@
 
+[cogt.model_deck_config]
+# Allow tests to run with restrictive routing profiles that don't support all presets
+missing_presets_reaction = "none"
+
 [pipelex.feature_config]
 is_reporting_enabled = true
-


### PR DESCRIPTION
- Rename SDK for Azure Img Gen
- Restrict Backend fallback to only kick in if opted-in
- fix unit test config override
- unit test now tolerate unavailable models fin the deck
