### PR TITLE
Add GPT-5.1, Claude 4.5 Opus and Gemini 3 Preview

### DIFF
--- a/.pipelex/inference/backends/anthropic.toml
+++ b/.pipelex/inference/backends/anthropic.toml
@@ -98,3 +98,11 @@ inputs = ["text", "images"]
 outputs = ["text", "structured"]
 max_prompt_images = 100
 costs = { input = 1.0, output = 5.0 }
+
+["claude-4.5-opus"]
+model_id = "claude-opus-4-5-20251101"
+max_tokens = 32000
+inputs = ["text", "images"]
+outputs = ["text", "structured"]
+max_prompt_images = 100
+costs = { input = 5.0, output = 25.0 }

--- a/.pipelex/inference/backends/azure_openai.toml
+++ b/.pipelex/inference/backends/azure_openai.toml
@@ -120,6 +120,21 @@ outputs = ["text", "structured"]
 costs = { input = 1.25, output = 10.0 }
 constraints = ["temperature_must_be_1"]
 
+# --- GPT-5.1 Series -------------------------------------------------------------
+["gpt-5.1"]
+model_id = "gpt-5.1-2025-11-13"
+inputs = ["text", "images"]
+outputs = ["text", "structured"]
+costs = { input = 1.25, output = 10.0 }
+constraints = ["temperature_must_be_1"]
+
+["gpt-5.1-chat"]
+model_id = "gpt-5.1-chat-2025-11-13"
+inputs = ["text", "images"]
+outputs = ["text", "structured"]
+costs = { input = 1.25, output = 10.0 }
+constraints = ["temperature_must_be_1"]
+
 ################################################################################
 # IMAGE GENERATION MODELS
 ################################################################################

--- a/.pipelex/inference/backends/bedrock.toml
+++ b/.pipelex/inference/backends/bedrock.toml
@@ -109,3 +109,12 @@ inputs = ["text", "images"]
 outputs = ["text", "structured"]
 max_prompt_images = 100
 costs = { input = 1.0, output = 5.0 }
+
+["claude-4.5-opus"]
+sdk = "bedrock_anthropic"
+model_id = "global.anthropic.claude-opus-4-5-20251101-v1:0"
+max_tokens = 8192
+inputs = ["text", "images"]
+outputs = ["text", "structured"]
+max_prompt_images = 100
+costs = { input = 5.0, output = 25.0 }

--- a/.pipelex/inference/backends/google.toml
+++ b/.pipelex/inference/backends/google.toml
@@ -59,3 +59,11 @@ inputs = ["text", "images"]
 outputs = ["text", "structured"]
 max_prompt_images = 3000
 costs = { input = 0.10, output = 0.40 }
+
+# --- Gemini 3.0 Series ----------------------------------------
+["gemini-3.0-pro"]
+model_id = "gemini-3-pro-preview"
+inputs = ["text", "images"]
+outputs = ["text", "structured"]
+max_prompt_images = 3000
+costs = { input = 2, output = 12.0 }

--- a/.pipelex/inference/backends/openai.toml
+++ b/.pipelex/inference/backends/openai.toml
@@ -157,6 +157,13 @@ outputs = ["text"]
 costs = { input = 1.25, output = 10.0 }
 constraints = ["temperature_must_be_1"]
 
+# --- GPT-5.1 Series -------------------------------------------------------------
+["gpt-5.1"]
+model_id = "gpt-5.1"
+inputs = ["text", "images"]
+outputs = ["text", "structured"]
+costs = { input = 1.25, output = 10.0 }
+
 ################################################################################
 # IMAGE GENERATION MODELS
 ################################################################################

--- a/.pipelex/inference/backends/pipelex_inference.toml
+++ b/.pipelex/inference/backends/pipelex_inference.toml
@@ -85,6 +85,18 @@ inputs = ["text", "images"]
 outputs = ["text"]
 costs = { input = 1.25, output = 10.00 }
 
+["gpt-5.1"]
+model_id = "pipelex/gpt-5.1"
+inputs = ["text", "images"]
+outputs = ["text", "structured"]
+costs = { input = 1.25, output = 10.00 }
+
+["gpt-5.1-chat"]
+model_id = "pipelex/gpt-5.1-chat"
+inputs = ["text", "images"]
+outputs = ["text", "structured"]
+costs = { input = 1.25, output = 10.00 }
+
 # --- Claude LLMs --------------------------------------------------------------
 ["claude-4-sonnet"]
 model_id = "pipelex/claude-4-sonnet"
