### PR TITLE
fix/remove-pyproject.toml-from-build

### DIFF
--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - main
-      - "release/v[0-9]+.[0-9]+.[0-9]+"
 jobs:
   version-check:
     runs-on: ubuntu-latest
@@ -24,17 +23,6 @@ jobs:
           echo "base_branch=$BASE_BRANCH" >> $GITHUB_OUTPUT
           echo "source_branch=$SOURCE_BRANCH" >> $GITHUB_OUTPUT
           
-          # Check if target is a release branch
-          if [[ "$BASE_BRANCH" =~ ^release/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Target is a release branch"
-            echo "is_release_target=true" >> $GITHUB_OUTPUT
-            echo "target_release_version=${BASE_BRANCH#release/v}" >> $GITHUB_OUTPUT
-            echo "Extracted target release version: ${BASE_BRANCH#release/v}"
-          else
-            echo "Target is NOT a release branch"
-            echo "is_release_target=false" >> $GITHUB_OUTPUT
-          fi
-          
           # Check if source is a release branch
           if [[ "$SOURCE_BRANCH" =~ ^release/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Source is a release branch"
@@ -42,8 +30,10 @@ jobs:
             echo "source_release_version=${SOURCE_BRANCH#release/v}" >> $GITHUB_OUTPUT
             echo "Extracted source release version: ${SOURCE_BRANCH#release/v}"
           else
-            echo "Source is NOT a release branch"
+            echo "Source is NOT a release branch - skipping version check"
             echo "is_release_source=false" >> $GITHUB_OUTPUT
+            echo "This workflow only runs for PRs from release branches to main"
+            exit 0
           fi
           echo "======================================="
 
@@ -61,74 +51,24 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "======================================="
 
-      # MAIN BRANCH CASE - Check that version is bumped
-      - name: Check version bump for main branch
-        if: steps.branch_info.outputs.base_branch == 'main'
+      # Check that version in pyproject.toml matches the source release branch name
+      - name: Check version matches release branch
         run: |
-          echo "====== CHECKING VERSION BUMP FOR MAIN ======"
-          # Get version from main branch
-          git checkout ${{ github.event.pull_request.base.ref }}
-          MAIN_VERSION=$(grep '^version' pyproject.toml | sed -E 's/version = "(.*)"/\1/')
-          
-          # Get version from PR branch
-          git checkout ${{ github.event.pull_request.head.sha }}
-          PR_VERSION="${{ steps.current_version.outputs.version }}"
-          
-          echo "Main version: $MAIN_VERSION"
-          echo "PR version: $PR_VERSION"
-          
-          # Check that PR version is greater than main version
-          if dpkg --compare-versions "$PR_VERSION" le "$MAIN_VERSION"; then
-            echo "❌ ERROR: PR version ($PR_VERSION) is not greater than main version ($MAIN_VERSION)."
-            echo "Please bump the version."
-            exit 1
-          else
-            echo "✅ Version was properly bumped from $MAIN_VERSION to $PR_VERSION"
-          fi
-          echo "======================================="
-
-      # TARGET RELEASE BRANCH CASE - Check that version matches release branch name
-      - name: Check version matches target release branch
-        if: steps.branch_info.outputs.is_release_target == 'true'
-        run: |
-          echo "====== CHECKING VERSION MATCH FOR TARGET RELEASE BRANCH ======"
-          # Extract version from branch name
-          RELEASE_VERSION="${{ steps.branch_info.outputs.target_release_version }}"
-          
-          # Get version from PR branch
-          PR_VERSION="${{ steps.current_version.outputs.version }}"
-          
-          echo "Target release branch version: $RELEASE_VERSION"
-          echo "PR version: $PR_VERSION"
-          
-          # Check if versions match
-          if [[ "$PR_VERSION" != "$RELEASE_VERSION" ]]; then
-            echo "❌ ERROR: Version in pyproject.toml ($PR_VERSION) does not match target release branch version ($RELEASE_VERSION)"
-            exit 1
-          else
-            echo "✅ Version in pyproject.toml matches target release branch version"
-          fi
-          echo "======================================="
-          
-      # SOURCE RELEASE BRANCH CASE - Check that version matches release branch name
-      - name: Check version matches source release branch
-        if: steps.branch_info.outputs.is_release_source == 'true'
-        run: |
-          echo "====== CHECKING VERSION MATCH FOR SOURCE RELEASE BRANCH ======"
+          echo "====== CHECKING VERSION MATCH FOR RELEASE BRANCH ======"
           # Extract version from branch name
           RELEASE_VERSION="${{ steps.branch_info.outputs.source_release_version }}"
           
           # Get version from PR branch
           PR_VERSION="${{ steps.current_version.outputs.version }}"
           
-          echo "Source release branch version: $RELEASE_VERSION"
-          echo "PR version: $PR_VERSION"
+          echo "Release branch version: $RELEASE_VERSION"
+          echo "pyproject.toml version: $PR_VERSION"
           
           # Check if versions match
           if [[ "$PR_VERSION" != "$RELEASE_VERSION" ]]; then
-            echo "❌ ERROR: Version in pyproject.toml ($PR_VERSION) does not match source release branch version ($RELEASE_VERSION)"
+            echo "❌ ERROR: Version in pyproject.toml ($PR_VERSION) does not match release branch version ($RELEASE_VERSION)"
             exit 1
           else
-            echo "✅ Version in pyproject.toml matches source release branch version"
+            echo "✅ Version in pyproject.toml ($PR_VERSION) matches release branch version ($RELEASE_VERSION)"
           fi
           echo "======================================="

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### Unreleased
+
+### Changed
+
+- Modified the GHA `version-check.yml` so that the check of the version is only applying to release branches.
+- Removed the `pyproject.toml` file from the build.
+
 ## [v0.16.0] - 2025-11-25
 
 **Highlights:** - Library manager now supports multiple libraries. You can now have multiple libraries in your project, each with its own set of concepts, pipes, and stuffs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -372,15 +372,10 @@ required-version = ">=0.7.2"
 packages = ["pipelex"]
 exclude = ["pipelex/cli/dev_cli"]
 
-[tool.hatch.build.targets.wheel.force-include]
-"pyproject.toml" = "pipelex/pyproject.toml"
 
 [tool.hatch.build.targets.sdist]
 packages = ["pipelex"]
 exclude = ["pipelex/cli/dev_cli"]
-
-[tool.hatch.build.targets.sdist.force-include]
-"pyproject.toml" = "pipelex/pyproject.toml"
 
 [tool.hatch.metadata]
 allow-direct-references = true


### PR DESCRIPTION
### Unreleased

### Changed

- Modified the GHA `version-check.yml` so that the check of the version is only applying to release branches.
- Removed the `pyproject.toml` file from the build.