### PR TITLE
docs/Library dirs

### DIFF
--- a/docs/home/6-build-reliable-ai-workflows/pipes/executing-pipelines.md
+++ b/docs/home/6-build-reliable-ai-workflows/pipes/executing-pipelines.md
@@ -1,34 +1,74 @@
 # Executing Pipelines
 
-Once your pipes are defined in `.plx` files, you can execute them in multiple ways:
+Once your pipes are defined in `.plx` files, you can execute them in multiple ways.
 
-## Option 1: Using the Pipelex CLI
+## The Simplest Approach: Run a Bundle File
 
-First you can prepare the inputs for your pipeline in a JSON file.
+The easiest way to execute a pipeline is to point directly to your `.plx` bundle file. No library configuration needed.
 
-```bash
-pipelex build inputs path/to/my_pipe.plx
-```
-
-This will create a `inputs.json` file in the `results` directory, with the needed inputs for your pipeline. You can fill in the values for the inputs in the `results/inputs.json` file.
-
-Then you can execute the pipeline with the CLI.
+### Using the CLI
 
 ```bash
-pipelex run path/to/my_pipe.plx --inputs results/inputs.json
+# Run the bundle's main_pipe
+pipelex run path/to/my_bundle.plx
+
+# Run a specific pipe from the bundle
+pipelex run path/to/my_bundle.plx --pipe my_specific_pipe
+
+# Run with inputs
+pipelex run path/to/my_bundle.plx --inputs inputs.json
 ```
 
-See more about the CLI [here](../../9-tools/cli/index.md).
+!!! tip "Preparing Inputs"
+    You can generate an input template with `pipelex build inputs path/to/my_bundle.plx`, which creates a `results/inputs.json` file with the required input structure.
 
-## Option 2: Using the python method `execute_pipeline`
+### Using Python
 
-This function executes the specified pipe and waits for it to complete, returning the final output.
+```python
+from pipelex.pipelex import Pipelex
+from pipelex.pipeline.execute import execute_pipeline
 
-There are 2 ways of using the `execute_pipeline` method:
+Pipelex.make()
+
+# Run the bundle's main_pipe
+pipe_output = await execute_pipeline(
+    bundle_uri="path/to/my_bundle.plx",
+    inputs={
+        "my_input": {
+            "concept": "Text",
+            "content": "Hello world",
+        },
+    },
+)
+
+# Or run a specific pipe from the bundle
+pipe_output = await execute_pipeline(
+    bundle_uri="path/to/my_bundle.plx",
+    pipe_code="my_specific_pipe",
+    inputs={...},
+)
+```
+
+!!! info "How `main_pipe` Works"
+    When you run a bundle without specifying a `pipe_code`, Pipelex executes the bundle's `main_pipe` (declared at the top of the `.plx` file). If no `main_pipe` is defined and no `pipe_code` is provided, an error is raised.
+
+    If you provide both `bundle_uri` and `pipe_code`, the explicit `pipe_code` takes priority over `main_pipe`.
+
+See the [Pipelex Bundle Specification](../pipelex-bundle-specification.md) for more about the `main_pipe` property.
+
+---
+
+## Advanced: Using Library Directories
+
+For larger projects with multiple bundles spread across directories, you can configure **library directories** to load all your pipes at once and reference them by code.
 
 ### Understanding Libraries
 
-When executing pipelines programmatically, Pipelex loads the pipe **libraries** to execute the pipes. A library is a collection of pipes loaded from one or more directories.
+When executing pipelines programmatically, Pipelex can load pipe **libraries** - collections of pipes loaded from one or more directories. This is useful when:
+
+- You have multiple bundles across different directories
+- You want to reference pipes by code without specifying the bundle path each time
+- You're building an application that needs access to many pipes
 
 #### Library Parameters
 
@@ -40,14 +80,6 @@ When using `execute_pipeline` or `start_pipeline`, you can control library behav
 
 - **`plx_content`**: When provided, Pipelex will load only this PLX content into the library, bypassing directory scanning. This is useful for dynamic pipeline execution without file-based definitions.
 
