### PR TITLE
Fix: Preserve ImageContent Metadata

### DIFF
--- a/pipelex/cogt/content_generation/content_generator.py
+++ b/pipelex/cogt/content_generation/content_generator.py
@@ -207,12 +207,17 @@ class ContentGenerator(ContentGeneratorProtocol):
         self,
         job_metadata: JobMetadata,
         generated_image_raw_details: GeneratedImageRawDetails,
+        img_gen_prompt: ImgGenPrompt | None,
     ) -> ImageContent:
-        return await self._generated_content_factory.make_image_content(
+        image_content = await self._generated_content_factory.make_image_content(
             primary_id=job_metadata.user_id,
             secondary_id=job_metadata.pipeline_run_id,
             raw_details=generated_image_raw_details,
         )
+        if img_gen_prompt:
+            image_content.source_prompt = img_gen_prompt.positive_text
+            image_content.source_negative_prompt = img_gen_prompt.negative_text
+        return image_content
 
     @override
     async def make_page_contents(
@@ -237,18 +242,21 @@ class ContentGenerator(ContentGeneratorProtocol):
         img_gen_job_config: ImgGenJobConfig | None = None,
     ) -> ImageContent:
         img_gen_config = get_config().cogt.img_gen_config
+        img_gen_job_params = img_gen_job_params or img_gen_config.make_default_img_gen_job_params()
+        img_gen_job_config = img_gen_job_config or img_gen_config.img_gen_job_config
         img_gen_assignment = ImgGenAssignment(
             job_metadata=job_metadata,
             img_gen_handle=img_gen_handle,
             img_gen_prompt=img_gen_prompt,
-            img_gen_job_params=img_gen_job_params or img_gen_config.make_default_img_gen_job_params(),
-            img_gen_job_config=img_gen_job_config or img_gen_config.img_gen_job_config,
+            img_gen_job_params=img_gen_job_params,
+            img_gen_job_config=img_gen_job_config,
             nb_images=1,
         )
         generated_image_raw_details = await img_gen_single_image(img_gen_assignment=img_gen_assignment)
         log.verbose(f"{self.__class__.__name__} generated image raw details: {generated_image_raw_details}")
         return await self.make_image_content(
             job_metadata=job_metadata,
+            img_gen_prompt=img_gen_prompt,
             generated_image_raw_details=generated_image_raw_details,
         )
 
@@ -278,6 +286,7 @@ class ContentGenerator(ContentGeneratorProtocol):
             await self.make_image_content(
                 job_metadata=job_metadata,
                 generated_image_raw_details=raw_details,
+                img_gen_prompt=img_gen_prompt,
             )
             for raw_details in generated_images_as_raw_details
         ]
@@ -321,6 +330,7 @@ class ContentGenerator(ContentGeneratorProtocol):
                     pil_image=page_view_image,
                     output_format=ImageFormat.PNG,
                 ),
+                img_gen_prompt=None,
             )
             page_view_images_resolved.append(image_content)
 

--- a/pipelex/cogt/content_generation/content_generator_dry.py
+++ b/pipelex/cogt/content_generation/content_generator_dry.py
@@ -152,6 +152,7 @@ class ContentGeneratorDry(ContentGeneratorProtocol):
         self,
         job_metadata: JobMetadata,
         generated_image_raw_details: GeneratedImageRawDetails,
+        img_gen_prompt: ImgGenPrompt | None,
     ) -> ImageContent:
         return self._make_generated_image_fake(raw_details=generated_image_raw_details)
 
@@ -169,6 +170,7 @@ class ContentGeneratorDry(ContentGeneratorProtocol):
                 image_content = await self.make_image_content(
                     job_metadata=job_metadata,
                     generated_image_raw_details=extracted_image,
+                    img_gen_prompt=None,
                 )
                 page_images.append(image_content)
             page_contents.append(

--- a/pipelex/cogt/content_generation/content_generator_dry.py
+++ b/pipelex/cogt/content_generation/content_generator_dry.py
@@ -154,7 +154,11 @@ class ContentGeneratorDry(ContentGeneratorProtocol):
         generated_image_raw_details: GeneratedImageRawDetails,
         img_gen_prompt: ImgGenPrompt | None,
     ) -> ImageContent:
-        return self._make_generated_image_fake(raw_details=generated_image_raw_details)
+        image_content = self._make_generated_image_fake(raw_details=generated_image_raw_details)
+        if img_gen_prompt:
+            image_content.source_prompt = img_gen_prompt.positive_text
+            image_content.source_negative_prompt = img_gen_prompt.negative_text
+        return image_content
 
     @override
     async def make_page_contents(
@@ -197,12 +201,14 @@ class ContentGeneratorDry(ContentGeneratorProtocol):
         log.verbose(f"🤡 DRY RUN: {self.__class__.__name__}.{func_name}")
         image_urls = get_config().pipelex.dry_run_config.image_urls
         image_url = image_urls[0]
-        return self._make_generated_image_fake(
-            raw_details=GeneratedImageRawDetails(
+        return await self.make_image_content(
+            job_metadata=job_metadata,
+            generated_image_raw_details=GeneratedImageRawDetails(
                 actual_url=image_url,
                 size=ImageSize(width=1024, height=1024),
                 mime_type="image/jpeg",
             ),
+            img_gen_prompt=img_gen_prompt,
         )
 
     @override
@@ -219,16 +225,19 @@ class ContentGeneratorDry(ContentGeneratorProtocol):
         func_name = "make_image_list"
         log.verbose(f"🤡 DRY RUN: {self.__class__.__name__}.{func_name}")
         image_urls = get_config().pipelex.dry_run_config.image_urls
-        return [
-            self._make_generated_image_fake(
-                raw_details=GeneratedImageRawDetails(
+        image_contents: list[ImageContent] = []
+        for image_index in range(nb_images):
+            image_content = await self.make_image_content(
+                job_metadata=job_metadata,
+                generated_image_raw_details=GeneratedImageRawDetails(
                     actual_url=image_urls[image_index % len(image_urls)],
                     size=ImageSize(width=1024, height=1024),
                     mime_type="image/jpeg",
                 ),
+                img_gen_prompt=img_gen_prompt,
             )
-            for image_index in range(nb_images)
-        ]
+            image_contents.append(image_content)
+        return image_contents
 
     @override
     async def make_templated_text(

--- a/pipelex/cogt/content_generation/content_generator_protocol.py
+++ b/pipelex/cogt/content_generation/content_generator_protocol.py
@@ -93,6 +93,7 @@ class ContentGeneratorProtocol(Protocol):
         self,
         job_metadata: JobMetadata,
         generated_image_raw_details: GeneratedImageRawDetails,
+        img_gen_prompt: ImgGenPrompt | None,
     ) -> ImageContent: ...
 
     async def make_page_contents(

--- a/pipelex/cogt/img_gen/img_gen_prompt.py
+++ b/pipelex/cogt/img_gen/img_gen_prompt.py
@@ -9,7 +9,6 @@ from pipelex.tools.misc.json_utils import json_str
 
 class ImgGenPrompt(BaseModel):
     positive_text: str
-    # TODO: actually support negative prompt in ImgGen pipes etc.
     negative_text: str | None = None
 
     def validate_before_execution(self):

--- a/pipelex/core/stuffs/image_content.py
+++ b/pipelex/core/stuffs/image_content.py
@@ -60,7 +60,7 @@ class ImageContent(StuffContent):
         group.renderables.append(title_text)
 
         # URL with clickable markdown link
-        display_url = f"{self.url[:35]}…" if len(self.url) > 36 else self.url
+        display_url = f"{self.url[:200]}…" if len(self.url) > 201 else self.url
         url_markdown = Markdown(f"**URL:** [{display_url}]({self.url})")
         group.renderables.append(url_markdown)
 

--- a/pipelex/pipe_operators/img_gen/pipe_img_gen.py
+++ b/pipelex/pipe_operators/img_gen/pipe_img_gen.py
@@ -213,7 +213,7 @@ class PipeImgGen(PipeOperator[PipeImgGenOutput]):
             base_class=ImageContent,
         )
         if nb_images > 1:
-            generated_image_list = await content_generator.make_image_list(
+            image_content_list = await content_generator.make_image_list(
                 job_metadata=job_metadata,
                 img_gen_handle=img_gen_handle,
                 img_gen_prompt=ImgGenPrompt(
@@ -224,20 +224,16 @@ class PipeImgGen(PipeOperator[PipeImgGenOutput]):
                 img_gen_job_params=img_gen_job_params,
                 img_gen_job_config=img_gen_config.img_gen_job_config,
             )
-            image_content_items: list[StuffContent] = []
-            for generated_image in generated_image_list:
-                image_content = image_content_subclass(
-                    url=generated_image.url,
-                    source_prompt=positive_prompt_text,
-                    source_negative_prompt=negative_prompt_text,
-                )
-                image_content_items.append(image_content)
+            subclass_content_items: list[ImageContent] = []
+            for image_content in image_content_list:
+                subclass_content = image_content_subclass.model_validate(image_content)
+                subclass_content_items.append(subclass_content)
             the_content = ListContent(
-                items=image_content_items,
+                items=subclass_content_items,
             )
             log.verbose(the_content, title="List of image contents")
         else:
-            generated_image = await content_generator.make_single_image(
+            image_content = await content_generator.make_single_image(
                 job_metadata=job_metadata,
                 img_gen_handle=img_gen_handle,
                 img_gen_prompt=ImgGenPrompt(
@@ -248,11 +244,7 @@ class PipeImgGen(PipeOperator[PipeImgGenOutput]):
                 img_gen_job_config=img_gen_config.img_gen_job_config,
             )
 
-            the_content = image_content_subclass(
-                url=generated_image.url,
-                source_prompt=positive_prompt_text,
-                source_negative_prompt=negative_prompt_text,
-            )
+            the_content = image_content_subclass.model_validate(image_content)
             log.verbose(the_content, title=f"output stuff content of PipeImg {self.code}")
 
         output_stuff = StuffFactory.make_stuff(


### PR DESCRIPTION
- Fix: Preserve ImageContent Metadata

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures generated images retain their metadata and associated prompts throughout the pipeline.
> 
> - Add `img_gen_prompt` to `make_image_content` and set `source_prompt`/`source_negative_prompt` on `ImageContent`
> - Update `ContentGenerator`, `ContentGeneratorDry`, and `ContentGeneratorProtocol`, and pass prompts from `make_single_image`/`make_image_list`; pass `None` for extract/render paths
> - Change `PipeImgGen` to validate and reuse returned `ImageContent` (single and list) via `.model_validate(...)` instead of reconstructing, preserving fields like `mime_type`, `size`, and display link
> - Increase URL preview truncation in `ImageContent.rendered_pretty` (200 chars)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2c4dc8dcb234502c7800d59e18357276517b4ccd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->