### PR TITLE
Refactor/less verbose console

### DIFF
--- a/.blackboxrules
+++ b/.blackboxrules
@@ -5,16 +5,17 @@
 
 ### Linting
 
-   After making code changes, you must always lint using `make check`.
+   After making code changes, you must always lint using `make agent-check`.
 
    ```bash
-   make check
-   # If the current system doesn't have the `make` command, lookup the "check" target in the Makefile and run the command manually.
+   make agent-check
+   # If the current system doesn't have the `make` command,
+   # lookup the "agent-check" target in the Makefile and run the commands one by one (targets fix-unused-imports format lint pyright mypy)
    ```
 
    This runs multiple code quality tools:
    - Pyright: Static type checking
-   - Ruff: Fast Python linter  
+   - Ruff: Fix unised imports, lint, format  
    - Mypy: Static type checker
 
    Always fix any issues reported by these tools before proceeding.
@@ -92,6 +93,19 @@
    ```
 
    If the installation uses a different venv name or location, activate that one instead. All subsequent `pipelex` and `pytest` commands assume the venv is active.
+
+### Pipelex CLI Commands
+
+   To run the Pipelex CLI commands without the logo, you can use the `--no-logo` flag, this will avoid useless tokens in the console output.
+
+   ```bash
+   pipelex --help
+   pipelex build --help --no-logo
+   pipelex run --help --no-logo
+   pipelex validate --help --no-logo
+   pipelex doctor --help --no-logo
+   pipelex init --help --no-logo
+   ```
 
 ## Coding Standards & Best Practices for Python Code
 

--- a/.cursor/rules/commands.mdc
+++ b/.cursor/rules/commands.mdc
@@ -6,16 +6,17 @@ description: Guidelines for running commands
 
 ## Linting
 
-   After making code changes, you must always lint using `make check`.
+   After making code changes, you must always lint using `make agent-check`.
 
    ```bash
-   make check
-   # If the current system doesn't have the `make` command, lookup the "check" target in the Makefile and run the command manually.
+   make agent-check
+   # If the current system doesn't have the `make` command,
+   # lookup the "agent-check" target in the Makefile and run the commands one by one (targets fix-unused-imports format lint pyright mypy)
    ```
 
    This runs multiple code quality tools:
    - Pyright: Static type checking
-   - Ruff: Fast Python linter  
+   - Ruff: Fix unised imports, lint, format  
    - Mypy: Static type checker
 
    Always fix any issues reported by these tools before proceeding.
@@ -93,3 +94,16 @@ description: Guidelines for running commands
    ```
 
    If the installation uses a different venv name or location, activate that one instead. All subsequent `pipelex` and `pytest` commands assume the venv is active.
+
+## Pipelex CLI Commands
+
+   To run the Pipelex CLI commands without the logo, you can use the `--no-logo` flag, this will avoid useless tokens in the console output.
+
+   ```bash
+   pipelex --help
+   pipelex build --help --no-logo
+   pipelex run --help --no-logo
+   pipelex validate --help --no-logo
+   pipelex doctor --help --no-logo
+   pipelex init --help --no-logo
+   ```

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,16 +5,17 @@
 
 ### Linting
 
-   After making code changes, you must always lint using `make check`.
+   After making code changes, you must always lint using `make agent-check`.
 
    ```bash
-   make check
-   # If the current system doesn't have the `make` command, lookup the "check" target in the Makefile and run the command manually.
+   make agent-check
+   # If the current system doesn't have the `make` command,
+   # lookup the "agent-check" target in the Makefile and run the commands one by one (targets fix-unused-imports format lint pyright mypy)
    ```
 
    This runs multiple code quality tools:
    - Pyright: Static type checking
-   - Ruff: Fast Python linter  
+   - Ruff: Fix unised imports, lint, format  
    - Mypy: Static type checker
 
    Always fix any issues reported by these tools before proceeding.