@@ -110,31 +122,44 @@ inputs = ["text", "images"]
 outputs = ["text", "structured"]
 costs = { input = 1, output = 5 }
 
+["claude-4.5-opus"]
+model_id = "pipelex/claude-4.5-opus"
+inputs = ["text", "images"]
+outputs = ["text", "structured"]
+costs = { input = 5, output = 25 }
+
 # --- Gemini LLMs --------------------------------------------------------------
 ["gemini-2.0-flash"]
-model_id = "gemini/gemini-2.0-flash"
+model_id = "pipelex/gemini-2.0-flash"
 inputs = ["text", "images"]
 outputs = ["text", "structured"]
 costs = { input = 0.10, output = 0.40 }
 
 ["gemini-2.5-pro"]
-model_id = "gemini/gemini-2.5-pro"
+model_id = "pipelex/gemini-2.5-pro"
 inputs = ["text", "images"]
 outputs = ["text", "structured"]
 max_prompt_images = 3000
 costs = { input = 1.25, output = 10.0 }
 
 ["gemini-2.5-flash"]
-model_id = "gemini/gemini-2.5-flash"
+model_id = "pipelex/gemini-2.5-flash"
 inputs = ["text", "images"]
 outputs = ["text", "structured"]
 costs = { input = 0.30, output = 2.50 }
 
 ["gemini-2.5-flash-lite"]
-model_id = "gemini/gemini-2.5-flash-lite"
+model_id = "pipelex/gemini-2.5-flash-lite"
 inputs = ["text", "images"]
 outputs = ["text", "structured"]
 costs = { input = 0.10, output = 0.40 }
+
+["gemini-3.0-pro"]
+model_id = "pipelex/gemini-3.0-pro"
+inputs = ["text", "images"]
+outputs = ["text", "structured"]
+max_prompt_images = 3000
+costs = { input = 2, output = 12.0 }
 
 # --- XAI LLMs --------------------------------------------------------------
 

--- a/pipelex/kit/configs/inference/backends/anthropic.toml
+++ b/pipelex/kit/configs/inference/backends/anthropic.toml
@@ -98,3 +98,11 @@ inputs = ["text", "images"]
 outputs = ["text", "structured"]
 max_prompt_images = 100
 costs = { input = 1.0, output = 5.0 }
+
+["claude-4.5-opus"]
+model_id = "claude-opus-4-5-20251101"
+max_tokens = 32000
+inputs = ["text", "images"]
+outputs = ["text", "structured"]
+max_prompt_images = 100
+costs = { input = 5.0, output = 25.0 }

--- a/pipelex/kit/configs/inference/backends/azure_openai.toml
+++ b/pipelex/kit/configs/inference/backends/azure_openai.toml
@@ -120,6 +120,21 @@ outputs = ["text", "structured"]
 costs = { input = 1.25, output = 10.0 }
 constraints = ["temperature_must_be_1"]
 
+# --- GPT-5.1 Series -------------------------------------------------------------
+["gpt-5.1"]
+model_id = "gpt-5.1-2025-11-13"
+inputs = ["text", "images"]
+outputs = ["text", "structured"]
+costs = { input = 1.25, output = 10.0 }
+constraints = ["temperature_must_be_1"]
+
+["gpt-5.1-chat"]
+model_id = "gpt-5.1-chat-2025-11-13"
+inputs = ["text", "images"]
+outputs = ["text", "structured"]
+costs = { input = 1.25, output = 10.0 }
+constraints = ["temperature_must_be_1"]
+
 ################################################################################
 # IMAGE GENERATION MODELS
 ################################################################################

--- a/pipelex/kit/configs/inference/backends/bedrock.toml
+++ b/pipelex/kit/configs/inference/backends/bedrock.toml
@@ -109,3 +109,12 @@ inputs = ["text", "images"]
 outputs = ["text", "structured"]
 max_prompt_images = 100
 costs = { input = 1.0, output = 5.0 }
+
+["claude-4.5-opus"]
+sdk = "bedrock_anthropic"
+model_id = "global.anthropic.claude-opus-4-5-20251101-v1:0"
+max_tokens = 8192
+inputs = ["text", "images"]
+outputs = ["text", "structured"]
+max_prompt_images = 100
+costs = { input = 5.0, output = 25.0 }

