### PR TITLE
Check`bundle_path` to avoid double-loading.

### DIFF
--- a/pipelex/cli/commands/run_cmd.py
+++ b/pipelex/cli/commands/run_cmd.py
@@ -233,6 +233,7 @@ def run_cmd(
             pipe_output = await execute_pipeline(
                 pipe_code=pipe_code,
                 plx_content=plx_content,
+                bundle_path=bundle_path,
                 inputs=pipeline_inputs,
                 pipe_run_mode=pipe_run_mode,
                 execution_config=execution_config,

--- a/pipelex/cogt/content_generation/content_generator.py
+++ b/pipelex/cogt/content_generation/content_generator.py
@@ -376,7 +376,5 @@ class ContentGenerator(ContentGeneratorProtocol):
                 raise ValueError(msg)
             for page_content in page_contents:
                 page_content.page_view = page_view_contents.pop(0)
-        else:
-            log.dev(f"No page views to make because: {extract_job_params} and {extract_input}")
 
         return page_contents

--- a/pipelex/libraries/library.py
+++ b/pipelex/libraries/library.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from pipelex.base_exceptions import PipelexUnexpectedError
 from pipelex.libraries.concept.concept_library import ConceptLibrary
@@ -24,6 +24,7 @@ class Library(BaseModel):
     domain_library: DomainLibrary
     concept_library: ConceptLibrary
     pipe_library: PipeLibrary
+    loaded_plx_paths: list[str] = Field(default_factory=list)
 
     def get_domain_library(self) -> DomainLibrary:
         return self.domain_library

--- a/pipelex/libraries/library.py
+++ b/pipelex/libraries/library.py
@@ -39,6 +39,7 @@ class Library(BaseModel):
         self.pipe_library.teardown()
         self.concept_library.teardown()
         self.domain_library.teardown()
+        self.loaded_plx_paths = []
 
     def validate_library(self) -> None:
         self.validate_pipe_library_with_libraries()

--- a/pipelex/libraries/library_manager.py
+++ b/pipelex/libraries/library_manager.py
@@ -283,7 +283,14 @@ class LibraryManager(LibraryManagerAbstract):
                 ) from interpreter_error
             blueprints.append(blueprint)
 
-        self.loaded_plx_paths.extend([str(plx_file_path) for plx_file_path in valid_plx_paths])
+        # Store resolved absolute paths for duplicate detection
+        for plx_file_path in valid_plx_paths:
+            try:
+                resolved_path = str(plx_file_path.resolve())
+            except (OSError, RuntimeError):
+                resolved_path = str(plx_file_path)
+            self.loaded_plx_paths.append(resolved_path)
+
         return self.load_from_blueprints(library_id=library_id, blueprints=blueprints)
 
     def _remove_pipes_from_blueprint(self, blueprint: PipelexBundleBlueprint) -> None:

--- a/pipelex/libraries/library_manager.py
+++ b/pipelex/libraries/library_manager.py
@@ -68,7 +68,7 @@ class LibraryManager(LibraryManagerAbstract):
         for library in self._libraries.values():
             library.teardown()
         self._libraries = {}
-        self._pipe_source_map.clear()
+        self._pipe_source_map = {}
 
     @override
     def reset(self) -> None:

--- a/pipelex/libraries/library_manager.py
+++ b/pipelex/libraries/library_manager.py
@@ -39,7 +39,6 @@ class LibraryManager(LibraryManagerAbstract):
     def __init__(self):
         # UNTITLED library is the fallback library for all others
         self._libraries: dict[str, Library] = {}
-        self.loaded_plx_paths: list[str] = []
         self._pipe_source_map: dict[str, Path] = {}  # pipe_code -> source .plx file
 
     ############################################################
@@ -283,13 +282,14 @@ class LibraryManager(LibraryManagerAbstract):
                 ) from interpreter_error
             blueprints.append(blueprint)
 