@@ -92,6 +93,19 @@
    ```
 
    If the installation uses a different venv name or location, activate that one instead. All subsequent `pipelex` and `pytest` commands assume the venv is active.
+
+### Pipelex CLI Commands
+
+   To run the Pipelex CLI commands without the logo, you can use the `--no-logo` flag, this will avoid useless tokens in the console output.
+
+   ```bash
+   pipelex --help
+   pipelex build --help --no-logo
+   pipelex run --help --no-logo
+   pipelex validate --help --no-logo
+   pipelex doctor --help --no-logo
+   pipelex init --help --no-logo
+   ```
 
 ## Coding Standards & Best Practices for Python Code
 

--- a/.windsurfrules.md
+++ b/.windsurfrules.md
@@ -5,16 +5,17 @@
 
 ### Linting
 
-   After making code changes, you must always lint using `make check`.
+   After making code changes, you must always lint using `make agent-check`.
 
    ```bash
-   make check
-   # If the current system doesn't have the `make` command, lookup the "check" target in the Makefile and run the command manually.
+   make agent-check
+   # If the current system doesn't have the `make` command,
+   # lookup the "agent-check" target in the Makefile and run the commands one by one (targets fix-unused-imports format lint pyright mypy)
    ```
 
    This runs multiple code quality tools:
    - Pyright: Static type checking
-   - Ruff: Fast Python linter  
+   - Ruff: Fix unised imports, lint, format  
    - Mypy: Static type checker
 
    Always fix any issues reported by these tools before proceeding.
@@ -92,6 +93,19 @@
    ```
 
    If the installation uses a different venv name or location, activate that one instead. All subsequent `pipelex` and `pytest` commands assume the venv is active.
+
+### Pipelex CLI Commands
+
+   To run the Pipelex CLI commands without the logo, you can use the `--no-logo` flag, this will avoid useless tokens in the console output.
+
+   ```bash
+   pipelex --help
+   pipelex build --help --no-logo
+   pipelex run --help --no-logo
+   pipelex validate --help --no-logo
+   pipelex doctor --help --no-logo
+   pipelex init --help --no-logo
+   ```
 
 ## Coding Standards & Best Practices for Python Code
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,16 +5,17 @@
 
 ### Linting
 
-   After making code changes, you must always lint using `make check`.
+   After making code changes, you must always lint using `make agent-check`.
 
    ```bash
-   make check
-   # If the current system doesn't have the `make` command, lookup the "check" target in the Makefile and run the command manually.
+   make agent-check
+   # If the current system doesn't have the `make` command,
+   # lookup the "agent-check" target in the Makefile and run the commands one by one (targets fix-unused-imports format lint pyright mypy)
    ```
 
    This runs multiple code quality tools:
    - Pyright: Static type checking
-   - Ruff: Fast Python linter  
+   - Ruff: Fix unised imports, lint, format  
    - Mypy: Static type checker
 
    Always fix any issues reported by these tools before proceeding.
