### PR TITLE
Fix/fetch remote config vs pytest

### DIFF
--- a/pipelex/system/pipelex_service/pipelex_details.py
+++ b/pipelex/system/pipelex_service/pipelex_details.py
@@ -2,7 +2,7 @@ from pipelex.tools.misc.hash_utils import hash_sha256
 
 
 class PipelexDetails:
-    REMOTE_CONFIG_URL = "https://pipelex-config.s3.amazonaws.com/pipelex_remote_config_01.json"
+    REMOTE_CONFIG_URL = "https://pipelex-config.s3.eu-west-3.amazonaws.com/pipelex_remote_config_01.json"
     PIPELEX_GATEWAY_API_KEY_VAR = "PIPELEX_GATEWAY_API_KEY"
 
     @classmethod

--- a/pipelex/system/pipelex_service/remote_config_fetcher.py
+++ b/pipelex/system/pipelex_service/remote_config_fetcher.py
@@ -9,6 +9,7 @@ from pipelex.system.pipelex_service.exceptions import (
 )
 from pipelex.system.pipelex_service.pipelex_details import PipelexDetails
 from pipelex.system.pipelex_service.remote_config import RemoteConfig
+from pipelex.tools.misc.terminal_utils import print_to_stderr
 from pipelex.tools.typing.pydantic_utils import format_pydantic_validation_error
 
 
@@ -27,7 +28,7 @@ class RemoteConfigFetcher:
     def _log_retry_attempt(cls, retry_state: RetryCallState) -> None:
         """Log retry attempts for remote config fetch."""
         exc = retry_state.outcome.exception() if retry_state.outcome else None
-        log.verbose(f"Remote config fetch attempt {retry_state.attempt_number} failed: {exc}. Retrying...")
+        print_to_stderr(f"Remote config fetch attempt {retry_state.attempt_number} failed: {exc}. Retrying...")
 
     @classmethod
     def _fetch_remote_config_with_retry(cls, url: str) -> httpx.Response:
@@ -73,6 +74,7 @@ class RemoteConfigFetcher:
         url = PipelexDetails.REMOTE_CONFIG_URL
 
         try:
+            print("Fetching remote configuration")
             response = cls._fetch_remote_config_with_retry(url)
         except httpx.TimeoutException as exc:
             msg = f"Timeout while fetching remote configuration from {url}: {exc}"

--- a/pipelex/system/pipelex_service/remote_config_fetcher.py
+++ b/pipelex/system/pipelex_service/remote_config_fetcher.py
@@ -73,7 +73,6 @@ class RemoteConfigFetcher:
         url = PipelexDetails.REMOTE_CONFIG_URL
 
         try:
-            print("Fetching remote configuration")
             response = cls._fetch_remote_config_with_retry(url)
         except httpx.TimeoutException as exc:
             msg = f"Timeout while fetching remote configuration from {url}: {exc}"

--- a/pipelex/system/pipelex_service/remote_config_fetcher.py
+++ b/pipelex/system/pipelex_service/remote_config_fetcher.py
@@ -2,7 +2,6 @@ import httpx
 from pydantic import ValidationError
 from tenacity import RetryCallState, retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
-from pipelex import log
 from pipelex.system.pipelex_service.exceptions import (
     RemoteConfigFetchError,
     RemoteConfigValidationError,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,10 +2,13 @@ from collections.abc import Callable, Generator
 from pathlib import Path
 
 import pytest
+from pytest_mock import MockerFixture
 
 from pipelex import log
 from pipelex.hub import get_library_manager, set_current_library
 from pipelex.pipelex import Pipelex
+from pipelex.system.pipelex_service.remote_config import RemoteConfig
+from pipelex.system.pipelex_service.remote_config_fetcher import RemoteConfigFetcher
 from pipelex.system.runtime import IntegrationMode, runtime_manager
 
 pytest_plugins = [
@@ -13,6 +16,23 @@ pytest_plugins = [
 ]
 
 TEST_OUTPUTS_DIR = "temp/test_outputs"
+
+# Session-level cache for remote config (using dict to avoid global statement)
+_remote_config_cache: dict[str, RemoteConfig] = {}
+_original_fetch_remote_config = RemoteConfigFetcher.fetch_remote_config
+
+
+def _cached_fetch_remote_config() -> RemoteConfig:
+    """Wrapper that caches the remote config for the entire test session."""
+    if "config" not in _remote_config_cache:
+        _remote_config_cache["config"] = _original_fetch_remote_config()
+    return _remote_config_cache["config"]
+
+
+@pytest.fixture(scope="session", autouse=True)
+def cache_remote_config_for_session(session_mocker: MockerFixture):
+    """Cache remote configuration for the entire test session to avoid repeated fetches."""
+    session_mocker.patch.object(RemoteConfigFetcher, "fetch_remote_config", _cached_fetch_remote_config)
 
 
 def _get_test_integration_mode() -> IntegrationMode:


### PR DESCRIPTION
- fetch remote config cache during test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Caches remote config for the test session, switches the remote config URL to an EU region S3 bucket, and prints retry logs to stderr.
> 
> - **Tests**:
>   - Cache `RemoteConfig` for the entire session by patching `RemoteConfigFetcher.fetch_remote_config` via an autouse session fixture (uses `pytest-mock`).
> - **Service**:
>   - Update `PipelexDetails.REMOTE_CONFIG_URL` to `https://pipelex-config.s3.eu-west-3.amazonaws.com/pipelex_remote_config_01.json`.
>   - Log remote config fetch retries to stderr via `print_to_stderr` in `RemoteConfigFetcher`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 50bdeaa60b0accfb1722299e3f96f7a373336354. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->