### PR TITLE
Validate bundle with libraries

### DIFF
--- a/pipelex/cli/commands/run_cmd.py
+++ b/pipelex/cli/commands/run_cmd.py
@@ -17,8 +17,9 @@ from pipelex.cli.error_handlers import (
     handle_model_choice_error,
 )
 from pipelex.config import get_config
+from pipelex.core.interpreter.exceptions import PipelexInterpreterError
+from pipelex.core.interpreter.interpreter import PipelexInterpreter
 from pipelex.core.pipes.exceptions import PipeOperatorModelChoiceError
-from pipelex.core.pipes.inputs.exceptions import PipeInputError
 from pipelex.core.stuffs.stuff_viewer import render_stuff_viewer
 from pipelex.graph.graph_factory import generate_graph_outputs
 from pipelex.hub import get_console, get_telemetry_manager
@@ -27,7 +28,6 @@ from pipelex.pipe_run.pipe_run_mode import PipeRunMode
 from pipelex.pipelex import Pipelex
 from pipelex.pipeline.exceptions import PipelineExecutionError
 from pipelex.pipeline.execute import execute_pipeline
-from pipelex.pipeline.validate_bundle import ValidateBundleError, validate_bundle
 from pipelex.system.runtime import IntegrationMode
 from pipelex.system.telemetry.events import EventProperty
 from pipelex.tools.misc.file_utils import get_incremental_directory_path