@@ -92,6 +93,19 @@
    ```
 
    If the installation uses a different venv name or location, activate that one instead. All subsequent `pipelex` and `pytest` commands assume the venv is active.
+
+### Pipelex CLI Commands
+
+   To run the Pipelex CLI commands without the logo, you can use the `--no-logo` flag, this will avoid useless tokens in the console output.
+
+   ```bash
+   pipelex --help
+   pipelex build --help --no-logo
+   pipelex run --help --no-logo
+   pipelex validate --help --no-logo
+   pipelex doctor --help --no-logo
+   pipelex init --help --no-logo
+   ```
 
 ## Coding Standards & Best Practices for Python Code
 

--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ endef
 export HELP
 
 .PHONY: \
-	all help env lock install update build \
+	all help env env-verbose check-uv check-uv-verbose lock install update build \
 	format lint pyright mypy pylint \
     rules up-kit-configs ukc check-config-sync ccs check-rules check-urls cu \
 	cleanderived cleanenv cleanall \
@@ -123,7 +123,7 @@ export HELP
 	run-all-tests run-manual-trigger-gha-tests run-gha_disabled-tests \
 	validate v check c cc \
 	merge-check-ruff-lint merge-check-ruff-format merge-check-mypy merge-check-pyright \
-	li check-unused-imports fix-unused-imports check-uv check-TODOs docs docs-check docs-deploy \
+	li check-unused-imports fix-unused-imports check-TODOs docs docs-check docs-deploy \
 	test-count check-test-badge
 
 all help:
@@ -134,7 +134,18 @@ all help:
 ### SETUP
 ##########################################################################################
 
+# Quiet check-uv: only shows output if uv is missing (needs install)
 check-uv:
+	@command -v uv >/dev/null 2>&1 || { \
+		echo ""; \
+		echo "=== [$(PROJECT_NAME)] ===== (check-uv) ====== Ensuring uv ≥ $(UV_MIN_VERSION) =========="; \
+		echo "uv not found – installing latest …"; \
+		curl -LsSf https://astral.sh/uv/install.sh | sh; \
+	}
+	@uv self update >/dev/null 2>&1 || true
+
+# Verbose check-uv: always shows output (for setup commands)
+check-uv-verbose:
 	$(call PRINT_TITLE,"Ensuring uv ≥ $(UV_MIN_VERSION)")
 	@command -v uv >/dev/null 2>&1 || { \
 		echo "uv not found – installing latest …"; \
@@ -142,8 +153,18 @@ check-uv:
 	}
 	@uv self update >/dev/null 2>&1 || true
 
-
+# Quiet env: only shows output if venv needs to be created
 env: check-uv
+	@if [ ! -d "$(VIRTUAL_ENV)" ]; then \
+		echo ""; \
+		echo "=== [$(PROJECT_NAME)] ===== (env) ====== Creating virtual environment ================="; \
+		echo "Creating Python virtual env in \`${VIRTUAL_ENV}\`"; \
+		uv venv "$(VIRTUAL_ENV)" --python $(PYTHON_VERSION); \
+		echo "Using Python: $$($(VENV_PYTHON) --version) from $$(readlink $(VENV_PYTHON) 2>/dev/null || echo $(VENV_PYTHON))"; \
+	fi
+
+# Verbose env: always shows output (for setup commands like install, lock, update)
+env-verbose: check-uv-verbose
 	$(call PRINT_TITLE,"Creating virtual environment")
 	@if [ ! -d "$(VIRTUAL_ENV)" ]; then \
 		echo "Creating Python virtual env in \`${VIRTUAL_ENV}\`"; \
@@ -153,7 +174,7 @@ env: check-uv
 	fi
 	@echo "Using Python: $$($(VENV_PYTHON) --version) from $$(readlink $(VENV_PYTHON) 2>/dev/null || echo $(VENV_PYTHON))"
 
-install: env
+install: env-verbose
 	$(call PRINT_TITLE,"Installing dependencies")
 	@. "$(VIRTUAL_ENV)/bin/activate" && \
 	uv sync --all-extras && \

--- a/Makefile
+++ b/Makefile
@@ -590,6 +590,9 @@ cc: cleanderived c
 check: cc check-unused-imports check-config-sync check-rules check-urls pylint
 	@echo "> done: check"
 
+agent-check: fix-unused-imports format lint pyright mypy
+	@echo "> done: agent-check"
+
 v: validate
 	@echo "> done: v = validate"
 

--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ export HELP
 	test test-xdist t test-quiet tq test-with-prints tp test-inference ti \
 	test-llm tl test-img-gen tg test-extract te codex-tests gha-tests \
 	run-all-tests run-manual-trigger-gha-tests run-gha_disabled-tests \
-	validate v check c cc \
+	validate v check c cc agent-check \
 	merge-check-ruff-lint merge-check-ruff-format merge-check-mypy merge-check-pyright \
 	li check-unused-imports fix-unused-imports check-TODOs docs docs-check docs-deploy \
 	test-count check-test-badge

--- a/pipelex/cli/_cli.py
+++ b/pipelex/cli/_cli.py
@@ -1,5 +1,6 @@
 from typing import Annotated
 
+import click
 import typer
 from click import Command, Context
 from typer.core import TyperGroup
@@ -19,6 +20,8 @@ from pipelex.tools.misc.package_utils import get_package_version
 
 
 class PipelexCLI(TyperGroup):
+    """Custom CLI group that handles global options like --no-logo."""
+
     @override
     def list_commands(self, ctx: Context) -> list[str]:
         # List the commands in the proper order because natural ordering doesn't work between Typer groups and commands
@@ -33,10 +36,27 @@ class PipelexCLI(TyperGroup):
             ctx.exit(1)
         return cmd
 
+    @override
+    def make_context(
+        self,
+        info_name: str | None,
+        args: list[str],
+        parent: Context | None = None,
+        **extra: object,
+    ) -> Context:
+        """Intercept --no-logo from args before Click/Typer processes them.
 
-def main() -> None:
-    """Entry point for the pipelex CLI."""
-    app()
+        This allows --no-logo to be placed anywhere in the command line
+        (before or after subcommands) while keeping the CLI architecture clean.
+        """
+        no_logo = "--no-logo" in args
+        if no_logo:
+            args = [arg for arg in args if arg != "--no-logo"]
+
+        ctx = super().make_context(info_name, args, parent, **extra)
+        ctx.ensure_object(dict)
+        ctx.obj["no_logo"] = no_logo
+        return ctx
 
 
 app = typer.Typer(
@@ -51,8 +71,16 @@ app = typer.Typer(
 def app_callback(ctx: typer.Context) -> None:
     console = get_console()
     package_version = get_package_version()
-    console.print(
-        f"""
+
+    # Get no_logo flag from context (set by PipelexCLI.make_context)
+    click_ctx = click.get_current_context()
+    no_logo = click_ctx.obj.get("no_logo", False) if click_ctx.obj else False
+
+    if no_logo:
+        console.print(f"Pipelex v{package_version}")
+    else:
+        console.print(
+            f"""
 
 ░█████████  ░[bold green4]██[/bold green4]                      ░██
 ░██     ░██                          ░██
@@ -64,7 +92,7 @@ def app_callback(ctx: typer.Context) -> None:
                ░██
                ░██                                     v[cyan]{package_version}[/cyan]
 """
-    )
+        )
     # Skip checks if no command is being run (e.g., just --help) or if running init/doctor command
     if ctx.invoked_subcommand is None or ctx.invoked_subcommand in {"init", "doctor"}:
         return

--- a/pipelex/kit/agent_rules/commands.md
+++ b/pipelex/kit/agent_rules/commands.md
@@ -2,16 +2,17 @@
 
 ## Linting
 
-   After making code changes, you must always lint using `make check`.
+   After making code changes, you must always lint using `make agent-check`.
 
    ```bash
