### PR TITLE
Remove hidden code in __init__.py file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- **`pipelex build inputs` Command**: New CLI command to generate example input JSON files for pipes. Supports `--library-dir` (`-L`) to specify library directories.
+- **Pipe Code Syntax Validation**: Bundle validation now checks that pipe codes and `main_pipe` values use valid snake_case syntax, with proper error categorization (`INVALID_PIPE_CODE_SYNTAX`).
+
+### Changed
+
+- Simplified `.plx` file detection to check file extension only.
+
 ## [v0.18.0b1] - 2026-01-16
 
 **Highlights:**

--- a/pipelex/builder/builder_loop.py
+++ b/pipelex/builder/builder_loop.py
@@ -227,6 +227,7 @@ class BuilderLoop:
                 case (
                     PipeValidationErrorType.LLM_OUTPUT_CANNOT_BE_IMAGE
                     | PipeValidationErrorType.IMG_GEN_INPUT_NOT_TEXT_COMPATIBLE
+                    | PipeValidationErrorType.INVALID_PIPE_CODE_SYNTAX
                     | PipeValidationErrorType.UNKNOWN_VALIDATION_ERROR
                     | PipeValidationErrorType.CIRCULAR_DEPENDENCY_ERROR
                 ):

--- a/pipelex/cli/_cli.py
+++ b/pipelex/cli/_cli.py
@@ -6,7 +6,7 @@ from click import Command, Context
 from typer.core import TyperGroup
 from typing_extensions import override
 
-from pipelex.cli.commands.build import build_app
+from pipelex.cli.commands.build.app import build_app
 from pipelex.cli.commands.doctor_cmd import doctor_cmd
 from pipelex.cli.commands.graph_cmd import graph_app
 from pipelex.cli.commands.init.command import init_cmd

--- a/pipelex/cli/commands/build/__init__.py
+++ b/pipelex/cli/commands/build/__init__.py
@@ -1,6 +1,0 @@
-# Import command modules to register them with build_app
-from pipelex.cli.commands.build import inputs_cmd as inputs_cmd
-from pipelex.cli.commands.build import pipe_cmd as pipe_cmd
-from pipelex.cli.commands.build import runner_cmd as runner_cmd
-from pipelex.cli.commands.build import structures_cmd as structures_cmd
-from pipelex.cli.commands.build.app import build_app as build_app

--- a/pipelex/cli/commands/build/app.py
+++ b/pipelex/cli/commands/build/app.py
@@ -1,3 +1,14 @@
 import typer
 
+from pipelex.cli.commands.build.inputs_cmd import generate_inputs_cmd
+from pipelex.cli.commands.build.pipe_cmd import build_pipe_cmd
+from pipelex.cli.commands.build.runner_cmd import prepare_runner_cmd
+from pipelex.cli.commands.build.structures_cmd import build_structures_command
+
 build_app = typer.Typer(help="Build working pipelines from natural language requirements", no_args_is_help=True)
+
+# Register commands explicitly
+build_app.command("inputs", help="Generate example input JSON for a pipe")(generate_inputs_cmd)
+build_app.command("pipe", help="Build a Pipelex bundle with one validation/fix loop correcting deterministic issues")(build_pipe_cmd)
+build_app.command("runner", help="Build the Python code to run a pipe with the necessary inputs")(prepare_runner_cmd)
+build_app.command("structures", help="Generate Python structure files from concept definitions in PLX files")(build_structures_command)

--- a/pipelex/cli/commands/build/inputs_cmd.py
+++ b/pipelex/cli/commands/build/inputs_cmd.py
@@ -2,12 +2,10 @@ import asyncio
 from pathlib import Path
 from typing import Annotated
 
-import click
 import typer
 from posthog import tag
 
 from pipelex.cli.cli_factory import make_pipelex_for_cli
