### PR TITLE
Feature/library dirs from pipelexpath

### DIFF
--- a/pipelex/cli/_cli.py
+++ b/pipelex/cli/_cli.py
@@ -15,6 +15,7 @@ from pipelex.cli.commands.kit_cmd import kit_app
 from pipelex.cli.commands.run_cmd import run_cmd
 from pipelex.cli.commands.show_cmd import show_app
 from pipelex.cli.commands.validate_cmd import validate_cmd
+from pipelex.cli.commands.which_cmd import which_cmd
 from pipelex.cli.readiness import check_readiness
 from pipelex.hub import get_console
 from pipelex.tools.misc.package_utils import get_package_version
@@ -26,7 +27,7 @@ class PipelexCLI(TyperGroup):
     @override
     def list_commands(self, ctx: Context) -> list[str]:
         # List the commands in the proper order because natural ordering doesn't work between Typer groups and commands
-        return ["init", "doctor", "kit", "build", "validate", "run", "graph", "show"]
+        return ["init", "doctor", "kit", "build", "validate", "run", "graph", "show", "which"]
 
     @override
     def get_command(self, ctx: Context, cmd_name: str) -> Command | None:
@@ -132,3 +133,4 @@ app.command(name="validate", help="Validate pipes: static validation for syntax 
 app.command(name="run", help="Run a pipe, optionally providing a specific bundle file (.plx)")(run_cmd)
 app.add_typer(graph_app, name="graph", help="Generate and render execution graphs")
 app.add_typer(show_app, name="show", help="Show configuration, pipes, and list AI models")
+app.command(name="which", help="Locate where a pipe is defined, similar to 'which' for executables")(which_cmd)

--- a/pipelex/cli/commands/which_cmd.py
+++ b/pipelex/cli/commands/which_cmd.py
@@ -28,7 +28,7 @@ from pipelex.tools.misc.package_utils import get_package_version
 COMMAND = "which"
 
 
-def do_which_pipe(pipe_code: str, library_dirs: list[Path]) -> None:
+def do_which_pipe(pipe_code: str, library_dirs: list[Path]) -> bool:
     """Locate where a pipe is defined."""
     console = get_console()
 
@@ -58,12 +58,14 @@ def do_which_pipe(pipe_code: str, library_dirs: list[Path]) -> None:
         if source_path:
             console.print(f"  Source: [cyan]{source_path}[/cyan]")
         log.verbose(f"Pipe '{pipe_code}' resolved", title="which")
+        console.print("")
+        return True
     else:
         console.print(f"[red]Not found:[/red] [bold]{pipe_code}[/bold]")
         console.print("\n[dim]Tip: Check that the pipe code is correct and that the containing[/dim]")
         console.print(f"[dim]directory is in {PIPELEXPATH_ENV_KEY} or passed via --library-dir[/dim]")
-
-    console.print("")
+        console.print("")
+        return False
 
 
 def which_cmd(
@@ -102,7 +104,9 @@ def which_cmd(
             tag(name=EventProperty.PIPELEX_VERSION, value=get_package_version())
             tag(name=EventProperty.CLI_COMMAND, value=COMMAND)
 
-            do_which_pipe(pipe_code=pipe_code, library_dirs=cli_dirs)
+            found = do_which_pipe(pipe_code=pipe_code, library_dirs=cli_dirs)
             get_telemetry_manager().track_event(EventName.PIPE_SHOW)
+            if not found:
+                raise typer.Exit(1)
     finally:
         Pipelex.teardown_if_needed()

--- a/pipelex/cli/commands/which_cmd.py
+++ b/pipelex/cli/commands/which_cmd.py
@@ -1,0 +1,104 @@
+"""CLI command to locate a pipe definition, similar to 'which' for executables."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Annotated
+
+import typer
+from posthog import tag
+
+from pipelex import log
+from pipelex.cli.cli_factory import make_pipelex_for_cli
+from pipelex.cli.error_handlers import ErrorContext
+from pipelex.hub import (
+    get_console,
+    get_library_manager,
+    get_optional_pipe,
+    get_telemetry_manager,
+    set_current_library,
+)
+from pipelex.pipelex import Pipelex
+from pipelex.system.environment import PIPELEXPATH_ENV_KEY, get_pipelexpath_dirs
+from pipelex.system.runtime import IntegrationMode
+from pipelex.system.telemetry.events import EventName, EventProperty
+from pipelex.tools.misc.package_utils import get_package_version
+
+COMMAND = "which"
+
+
+def do_which_pipe(pipe_code: str, library_dirs: list[Path]) -> None:
+    """Locate where a pipe is defined."""
+    console = get_console()
+
+    # Show search path
+    pipelexpath_dirs = get_pipelexpath_dirs()
+    all_dirs = pipelexpath_dirs + library_dirs
+
+    console.print(f"\n[bold]Search path for '[cyan]{pipe_code}[/cyan]':[/bold]")
+    if not all_dirs:
+        console.print("  [dim](no directories configured)[/dim]")
+    else:
+        for index_dir, dir_path in enumerate(all_dirs):
+            source = f"({PIPELEXPATH_ENV_KEY})" if index_dir < len(pipelexpath_dirs) else "(--library-dir)"
+            exists_marker = "[green]✓[/green]" if dir_path.exists() else "[red]✗[/red]"
+            console.print(f"  {exists_marker} {dir_path} [dim]{source}[/dim]")
+
+    console.print("")
+
+    # Try to find the pipe
+    pipe = get_optional_pipe(pipe_code=pipe_code)
+
+    if pipe:
+        console.print(f"[green]Found:[/green] [bold]{pipe_code}[/bold]")
+        console.print(f"  Type: [cyan]{pipe.pipe_type}[/cyan]")
+        console.print(f"  Domain: [cyan]{pipe.domain_code}[/cyan]")
+        log.verbose(f"Pipe '{pipe_code}' resolved", title="which")
+    else:
+        console.print(f"[red]Not found:[/red] [bold]{pipe_code}[/bold]")
+        console.print("\n[dim]Tip: Check that the pipe code is correct and that the containing[/dim]")
+        console.print(f"[dim]directory is in {PIPELEXPATH_ENV_KEY} or passed via --library-dir[/dim]")
+
+    console.print("")
+
+
+def which_cmd(
+    pipe_code: Annotated[str, typer.Argument(help="Pipe code to locate (e.g., 'my_domain.my_pipe')")],
+    library_dir: Annotated[
+        list[str] | None,
+        typer.Option("--library-dir", "-L", help="Directory to search for pipe definitions. Can be specified multiple times."),
+    ] = None,
+) -> None:
+    """Locate where a pipe is defined, similar to 'which' for executables.
+
+    Shows the search path (PIPELEXPATH + --library-dir) and whether the pipe was found.
+
+    Examples:
+        pipelex which hello_world
+        pipelex which my_domain.my_pipe -L ./my_pipes
+        PIPELEXPATH=/path/to/pipes pipelex which some_pipe
+    """
+    make_pipelex_for_cli(context=ErrorContext.VALIDATION_BEFORE_SHOW_PIPE)
+
+    try:
+        library_manager = get_library_manager()
+        library_id, _ = library_manager.open_library()
+        set_current_library(library_id=library_id)
+
+        # Combine PIPELEXPATH with library_dir args
+        pipelexpath_dirs = get_pipelexpath_dirs()
+        cli_dirs = [Path(lib_dir) for lib_dir in library_dir] if library_dir else []
+        effective_dirs = pipelexpath_dirs + cli_dirs
+
+        if effective_dirs:
+            library_manager.load_libraries(library_id=library_id, library_dirs=effective_dirs)
+
+        with get_telemetry_manager().telemetry_context():
+            tag(name=EventProperty.INTEGRATION, value=IntegrationMode.CLI)
+            tag(name=EventProperty.PIPELEX_VERSION, value=get_package_version())
+            tag(name=EventProperty.CLI_COMMAND, value=COMMAND)
+
+            do_which_pipe(pipe_code=pipe_code, library_dirs=cli_dirs)
+            get_telemetry_manager().track_event(EventName.PIPE_SHOW)
+    finally:
+        Pipelex.teardown_if_needed()

--- a/pipelex/cli/commands/which_cmd.py
+++ b/pipelex/cli/commands/which_cmd.py
@@ -15,6 +15,7 @@ from pipelex.hub import (
     get_console,
     get_library_manager,
     get_optional_pipe,
+    get_pipe_source,
     get_telemetry_manager,
     set_current_library,
 )
@@ -53,6 +54,9 @@ def do_which_pipe(pipe_code: str, library_dirs: list[Path]) -> None:
         console.print(f"[green]Found:[/green] [bold]{pipe_code}[/bold]")
         console.print(f"  Type: [cyan]{pipe.pipe_type}[/cyan]")
         console.print(f"  Domain: [cyan]{pipe.domain_code}[/cyan]")
+        source_path = get_pipe_source(pipe_code=pipe_code)
+        if source_path:
+            console.print(f"  Source: [cyan]{source_path}[/cyan]")
         log.verbose(f"Pipe '{pipe_code}' resolved", title="which")
     else:
         console.print(f"[red]Not found:[/red] [bold]{pipe_code}[/bold]")

--- a/pipelex/hub.py
+++ b/pipelex/hub.py
@@ -1,5 +1,6 @@
 import sys
 from contextvars import ContextVar
+from pathlib import Path
 from typing import ClassVar, Optional
 
 from kajson.class_registry_abstract import ClassRegistryAbstract
@@ -453,6 +454,18 @@ def get_required_pipe(pipe_code: str) -> PipeAbstract:
 
 def get_optional_pipe(pipe_code: str) -> PipeAbstract | None:
     return get_pipelex_hub().get_required_pipe_library().get_optional_pipe(pipe_code=pipe_code)
+
+
+def get_pipe_source(pipe_code: str) -> Path | None:
+    """Get the source file path for a pipe.
+
+    Args:
+        pipe_code: The pipe code to look up.
+
+    Returns:
+        Path to the .plx file the pipe was loaded from, or None if unknown.
+    """
+    return get_pipelex_hub().get_library_manager().get_pipe_source(pipe_code=pipe_code)
 
 
 def get_concept_library() -> ConceptLibraryAbstract:

--- a/pipelex/libraries/library_manager.py
+++ b/pipelex/libraries/library_manager.py
@@ -59,6 +59,9 @@ class LibraryManager(LibraryManagerAbstract):
                 msg = f"Trying to teardown a library that does not exist: '{library_id}'"
                 raise LibraryError(msg)
             library = self._libraries[library_id]
+            # Remove source map entries for pipes in this library
+            for pipe_code in library.pipe_library.root:
+                self._pipe_source_map.pop(pipe_code, None)
             library.teardown()
             del self._libraries[library_id]
             return

--- a/pipelex/libraries/library_manager.py
+++ b/pipelex/libraries/library_manager.py
@@ -40,6 +40,7 @@ class LibraryManager(LibraryManagerAbstract):
         # UNTITLED library is the fallback library for all others
         self._libraries: dict[str, Library] = {}
         self.loaded_plx_paths: list[str] = []
+        self._pipe_source_map: dict[str, Path] = {}  # pipe_code -> source .plx file
 
     ############################################################
     # Manager lifecycle
@@ -65,6 +66,7 @@ class LibraryManager(LibraryManagerAbstract):
         for library in self._libraries.values():
             library.teardown()
         self._libraries = {}
+        self._pipe_source_map.clear()
 
     @override
     def reset(self) -> None:
@@ -102,6 +104,18 @@ class LibraryManager(LibraryManagerAbstract):
             msg = f"No current library set. Library '{library_id}' does not exist"
             raise LibraryError(msg)
         return self._libraries[library_id]
+
+    @override
+    def get_pipe_source(self, pipe_code: str) -> Path | None:
+        """Get the source file path for a pipe.
+
+        Args:
+            pipe_code: The pipe code to look up.
+
+        Returns:
+            Path to the .plx file the pipe was loaded from, or None if unknown.
+        """
+        return self._pipe_source_map.get(pipe_code)
 
     ############################################################
     # Private methods
@@ -224,6 +238,9 @@ class LibraryManager(LibraryManagerAbstract):
                         concept_codes_from_the_same_domain=[the_concept.code for the_concept in all_concepts],
                     )
                     pipes.append(pipe)
+                    # Track source file for this pipe
+                    if blueprint.source:
+                        self._pipe_source_map[pipe_code] = Path(blueprint.source)
             all_pipes.extend(pipes)
 
         library.pipe_library.add_pipes(pipes=all_pipes)

--- a/pipelex/libraries/library_manager_abstract.py
+++ b/pipelex/libraries/library_manager_abstract.py
@@ -34,6 +34,17 @@ class LibraryManagerAbstract(ABC):
     def get_current_library(self) -> "Library":
         """Get the Library object for the current library."""
 
+    def get_pipe_source(self, pipe_code: str) -> Path | None:  # noqa: ARG002
+        """Get the source file path for a pipe.
+
+        Args:
+            pipe_code: The pipe code to look up.
+
+        Returns:
+            Path to the .plx file the pipe was loaded from, or None if unknown.
+        """
+        return None
+
     @abstractmethod
     def load_from_blueprints(self, library_id: str, blueprints: list[PipelexBundleBlueprint]) -> list[PipeAbstract]:
         pass

--- a/pipelex/pipeline/execute.py
+++ b/pipelex/pipeline/execute.py
@@ -50,19 +50,19 @@ async def execute_pipeline(
         auto-generated ``pipeline_run_id``. Use a custom ID when you need to manage
         multiple library instances or maintain library state across executions.
     library_dirs:
-        List of directory paths to load pipe definitions from. If not provided, loads
-        from the current working directory (the directory from which the Python script
-        is executed). Ignored when ``plx_content`` is provided.
+        List of directory paths to load pipe definitions from. Combined with directories
+        from the ``PIPELEXPATH`` environment variable (PIPELEXPATH directories are searched
+        first). When provided alongside ``plx_content``, definitions from both sources
+        are loaded into the library.
     pipe_code:
         Code identifying the pipe to execute. Required when ``plx_content`` is not
         provided. When both ``plx_content`` and ``pipe_code`` are provided, the
         specified pipe from the PLX content will be executed (overriding any
         ``main_pipe`` defined in the plx_content).
     plx_content:
-        Complete PLX file content as a string. When provided, only this content is
-        loaded into the library, creating an isolated execution environment. The pipe
-        to execute is determined by ``pipe_code`` (if provided) or the ``main_pipe``
-        property in the PLX content.
+        Complete PLX file content as a string. The pipe to execute is determined by
+        ``pipe_code`` (if provided) or the ``main_pipe`` property in the PLX content.
+        Can be combined with ``library_dirs`` to load additional definitions.
     inputs:
         Inputs passed to the pipeline. Can be either a ``PipelineInputs`` dictionary
         or a ``WorkingMemory`` instance.

--- a/pipelex/pipeline/pipeline_run_setup.py
+++ b/pipelex/pipeline/pipeline_run_setup.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from pipelex import log
 from pipelex.client.protocol import PipelineInputs
 from pipelex.core.memory.working_memory import WorkingMemory
 from pipelex.core.memory.working_memory_factory import WorkingMemoryFactory
@@ -29,7 +30,7 @@ from pipelex.pipeline.input_normalizer import normalize_data_urls_to_storage
 from pipelex.pipeline.job_metadata import JobMetadata, OtelContext
 from pipelex.pipeline.validate_bundle import validate_bundle
 from pipelex.system.configuration.configs import PipelineExecutionConfig
-from pipelex.system.environment import get_optional_env
+from pipelex.system.environment import PIPELEXPATH_ENV_KEY, get_optional_env, get_pipelexpath_dirs
 from pipelex.system.telemetry.events import EventName, EventProperty
 from pipelex.system.telemetry.otel_constants import OTelConstants
 from pipelex.system.telemetry.otel_factory import OtelFactory
@@ -70,19 +71,19 @@ async def pipeline_run_setup(
         auto-generated ``pipeline_run_id``. Use a custom ID when you need to manage
         multiple library instances or maintain library state across executions.
     library_dirs:
-        List of directory paths to load pipe definitions from. If not provided, loads
-        from the current working directory (the directory from which the Python script
-        is executed). Ignored when ``plx_content`` is provided.
+        List of directory paths to load pipe definitions from. Combined with directories
+        from the ``PIPELEXPATH`` environment variable (PIPELEXPATH directories are searched
+        first). When provided alongside ``plx_content``, definitions from both sources
+        are loaded into the library.
     pipe_code:
         Code identifying the pipe to execute. Required when ``plx_content`` is not
         provided. When both ``plx_content`` and ``pipe_code`` are provided, the
         specified pipe from the PLX content will be executed (overriding any
         ``main_pipe`` defined in the content).
     plx_content:
-        Complete PLX file content as a string. When provided, only this content is
-        loaded into the library, creating an isolated execution environment. The pipe
-        to execute is determined by ``pipe_code`` (if provided) or the ``main_pipe``
-        property in the PLX content.
+        Complete PLX file content as a string. The pipe to execute is determined by
+        ``pipe_code`` (if provided) or the ``main_pipe`` property in the PLX content.
+        Can be combined with ``library_dirs`` to load additional definitions.
     inputs:
         Inputs passed to the pipeline. Can be either a ``PipelineInputs`` dictionary
         or a ``WorkingMemory`` instance.
@@ -127,6 +128,25 @@ async def pipeline_run_setup(
     pipe: PipeAbstract | None = None
     blueprint: PipelexBundleBlueprint | None = None
 
+    # Combine PIPELEXPATH (env var) with library_dirs (CLI/API args)
+    # PIPELEXPATH provides base directories, library_dirs extends/overrides
+    pipelexpath_dirs = get_pipelexpath_dirs()
+    cli_dirs = [Path(lib_dir) for lib_dir in library_dirs] if library_dirs else []
+    effective_dirs = pipelexpath_dirs + cli_dirs
+
+    if effective_dirs:
+        log.verbose(f"Loading libraries from {len(effective_dirs)} directory(ies):")
+        for index_dir, dir_path in enumerate(effective_dirs):
+            source = f"({PIPELEXPATH_ENV_KEY})" if index_dir < len(pipelexpath_dirs) else "(--library-dir)"
+            log.verbose(f"  [{index_dir + 1}] {dir_path} {source}")
+        library_manager.load_libraries(
+            library_id=library_id,
+            library_dirs=effective_dirs,
+        )
+    else:
+        log.verbose("No library directories specified (PIPELEXPATH not set, no --library-dir provided)")
+
+    # Then handle plx_content or pipe_code
     if plx_content:
         validate_bundle_result = await validate_bundle(plx_content=plx_content)
         library_manager.load_from_blueprints(library_id=library_id, blueprints=validate_bundle_result.blueprints)
@@ -140,13 +160,6 @@ async def pipeline_run_setup(
             msg = "No pipe code or main pipe in the PLX content provided to the pipeline API."
             raise PipeExecutionError(message=msg)
     elif pipe_code:
-        if library_dirs:
-            library_manager.load_libraries(
-                library_id=library_id,
-                library_dirs=[Path(library_dir) for library_dir in library_dirs],
-            )
-        else:
-            library_manager.load_libraries(library_id=library_id, library_dirs=[Path.cwd()])
         pipe = get_required_pipe(pipe_code=pipe_code)
     else:
         msg = "Either provide pipe_code or plx_content to the pipeline API. 'pipe_code' must be provided when 'plx_content' is None"

--- a/pipelex/pipeline/start.py
+++ b/pipelex/pipeline/start.py
@@ -39,19 +39,19 @@ async def start_pipeline(
         auto-generated ``pipeline_run_id``. Use a custom ID when you need to manage
         multiple library instances or maintain library state across executions.
     library_dirs:
-        List of directory paths to load pipe definitions from. If not provided, loads
-        from the current working directory (the directory from which the Python script
-        is executed). Ignored when ``plx_content`` is provided.
+        List of directory paths to load pipe definitions from. Combined with directories
+        from the ``PIPELEXPATH`` environment variable (PIPELEXPATH directories are searched
+        first). When provided alongside ``plx_content``, definitions from both sources
+        are loaded into the library.
     pipe_code:
         Code identifying the pipe to execute. Required when ``plx_content`` is not
         provided. When both ``plx_content`` and ``pipe_code`` are provided, the
         specified pipe from the PLX content will be executed (overriding any
         ``main_pipe`` defined in the content).
     plx_content:
-        Complete PLX file content as a string. When provided, only this content is
-        loaded into the library, creating an isolated execution environment. The pipe
-        to execute is determined by ``pipe_code`` (if provided) or the ``main_pipe``
-        property in the PLX content.
+        Complete PLX file content as a string. The pipe to execute is determined by
+        ``pipe_code`` (if provided) or the ``main_pipe`` property in the PLX content.
+        Can be combined with ``library_dirs`` to load additional definitions.
     inputs:
         Inputs passed to the pipeline. Can be either a ``PipelineInputs`` dictionary
         or a ``WorkingMemory`` instance.

--- a/pipelex/system/environment.py
+++ b/pipelex/system/environment.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 from dotenv import load_dotenv
 
@@ -6,6 +7,9 @@ from pipelex.system.exceptions import ToolError
 from pipelex.tools.misc.placeholder import value_is_placeholder
 
 load_dotenv(dotenv_path=".env", override=True)
+
+# Environment variable for specifying library directories (PATH-style, colon-separated on Unix, semicolon on Windows)
+PIPELEXPATH_ENV_KEY = "PIPELEXPATH"
 
 
 class EnvVarNotFoundError(ToolError):
@@ -48,3 +52,17 @@ def is_env_var_truthy(key: str) -> bool:
     """Return True if the env var is set and not a falsy sentinel ("false" or "0")."""
     value = get_optional_env(key)
     return (value is not None) and (value.lower() not in {"false", "0"})
+
+
+def get_pipelexpath_dirs() -> list[Path]:
+    """Get library directories from PIPELEXPATH environment variable.
+
+    PIPELEXPATH uses PATH-style syntax: colon-separated on Unix, semicolon-separated on Windows.
+
+    Returns:
+        List of Path objects for each directory in PIPELEXPATH, or empty list if not set.
+    """
+    pipelexpath = get_optional_env(PIPELEXPATH_ENV_KEY)
+    if not pipelexpath:
+        return []
+    return [Path(path_str) for path_str in pipelexpath.split(os.pathsep) if path_str]

--- a/tests/e2e/pipelex/pipes/pipe_operators/pipe_llm/test_pipe_llm_vision.py
+++ b/tests/e2e/pipelex/pipes/pipe_operators/pipe_llm/test_pipe_llm_vision.py
@@ -71,6 +71,7 @@ class TestPipeLLMVision:
         # Execute the pipeline with a complex image
         pipe_output = await execute_pipeline(
             pipe_code="vision_analysis_e2e",
+            library_dirs=["tests/e2e/pipelex/pipes/pipe_operators"],
             inputs={
                 "image": ImageContent(url=PipeTestCases.URL_IMG_GANTT_PNG),
             },


### PR DESCRIPTION
- library dirs from pipelexpath
- `pipelex which` to know where a pipe comes from

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces environment-driven library discovery and a locator tool for pipes.
> 
> - Adds `PIPELEXPATH` support with `get_pipelexpath_dirs()` and combines it with `--library-dir` across pipeline setup/execute/start; logs effective search dirs
> - New `which` CLI command: prints search path, resolves pipe metadata, and shows source `.plx` path
> - Library layer: `LibraryManager` tracks pipe→source mapping and exposes `get_pipe_source`; `hub.get_pipe_source()` helper added
> - CLI updated to register `which`; e2e tests specify `library_dirs` explicitly
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe7c514d8e4539d6e4735ac761099b4913c1ddc0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->