### PR TITLE
Issues with Validate bundle with libraries

### DIFF
--- a/pipelex/cli/commands/run_cmd.py
+++ b/pipelex/cli/commands/run_cmd.py
@@ -17,7 +17,7 @@ from pipelex.cli.error_handlers import (
     handle_model_choice_error,
 )
 from pipelex.config import get_config
-from pipelex.core.interpreter.exceptions import PipelexInterpreterError
+from pipelex.core.interpreter.exceptions import PipelexInterpreterError, PLXDecodeError
 from pipelex.core.interpreter.interpreter import PipelexInterpreter
 from pipelex.core.pipes.exceptions import PipeOperatorModelChoiceError
 from pipelex.core.stuffs.stuff_viewer import render_stuff_viewer
@@ -197,7 +197,7 @@ def run_cmd(
             except FileNotFoundError as exc:
                 typer.secho(f"Failed to load bundle '{bundle_path}': {exc}", fg=typer.colors.RED, err=True)
                 raise typer.Exit(1) from exc
-            except PipelexInterpreterError as exc:
+            except (PipelexInterpreterError, PLXDecodeError) as exc:
                 typer.secho(f"Failed to parse bundle '{bundle_path}': {exc}", fg=typer.colors.RED, err=True)
                 raise typer.Exit(1) from exc
         elif pipe_code:

--- a/pipelex/pipeline/pipeline_run_setup.py
+++ b/pipelex/pipeline/pipeline_run_setup.py
@@ -151,7 +151,7 @@ async def pipeline_run_setup(
     # Then handle plx_content or pipe_code
     if plx_content:
         blueprint = PipelexInterpreter.make_pipelex_bundle_blueprint(plx_content=plx_content)
-        validate_bundle_result_blueprints = [blueprint]
+        blueprints_to_load = [blueprint]
 
         # Check if this bundle was already loaded from library directories
         bundle_already_loaded = False
@@ -168,7 +168,7 @@ async def pipeline_run_setup(
                 log.verbose(f"Bundle '{bundle_uri}' already loaded from library directories, skipping duplicate load")
 
         if not bundle_already_loaded:
-            library_manager.load_from_blueprints(library_id=library_id, blueprints=validate_bundle_result_blueprints)
+            library_manager.load_from_blueprints(library_id=library_id, blueprints=blueprints_to_load)
 
         # For now, we only support one blueprint when given a plx_content. So blueprints is of length 1.
         # blueprint is already set from make_pipelex_bundle_blueprint above


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Strengthens bundle parsing and clarifies blueprint loading.
> 
> - **CLI (`run_cmd.py`)**: Parses `.plx` bundles more robustly by catching `PLXDecodeError` in addition to `PipelexInterpreterError`, surfacing a clear error and exiting.
> - **Pipeline setup (`pipeline_run_setup.py`)**: Minor refactor renaming `validate_bundle_result_blueprints` to `blueprints_to_load` and using it consistently when loading from blueprints (no behavior change).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d10c5f4994c38511a26723ffd8c741d0d452d8e1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->