### PR TITLE
Check extract model capability captions and skip tests if not

### DIFF
--- a/.pipelex/inference/backends/mistral.toml
+++ b/.pipelex/inference/backends/mistral.toml
@@ -135,7 +135,6 @@ costs = { input = 0.4, output = 2.0 }
 
 # TODO: add support to pricing per page
 
-# --- OCR Models ---------------------------------------------------------------
 [mistral-ocr-2503]
 model_type = "text_extractor"
 model_id = "mistral-ocr-2503"

--- a/pipelex/cogt/extract/extract_worker_abstract.py
+++ b/pipelex/cogt/extract/extract_worker_abstract.py
@@ -41,6 +41,10 @@ class ExtractWorkerAbstract(InferenceWorkerAbstract):
     def is_image_supported(self) -> bool:
         return self.inference_model.is_image_supported_for_extract
 
+    @property
+    def is_caption_supported(self) -> bool:
+        return self.inference_model.is_caption_supported_for_extract
+
     def _check_can_perform_job(self, extract_job: ExtractJob):
         # This can be overridden by subclasses for specific checks
         extract_input = extract_job.extract_input
@@ -51,6 +55,10 @@ class ExtractWorkerAbstract(InferenceWorkerAbstract):
         elif extract_input.pdf_uri:
             if not self.inference_model.is_pdf_supported_for_extract:
                 msg = f"Extract engine '{self.inference_model.tag}' does not support PDF extraction."
+                raise ExtractCapabilityError(msg)
+        if extract_job.job_params.should_caption_images:
+            if not self.inference_model.is_caption_supported_for_extract:
+                msg = f"Extract engine '{self.inference_model.tag}' does not support image captioning."
                 raise ExtractCapabilityError(msg)
 
     async def extract_pages(

--- a/pipelex/cogt/model_backends/model_spec.py
+++ b/pipelex/cogt/model_backends/model_spec.py
@@ -56,6 +56,10 @@ class InferenceModelSpec(ConfigModel):
     def is_image_supported_for_extract(self) -> bool:
         return "image" in self.inputs
 
+    @property
+    def is_caption_supported_for_extract(self) -> bool:
+        return "captions" in self.outputs
+
     def get_instructor_mode(self) -> InstructorMode | None:
         if self.structure_method:
             return self.structure_method.as_instructor_mode()

--- a/pipelex/kit/configs/inference/backends/mistral.toml
+++ b/pipelex/kit/configs/inference/backends/mistral.toml
@@ -135,7 +135,6 @@ costs = { input = 0.4, output = 2.0 }
 
 # TODO: add support to pricing per page
 
-# --- OCR Models ---------------------------------------------------------------
 [mistral-ocr-2503]
 model_type = "text_extractor"
 model_id = "mistral-ocr-2503"

--- a/tests/integration/pipelex/cogt/test_extract.py
+++ b/tests/integration/pipelex/cogt/test_extract.py
@@ -30,6 +30,9 @@ class TestExtract:
         if not extract_worker.is_pdf_supported:
             msg = f"PDF extraction is not supported for this extract worker: '{extract_worker.desc}'"
             pytest.skip(msg)
+        if extract_job_params.should_caption_images and not extract_worker.is_caption_supported:
+            msg = f"Image captioning is not supported for this extract worker: '{extract_worker.desc}'"
+            pytest.skip(msg)
         extract_job = ExtractJobFactory.make_extract_job(
             extract_input=ExtractInput(pdf_uri=file_path),
             extract_job_params=extract_job_params,
@@ -58,6 +61,9 @@ class TestExtract:
         if not extract_worker.is_pdf_supported:
             msg = f"PDF extraction is not supported for this extract worker: '{extract_worker.desc}'"
             pytest.skip(msg)
+        if extract_job_params.should_caption_images and not extract_worker.is_caption_supported:
+            msg = f"Image captioning is not supported for this extract worker: '{extract_worker.desc}'"
+            pytest.skip(msg)
         extract_job = ExtractJobFactory.make_extract_job(
             extract_input=ExtractInput(pdf_uri=url),
             extract_job_params=extract_job_params,
@@ -80,6 +86,9 @@ class TestExtract:
         if not extract_worker.is_image_supported:
             msg = f"Image extraction is not supported for this extract worker: '{extract_worker.desc}'"
             pytest.skip(msg)
+        if extract_job_params.should_caption_images and not extract_worker.is_caption_supported:
+            msg = f"Image captioning is not supported for this extract worker: '{extract_worker.desc}'"
+            pytest.skip(msg)
         extract_job = ExtractJobFactory.make_extract_job(
             extract_input=ExtractInput(image_uri=file_path),
             extract_job_params=extract_job_params,
@@ -100,6 +109,9 @@ class TestExtract:
         extract_worker = get_extract_worker(extract_handle=extract_handle_from_image)
         if not extract_worker.is_image_supported:
             msg = f"Image extraction is not supported for this extract worker: '{extract_worker.desc}'"
+            pytest.skip(msg)
+        if extract_job_params.should_caption_images and not extract_worker.is_caption_supported:
+            msg = f"Image captioning is not supported for this extract worker: '{extract_worker.desc}'"
             pytest.skip(msg)
         extract_job = ExtractJobFactory.make_extract_job(
             extract_input=ExtractInput(image_uri=url),


### PR DESCRIPTION
- Check extract model capability captions and skip tests if not

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces capability gating for image captioning in extraction.
> 
> - Adds `is_caption_supported` property to `ExtractWorkerAbstract` and enforces captioning support in `_check_can_perform_job`; uses `InferenceModelSpec.is_caption_supported_for_extract` (checks `"captions"` in `outputs`).
> - Integration tests now skip when `should_caption_images` is requested but the worker lacks caption support across PDF/image path and URL cases.
> - Minor config cleanup in Mistral backend TOML (comment removal).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 588a1d3e07f3aea08b86ffd6c87e9dd50e167d0c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->