--- a/pipelex/kit/configs/inference/backends/google.toml
+++ b/pipelex/kit/configs/inference/backends/google.toml
@@ -59,3 +59,11 @@ inputs = ["text", "images"]
 outputs = ["text", "structured"]
 max_prompt_images = 3000
 costs = { input = 0.10, output = 0.40 }
+
+# --- Gemini 3.0 Series ----------------------------------------
+["gemini-3.0-pro"]
+model_id = "gemini-3-pro-preview"
+inputs = ["text", "images"]
+outputs = ["text", "structured"]
+max_prompt_images = 3000
+costs = { input = 2, output = 12.0 }

--- a/pipelex/kit/configs/inference/backends/openai.toml
+++ b/pipelex/kit/configs/inference/backends/openai.toml
@@ -157,6 +157,13 @@ outputs = ["text"]
 costs = { input = 1.25, output = 10.0 }
 constraints = ["temperature_must_be_1"]
 
+# --- GPT-5.1 Series -------------------------------------------------------------
+["gpt-5.1"]
+model_id = "gpt-5.1"
+inputs = ["text", "images"]
+outputs = ["text", "structured"]
+costs = { input = 1.25, output = 10.0 }
+
 ################################################################################
 # IMAGE GENERATION MODELS
 ################################################################################

--- a/pipelex/kit/configs/inference/backends/pipelex_inference.toml
+++ b/pipelex/kit/configs/inference/backends/pipelex_inference.toml
@@ -85,6 +85,18 @@ inputs = ["text", "images"]
 outputs = ["text"]
 costs = { input = 1.25, output = 10.00 }
 
+["gpt-5.1"]
+model_id = "pipelex/gpt-5.1"
+inputs = ["text", "images"]
+outputs = ["text", "structured"]
+costs = { input = 1.25, output = 10.00 }
+
+["gpt-5.1-chat"]
+model_id = "pipelex/gpt-5.1-chat"
+inputs = ["text", "images"]
+outputs = ["text", "structured"]
+costs = { input = 1.25, output = 10.00 }
+
 # --- Claude LLMs --------------------------------------------------------------
 ["claude-4-sonnet"]
 model_id = "pipelex/claude-4-sonnet"
@@ -110,31 +122,44 @@ inputs = ["text", "images"]
 outputs = ["text", "structured"]
 costs = { input = 1, output = 5 }
 
+["claude-4.5-opus"]
+model_id = "pipelex/claude-4.5-opus"
+inputs = ["text", "images"]
+outputs = ["text", "structured"]
+costs = { input = 5, output = 25 }
+
 # --- Gemini LLMs --------------------------------------------------------------
 ["gemini-2.0-flash"]
-model_id = "gemini/gemini-2.0-flash"
+model_id = "pipelex/gemini-2.0-flash"
 inputs = ["text", "images"]
 outputs = ["text", "structured"]
 costs = { input = 0.10, output = 0.40 }
 
 ["gemini-2.5-pro"]
-model_id = "gemini/gemini-2.5-pro"
+model_id = "pipelex/gemini-2.5-pro"
 inputs = ["text", "images"]
 outputs = ["text", "structured"]
 max_prompt_images = 3000
 costs = { input = 1.25, output = 10.0 }
 
 ["gemini-2.5-flash"]
-model_id = "gemini/gemini-2.5-flash"
+model_id = "pipelex/gemini-2.5-flash"
 inputs = ["text", "images"]
 outputs = ["text", "structured"]
 costs = { input = 0.30, output = 2.50 }
 
 ["gemini-2.5-flash-lite"]
-model_id = "gemini/gemini-2.5-flash-lite"
+model_id = "pipelex/gemini-2.5-flash-lite"
 inputs = ["text", "images"]
 outputs = ["text", "structured"]
 costs = { input = 0.10, output = 0.40 }
+
+["gemini-3.0-pro"]
+model_id = "pipelex/gemini-3.0-pro"
+inputs = ["text", "images"]
+outputs = ["text", "structured"]
+max_prompt_images = 3000
+costs = { input = 2, output = 12.0 }
 
 # --- XAI LLMs --------------------------------------------------------------
 

--- a/pipelex/plugins/anthropic/anthropic_factory.py
+++ b/pipelex/plugins/anthropic/anthropic_factory.py
@@ -9,7 +9,6 @@ from openai.types.chat import (
     ChatCompletionSystemMessageParam,
 )
 