-        # Store resolved absolute paths for duplicate detection
+        # Store resolved absolute paths for duplicate detection in the library
+        library = self.get_library(library_id=library_id)
         for plx_file_path in valid_plx_paths:
             try:
                 resolved_path = str(plx_file_path.resolve())
             except (OSError, RuntimeError):
                 resolved_path = str(plx_file_path)
-            self.loaded_plx_paths.append(resolved_path)
+            library.loaded_plx_paths.append(resolved_path)
 
         return self.load_from_blueprints(library_id=library_id, blueprints=blueprints)
 

--- a/pipelex/libraries/library_manager_abstract.py
+++ b/pipelex/libraries/library_manager_abstract.py
@@ -10,6 +10,8 @@ if TYPE_CHECKING:
 
 
 class LibraryManagerAbstract(ABC):
+    loaded_plx_paths: list[str]
+
     @abstractmethod
     def setup(self) -> None:
         pass

--- a/pipelex/libraries/library_manager_abstract.py
+++ b/pipelex/libraries/library_manager_abstract.py
@@ -10,8 +10,6 @@ if TYPE_CHECKING:
 
 
 class LibraryManagerAbstract(ABC):
-    loaded_plx_paths: list[str]
-
     @abstractmethod
     def setup(self) -> None:
         pass