-#### Library Loading Behavior
-
-The loading behavior depends on which parameters you provide:
-
-1. **Using `pipe_code` only** (Option 2.1 below): Pipelex loads all pipe definitions from `library_dirs` (or current directory if not specified), then looks up the pipe by its code.
-
-2. **Using `plx_content`** (Option 2.2 below): Pipelex loads only the provided PLX content into the library, creating an isolated execution environment.
-
 !!! info "Python Structure Classes"
     If your concepts use Python `StructuredContent` classes instead of inline structures, those Python files must be in the directories specified by `library_dirs`. Pipelex auto-discovers and registers these classes during library loading. Learn more about [Python StructuredContent Classes](../concepts/python-classes.md).
 
@@ -57,7 +89,7 @@ The loading behavior depends on which parameters you provide:
 !!! tip "Library Directory Configuration"
     For complete configuration options including the `PIPELEXPATH` environment variable, CLI options, and priority resolution, see [Configuring Library Directories](../../7-configuration/config-technical/library-config.md#configuring-library-directories).
 
-### Option 2.1: Using the pipe code
+### Running Pipes by Code
 
 This approach loads pipe definitions from directories and executes a specific pipe by its code.
 
@@ -118,9 +150,9 @@ pipe_output = await execute_pipeline(
 !!! tip "Listing available pipes"
     Use the `pipelex show pipes` command to list all the pipes available in your project.
 
-### Option 2.2: Using the pipelex bundle content
+### Using PLX Content Directly
 
-You can directly pass to the `execute_pipeline` method the content of your pipelex file and the necessary inputs.
+You can directly pass PLX content as a string to `execute_pipeline`, useful for dynamic pipeline execution without file-based definitions.
 
 ```python
 from pipelex.pipelex import Pipelex
@@ -129,23 +161,28 @@ from pipelex.pipeline.execute import execute_pipeline
 my_pipe_content = """
 domain = "marketing"
 description = "Marketing content generation domain"
+main_pipe = "generate_tagline"
 
-# 1. Define the concepts used in our pipes
 [concept]
 ProductDescription = "A description of a product's features and benefits"
 Tagline = "A catchy marketing tagline"
 
-# 2. Define the pipe that does the work
 [pipe.generate_tagline]
 type = "PipeLLM"
 description = "Generate a catchy tagline for a product"
 inputs = { description = "ProductDescription" }
 output = "Tagline"
-prompt = "Product Description: @description \n Generate a catchy tagline based on the above description. The tagline should be memorable, concise, and highlight the key benefit.
+prompt = "
+Product Description: $description
+
+Generate a catchy tagline based on the above description. The tagline should be memorable, concise, and highlight the key benefit.
+"
 """
+
+Pipelex.make()
+
 pipe_output = await execute_pipeline(
     plx_content=my_pipe_content,
-    pipe_code="description_to_tagline",
     inputs={
         "description": {
             "concept": "ProductDescription",
@@ -155,16 +192,22 @@ pipe_output = await execute_pipeline(
 )
 ```
 
-!!! note "Using the pipe code"
-    If your `plx_content` contains a `main_pipe` property (See more about the [Pipelex Bundle Specification](../pipelex-bundle-specification.md)), there is no need to provide the `pipe_code` parameter, the pipe that will be executed will be the one defined by `main_pipe` property. However if it doesn't, you must to provide the `pipe_code` parameter.
+!!! note "Pipe Code Resolution"
+    When using `plx_content`:
 
-    If you provide the `pipe_code` and your `plx_content` does contain a `main_pipe` property, the pipe_code will be the one to be executed.
+    - If the content has a `main_pipe` property and you don't provide `pipe_code`, the `main_pipe` is executed
+    - If you provide `pipe_code`, it overrides `main_pipe`
+    - If there's no `main_pipe` and no `pipe_code`, an error is raised
 
-## Option 3: Using the Pipelex API
+---
 
-Pipelex has an API, see more about it [here](https://pipelex.github.io/pipelex-api/).
+## Using the Pipelex API
 
-# Background Execution with `start_pipeline`
+Pipelex has a REST API for executing pipelines. See more about it [here](https://pipelex.github.io/pipelex-api/).
+
+---
+
+## Background Execution with `start_pipeline`
 
 For more complex scenarios where you need asynchronous control, use `start_pipeline`. This function immediately returns a `pipeline_run_id` and an `asyncio.Task`, allowing you to run pipelines in the background.
 
@@ -176,7 +219,7 @@ Pipelex.make()
 
 # Start the pipeline without waiting
 pipeline_run_id, task = await start_pipeline(
-    pipe_code="description_to_tagline",
+    bundle_uri="path/to/my_bundle.plx",
     inputs={
         "description": {
             "concept": "ProductDescription",

--- a/docs/home/6-build-reliable-ai-workflows/pipes/executing-pipelines.md
+++ b/docs/home/6-build-reliable-ai-workflows/pipes/executing-pipelines.md
@@ -36,7 +36,7 @@ When using `execute_pipeline` or `start_pipeline`, you can control library behav
 
 - **`library_id`**: A unique identifier for the library instance. If not specified, it defaults to the `pipeline_run_id` (a unique ID generated for each pipeline execution).
 
-- **`library_dirs`**: A list of directory paths to load pipe definitions from. **These directories must contain both your `.plx` files AND any Python files defining `StructuredContent` classes** (e.g., `*_struct.py` files). If not specified, Pipelex will load from the current working directory (the directory from which your Python script is executed).
+- **`library_dirs`**: A list of directory paths to load pipe definitions from. **These directories must contain both your `.plx` files AND any Python files defining `StructuredContent` classes** (e.g., `*_struct.py` files). If not specified, Pipelex falls back to the `PIPELEXPATH` environment variable, then to the current working directory.
 
 - **`plx_content`**: When provided, Pipelex will load only this PLX content into the library, bypassing directory scanning. This is useful for dynamic pipeline execution without file-based definitions.
 
@@ -53,6 +53,9 @@ The loading behavior depends on which parameters you provide:
 
 !!! info "Learn More About Libraries"
     For a comprehensive understanding of libraries, including their structure, uniqueness rules, lifecycle, and best practices, see [Libraries](../libraries.md).
+
+!!! tip "Library Directory Configuration"
+    For complete configuration options including the `PIPELEXPATH` environment variable, CLI options, and priority resolution, see [Configuring Library Directories](../../7-configuration/config-technical/library-config.md#configuring-library-directories).
 
 ### Option 2.1: Using the pipe code
 

--- a/docs/home/7-configuration/config-technical/library-config.md
+++ b/docs/home/7-configuration/config-technical/library-config.md
@@ -1,6 +1,46 @@
 # Pipeline Discovery and Loading
 
-Pipelex automatically discovers and loads pipeline files (`.plx`) and structure classes from your project. This page explains how the discovery system works and how to organize your pipelines effectively.
+When running pipelines, Pipelex needs to find your `.plx` bundle files. There are two approaches:
+
+1. **Point to the bundle file directly** - The simplest option. Just pass the path to your `.plx` file. No configuration needed.
+
+2. **Configure library directories** - For larger projects. Pipelex scans directories to discover all bundles, letting you reference pipes by code.
+
+Most users should start with the first approach.
+
+## The Simplest Way: Use the Bundle Path Directly
+
+If you just want to run a pipe from a single `.plx` file, **you don't need any library configuration**. Simply point to your bundle file:
+
+```bash
+# CLI: run the bundle's main_pipe
+pipelex run path/to/my_bundle.plx
+
+# CLI: run a specific pipe from the bundle
+pipelex run path/to/my_bundle.plx --pipe my_pipe
+```
+
+```python
+# Python: run the bundle's main_pipe
+pipe_output = await execute_pipeline(
+    bundle_uri="path/to/my_bundle.plx",
+    inputs={...},
+)
+
+# Python: run a specific pipe from the bundle
+pipe_output = await execute_pipeline(
+    bundle_uri="path/to/my_bundle.plx",
+    pipe_code="my_pipe",
+    inputs={...},
+)
+```
+
+This is the recommended approach for newcomers and simple projects. Pipelex reads the file directly - no discovery needed.
+
+!!! tip "When to use library directories"
+    The library directory configuration below is useful when you have **multiple bundles across different directories** and want to reference pipes by code without specifying the bundle path each time. For most use cases, pointing to the `.plx` file directly is simpler.
+
+---
 
 ## How Pipeline Discovery Works
 

--- a/docs/home/7-configuration/config-technical/library-config.md
+++ b/docs/home/7-configuration/config-technical/library-config.md
@@ -13,6 +13,194 @@ When you initialize Pipelex with `Pipelex.make()`, the system:
 
 All of this happens automatically - no configuration needed.
 
+## Configuring Library Directories
+
+When executing pipelines, Pipelex needs to know where to find your `.plx` files and Python structure classes. You can configure this using a **3-tier priority system** that gives you flexibility from global defaults to per-execution overrides.
+
+### The 3-Tier Priority System
+
+Pipelex resolves library directories using this priority order (highest to lowest):
+
+| Priority | Source | When to Use |
+|----------|--------|-------------|
+| **1 (Highest)** | Per-call `library_dirs` parameter | Override for specific pipeline executions |
+| **2** | Instance default via `Pipelex.make(library_dirs=...)` | Application-wide default |
+| **3 (Fallback)** | `PIPELEXPATH` environment variable | System-wide or shell session default |
+
+!!! info "Empty List is Valid"
+    Passing an empty list `[]` to `library_dirs` is a valid explicit value that **disables** directory-based library loading. This is useful when using `plx_content` directly without needing files from the filesystem.
+
+### Using the PIPELEXPATH Environment Variable
+
+The `PIPELEXPATH` environment variable provides a system-wide default for library directories. It uses PATH-style syntax:
+
+- **Unix/macOS**: Colon-separated paths (`:`)
+- **Windows**: Semicolon-separated paths (`;`)
+
+**Bash / Zsh (macOS/Linux):**
+
+```bash
+# Single directory
+export PIPELEXPATH="/path/to/my/pipelines"
+
+# Multiple directories (colon-separated)
+export PIPELEXPATH="/path/to/shared_pipes:/path/to/project_pipes"
+
+# Add to your ~/.bashrc or ~/.zshrc for persistence
+echo 'export PIPELEXPATH="/path/to/my/pipelines"' >> ~/.bashrc
+```
+
+**PowerShell (Windows):**
+
+```powershell
+# Single directory
+$env:PIPELEXPATH = "C:\path\to\my\pipelines"
+
+# Multiple directories (semicolon-separated)
+$env:PIPELEXPATH = "C:\shared_pipes;C:\project_pipes"
+```
+
+**In a `.env` file:**
+
+```bash
+# .env file in your project root
+PIPELEXPATH=/path/to/shared_pipes:/path/to/project_pipes
+```
+
+### Using the CLI `--library-dir` Option
+
+When running pipelines from the command line, use the `-L` or `--library-dir` option. This option can be specified multiple times to include multiple directories.
+
+```bash
+# Single directory
+pipelex run my_pipe -L /path/to/pipelines
+
+# Multiple directories
+pipelex run my_pipe -L /path/to/shared_pipes -L /path/to/project_pipes
+
+# Combined with other options
+pipelex run my_bundle.plx --inputs data.json -L /path/to/pipelines
+
+# Available on multiple commands
+pipelex validate all -L /path/to/pipelines
+pipelex show pipes -L /path/to/pipelines
+pipelex which my_pipe -L /path/to/pipelines
+```
+
+!!! tip "CLI Option Overrides PIPELEXPATH"
+    When you use `-L` on the command line, it takes precedence over any `PIPELEXPATH` environment variable that may be set.
+
+### Setting Instance Defaults with `Pipelex.make()`
+
+For Python applications, you can set a default library directory when initializing Pipelex. This default will be used for all subsequent `execute_pipeline` calls unless overridden.
+
+```python
+from pipelex.pipelex import Pipelex
+from pipelex.pipeline.execute import execute_pipeline
+
+# Set instance-level defaults at initialization
+Pipelex.make(
+    library_dirs=["/path/to/shared_pipes", "/path/to/project_pipes"]
+)
+
+# All execute_pipeline calls will use these directories by default
+pipe_output = await execute_pipeline(
+    pipe_code="my_pipe",
+    inputs={"input": "value"},
+)
+```
+
+### Per-Call Override with `execute_pipeline`
+
+For maximum flexibility, you can override library directories on each `execute_pipeline` call:
+
+```python
+from pipelex.pipelex import Pipelex
+from pipelex.pipeline.execute import execute_pipeline
+
+# Initialize with default directories
+Pipelex.make(
+    library_dirs=["/path/to/default_pipes"]
+)
+
+# Use the default directories
+output1 = await execute_pipeline(
+    pipe_code="default_pipe",
+    inputs={"input": "value"},
+)
+
+# Override for a specific execution
+output2 = await execute_pipeline(
+    pipe_code="special_pipe",
+    library_dirs=["/path/to/special_pipes"],  # Overrides instance default
+    inputs={"input": "value"},
+)
+
+# Disable directory loading (use only plx_content)
+output3 = await execute_pipeline(
+    plx_content=my_plx_string,
+    library_dirs=[],  # Empty list disables directory-based loading
+    inputs={"input": "value"},
+)
+```
+
+### Priority Resolution Examples
+
+**Example 1: Environment variable as fallback**
+
+```bash
+# Shell: Set PIPELEXPATH
+export PIPELEXPATH="/shared/pipes"
+```
+
+```python
+# Python: No library_dirs specified anywhere
+Pipelex.make()  # No library_dirs
+
+# Uses PIPELEXPATH: /shared/pipes
+output = await execute_pipeline(pipe_code="my_pipe", inputs={...})
+```
+
+**Example 2: Instance default overrides PIPELEXPATH**
+
+```bash
+# Shell: PIPELEXPATH is set
+export PIPELEXPATH="/shared/pipes"
+```
+
+```python
+# Python: Instance default set
+Pipelex.make(library_dirs=["/project/pipes"])
+
+# Uses instance default: /project/pipes (PIPELEXPATH ignored)
+output = await execute_pipeline(pipe_code="my_pipe", inputs={...})
+```
+
+**Example 3: Per-call override takes highest priority**
+
+```python
+Pipelex.make(library_dirs=["/default/pipes"])
+
+# Uses per-call value: /special/pipes
+output = await execute_pipeline(
+    pipe_code="my_pipe",
+    library_dirs=["/special/pipes"],  # Highest priority
+    inputs={...},
+)
+```
+
+### Best Practices
+
+1. **Use PIPELEXPATH for shared libraries**: Set it in your shell profile for directories that should always be available.
+
+2. **Use `Pipelex.make(library_dirs=...)` for application defaults**: When building an application, set sensible defaults at initialization.
+
+3. **Use per-call `library_dirs` for exceptions**: Override only when a specific execution needs different directories.
+
+4. **Use empty list `[]` for isolated execution**: When you want to execute only from `plx_content` without loading any file-based definitions.
+
+5. **Include structure class directories**: Remember that `library_dirs` must contain both `.plx` files AND Python files defining `StructuredContent` classes.
+
 ## Excluded Directories
 
 To improve performance and avoid loading unnecessary files, Pipelex automatically excludes common directories from discovery:

--- a/docs/home/9-tools/cli/run.md
+++ b/docs/home/9-tools/cli/run.md
@@ -22,6 +22,7 @@ Executes a pipeline, either from a standalone bundle (.plx) file or from your pr
 - `--output`, `-o` - Path to save output JSON (defaults to `results/run_{pipe_code}.json`)
 - `--no-output` - Skip saving output to file
 - `--no-pretty-print` - Skip pretty printing the main output
+- `--library-dir`, `-L` - Directory to search for pipe definitions (.plx files). Can be specified multiple times.
 
 **Examples:**
 
@@ -43,6 +44,9 @@ pipelex run --pipe hello_world --output my_output.json
 
 # Run without saving or pretty printing
 pipelex run my_pipe --no-output --no-pretty-print
+
+# Run with custom library directories
+pipelex run my_pipe -L ./pipelines -L ./shared_pipes
 ```
 
 ## Input JSON Format

--- a/docs/home/9-tools/cli/validate.md
+++ b/docs/home/9-tools/cli/validate.md
@@ -16,11 +16,18 @@ Performs comprehensive validation:
 
 This is the recommended validation to run before committing changes or deploying pipelines.
 
+**Options:**
+
+- `--library-dir`, `-L` - Directory to search for pipe definitions. Can be specified multiple times.
+
 **Examples:**
 
 ```bash
 # Validate everything
 pipelex validate all
+
+# Validate with custom library directories
+pipelex validate all -L ./pipelines -L ./shared_pipes
 ```
 
 ## Validate Single Pipe
@@ -39,6 +46,7 @@ Validates and dry-runs a specific pipe from your imported packages, useful for i
 **Options:**
 
 - `--pipe PIPE_CODE` - Explicitly specify the pipe code to validate (alternative to positional argument)
+- `--library-dir`, `-L` - Directory to search for pipe definitions. Can be specified multiple times.
 
 **Examples:**
 
@@ -49,6 +57,9 @@ pipelex validate write_weekly_report
 
 # Validate a specific pipe (explicit option)
 pipelex validate --pipe analyze_cv_matching
+
+# Validate with custom library directories
+pipelex validate my_pipe -L ./pipelines
 ```
 
 ## Validate Bundle
@@ -67,6 +78,7 @@ Validates all pipes defined in a bundle file. The command automatically detects 
 **Options:**
 
 - `--bundle BUNDLE_FILE.plx` - Explicitly specify the bundle file path
+- `--library-dir`, `-L` - Directory to search for additional pipe definitions. Can be specified multiple times.
 
 **Examples:**
 
@@ -77,6 +89,9 @@ pipelex validate pipelines/invoice_processor.plx
 
 # Validate a bundle (explicit option)
 pipelex validate --bundle my_pipeline.plx
+
+# Validate a bundle with additional library directories
+pipelex validate my_bundle.plx -L ./shared_pipes
 ```
 
 !!! note


### PR DESCRIPTION
- docs/Library dirs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors execution docs to prioritize running pipelines by pointing to `.plx` bundle files, clarifies `main_pipe` behavior, and adds advanced guidance for using library directories with per-call, instance, and `PIPELEXPATH` resolution. Also updates CLI docs to include `--library-dir/-L` across `run` and `validate`, with examples, and introduces a comprehensive configuration page covering discovery, best practices, and troubleshooting.
> 
> - **Executing Pipelines:** New bundle-first workflow with CLI/Python examples; added notes on `main_pipe` precedence; `start_pipeline` example now uses `bundle_uri`.
> - **Library configuration:** New/expanded "Pipeline Discovery and Loading" page detailing 3-tier priority (`library_dirs`, `Pipelex.make`, `PIPELEXPATH`), environment/CLI usage, examples, best practices, excluded dirs, and project organization.
> - **CLI:** `run.md` and `validate.md` document `--library-dir/-L` and provide usage examples.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2900469ce77f84bceff1babc2d584ae0dc355a9b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->