-from pipelex.cli.commands.build.app import build_app
 from pipelex.cli.error_handlers import (
     ErrorContext,
     handle_model_availability_error,
@@ -30,19 +28,112 @@ COMMAND = "build"
 SUB_COMMAND_INPUTS = "inputs"
 
 
-@build_app.command(SUB_COMMAND_INPUTS, help="Generate example input JSON for a pipe")
+async def _generate_inputs_core(
+    pipe_code: str | None = None,
+    bundle_path: str | None = None,
+    output_path: str | None = None,
+) -> None:
+    """Core logic for generating input JSON for a pipe.
+
+    Args:
+        pipe_code: The pipe code to generate inputs for.
+        bundle_path: Path to the bundle file (.plx).
+        output_path: Path to save the generated JSON file.
+    """
+    if bundle_path:
+        try:
+            validate_bundle_result = await validate_bundle(plx_file_path=bundle_path)
+            bundle_blueprint = validate_bundle_result.blueprints[0]
+            if not pipe_code:
+                # No pipe code specified, use main_pipe from bundle
+                main_pipe_code = bundle_blueprint.main_pipe
+                if not main_pipe_code:
+                    msg = (
+                        f"Bundle '{bundle_path}' does not declare a main_pipe. In order to build inputs for a bundle, "
+                        "you must specify a main pipe in the bundle itself or specify a pipe code in the command line using the --pipe option."
+                    )
+                    typer.secho(
+                        msg,
+                        fg=typer.colors.RED,
+                        err=True,
+                    )
+                    raise typer.Exit(1) from ValueError(msg)
+                typer.echo(f"Using main pipe '{main_pipe_code}' from bundle '{bundle_path}'")
+                pipe_code = main_pipe_code
+            else:
+                typer.echo(f"Using pipe '{pipe_code}' from bundle '{bundle_path}'")
+        except FileNotFoundError as exc:
+            typer.secho(f"Failed to load bundle '{bundle_path}': {exc}", fg=typer.colors.RED, err=True)
+            raise typer.Exit(1) from exc
+        except ValidateBundleError as exc:
+            typer.secho(f"Failed to load bundle '{bundle_path}': {exc}", fg=typer.colors.RED, err=True)
+            raise typer.Exit(1) from exc
+        except PipeInputError as exc:
+            typer.secho(f"Failed to load bundle '{bundle_path}': {exc}", fg=typer.colors.RED, err=True)
+            raise typer.Exit(1) from exc
+    elif not pipe_code:
+        typer.secho("Failed to run: no pipe code specified", fg=typer.colors.RED, err=True)
+        raise typer.Exit(1)
+
+    # Get the pipe
+    try:
+        the_pipe = get_required_pipe(pipe_code=pipe_code)
+    except Exception as exc:
+        typer.secho(f"❌ Error: Could not find pipe '{pipe_code}': {exc}", fg=typer.colors.RED)
+        raise typer.Exit(1) from exc
+
+    # Check if pipe has any inputs
+    if not the_pipe.inputs.root:
+        typer.secho(f"No inputs required for pipe '{pipe_code}'.", fg=typer.colors.YELLOW)
+        raise typer.Exit(0)
+
+    # Generate the input JSON
+    try:
+        inputs_json_str = the_pipe.inputs.generate_json_string(indent=2)
+    except Exception as exc:
+        typer.secho(f"❌ Error generating input JSON: {exc}", fg=typer.colors.RED)
+        raise typer.Exit(1) from exc
+
+    # Determine output path - use bundle's directory if bundle provided, otherwise results/
+    if output_path:
+        final_output_path = output_path
+    elif bundle_path:
+        # Place inputs.json in the same directory as the PLX file
+        bundle_dir = Path(bundle_path).parent
+        final_output_path = str(bundle_dir / "inputs.json")
+    else:
+        final_output_path = "results/inputs.json"
+
+    # Save the file
+    try:
+        ensure_directory_for_file_path(file_path=final_output_path)
+        save_text_to_path(text=inputs_json_str, path=final_output_path)
+        typer.secho(f"✅ Generated input JSON file: {final_output_path}", fg=typer.colors.GREEN)
+    except Exception as exc:
+        typer.secho(f"❌ Error saving file: {exc}", fg=typer.colors.RED)
+        raise typer.Exit(1) from exc
+
+
 def generate_inputs_cmd(
     target: Annotated[
-        str | None,
-        typer.Argument(help="Pipe code or bundle file path (auto-detected)"),
-    ] = None,
-    pipe: Annotated[
-        str | None,
-        typer.Option("--pipe", help="Pipe code to use, can be omitted if you specify a bundle (.plx) that declares a main pipe"),
-    ] = None,
+        str,
+        typer.Argument(help="Pipe code or bundle file path (.plx). If a bundle path is provided, it must declare a main_pipe."),
+    ],
     bundle: Annotated[
         str | None,
-        typer.Option("--bundle", help="Bundle file path (.plx) - uses its main_pipe unless you specify a pipe code"),
+        typer.Option(
+            "--bundle",
+            "-b",
+            help="Bundle file path (.plx) containing the pipe. Use with a pipe code as target.",
+        ),
+    ] = None,
+    library_dir: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--library-dir",
+            "-L",
+            help="Directory to search for pipe definitions (.plx files). Can be specified multiple times.",
+        ),
     ] = None,
     output_path: Annotated[
         str | None,
@@ -57,133 +148,38 @@ def generate_inputs_cmd(
     based on their concept types.
 
     Examples:
-        pipelex build inputs my_pipe
-        pipelex build inputs --bundle my_bundle.plx
-        pipelex build inputs --bundle my_bundle.plx --pipe my_pipe
+        pipelex build inputs my_pipe_code
+        pipelex build inputs my_pipe_code -L ./my_pipes
+        pipelex build inputs my_pipe_code -b path/to/related/bundle.plx
         pipelex build inputs my_bundle.plx
-        pipelex build inputs my_pipe --output custom_inputs.json
+        pipelex build inputs my_pipe_code --output custom_inputs.json
     """
-    # Validate mutual exclusivity
-    provided_options = sum([target is not None, pipe is not None, bundle is not None])
-    if provided_options == 0:
-        ctx: click.Context = click.get_current_context()
-        typer.echo(ctx.get_help())
-        raise typer.Exit(0)
-
-    # Let's analyze the options and determine what pipe code to use and if we need to load a bundle
     pipe_code: str | None = None
     bundle_path: str | None = None
 
-    # Determine source:
-    if target:
-        # Check if target is a directory (not allowed for inputs command)
-        target_path = Path(target)
-        if target_path.is_dir():
+    target_path = Path(target)
+    if target_path.is_dir():
+        typer.secho(
+            f"Failed to run: '{target}' is a directory. The inputs command requires a .plx file or a pipe code.",
+            fg=typer.colors.RED,
+            err=True,
+        )
+        raise typer.Exit(1)
+
+    if target.endswith(".plx"):
+        if bundle:
             typer.secho(
-                f"Failed to run: '{target}' is a directory. The inputs command requires a .plx file or a pipe code, not a directory.",
+                "Failed to run: cannot use --bundle option when target is already a .plx file.",
                 fg=typer.colors.RED,
                 err=True,
             )
             raise typer.Exit(1)
-
-        if target.endswith(".plx"):
-            bundle_path = target
-            if bundle:
-                typer.secho(
-                    "Failed to run: cannot use option --bundle if you're already passing a bundle file (.plx) as positional argument",
-                    fg=typer.colors.RED,
-                    err=True,
-                )
-                raise typer.Exit(1)
-        else:
-            pipe_code = target
-            if pipe:
-                typer.secho(
-                    "Failed to run: cannot use option --pipe if you're already passing a pipe code as positional argument",
-                    fg=typer.colors.RED,
-                    err=True,
-                )
-                raise typer.Exit(1)
-
-    if bundle:
-        assert not bundle_path, "bundle_path should be None at this stage if --bundle is provided"
+        bundle_path = target
+    else:
+        pipe_code = target
         bundle_path = bundle
 
-    if pipe:
-        assert not pipe_code, "pipe_code should be None at this stage if --pipe is provided"
-        pipe_code = pipe
-
-    if not pipe_code and not bundle_path:
-        typer.secho("Failed to run: no pipe code or bundle file specified", fg=typer.colors.RED, err=True)
-        raise typer.Exit(1)
-
-    async def generate_inputs(pipe_code: str | None = None, bundle_path: str | None = None):
-        if bundle_path:
-            try:
-                validate_bundle_result = await validate_bundle(plx_file_path=bundle_path)
-                bundle_blueprint = validate_bundle_result.blueprints[0]
-                if not pipe_code:
-                    main_pipe_code = bundle_blueprint.main_pipe
-                    if not main_pipe_code:
-                        # Fall back to first pipe if no main_pipe declared
-                        if bundle_blueprint.pipe:
-                            main_pipe_code = next(iter(bundle_blueprint.pipe.keys()))
-                            typer.echo(f"No main_pipe declared, using first pipe '{main_pipe_code}' from bundle '{bundle_path}'")
-                        else:
-                            typer.secho(f"Bundle '{bundle_path}' has no pipes defined", fg=typer.colors.RED, err=True)
-                            raise typer.Exit(1)
-                    else:
-                        typer.echo(f"Using main pipe '{main_pipe_code}' from bundle '{bundle_path}'")
-                    pipe_code = main_pipe_code
-                else:
-                    typer.echo(f"Using pipe '{pipe_code}' from bundle '{bundle_path}'")
-            except FileNotFoundError as exc:
-                typer.secho(f"Failed to load bundle '{bundle_path}': {exc}", fg=typer.colors.RED, err=True)
-                raise typer.Exit(1) from exc
-            except ValidateBundleError as exc:
-                typer.secho(f"Failed to load bundle '{bundle_path}': {exc}", fg=typer.colors.RED, err=True)
-                raise typer.Exit(1) from exc
-            except PipeInputError as exc:
-                typer.secho(f"Failed to load bundle '{bundle_path}': {exc}", fg=typer.colors.RED, err=True)
-                raise typer.Exit(1) from exc
-        elif not pipe_code:
-            typer.secho("Failed to run: no pipe code specified", fg=typer.colors.RED, err=True)
-            raise typer.Exit(1)
-
-        # Get the pipe
-        try:
-            the_pipe = get_required_pipe(pipe_code=pipe_code)
-        except Exception as exc:
-            typer.secho(f"❌ Error: Could not find pipe '{pipe_code}': {exc}", fg=typer.colors.RED)
-            raise typer.Exit(1) from exc
-
-        # Generate the input JSON
-        try:
-            inputs_json_str = the_pipe.inputs.generate_json_string(indent=2)
-        except Exception as exc:
-            typer.secho(f"❌ Error generating input JSON: {exc}", fg=typer.colors.RED)
-            raise typer.Exit(1) from exc
-
-        # Determine output path - use bundle's directory if bundle provided, otherwise results/
-        if output_path:
-            final_output_path = output_path
-        elif bundle_path:
-            # Place inputs.json in the same directory as the PLX file
-            bundle_dir = Path(bundle_path).parent
-            final_output_path = str(bundle_dir / "inputs.json")
-        else:
-            final_output_path = "results/inputs.json"
-
-        # Save the file
-        try:
-            ensure_directory_for_file_path(file_path=final_output_path)
-            save_text_to_path(text=inputs_json_str, path=final_output_path)
-            typer.secho(f"✅ Generated input JSON file: {final_output_path}", fg=typer.colors.GREEN)
-        except Exception as exc:
-            typer.secho(f"❌ Error saving file: {exc}", fg=typer.colors.RED)
-            raise typer.Exit(1) from exc
-
-    pipelex_instance = make_pipelex_for_cli(context=ErrorContext.VALIDATION_BEFORE_BUILD_INPUTS)
+    pipelex_instance = make_pipelex_for_cli(context=ErrorContext.VALIDATION_BEFORE_BUILD_INPUTS, library_dirs=library_dir)
 
     try:
         with get_telemetry_manager().telemetry_context():
@@ -191,7 +187,7 @@ def generate_inputs_cmd(
             tag(name=EventProperty.PIPELEX_VERSION, value=PACKAGE_VERSION)
             tag(name=EventProperty.CLI_COMMAND, value=f"{COMMAND} {SUB_COMMAND_INPUTS}")
 
-            asyncio.run(generate_inputs(pipe_code=pipe_code, bundle_path=bundle_path))
+            asyncio.run(_generate_inputs_core(pipe_code=pipe_code, bundle_path=bundle_path, output_path=output_path))
 
     except PipeOperatorModelChoiceError as exc:
         handle_model_choice_error(exc, context=ErrorContext.BUILD)

--- a/pipelex/cli/commands/build/pipe_cmd.py
+++ b/pipelex/cli/commands/build/pipe_cmd.py
@@ -12,7 +12,6 @@ from pipelex.builder.builder_errors import PipeBuilderError
 from pipelex.builder.builder_loop import BuilderLoop
 from pipelex.builder.runner_code import generate_runner_code
 from pipelex.cli.cli_factory import make_pipelex_for_cli
-from pipelex.cli.commands.build.app import build_app
 from pipelex.cli.error_handlers import (
     ErrorContext,
     handle_model_availability_error,
@@ -128,7 +127,6 @@ pipelex build pipe "Given a theme, write a Haiku"
 """
 
 
-@build_app.command(SUB_COMMAND_PIPE, help="Build a Pipelex bundle with one validation/fix loop correcting deterministic issues")
 def build_pipe_cmd(
     prompt: Annotated[
         str,

--- a/pipelex/cli/commands/build/pipe_cmd.py
+++ b/pipelex/cli/commands/build/pipe_cmd.py
@@ -153,7 +153,7 @@ def build_pipe_cmd(
         typer.Option("--no-extras", help="Skip generating inputs.json and runner.py, only generate the PLX file"),
     ] = False,
     graph: Annotated[
-        bool | None,
+        bool,
         typer.Option("--graph/--no-graph", help="Generate execution graphs for both build process and built pipeline"),
     ] = True,
     graph_full_data: Annotated[

--- a/pipelex/cli/commands/build/pipe_cmd.py
+++ b/pipelex/cli/commands/build/pipe_cmd.py
@@ -155,7 +155,7 @@ def build_pipe_cmd(
     graph: Annotated[
         bool | None,
         typer.Option("--graph/--no-graph", help="Generate execution graphs for both build process and built pipeline"),
-    ] = None,
+    ] = True,
     graph_full_data: Annotated[
         bool | None,
         typer.Option(
@@ -308,8 +308,9 @@ def build_pipe_cmd(
                     if graph and builder_graph_spec:
                         typer.secho("\n📊 Generating graphs...", fg=typer.colors.CYAN)
 
-                        # Save builder pipeline graph
-                        builder_graph_dir = Path(extras_output_dir) / "builder_graph"
+                        # Save builder pipeline graph in graphs/ subfolder
+                        graphs_dir = Path(extras_output_dir) / "graphs"
+                        builder_graph_dir = graphs_dir / "builder_graph"
                         builder_graph_count = await _save_graph_outputs_to_dir(
                             graph_spec=builder_graph_spec,
                             graph_config=execution_config.graph_config,
@@ -330,7 +331,7 @@ def build_pipe_cmd(
                                 library_dirs=library_dir,
                             )
                             if built_pipe_output.graph_spec:
-                                pipeline_graph_dir = Path(extras_output_dir) / "pipeline_graph"
+                                pipeline_graph_dir = graphs_dir / "pipeline_graph"
                                 log.dev(f"Saving pipeline graph for pipe {main_pipe_code} to {pipeline_graph_dir}")
                                 pipeline_graph_count = await _save_graph_outputs_to_dir(
                                     graph_spec=built_pipe_output.graph_spec,

--- a/pipelex/cli/commands/build/runner_cmd.py
+++ b/pipelex/cli/commands/build/runner_cmd.py
@@ -11,7 +11,6 @@ from posthog import tag
 
 from pipelex.builder.runner_code import generate_runner_code
 from pipelex.cli.cli_factory import make_pipelex_for_cli
-from pipelex.cli.commands.build.app import build_app
 from pipelex.cli.commands.build.structures_cmd import generate_structures_from_blueprints
 from pipelex.cli.error_handlers import (
     ErrorContext,
@@ -39,7 +38,6 @@ COMMAND = "build"
 SUB_COMMAND_RUNNER = "runner"
 
 
-@build_app.command(SUB_COMMAND_RUNNER, help="Build the Python code to run a pipe with the necessary inputs")
 def prepare_runner_cmd(
     target: Annotated[
         str | None,

--- a/pipelex/cli/commands/build/structures_cmd.py
+++ b/pipelex/cli/commands/build/structures_cmd.py
@@ -8,7 +8,6 @@ from kajson.kajson_manager import KajsonManager
 from pipelex import log
 from pipelex.base_exceptions import PipelexError
 from pipelex.cli.cli_factory import make_pipelex_for_cli
-from pipelex.cli.commands.build.app import build_app
 from pipelex.cli.error_handlers import ErrorContext
 from pipelex.core.concepts.concept_factory import ConceptFactory
 from pipelex.core.concepts.helpers import normalize_structure_blueprint
@@ -186,7 +185,6 @@ def generate_structures_from_blueprints(
     return generated_files
 
 
-@build_app.command(SUB_COMMAND_STRUCTURES, help="Generate Python structure files from concept definitions in PLX files")
 def build_structures_command(
     target: Annotated[
         str,

--- a/pipelex/cli/commands/run_cmd.py
+++ b/pipelex/cli/commands/run_cmd.py
@@ -179,7 +179,11 @@ def run_cmd(
                 if not pipe_code:
                     main_pipe_code = validate_bundle_result.blueprints[0].main_pipe
                     if not main_pipe_code:
-                        typer.secho(f"Bundle '{bundle_path}' does not declare a main_pipe", fg=typer.colors.RED, err=True)
+                        msg = (
+                            f"Bundle '{bundle_path}' does not declare a main_pipe. In order to run a bundle, "
+                            "you must specify a main pipe in the bundle itself or specify a pipe code in the command line using the --pipe option."
+                        )
+                        typer.secho(msg, fg=typer.colors.RED, err=True)
                         raise typer.Exit(1)
                     pipe_code = main_pipe_code
                     source_description = f"bundle '{bundle_path}' • main pipe: '{pipe_code}'"

--- a/pipelex/cli/commands/validate_cmd.py
+++ b/pipelex/cli/commands/validate_cmd.py
@@ -18,7 +18,7 @@ from pipelex.cli.error_handlers import (
     handle_validate_bundle_error,
 )
 from pipelex.core.pipes.exceptions import PipeOperatorModelChoiceError
-from pipelex.hub import get_console, get_library_manager, get_required_pipe, get_telemetry_manager, set_current_library
+from pipelex.hub import get_console, get_default_library_dirs, get_library_manager, get_required_pipe, get_telemetry_manager, set_current_library
 from pipelex.pipe_operators.exceptions import PipeOperatorModelAvailabilityError
 from pipelex.pipe_run.dry_run import dry_run_pipe, dry_run_pipes
 from pipelex.pipelex import Pipelex
@@ -30,7 +30,7 @@ from pipelex.tools.misc.package_utils import get_package_version
 COMMAND = "validate"
 
 
-def do_validate_all_libraries_and_dry_run(library_dirs: list[Path] | None = None) -> None:
+def do_validate_all_libraries_and_dry_run() -> None:
     try:
         with get_telemetry_manager().telemetry_context():
             tag(name=EventProperty.INTEGRATION, value=IntegrationMode.CLI)
@@ -40,9 +40,9 @@ def do_validate_all_libraries_and_dry_run(library_dirs: list[Path] | None = None
             library_manager = get_library_manager()
             library_id, library = library_manager.open_library()
             set_current_library(library_id=library_id)
-            library_manager.load_libraries(library_id=library_id, library_dirs=library_dirs or [Path.cwd()])
+            library_manager.load_libraries(library_id=library_id, library_dirs=get_default_library_dirs())
 
-            pipes = library.get_pipe_library().get_pipes()
+            pipes = library.pipe_library.get_pipes()
             for pipe in pipes:
                 pipe.validate_with_libraries()
 
@@ -87,12 +87,10 @@ def validate_cmd(
         pipelex validate --bundle my_bundle.plx --pipe my_pipe
         pipelex validate all
     """
-    # Check for "all" keyword
     if target == "all" and not pipe and not bundle:
         try:
-            make_pipelex_for_cli(context=ErrorContext.VALIDATION)
-            library_dirs_paths = [Path(lib_dir) for lib_dir in library_dir] if library_dir else None
-            do_validate_all_libraries_and_dry_run(library_dirs=library_dirs_paths)
+            make_pipelex_for_cli(context=ErrorContext.VALIDATION, library_dirs=[Path(lib_dir) for lib_dir in library_dir] if library_dir else None)
+            do_validate_all_libraries_and_dry_run()
         finally:
             Pipelex.teardown_if_needed()
         return

--- a/pipelex/core/bundles/pipelex_bundle_blueprint.py
+++ b/pipelex/core/bundles/pipelex_bundle_blueprint.py
@@ -7,6 +7,7 @@ from pipelex.core.concepts.native.concept_native import NativeConceptCode
 from pipelex.core.concepts.validation import is_concept_code_valid
 from pipelex.core.domains.exceptions import DomainCodeError
 from pipelex.core.domains.validation import validate_domain_code
+from pipelex.core.pipes.validation import is_pipe_code_valid
 from pipelex.pipe_controllers.batch.pipe_batch_blueprint import PipeBatchBlueprint
 from pipelex.pipe_controllers.condition.pipe_condition_blueprint import PipeConditionBlueprint
 from pipelex.pipe_controllers.parallel.pipe_parallel_blueprint import PipeParallelBlueprint
@@ -80,3 +81,22 @@ class PipelexBundleBlueprint(BaseModel):
             msg = f"Main pipe '{self.main_pipe}' could not be found in pipelex bundle at source '{self.source}' and domain '{self.domain}'"
             raise ValueError(msg)
         return self
+
+    @field_validator("main_pipe", mode="before")
+    @classmethod
+    def validate_main_pipe_syntax(cls, main_pipe: str) -> str:
+        if not is_pipe_code_valid(main_pipe):
+            msg = f"Invalid main pipe syntax '{main_pipe}'. Must be in snake_case."
+            raise ValueError(msg)
+        return main_pipe
+
+    @field_validator("pipe", mode="before")
+    @classmethod
+    def validate_pipe_keys(cls, pipe: dict[str, PipeBlueprintUnion] | None) -> dict[str, PipeBlueprintUnion] | None:
+        if pipe is None:
+            return None
+        for pipe_code in pipe:
+            if not is_pipe_code_valid(pipe_code=pipe_code):
+                msg = f"Pipe code '{pipe_code}' is not a valid pipe code. Must be in snake_case."
+                raise ValueError(msg)
+        return pipe

--- a/pipelex/core/bundles/pipelex_bundle_blueprint.py
+++ b/pipelex/core/bundles/pipelex_bundle_blueprint.py
@@ -75,16 +75,11 @@ class PipelexBundleBlueprint(BaseModel):
                 raise ValueError(msg)
         return concept
 
-    @model_validator(mode="after")
-    def validate_main_pipe(self) -> "PipelexBundleBlueprint":
-        if self.main_pipe and (not self.pipe or (self.main_pipe not in self.pipe)):
-            msg = f"Main pipe '{self.main_pipe}' could not be found in pipelex bundle at source '{self.source}' and domain '{self.domain}'"
-            raise ValueError(msg)
-        return self
-
     @field_validator("main_pipe", mode="before")
     @classmethod
-    def validate_main_pipe_syntax(cls, main_pipe: str) -> str:
+    def validate_main_pipe_syntax(cls, main_pipe: str | None) -> str | None:
+        if main_pipe is None:
+            return None
         if not is_pipe_code_valid(main_pipe):
             msg = f"Invalid main pipe syntax '{main_pipe}'. Must be in snake_case."
             raise ValueError(msg)
@@ -100,3 +95,10 @@ class PipelexBundleBlueprint(BaseModel):
                 msg = f"Pipe code '{pipe_code}' is not a valid pipe code. Must be in snake_case."
                 raise ValueError(msg)
         return pipe
+
+    @model_validator(mode="after")
+    def validate_main_pipe(self) -> "PipelexBundleBlueprint":
+        if self.main_pipe and (not self.pipe or (self.main_pipe not in self.pipe)):
+            msg = f"Main pipe '{self.main_pipe}' could not be found in pipelex bundle at source '{self.source}' and domain '{self.domain}'"
+            raise ValueError(msg)
+        return self

--- a/pipelex/core/interpreter/interpreter.py
+++ b/pipelex/core/interpreter/interpreter.py
@@ -19,38 +19,15 @@ class PipelexInterpreter(BaseModel):
     # TODO: rethink this method
     @staticmethod
     def is_pipelex_file(file_path: Path) -> bool:
-        """Check if a file is a valid Pipelex PLX file.
+        """Check if a file is a Pipelex PLX file based on its extension.
 
         Args:
             file_path: Path to the file to check
 
         Returns:
-            True if the file is a Pipelex file, False otherwise
-
-        Criteria:
-            - Has .plx extension
-            - Starts with "domain =" (ignoring leading whitespace)
-
+            True if the file has .plx extension, False otherwise
         """
-        # Check if it has .toml extension
-        if file_path.suffix != ".plx":
-            return False
-
-        # Check if file exists
-        if not file_path.exists() or not file_path.is_file():
-            return False
-
-        try:
-            # Read the first few lines to check for "domain ="
-            with open(file_path, encoding="utf-8") as file:
-                # Read first 100 characters (should be enough to find domain)
-                content = file.read(100)
-                # Remove leading whitespace and check if it starts with "domain ="
-                stripped_content = content.lstrip()
-                return stripped_content.startswith("domain =")
-        except Exception:
-            # If we can't read the file, it's not a valid Pipelex file
-            return False
+        return file_path.suffix == ".plx"
 
     @classmethod
     def make_pipelex_bundle_blueprint(cls, bundle_path: str | None = None, plx_content: str | None = None) -> PipelexBundleBlueprint:

--- a/pipelex/core/interpreter/validation_error_categorizer.py
+++ b/pipelex/core/interpreter/validation_error_categorizer.py
@@ -78,6 +78,44 @@ def _categorize_input_validation_error(
     return None
 
 
+def _categorize_syntax_validation_error(
+    message: str,
+    domain: str | None,
+    source: str | None,
+) -> PipelexBundleBlueprintValidationErrorData | None:
+    """Categorize syntax validation errors (invalid pipe code, invalid main_pipe).
+
+    Args:
+        message: The error message from the validation
+        domain: Domain code
+        source: Source file path
+
+    Returns:
+        Categorized error data, or None if not a syntax validation error
+    """
+    message_lower = message.lower()
+
+    # Detect invalid main_pipe syntax
+    if "invalid main pipe syntax" in message_lower:
+        return PipelexBundleBlueprintValidationErrorData(
+            error_type=PipeValidationErrorType.INVALID_PIPE_CODE_SYNTAX,
+            domain_code=domain,
+            source=source,
+            message=message,
+        )
+
+    # Detect invalid pipe code syntax
+    if "is not a valid pipe code" in message_lower:
+        return PipelexBundleBlueprintValidationErrorData(
+            error_type=PipeValidationErrorType.INVALID_PIPE_CODE_SYNTAX,
+            domain_code=domain,
+            source=source,
+            message=message,
+        )
+
+    return None
+
+
 def categorize_blueprint_validation_error(
     blueprint_dict: dict[str, Any],
     error: ErrorDetails,
@@ -111,6 +149,15 @@ def categorize_blueprint_validation_error(
     )
     if input_error:
         return input_error
+
+    # Try to categorize syntax validation errors (invalid pipe code, main_pipe)
+    syntax_error = _categorize_syntax_validation_error(
+        message=message,
+        domain=domain,
+        source=source,
+    )
+    if syntax_error:
+        return syntax_error
 
     # If we couldn't categorize the error, log a warning
     error_scope = get_error_scope(loc)

--- a/pipelex/core/pipes/exceptions.py
+++ b/pipelex/core/pipes/exceptions.py
@@ -112,6 +112,7 @@ class PipeValidationErrorType(StrEnum):
     # Errors that are raised but NOT auto-fixed (will fail validation)
     LLM_OUTPUT_CANNOT_BE_IMAGE = "llm_output_cannot_be_image"
     IMG_GEN_INPUT_NOT_TEXT_COMPATIBLE = "img_gen_input_not_text_compatible"
+    INVALID_PIPE_CODE_SYNTAX = "invalid_pipe_code_syntax"
 
     # Generic fallback for unexpected validation errors
     UNKNOWN_VALIDATION_ERROR = "unknown_validation_error"

--- a/pipelex/core/pipes/validation.py
+++ b/pipelex/core/pipes/validation.py
@@ -121,3 +121,7 @@ def validate_input_name(input_name: str) -> None:
             "where each part must also be in snake_case."
         )
         raise ValueError(msg)
+
+
+def is_pipe_code_valid(pipe_code: str) -> bool:
+    return is_snake_case(pipe_code)

--- a/pipelex/hub.py
+++ b/pipelex/hub.py
@@ -436,6 +436,10 @@ def get_current_library() -> str:
     return library_id
 
 
+def get_default_library_dirs() -> list[Path] | None:
+    return get_pipelex_hub().get_default_library_dirs()
+
+
 def teardown_current_library() -> None:
     """Teardown the library_id for the current async context."""
     _library_id.set(None)

--- a/pipelex/libraries/library_utils.py
+++ b/pipelex/libraries/library_utils.py
@@ -87,5 +87,4 @@ def get_pipelex_plx_files_from_dirs(dirs: set[Path]) -> list[Path]:
                 all_plx_paths.append(plx_file)
             else:
                 log.debug(f"Skipping non-Pipelex PLX file: {plx_file}")
-
     return all_plx_paths

--- a/pipelex/tools/misc/file_utils.py
+++ b/pipelex/tools/misc/file_utils.py
@@ -387,7 +387,6 @@ def find_files_in_dir(
         files = list(path.rglob(pattern))
     else:
         files = list(path.glob(pattern))
-
     for file in files:
         # Check if file is under any excluded directory
         is_excluded = False
@@ -432,4 +431,5 @@ def find_files_in_dir(
         # Include if not excluded, or if force included
         if not is_excluded or should_force_include:
             filtered_files.append(file)
+
     return filtered_files


### PR DESCRIPTION
1:  Remove hidden code in pipelex/cli/build/__init__.py file
2: Fix build input cli: 
    - If no input is required by the pipe, it says so, instead of creating an empty json.
    - add the library-dir argument
    - Reorganized how the code is managed
 3: Fix a bug with is_pipelex_file
 4: add the validation of pipe code at the blueprint level, instead of factory level

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables input JSON generation and strengthens bundle validation while simplifying file detection.
> 
> - **New CLI:** `pipelex build inputs` to generate example inputs for a pipe; supports `--library-dir` (`-L`), clearer target parsing (pipe code or `.plx`), requires bundle `main_pipe`, respects no-input pipes, and configurable output path
> - **CLI structure:** Explicit command registration moved to `build/app.py`; imports updated; minor UX tweaks in `run` (clearer message when `main_pipe` missing) and `validate all` (uses `get_default_library_dirs`)
> - **Build defaults:** `build pipe` now enables `--graph` by default and saves graphs under `graphs/` subfolder
> - **Validation:** Bundle blueprint now validates `main_pipe` and pipe codes with snake_case (`is_pipe_code_valid`); interpreter error categorizer maps these to `INVALID_PIPE_CODE_SYNTAX`; builder loop ignores this error type
> - **Interpreter/File discovery:** `is_pipelex_file()` now checks extension only; library discovery updated accordingly
> - **Changelog:** Documented added command, new validation, and changed `.plx` detection
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c801f457256ad920118fb1f50a651c03d8b3082. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->