@@ -178,9 +178,11 @@ def run_cmd(
         if bundle_path:
             try:
                 plx_content = Path(bundle_path).read_text(encoding="utf-8")
-                validate_bundle_result = await validate_bundle(plx_content=plx_content)
+                # Use lightweight parsing to extract main_pipe without full validation
+                # Full validation happens later during execute_pipeline
                 if not pipe_code:
-                    main_pipe_code = validate_bundle_result.blueprints[0].main_pipe
+                    bundle_blueprint = PipelexInterpreter.make_pipelex_bundle_blueprint(plx_content=plx_content)
+                    main_pipe_code = bundle_blueprint.main_pipe
                     if not main_pipe_code:
                         msg = (
                             f"Bundle '{bundle_path}' does not declare a main_pipe. In order to run a bundle, "
@@ -195,11 +197,8 @@ def run_cmd(
             except FileNotFoundError as exc:
                 typer.secho(f"Failed to load bundle '{bundle_path}': {exc}", fg=typer.colors.RED, err=True)
                 raise typer.Exit(1) from exc
-            except ValidateBundleError as exc:
-                typer.secho(f"Failed to load bundle '{bundle_path}': {exc}", fg=typer.colors.RED, err=True)
-                raise typer.Exit(1) from exc
-            except PipeInputError as exc:
-                typer.secho(f"Failed to load bundle '{bundle_path}': {exc}", fg=typer.colors.RED, err=True)
+            except PipelexInterpreterError as exc:
+                typer.secho(f"Failed to parse bundle '{bundle_path}': {exc}", fg=typer.colors.RED, err=True)
                 raise typer.Exit(1) from exc
         elif pipe_code:
             source_description = f"pipe '{pipe_code}'"

--- a/pipelex/pipeline/pipeline_run_setup.py
+++ b/pipelex/pipeline/pipeline_run_setup.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING
 
 from pipelex import log
 from pipelex.client.protocol import PipelineInputs
+from pipelex.core.interpreter.interpreter import PipelexInterpreter
 from pipelex.core.memory.working_memory import WorkingMemory
 from pipelex.core.memory.working_memory_factory import WorkingMemoryFactory
 from pipelex.graph.graph_tracer_manager import GraphTracerManager
@@ -29,7 +30,6 @@ from pipelex.pipe_run.pipe_run_params_factory import PipeRunParamsFactory
 from pipelex.pipeline.exceptions import PipeExecutionError
 from pipelex.pipeline.input_normalizer import normalize_data_urls_to_storage
 from pipelex.pipeline.job_metadata import JobMetadata, OtelContext
-from pipelex.pipeline.validate_bundle import validate_bundle
 from pipelex.system.configuration.configs import PipelineExecutionConfig
 from pipelex.system.environment import get_optional_env
 from pipelex.system.telemetry.events import EventName, EventProperty
@@ -150,7 +150,8 @@ async def pipeline_run_setup(
 
     # Then handle plx_content or pipe_code
     if plx_content:
-        validate_bundle_result = await validate_bundle(plx_content=plx_content)
+        blueprint = PipelexInterpreter.make_pipelex_bundle_blueprint(plx_content=plx_content)
+        validate_bundle_result_blueprints = [blueprint]
 
         # Check if this bundle was already loaded from library directories
         bundle_already_loaded = False
@@ -167,10 +168,10 @@ async def pipeline_run_setup(
                 log.verbose(f"Bundle '{bundle_uri}' already loaded from library directories, skipping duplicate load")
 
         if not bundle_already_loaded:
-            library_manager.load_from_blueprints(library_id=library_id, blueprints=validate_bundle_result.blueprints)
+            library_manager.load_from_blueprints(library_id=library_id, blueprints=validate_bundle_result_blueprints)
 
         # For now, we only support one blueprint when given a plx_content. So blueprints is of length 1.
-        blueprint = validate_bundle_result.blueprints[0]
+        # blueprint is already set from make_pipelex_bundle_blueprint above
         if pipe_code:
             pipe = get_required_pipe(pipe_code=pipe_code)
         elif blueprint.main_pipe:

--- a/pipelex/pipeline/validate_bundle.py
+++ b/pipelex/pipeline/validate_bundle.py
@@ -1,7 +1,9 @@
 from pathlib import Path
+from typing import Sequence
 
 from pydantic import BaseModel, ValidationError
 
+from pipelex import log
 from pipelex.base_exceptions import PipelexError
 from pipelex.core.bundles.exceptions import PipelexBundleBlueprintValidationErrorData
 from pipelex.core.bundles.pipelex_bundle_blueprint import PipelexBundleBlueprint
@@ -16,7 +18,7 @@ from pipelex.core.pipes.handle_pipe_errors import (
 )
 from pipelex.core.pipes.pipe_abstract import PipeAbstract
 from pipelex.core.validation import report_validation_error
-from pipelex.hub import get_library_manager, set_current_library
+from pipelex.hub import get_library_manager, resolve_library_dirs, set_current_library
 from pipelex.libraries.library_utils import get_pipelex_plx_files_from_dirs
 from pipelex.pipe_run.dry_run import DryRunError, DryRunOutput, dry_run_pipes
 
@@ -83,6 +85,7 @@ async def validate_bundle(
     plx_file_path: str | None = None,
     plx_content: str | None = None,
     blueprints: list[PipelexBundleBlueprint] | None = None,
+    library_dirs: Sequence[str | Path] | None = None,
 ) -> ValidateBundleResult:
     provided_params = sum([blueprints is not None, plx_content is not None, plx_file_path is not None])
     if provided_params == 0:
@@ -95,6 +98,15 @@ async def validate_bundle(
     library_manager = get_library_manager()
     library_id, _ = library_manager.open_library()
     set_current_library(library_id=library_id)
+
+    # Load libraries from resolved directories before loading the bundle
+    effective_dirs, source_label = resolve_library_dirs(library_dirs)
+    if effective_dirs:
+        log.debug(f"Loading libraries from {len(effective_dirs)} directory(ies) ({source_label}) for validation")
+        library_manager.load_libraries(
+            library_id=library_id,
+            library_dirs=effective_dirs,
+        )
 
     loaded_pipes: list[PipeAbstract] | None = None
     loaded_blueprints: list[PipelexBundleBlueprint] | None = None

--- a/pipelex/pipeline/validate_bundle.py
+++ b/pipelex/pipeline/validate_bundle.py
@@ -101,16 +101,16 @@ async def validate_bundle(
 
     # Load libraries from resolved directories before loading the bundle
     effective_dirs, source_label = resolve_library_dirs(library_dirs)
-    if effective_dirs:
-        log.debug(f"Loading libraries from {len(effective_dirs)} directory(ies) ({source_label}) for validation")
-        library_manager.load_libraries(
-            library_id=library_id,
-            library_dirs=effective_dirs,
-        )
 
     loaded_pipes: list[PipeAbstract] | None = None
     loaded_blueprints: list[PipelexBundleBlueprint] | None = None
     try:
+        if effective_dirs:
+            log.verbose(f"Loading libraries from {len(effective_dirs)} directory(ies) ({source_label}) for validation")
+            library_manager.load_libraries(
+                library_id=library_id,
+                library_dirs=effective_dirs,
+            )
         if blueprints is not None:
             loaded_blueprints = blueprints
             loaded_pipes = library_manager.load_from_blueprints(library_id=library_id, blueprints=blueprints)


### PR DESCRIPTION
- don't validate just to get the main_pipe in run_cmd
- Validate bundle with libraries

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements lightweight bundle parsing in the CLI and enhances bundle validation to include libraries.
> 
> - **CLI `run`**: replaces `validate_bundle` with `PipelexInterpreter.make_pipelex_bundle_blueprint` to extract `main_pipe` without full validation; updates error handling to `PipelexInterpreterError`; passes `--library-dir` through to execution.
> - **Pipeline setup**: resolves and loads libraries via `resolve_library_dirs`; builds blueprint from `plx_content`; avoids duplicate bundle loads by checking `loaded_plx_paths`.
> - **Validation**: `validate_bundle` now accepts `library_dirs`, resolves/loads libraries before validation, constructs blueprints with the interpreter (from content or file), then runs `dry_run_pipes`; adds verbose logging and keeps structured error aggregation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0d52e6f5ef4fdf6e83fa11f335d44cb1ad350d14. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->