### PR TITLE
Feature/chicago polish

### DIFF
--- a/pipelex/graph/graphspec.py
+++ b/pipelex/graph/graphspec.py
@@ -10,7 +10,7 @@ from typing import Any
 from pydantic import BaseModel, ConfigDict, Field, computed_field, field_validator, model_validator
 
 from pipelex.tools.typing.pydantic_utils import empty_list_factory_of
-from pipelex.types import StrEnum
+from pipelex.types import Self, StrEnum
 
 # Redaction limits
 MAX_PREVIEW_LENGTH = 200
@@ -85,9 +85,10 @@ class TimingSpec(BaseModel):
     # pop the duration field
     @model_validator(mode="before")
     @classmethod
-    def validate_duration(cls, data: dict[str, Any]) -> dict[str, Any]:
-        """Pop the duration field from the data."""
-        data.pop("duration", None)
+    def validate_duration(cls, data: dict[str, Any] | Self) -> dict[str, Any] | Self:
+        """Pop the duration field from the data if it is a dict."""
+        if isinstance(data, dict):
+            data.pop("duration", None)
         return data
 
 

--- a/pipelex/graph/graphspec.py
+++ b/pipelex/graph/graphspec.py
@@ -82,13 +82,13 @@ class TimingSpec(BaseModel):
         """Duration in seconds, included in JSON serialization."""
         return (self.ended_at - self.started_at).total_seconds()
 
-    # pop the duration field
+    # filter out the duration field (computed, not stored)
     @model_validator(mode="before")
     @classmethod
     def validate_duration(cls, data: dict[str, Any] | Self) -> dict[str, Any] | Self:
-        """Pop the duration field from the data if it is a dict."""
-        if isinstance(data, dict):
-            data.pop("duration", None)
+        """Filter out the duration field from dict input without mutating the original."""
+        if isinstance(data, dict) and "duration" in data:
+            return {key: value for key, value in data.items() if key != "duration"}
         return data
 
 

--- a/pipelex/graph/graphspec.py
+++ b/pipelex/graph/graphspec.py
@@ -7,7 +7,7 @@ GraphSpec is renderer-agnostic and designed for JSON serialization.
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field, computed_field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, computed_field, field_validator, model_validator
 
 from pipelex.tools.typing.pydantic_utils import empty_list_factory_of
 from pipelex.types import StrEnum
@@ -73,14 +73,22 @@ class TimingSpec(BaseModel):
 
     model_config = ConfigDict(extra="forbid", strict=True)
 
-    started_at: datetime
-    ended_at: datetime
+    started_at: datetime = Field(strict=False)
+    ended_at: datetime = Field(strict=False)
 
     @computed_field  # type: ignore[prop-decorator]
     @property
     def duration(self) -> float:
         """Duration in seconds, included in JSON serialization."""
         return (self.ended_at - self.started_at).total_seconds()
+
+    # pop the duration field
+    @model_validator(mode="before")
+    @classmethod
+    def validate_duration(cls, data: dict[str, Any]) -> dict[str, Any]:
+        """Pop the duration field from the data."""
+        data.pop("duration", None)
+        return data
 
 
 class IOSpec(BaseModel):

--- a/pipelex/pipe_operators/llm/document_reference.py
+++ b/pipelex/pipe_operators/llm/document_reference.py
@@ -17,7 +17,7 @@ class DocumentReferenceKind(StrEnum):
     """Direct reference to a DocumentContent variable, e.g., {{ report }}"""
 
     DIRECT_LIST = "direct_list"
-    """Direct reference to a list of DocumentContent, e.g., {{ documents }}"""
+    """Direct reference to a ListContent of DocumentContent, e.g., {{ documents }}"""
 
 
 class DocumentReference(BaseModel):

--- a/pipelex/pipe_operators/llm/image_reference.py
+++ b/pipelex/pipe_operators/llm/image_reference.py
@@ -17,7 +17,7 @@ class ImageReferenceKind(StrEnum):
     """Direct reference to an ImageContent variable, e.g., {{ portrait }}"""
 
     DIRECT_LIST = "direct_list"