--- a/pipelex/pipeline/execute.py
+++ b/pipelex/pipeline/execute.py
@@ -30,6 +30,7 @@ async def execute_pipeline(
     library_dirs: list[str] | None = None,
     pipe_code: str | None = None,
     plx_content: str | None = None,
+    bundle_path: str | None = None,
     inputs: PipelineInputs | WorkingMemory | None = None,
     output_name: str | None = None,
     output_multiplicity: VariableMultiplicity | None = None,
@@ -63,6 +64,10 @@ async def execute_pipeline(
         Complete PLX file content as a string. The pipe to execute is determined by
         ``pipe_code`` (if provided) or the ``main_pipe`` property in the PLX content.
         Can be combined with ``library_dirs`` to load additional definitions.
+    bundle_path:
+        Path to the bundle file that ``plx_content`` was loaded from. Used to detect
+        if the bundle was already loaded from library directories (e.g., via PIPELEXPATH)
+        to avoid duplicate domain registration.
     inputs:
         Inputs passed to the pipeline. Can be either a ``PipelineInputs`` dictionary
         or a ``WorkingMemory`` instance.
@@ -110,6 +115,7 @@ async def execute_pipeline(
             library_dirs=library_dirs,
             pipe_code=pipe_code,
             plx_content=plx_content,
+            bundle_path=bundle_path,
             inputs=inputs,
             output_name=output_name,
             output_multiplicity=output_multiplicity,

--- a/pipelex/pipeline/pipeline_run_setup.py
+++ b/pipelex/pipeline/pipeline_run_setup.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from pipelex import log
@@ -47,6 +48,7 @@ async def pipeline_run_setup(
     library_dirs: list[str] | None = None,
     pipe_code: str | None = None,
     plx_content: str | None = None,
+    bundle_path: str | None = None,
     inputs: PipelineInputs | WorkingMemory | None = None,
     output_name: str | None = None,
     output_multiplicity: VariableMultiplicity | None = None,
@@ -84,6 +86,11 @@ async def pipeline_run_setup(
         Complete PLX file content as a string. The pipe to execute is determined by
         ``pipe_code`` (if provided) or the ``main_pipe`` property in the PLX content.
         Can be combined with ``library_dirs`` to load additional definitions.
+    bundle_path:
+        Path to the bundle file that ``plx_content`` was loaded from. Used to detect
+        if the bundle was already loaded from library directories (e.g., via PIPELEXPATH)
+        to avoid duplicate domain registration. If provided and the resolved absolute path
+        is already in the loaded PLX paths, the ``plx_content`` loading will be skipped.
     inputs:
         Inputs passed to the pipeline. Can be either a ``PipelineInputs`` dictionary
         or a ``WorkingMemory`` instance.
@@ -144,7 +151,21 @@ async def pipeline_run_setup(
     # Then handle plx_content or pipe_code
     if plx_content:
         validate_bundle_result = await validate_bundle(plx_content=plx_content)
-        library_manager.load_from_blueprints(library_id=library_id, blueprints=validate_bundle_result.blueprints)
+
+        # Check if this bundle was already loaded from library directories
+        bundle_already_loaded = False
+        if bundle_path:
+            try:
+                resolved_bundle_path = str(Path(bundle_path).resolve())
+            except (OSError, RuntimeError):
+                resolved_bundle_path = bundle_path
+            bundle_already_loaded = resolved_bundle_path in library_manager.loaded_plx_paths
+            if bundle_already_loaded:
+                log.verbose(f"Bundle '{bundle_path}' already loaded from library directories, skipping duplicate load")
+
+        if not bundle_already_loaded:
+            library_manager.load_from_blueprints(library_id=library_id, blueprints=validate_bundle_result.blueprints)
+
         # For now, we only support one blueprint when given a plx_content. So blueprints is of length 1.
         blueprint = validate_bundle_result.blueprints[0]
         if pipe_code:

--- a/pipelex/pipeline/pipeline_run_setup.py
+++ b/pipelex/pipeline/pipeline_run_setup.py
@@ -297,7 +297,6 @@ async def pipeline_run_setup(
             if tracer_manager is not None:
                 tracer_manager.close_tracer(pipeline_run_id)
         # Cleanup library
-        library = library_manager.get_library(library_id=library_id)
-        library.teardown()
+        library_manager.teardown(library_id=library_id)
         teardown_current_library()
         raise

--- a/pipelex/pipeline/pipeline_run_setup.py
+++ b/pipelex/pipeline/pipeline_run_setup.py
@@ -159,7 +159,8 @@ async def pipeline_run_setup(
                 resolved_bundle_path = str(Path(bundle_path).resolve())
             except (OSError, RuntimeError):
                 resolved_bundle_path = bundle_path
-            bundle_already_loaded = resolved_bundle_path in library_manager.loaded_plx_paths
+            current_library = library_manager.get_library(library_id=library_id)
+            bundle_already_loaded = resolved_bundle_path in current_library.loaded_plx_paths
             if bundle_already_loaded:
                 log.verbose(f"Bundle '{bundle_path}' already loaded from library directories, skipping duplicate load")
 

--- a/pipelex/pipeline/pipeline_run_setup.py
+++ b/pipelex/pipeline/pipeline_run_setup.py
@@ -158,7 +158,9 @@ async def pipeline_run_setup(
             try:
                 resolved_bundle_path = str(Path(bundle_path).resolve())
             except (OSError, RuntimeError):
-                resolved_bundle_path = bundle_path
+                # Use str(Path(...)) to normalize the path (e.g., "./file.plx" -> "file.plx")
+                # to match the normalization done in library_manager._load_plx_files_into_library
+                resolved_bundle_path = str(Path(bundle_path))
             current_library = library_manager.get_library(library_id=library_id)
             bundle_already_loaded = resolved_bundle_path in current_library.loaded_plx_paths
             if bundle_already_loaded:


### PR DESCRIPTION
- avoid double-loading

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents duplicate PLX bundle loading when a bundle is already sourced from library directories.
> 
> - Propagates `bundle_path` from CLI (`run_cmd.py`) to `execute_pipeline` and `pipeline_run_setup`; if the resolved path is already in the current library’s `loaded_plx_paths`, skip `plx_content` loading
> - Introduces per-library tracking of resolved PLX paths via `Library.loaded_plx_paths` (populated in `LibraryManager._load_plx_files_into_library`, cleared on teardown)
> - Switches failure cleanup in `pipeline_run_setup` to `LibraryManager.teardown(library_id=...)`; small internal cleanups and removes a noisy log in content generation
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a395c330a67bc39f703ad7c0403fbb5f53e5deab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->