-from pipelex import log
 from pipelex.cogt.exceptions import CogtError
 from pipelex.cogt.image.prompt_image import (
     PromptImage,
@@ -130,7 +129,6 @@ class AnthropicFactory:
         text_block_param: TextBlockParam = {"type": "text", "text": user_content_txt}
         message: MessageParam
         if prepped_user_images is not None:
-            log.verbose(prepped_user_images)
             images_block_params: list[ImageBlockParam] = []
             for prepped_image in prepped_user_images:
                 image_block_param_in_loop: ImageBlockParam

--- a/tests/integration/pipelex/cogt/test_data.py
+++ b/tests/integration/pipelex/cogt/test_data.py
@@ -90,6 +90,7 @@ class LLMVisionTestCases:
 
 class LLMTestConstants:
     USER_TEXT_SHORT = "In one sentence, who is Bill Gates?"
+    USER_TEXT_TO_EXTRACT_PERSON = "It's Robert, the nice plumber, he turns 57 next week."
     # USER_TEXT_SHORT = "What's the biggest football match tonight in Europe?"
     PROMPT_TEMPLATE_TEXT = "Can you give one example of flower which is {color} in color ?"
     PROMPT_COLOR_EXAMPLES: ClassVar[list[str]] = [

--- a/tests/integration/pipelex/cogt/test_llm_inference.py
+++ b/tests/integration/pipelex/cogt/test_llm_inference.py
@@ -40,7 +40,7 @@ class TestLLMInference:
         llm_job = LLMJobFactory.make_llm_job(
             llm_prompt=LLMPrompt(
                 system_text=None,
-                user_text=LLMTestConstants.USER_TEXT_SHORT,
+                user_text=LLMTestConstants.USER_TEXT_TO_EXTRACT_PERSON,
             ),
             llm_job_params=llm_job_params,
         )

--- a/tests/integration/pipelex/fixtures/llm_fixtures.py
+++ b/tests/integration/pipelex/fixtures/llm_fixtures.py
@@ -63,6 +63,7 @@ ANTHROPIC_MODELS = [
     "claude-4.5-haiku",
     "claude-4.5-sonnet",
     "claude-opus-4",
+    "claude-4.5-opus",
 ]
 
 # --- DeepSeek Models ----------------------------------------------------------------------------
@@ -78,6 +79,7 @@ GOOGLE_MODELS = [
     "gemini-2.5-flash-lite",
     "gemini-2.5-pro",
     "gemini-flash-1.5-8b",
+    "gemini-3.0-pro",
 ]
 
 # --- Groq Models --------------------------------------------------------------------------------
@@ -138,6 +140,8 @@ OPENAI_MODELS = [
     "gpt-5-chat",
     "gpt-5-mini",
     "gpt-5-nano",
+    "gpt-5.1",
+    "gpt-5.1-chat",
     "o1",
     "o1-mini",
     "o3",


### PR DESCRIPTION
- Add GPT-5.1, Claude 4.5 Opus and Gemini 3 Preview

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds GPT-5.1 (+chat), Claude 4.5 Opus, and Gemini 3.0 Pro preview across OpenAI/Azure, Anthropic/Bedrock, Google, and Pipelex backends, with tests and fixtures updated.
> 
> - **Model additions/updates**
>   - **OpenAI/Azure**: Add `gpt-5.1` and `gpt-5.1-chat` in `openai.toml`, `azure_openai.toml` and kit configs.
>   - **Anthropic/Bedrock**: Add `claude-4.5-opus` to `.pipelex` and kit configs.
>   - **Google**: Add `gemini-3.0-pro` (preview) to `google.toml` and kit configs.
>   - **Pipelex Inference**: Add `gpt-5.1`, `gpt-5.1-chat`, `claude-4.5-opus`, `gemini-3.0-pro`; normalize Gemini model_ids to `pipelex/...`.
> - **Tests**
>   - Update fixtures to include new models (`gpt-5.1`, `gpt-5.1-chat`, `claude-4.5-opus`, `gemini-3.0-pro`).
>   - Add `USER_TEXT_TO_EXTRACT_PERSON` and use it in `test_simple_gen_object_from_text`.
> - **Plugin cleanup**
>   - Remove unused logging in `anthropic_factory.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 95364761c5da3ee94e764252c2f3518760a5d12c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->