-    """Direct reference to a list of ImageContent, e.g., {{ photos }}"""
+    """Direct reference to a ListContent of ImageContent, e.g., {{ photos }}"""
 
     NESTED = "nested"
     """Reference with | with_images filter for nested image extraction,

--- a/pipelex/pipelex.py
+++ b/pipelex/pipelex.py
@@ -10,6 +10,7 @@ from pydantic import ValidationError
 from pipelex import log
 from pipelex.base_exceptions import PipelexConfigError, PipelexSetupError
 from pipelex.cogt.content_generation.content_generator import ContentGenerator
+from pipelex.cogt.content_generation.content_generator_dry import ContentGeneratorDry
 from pipelex.cogt.content_generation.content_generator_protocol import (
     ContentGeneratorProtocol,
 )
@@ -154,6 +155,7 @@ If you need help, drop by our Discord: we're happy to assist: {URLs.discord}.
     def setup(
         self,
         integration_mode: IntegrationMode,
+        disable_inference: bool = False,
         class_registry: ClassRegistryAbstract | None = None,
         secrets_provider: SecretsProviderAbstract | None = None,
         storage_provider: StorageProviderAbstract | None = None,
@@ -186,22 +188,30 @@ If you need help, drop by our Discord: we're happy to assist: {URLs.discord}.
         remote_config: RemoteConfig | None = None
         gateway_model_specs: BackendModelSpecs | None = None
         if is_pipelex_service_enabled:
-            # Skip terms check for CI mode - automated CI/CD pipelines don't require human consent
-            if integration_mode.requires_terms_acceptance:
-                # Check if terms are accepted
-                pipelex_service_config = load_pipelex_service_config_if_exists(config_dir=config_manager.pipelex_config_dir)
-                if pipelex_service_config is None or not pipelex_service_config.agreement.terms_accepted:
-                    raise GatewayTermsNotAcceptedError
-            # Fetch remote configuration
-            remote_config = RemoteConfigFetcher.fetch_remote_config()
-            log.verbose("Successfully fetched Pipelex Gateway remote configuration")
-            gateway_model_specs = remote_config.backend_model_specs
+            if disable_inference:
+                # Use dummy config when inference is disabled (for testing without network access)
+                remote_config = RemoteConfigFetcher.make_dummy_remote_config()
+                gateway_model_specs = remote_config.backend_model_specs
+                log.verbose("Using dummy remote config (inference disabled)")
+            else:
+                # Skip terms check for CI mode - automated CI/CD pipelines don't require human consent
+                if integration_mode.requires_terms_acceptance:
+                    # Check if terms are accepted
+                    pipelex_service_config = load_pipelex_service_config_if_exists(config_dir=config_manager.pipelex_config_dir)
+                    if pipelex_service_config is None or not pipelex_service_config.agreement.terms_accepted:
+                        raise GatewayTermsNotAcceptedError
+                # Fetch remote configuration
+                remote_config = RemoteConfigFetcher.fetch_remote_config()
+                log.verbose("Successfully fetched Pipelex Gateway remote configuration")
+                gateway_model_specs = remote_config.backend_model_specs
 
+        # Disable Pipelex telemetry when inference is disabled (no remote config available)
+        is_pipelex_telemetry_enabled = is_pipelex_service_enabled and not disable_inference
         self.telemetry_manager = TelemetryFactory.make_telemetry_manager(
             secrets_provider=secrets_provider,
             integration_mode=integration_mode,
             remote_config=remote_config,
-            is_pipelex_telemetry_enabled=is_pipelex_service_enabled,
+            is_pipelex_telemetry_enabled=is_pipelex_telemetry_enabled,
             telemetry_config=telemetry_config,
             injected_telemetry_manager=telemetry_manager,
         )
@@ -287,8 +297,11 @@ If you need help, drop by our Discord: we're happy to assist: {URLs.discord}.
             raise PipelexSetupError(error_msg) from credentials_exc
 
         if content_generator is None:
-            generated_content_factory = GeneratedContentFactory(storage_provider=storage_provider)
-            content_generator = ContentGenerator(generated_content_factory=generated_content_factory)
+            if disable_inference:
+                content_generator = ContentGeneratorDry()
+            else:
+                generated_content_factory = GeneratedContentFactory(storage_provider=storage_provider)
+                content_generator = ContentGenerator(generated_content_factory=generated_content_factory)
         self.pipelex_hub.set_content_generator(content_generator)
 
         self.inference_manager = inference_manager or InferenceManager()
@@ -376,6 +389,7 @@ If you need help, drop by our Discord: we're happy to assist: {URLs.discord}.
     def make(
         cls,
         integration_mode: IntegrationMode = IntegrationMode.PYTHON,
+        disable_inference: bool = False,
         class_registry: ClassRegistryAbstract | None = None,
         secrets_provider: SecretsProviderAbstract | None = None,
         storage_provider: StorageProviderAbstract | None = None,
@@ -399,6 +413,9 @@ If you need help, drop by our Discord: we're happy to assist: {URLs.discord}.
 
         Args:
             integration_mode: Integration mode (CLI, FASTAPI, DOCKER, MCP, N8N, PYTHON, PYTEST)
+            disable_inference: When True, disables all inference functionality by using a mock
+                content generator. This skips gateway terms acceptance check and auto-skips
+                inference tests. Useful for CI/testing scenarios where inference is not needed.
             class_registry: Custom class registry for dynamic loading
             secrets_provider: Custom secrets/credentials provider
             storage_provider: Custom storage backend
@@ -431,6 +448,7 @@ If you need help, drop by our Discord: we're happy to assist: {URLs.discord}.
         try:
             pipelex_instance.setup(
                 integration_mode=integration_mode,
+                disable_inference=disable_inference,
                 class_registry=class_registry,
                 secrets_provider=secrets_provider,
                 storage_provider=storage_provider,

--- a/pipelex/system/pipelex_service/remote_config_fetcher.py
+++ b/pipelex/system/pipelex_service/remote_config_fetcher.py
@@ -61,7 +61,7 @@ class RemoteConfigFetcher:
         return _fetch_with_retry(url)
 
     @classmethod
-    def _make_dummy_remote_config(cls) -> RemoteConfig:
+    def make_dummy_remote_config(cls) -> RemoteConfig:
         """Create a default RemoteConfig for testing in offline environments.
 
         Returns:
@@ -91,7 +91,7 @@ class RemoteConfigFetcher:
         # In Codex Cloud, return dummy config to avoid SSL issues with MITM proxy
         if runtime_manager.is_in_codex_cloud:
             print_to_stderr("Skipping remote config fetch in Codex Cloud, using dummy config instead")
-            return cls._make_dummy_remote_config()
+            return cls.make_dummy_remote_config()
 
         url = PipelexDetails.REMOTE_CONFIG_URL
 

--- a/pipelex/test_extras/shared_pytest_plugins.py
+++ b/pipelex/test_extras/shared_pytest_plugins.py
@@ -63,14 +63,25 @@ def pytest_addoption(parser: Parser):
         help="Pipe run mode: 'live' or 'dry'",
         choices=("live", "dry"),
     )
+    parser.addoption(
+        "--disable-inference",
+        action="store_true",
+        default=False,
+        help="Disable inference for this test session. Uses mock content generator, "
+        "skips gateway terms check, and auto-skips tests marked with @pytest.mark.inference.",
+    )
 
 
-def pytest_configure(config: Config) -> None:  # noqa: ARG001
+def pytest_configure(config: Config) -> None:
     """Check prerequisites before test collection starts.
 
     Validates that Pipelex Gateway terms are accepted when gateway is enabled.
     This runs early to provide clear feedback before wasting time on test collection.
     """
+    # Skip check when inference is disabled via CLI option
+    if config.getoption("--disable-inference", default=False):
+        return
+
     # Skip check in CI environments (IntegrationMode.CI doesn't require terms)
     if is_env_var_set(key="GITHUB_ACTIONS") or is_env_var_set(key="CI"):
         return
@@ -112,6 +123,9 @@ def pytest_configure(config: Config) -> None:  # noqa: ARG001
 
 @pytest.fixture
 def pipe_run_mode(request: FixtureRequest) -> PipeRunMode:
+    # Force dry mode when inference is disabled
+    if request.config.getoption("--disable-inference", default=False):
+        return PipeRunMode.DRY
     mode_str = request.config.getoption("--pipe-run-mode")
     return PipeRunMode(mode_str)
 
@@ -172,3 +186,48 @@ def setup_ci_environment():
     # Cleanup placeholder environment variables after tests complete
     if runtime_manager.is_ci_testing:
         _cleanup_placeholder_env_vars(env_var_keys=env_var_keys)
+
+
+def pytest_collection_modifyitems(config: Config, items: list[pytest.Item]) -> None:
+    """Auto-skip non-dry-runnable inference tests when --disable-inference is set.
+
+    This hook runs after test collection and adds skip markers to tests that:
+    - Are marked with @pytest.mark.inference
+    - Are NOT marked with @pytest.mark.dry_runnable
+
+    Tests marked with both inference and dry_runnable can still run because
+    they use the mock ContentGeneratorDry.
+    """
+    if not config.getoption("--disable-inference", default=False):
+        return
+
+    skip_inference = pytest.mark.skip(reason="Inference disabled via --disable-inference (test is not dry_runnable)")
+    for item in items:
+        if "inference" in item.keywords and "dry_runnable" not in item.keywords:
+            item.add_marker(skip_inference)
+
+
+def is_inference_disabled_in_pipelex(request: FixtureRequest) -> bool:
+    """Check if inference is disabled for this test session.
+
+    Use this helper in your conftest.py to pass the disable_inference flag
+    to Pipelex.make():
+
+        from pipelex.test_extras.shared_pytest_plugins import is_inference_disabled
+
+        @pytest.fixture(scope="module", autouse=True)
+        def reset_pipelex_config_fixture(request):
+            pipelex_instance = Pipelex.make(
+                disable_inference=is_inference_disabled(request),
+            )
+
+    Yield:
+            pipelex_instance.teardown()
+
+    Args:
+        request: The pytest FixtureRequest object.
+
+    Returns:
+        True if --disable-inference was passed, False otherwise.
+    """
+    return bool(request.config.getoption("--disable-inference", default=False))


### PR DESCRIPTION
  # Summary of Changes

  pipelex/pipelex.py

  - Added disable_inference: bool = False parameter to make() and setup()
  - When disable_inference=True:
    - Uses dummy remote config instead of fetching from network
    - Disables Pipelex telemetry
    - Uses ContentGeneratorDry (mock) for all content generation

  pipelex/system/pipelex_service/remote_config_fetcher.py

  - Renamed _make_dummy_remote_config() → make_dummy_remote_config() (made public)

  pipelex/test_extras/shared_pytest_plugins.py

  - Added --disable-inference pytest CLI option
  - Updated pytest_configure to skip gateway check when --disable-inference is set
  - Added pytest_collection_modifyitems hook to auto-skip tests marked with @pytest.mark.inference that are NOT also @pytest.mark.dry_runnable
  - Updated pipe_run_mode fixture to force DRY mode when --disable-inference is set
  - Added is_inference_disabled_in_pipelex(request) helper function

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces an optional inference-disabled workflow for local/CI testing and minor model/doc tweaks.
> 
> - **Pipelex core**: New `disable_inference` param in `setup()`/`make()`; when enabled uses `RemoteConfigFetcher.make_dummy_remote_config()`, turns off telemetry, skips gateway terms check, and uses `ContentGeneratorDry`.
> - **Remote config**: `_make_dummy_remote_config` renamed to public `make_dummy_remote_config`; used for Codex Cloud and inference-disabled paths.
> - **Pytest plugins**: Adds `--disable-inference` option; skips gateway terms check, forces `PipeRunMode.DRY`, auto-skips `@inference` tests unless also `@dry_runnable`, and provides `is_inference_disabled_in_pipelex(request)` helper.
> - **GraphSpec**: `TimingSpec` relaxes strictness on timestamps and adds a `model_validator` to strip computed `duration` from input.
> - **LLM refs**: Clarifies `DIRECT_LIST` docstrings for document/image references to indicate `ListContent`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c13652c7fe52925e0e025245aa2e2fdc6ce782ce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->