### PR TITLE
Release/v0.17.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [v0.17.5] - 2026-01-16
+
+- Added target `make docs-deploy-404` to deploy the 404.html file to the gh-pages root for versionless URL redirects.
+
 ## [v0.17.4] - 2026-01-16
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,7 @@ make docs-list                - List deployed documentation versions
 make docs-deploy VERSION=x.y.z - Deploy docs as version x.y.z (local, no push)
 make docs-deploy-stable       - Deploy stable docs with 'latest' alias (CI only)
 make docs-deploy-beta         - Manually deploy pre-release docs with '-beta' suffix
+make docs-deploy-404          - Deploy 404.html for versionless URL redirects
 
 make check                    - Shorthand -> format lint mypy
 make c                        - Shorthand -> check
@@ -128,7 +129,8 @@ export HELP
 	merge-check-ruff-lint merge-check-ruff-format merge-check-mypy merge-check-pyright \
 	li check-unused-imports fix-unused-imports check-uv check-TODOs \
 	docs docs-check docs-serve-versioned docs-list docs-deploy docs-deploy-stable docs-deploy-beta \
-	test-count check-test-badge
+	test-count check-test-badge \
+	docs-deploy-404
 
 all help:
 	@echo "$$HELP"
@@ -557,14 +559,26 @@ docs-deploy: env
 	$(call PRINT_TITLE,"Deploying documentation version $(if $(VERSION),$(VERSION),$(DOCS_VERSION))")
 	$(VENV_MIKE) deploy $(if $(VERSION),$(VERSION),$(DOCS_VERSION))
 
-docs-deploy-stable: env
+docs-deploy-stable: env docs-deploy-404
 	$(call PRINT_TITLE,"Deploying stable documentation $(DOCS_VERSION) with latest alias")
 	$(VENV_MIKE) deploy --push --update-aliases $(DOCS_VERSION) latest
 	$(VENV_MIKE) set-default --push latest
 
-docs-deploy-beta: env
+docs-deploy-beta: env docs-deploy-404
 	$(call PRINT_TITLE,"Deploying pre-release documentation $(DOCS_VERSION)-beta")
 	$(VENV_MIKE) deploy --push $(DOCS_VERSION)-beta
+
+docs-deploy-404:
+	$(call PRINT_TITLE,"Deploying 404.html to gh-pages root for versionless URL redirects")
+	@TMPDIR=$$(mktemp -d) && \
+	git worktree add "$$TMPDIR" gh-pages && \
+	cp docs/404.html "$$TMPDIR/404.html" && \
+	cd "$$TMPDIR" && \
+	git add 404.html && \
+	git diff --cached --quiet || git commit -m "Update 404.html for versionless URL redirects" && \
+	git push origin gh-pages && \
+	cd - > /dev/null && \
+	git worktree remove "$$TMPDIR"
 
 ##########################################################################################
 ### SHORTHANDS

--- a/Makefile
+++ b/Makefile
@@ -570,15 +570,14 @@ docs-deploy-beta: env docs-deploy-404
 
 docs-deploy-404:
 	$(call PRINT_TITLE,"Deploying 404.html to gh-pages root for versionless URL redirects")
-	@TMPDIR=$$(mktemp -d) && \
+	@TMPDIR=$$(mktemp -d); \
+	trap "cd '$(CURDIR)'; git worktree remove '$$TMPDIR' 2>/dev/null || true; rm -rf '$$TMPDIR'" EXIT; \
 	git worktree add "$$TMPDIR" gh-pages && \
 	cp docs/404.html "$$TMPDIR/404.html" && \
 	cd "$$TMPDIR" && \
 	git add 404.html && \
-	git diff --cached --quiet || git commit -m "Update 404.html for versionless URL redirects" && \
-	git push origin gh-pages && \
-	cd - > /dev/null && \
-	git worktree remove "$$TMPDIR"
+	(git diff --cached --quiet || git commit -m "Update 404.html for versionless URL redirects") && \
+	git push origin gh-pages
 
 ##########################################################################################
 ### SHORTHANDS

--- a/docs/404.html
+++ b/docs/404.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Redirecting...</title>
+    <script>
+        const path = window.location.pathname;
+        // Get the first path segment (e.g., "/latest/foo/bar" → "latest")
+        const firstSegment = path.split('/').filter(seg => seg)[0];
+
+        // Check if it's a version: either "latest" or starts with "0." (e.g., "0.17")
+        const hasVersion = firstSegment === 'latest' || (firstSegment && firstSegment.startsWith('0.'));
+
+        if (!hasVersion) {
+            // No version in URL, redirect to /latest/...
+            const newUrl = '/latest' + path + window.location.search + window.location.hash;
+            window.location.replace(newUrl);
+        } else {
+            // Already has version, this is a real 404
+            document.write('<h1>Page not found</h1><p>The page you requested does not exist.</p>');
+        }
+    </script>
+</head>
+<body>
+    <noscript>
+        <h1>Page not found</h1>
+        <p>Enable JavaScript for automatic redirects, or go to <a href="/latest/">the documentation</a>.</p>
+    </noscript>
+</body>
+</html>