-   make check
-   # If the current system doesn't have the `make` command, lookup the "check" target in the Makefile and run the command manually.
+   make agent-check
+   # If the current system doesn't have the `make` command,
+   # lookup the "agent-check" target in the Makefile and run the commands one by one (targets fix-unused-imports format lint pyright mypy)
    ```
 
    This runs multiple code quality tools:
    - Pyright: Static type checking
-   - Ruff: Fast Python linter  
+   - Ruff: Fix unised imports, lint, format  
    - Mypy: Static type checker
 
    Always fix any issues reported by these tools before proceeding.
@@ -89,3 +90,16 @@
    ```
 
    If the installation uses a different venv name or location, activate that one instead. All subsequent `pipelex` and `pytest` commands assume the venv is active.
+
+## Pipelex CLI Commands
+
+   To run the Pipelex CLI commands without the logo, you can use the `--no-logo` flag, this will avoid useless tokens in the console output.
+
+   ```bash
+   pipelex --help
+   pipelex build --help --no-logo
+   pipelex run --help --no-logo
+   pipelex validate --help --no-logo
+   pipelex doctor --help --no-logo
+   pipelex init --help --no-logo
+   ```


### PR DESCRIPTION
- less verbose console
- faster agent check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **CLI behavior**
> 
> - Adds global `--no-logo` flag handled in custom `PipelexCLI` (suppresses ASCII logo; prints `Pipelex v<version>` instead)
> - Keeps command ordering/unknown command handling; readiness checks unchanged
> 
> **Build/Makefile**
> 
> - Introduces quieter `check-uv` and `env` plus verbose variants; `install` now uses `env-verbose`
> - Adds `agent-check` target: `fix-unused-imports format lint pyright mypy`
> - Updates phony targets/help; minor tweaks to check flow
> 
> **Docs/Rules**
> 
> - Replace `make check` with `make agent-check` across rules and guides
> - Document CLI usage with `--no-logo` in contributor rules and templates
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 27469f01af9b3efdc9815165b4c710168933f3fe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->