--- a/docs/404.html
+++ b/docs/404.html
@@ -11,13 +11,24 @@
         // Check if it's a version: either "latest" or starts with "0." (e.g., "0.17")
         const hasVersion = firstSegment === 'latest' || (firstSegment && firstSegment.startsWith('0.'));
 
+        // Check if we're already on a 404.html path (prevents infinite loop for invalid versions)
+        const isAlready404 = path.endsWith('/404.html');
+
         if (!hasVersion) {
             // No version in URL, redirect to /latest/...
             const newUrl = '/latest' + path + window.location.search + window.location.hash;
             window.location.replace(newUrl);
+        } else if (isAlready404 && firstSegment !== 'latest') {
+            // We tried a version's 404.html but it doesn't exist (invalid version)
+            // Fall back to /latest/404.html
+            window.location.replace('/latest/404.html');
+        } else if (!isAlready404) {
+            // Has version, redirect to that version's styled 404 page
+            const version404Url = '/' + firstSegment + '/404.html';
+            window.location.replace(version404Url);
         } else {
-            // Already has version, this is a real 404
-            document.write('<h1>Page not found</h1><p>The page you requested does not exist.</p>');
+            // We're on /latest/404.html and it still 404'd - show basic error
+            document.write('<h1>Page not found</h1><p>The page you requested does not exist. <a href="/latest/">Go to documentation</a>.</p>');
         }
     </script>
 </head>

--- a/docs/404.html
+++ b/docs/404.html
@@ -5,25 +5,26 @@
     <title>Redirecting...</title>
     <script>
         const path = window.location.pathname;
-        // Get the first path segment (e.g., "/latest/foo/bar" → "latest")
-        const firstSegment = path.split('/').filter(seg => seg)[0];
+        // Get path segments (e.g., "/latest/foo/bar" → ["latest", "foo", "bar"])
+        const segments = path.split('/').filter(seg => seg);
+        const firstSegment = segments[0];
 
         // Check if it's a version: either "latest" or starts with "0." (e.g., "0.17")
         const hasVersion = firstSegment === 'latest' || (firstSegment && firstSegment.startsWith('0.'));
 
-        // Check if we're already on a 404.html path (prevents infinite loop for invalid versions)
-        const isAlready404 = path.endsWith('/404.html');
+        // Check if we're on a version's root 404 page (exactly /{version}/404.html)
+        const isVersionRoot404 = segments.length === 2 && segments[1] === '404.html';
 
         if (!hasVersion) {
             // No version in URL, redirect to /latest/...
             const newUrl = '/latest' + path + window.location.search + window.location.hash;
             window.location.replace(newUrl);
-        } else if (isAlready404 && firstSegment !== 'latest') {
+        } else if (isVersionRoot404 && firstSegment !== 'latest') {
             // We tried a version's 404.html but it doesn't exist (invalid version)
             // Fall back to /latest/404.html
             window.location.replace('/latest/404.html');
-        } else if (!isAlready404) {
-            // Has version, redirect to that version's styled 404 page
+        } else if (!isVersionRoot404) {
+            // Has version but not on 404 page, redirect to that version's styled 404 page
             const version404Url = '/' + firstSegment + '/404.html';
             window.location.replace(version404Url);
         } else {

--- a/docs/404.md
+++ b/docs/404.md
@@ -1,0 +1,10 @@
+---
+template: main.html
+title: Page not found
+---
+
+# Page not found
+
+The page you requested does not exist.
+
+[Return to the documentation homepage](index.md){ .md-button .md-button--primary }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pipelex"
-version = "0.17.4"
+version = "0.17.5"
 description = "The open standard for repeatable AI workflows. Write business logic, not API calls."
 authors = [{ name = "Evotis S.A.S.", email = "oss@pipelex.com" }]
 maintainers = [{ name = "Pipelex staff", email = "oss@pipelex.com" }]

--- a/uv.lock
+++ b/uv.lock
@@ -1752,7 +1752,7 @@ wheels = [
 
 [[package]]
 name = "pipelex"
-version = "0.17.4"
+version = "0.17.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
- Added target `make docs-deploy-404` to deploy the 404.html file to the gh-pages root for versionless URL redirects.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves docs hosting with version-aware 404 redirects and automates deployment of the root 404 page.
> 
> - New `docs/404.html` (JS redirect to `/latest/...`) and styled `docs/404.md`
> - New `make docs-deploy-404` target uses a gh-pages worktree to publish `404.html` at repo root
> - `docs-deploy-stable` and `docs-deploy-beta` now depend on `docs-deploy-404`
> - Version bump to `0.17.5` and changelog update
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2cfb386bb8835da0b39c249d3901e967bcc1740c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->