### PR TITLE
feature/pipe-output-json-and-fix-pipe_condition_spec-validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   - **Nested concepts in inline structures**: You can now define nested structures for your concepts in your `.plx` files. Learn more here: [Nested Concepts in Inline Structures](https://docs.pipelex.com/home/6-build-reliable-ai-workflows/concepts/inline-structures).
 
 ### Added
- - **`pipelex build output` CLI Command**: New command to generate example output JSON for a pipe, complementing the existing `pipelex build inputs` command. Shows the expected output structure based on the pipe's output concept type, with multiplicity support.
+ - **`pipelex build output` CLI Command**: New command to generate example output JSON for a pipe, complementing the existing `pipelex build inputs` command. Shows the expected output structure based on the pipe's output concept type, with multiplicity support. For pipes with `native.Anything` output (e.g., `PipeCondition` with different mapped pipe outputs), displays all possible outputs from mapped pipes.
  - **Telemetry System**: Introduced anonymous usage tracking and exception capture for CLI commands (`graph render`, `kit rules`, `kit remove-rules`, `kit migrations`), reporting to both user-configured and Pipelex analytics endpoints.
  - **PipeExtract Operator Validation**: Added strict input validation that raises configuration errors for incompatible input types or when document-specific parameters are used with image inputs.
  - **PipeCondition Output Auto-Fix in Builder Loop**: The pipe builder now automatically fixes `PipeCondition` output concept errors during validation. If all mapped pipes have the same output, the `PipeCondition` output is set to that concept; otherwise it's set to `native.Anything`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@
   - **Nested concepts in inline structures**: You can now define nested structures for your concepts in your `.plx` files. Learn more here: [Nested Concepts in Inline Structures](https://docs.pipelex.com/home/6-build-reliable-ai-workflows/concepts/inline-structures).
 
 ### Added
+ - **`pipelex build output` CLI Command**: New command to generate example output JSON for a pipe, complementing the existing `pipelex build inputs` command. Shows the expected output structure based on the pipe's output concept type, with multiplicity support.
  - **Telemetry System**: Introduced anonymous usage tracking and exception capture for CLI commands (`graph render`, `kit rules`, `kit remove-rules`, `kit migrations`), reporting to both user-configured and Pipelex analytics endpoints.
  - **PipeExtract Operator Validation**: Added strict input validation that raises configuration errors for incompatible input types or when document-specific parameters are used with image inputs.
+ - **PipeCondition Output Auto-Fix in Builder Loop**: The pipe builder now automatically fixes `PipeCondition` output concept errors during validation. If all mapped pipes have the same output, the `PipeCondition` output is set to that concept; otherwise it's set to `native.Anything`.
 
 ### Changed
  - **Test Profile System**: Refactored integration tests to use a new configuration system (`.pipelex/test_profiles.toml`) with `dev`, `ci`, and `full` profiles for controlling which AI models are used in parametrized tests, replacing runtime filtering and hardcoded model lists.

--- a/docs/home/9-tools/cli/build/index.md
+++ b/docs/home/9-tools/cli/build/index.md
@@ -1,6 +1,6 @@
 # Build Commands
 
-Generate pipelines, runner code, and Python structures from natural language descriptions.
+Generate pipelines, runner code, Python structures, and JSON templates from natural language descriptions.
 
 ## Available Commands
 
@@ -9,3 +9,5 @@ Generate pipelines, runner code, and Python structures from natural language des
 | [**build pipe**](pipe.md) | Generate a pipeline from natural language |
 | [**build runner**](runner.md) | Generate Python code to run a pipe |
 | [**build structures**](structures.md) | Generate the structures (Pydantic models) of your concepts |
+| [**build inputs**](inputs.md) | Generate example input JSON for a pipe |
+| [**build output**](output.md) | Generate example output JSON for a pipe |

--- a/docs/home/9-tools/cli/build/inputs.md
+++ b/docs/home/9-tools/cli/build/inputs.md
@@ -1,0 +1,95 @@
+# Build Inputs
+
+Generate example input JSON for a pipe, showing the expected input structure based on the pipe's input types.
+
+## Usage
+
+```bash
+pipelex build inputs <TARGET> [OPTIONS]
+```
+
+**Arguments:**
+
+- `TARGET` - Either a pipe code or a bundle file path (`.plx`) - auto-detected
+
+**Options:**
+
+- `--pipe` - Pipe code to use (can be omitted if you specify a bundle that declares a `main_pipe`)
+- `--library-dir`, `-L` - Directory to search for pipe definitions. Can be specified multiple times.
+- `--output`, `-o` - Path to save the generated JSON file (defaults to bundle's directory if bundle provided, otherwise `results/`)
+
+## Examples
+
+**Generate inputs from a bundle (uses main_pipe):**
+
+```bash
+pipelex build inputs my_bundle.plx
+```
+
+**Specify which pipe to use from a bundle:**
+
+```bash
+pipelex build inputs my_bundle.plx --pipe my_pipe
+```
+
+**Generate inputs for a pipe using a library directory:**
+
+```bash
+pipelex build inputs my_domain.my_pipe -L ./my_library/
+```
+
+**Custom output path:**
+
+```bash
+pipelex build inputs my_bundle.plx --output custom_inputs.json
+```
+
+## Output Format
+
+The generated JSON file contains all inputs required by the pipe, with example values based on each input's concept type:
+
+```json
+{
+  "text_input": {
+    "concept": "native.Text",
+    "content": {
+      "text": "text_value"
+    }
+  },
+  "document_input": {
+    "concept": "native.Document",
+    "content": {
+      "url": "url_value"
+    }
+  }
+}
+```
+
+### Multiplicity Support
+
+When an input has multiplicity (accepts multiple items), the content is wrapped in a list:
+
+```json
+{
+  "documents": {
+    "concept": "native.Document",
+    "content": [
+      {
+        "url": "url_value"
+      }
+    ]
+  }
+}
+```
+
+## Use Cases
+
+- **Understanding pipe requirements** - Quickly see what inputs a pipe expects
+- **Creating input templates** - Generate a starting point for your input JSON files
+- **API integration** - Know the exact structure to send when calling pipes programmatically
+
+## Related Documentation
+
+- [Build Output](output.md) - Generate example output JSON for a pipe
+- [Build Runner](runner.md) - Generate Python code to run a pipe
+- [Provide Inputs](../../../6-build-reliable-ai-workflows/pipes/provide-inputs.md) - Learn about input formats

--- a/docs/home/9-tools/cli/build/output.md
+++ b/docs/home/9-tools/cli/build/output.md
@@ -46,12 +46,15 @@ pipelex build output my_bundle.plx --output expected_output.json
 
 ## Output Format
 
-The generated JSON file shows the content structure of the pipe's output, with example values based on the output concept type:
+The generated JSON file shows the output structure including the concept type and content:
 
 ```json
 {
-  "title": "title_value",
-  "key_points": "key_points_value"
+  "concept": "my_domain.MyOutputConcept",
+  "content": {
+    "title": "title_value",
+    "key_points": "key_points_value"
+  }
 }
 ```
 
@@ -61,7 +64,10 @@ For native concepts like `Text`, `Image`, or `Document`:
 
 ```json
 {
-  "text": "text_value"
+  "concept": "native.Text",
+  "content": {
+    "text": "text_value"
+  }
 }
 ```
 
@@ -70,13 +76,39 @@ For native concepts like `Text`, `Image`, or `Document`:
 When a pipe's output has multiplicity (returns multiple items), the content is a list:
 
 ```json
-[
-  {
-    "name": "name_value",
-    "description": "description_value"
-  }
-]
+{
+  "concept": "my_domain.Item",
+  "content": [
+    {
+      "name": "name_value",
+      "description": "description_value"
+    }
+  ]
+}
 ```
+
+### `native.Anything` Output
+
+When a pipe's output is `native.Anything` (e.g., a `PipeCondition` with mapped pipes that have different output types), the command shows all possible outputs from the mapped pipes:
+
+```json
+{
+  "output_option_1": {
+    "concept": "my_domain.Result1",
+    "content": {
+      "field1": "field1_value"
+    }
+  },
+  "output_option_2": {
+    "concept": "my_domain.Result2",
+    "content": {
+      "field2": "field2_value"
+    }
+  }
+}
+```
+
+This helps you understand all possible output structures that the pipe could return depending on execution path.
 
 ## Use Cases
 

--- a/docs/home/9-tools/cli/build/output.md
+++ b/docs/home/9-tools/cli/build/output.md
@@ -1,0 +1,92 @@
+# Build Output
+
+Generate example output JSON for a pipe, showing the expected output structure based on the pipe's output concept type.
+
+## Usage
+
+```bash
+pipelex build output <TARGET> [OPTIONS]
+```
+
+**Arguments:**
+
+- `TARGET` - Either a pipe code or a bundle file path (`.plx`) - auto-detected
+
+**Options:**
+
+- `--pipe` - Pipe code to use (can be omitted if you specify a bundle that declares a `main_pipe`)
+- `--library-dir`, `-L` - Directory to search for pipe definitions. Can be specified multiple times.
+- `--output`, `-o` - Path to save the generated JSON file (defaults to bundle's directory if bundle provided, otherwise `results/`)
+
+## Examples
+
+**Generate output from a bundle (uses main_pipe):**
+
+```bash
+pipelex build output my_bundle.plx
+```
+
+**Specify which pipe to use from a bundle:**
+
+```bash
+pipelex build output my_bundle.plx --pipe my_pipe
+```
+
+**Generate output for a pipe using a library directory:**
+
+```bash
+pipelex build output my_domain.my_pipe -L ./my_library/
+```
+
+**Custom output path:**
+
+```bash
+pipelex build output my_bundle.plx --output expected_output.json
+```
+
+## Output Format
+
+The generated JSON file shows the content structure of the pipe's output, with example values based on the output concept type:
+
+```json
+{
+  "title": "title_value",
+  "key_points": "key_points_value"
+}
+```
+
+### Native Concepts
+
+For native concepts like `Text`, `Image`, or `Document`:
+
+```json
+{
+  "text": "text_value"
+}
+```
+
+### Multiplicity Support
+
+When a pipe's output has multiplicity (returns multiple items), the content is a list:
+
+```json
+[
+  {
+    "name": "name_value",
+    "description": "description_value"
+  }
+]
+```
+
+## Use Cases
+
+- **Understanding pipe outputs** - Quickly see what structure a pipe returns
+- **API integration** - Know the exact structure to expect when calling pipes programmatically
+- **Type definitions** - Use as reference for defining types in your application code
+- **Testing** - Create expected output templates for validation
+
+## Related Documentation
+
+- [Build Inputs](inputs.md) - Generate example input JSON for a pipe
+- [Build Runner](runner.md) - Generate Python code to run a pipe
+- [Pipe Output](../../../6-build-reliable-ai-workflows/pipes/pipe-output.md) - Learn about pipe outputs

--- a/docs/home/9-tools/cli/build/pipe.md
+++ b/docs/home/9-tools/cli/build/pipe.md
@@ -14,10 +14,26 @@ The Pipe Builder is an AI-powered tool that generates Pipelex pipelines from nat
 ## Usage
 
 ```bash
-pipelex build pipe "Brief description of what the pipeline should do"
+pipelex build pipe <PROMPT> [OPTIONS]
 ```
 
-The resulting pipeline will be saved in a folder `pipeline_01/` (with increasing number) containing:
+**Arguments:**
+
+- `PROMPT` - Description of what the pipeline should do (required)
+
+**Options:**
+
+- `--output-name`, `-o` - Base name for the generated file or directory (without extension)
+- `--output-dir` - Directory where files will be generated
+- `--no-output` - Skip saving the pipeline to file (useful for testing)
+- `--no-extras` - Skip generating `inputs.json` and `runner.py`, only generate the PLX file
+- `--builder-pipe` - Builder pipe to use for generating the pipeline (default: `pipe_builder`)
+- `--graph` / `--no-graph` - Generate execution graphs for both build process and built pipeline
+- `--graph-full-data` / `--graph-no-data` - Include or exclude full serialized data in graphs (requires `--graph`)
+
+## Output
+
+The resulting pipeline will be saved in a folder (e.g., `pipeline_01/`) containing:
 
 | File | Description |
 |------|-------------|
@@ -31,16 +47,31 @@ The resulting pipeline will be saved in a folder `pipeline_01/` (with increasing
 
 The HTML and SVG files provide a visual representation of the resulting workflow.
 
-**Example:**
+## Examples
+
+**Basic usage:**
 
 ```bash
-pipelex build pipe "Given an expense report, apply company rules" -o results/expense_pipeline.plx
+pipelex build pipe "Given an expense report, apply company rules"
 ```
 
-## Options
+**Custom output name:**
 
-- `--output`, `-o`: Path to save the generated `.plx` file
-- `--no-output`: Skip saving the file (useful for testing)
+```bash
+pipelex build pipe "Extract data from invoices" -o invoice_extractor
+```
+
+**Custom output directory:**
+
+```bash
+pipelex build pipe "Analyze customer feedback" --output-dir ./pipelines/
+```
+
+**Generate only the PLX file (no extras):**
+
+```bash
+pipelex build pipe "Summarize documents" --no-extras
+```
 
 ## Example Use Cases
 
@@ -96,11 +127,15 @@ After generating your pipeline:
 2. **Run it**: `pipelex run your_pipe.plx` - See [Run Command](../run.md)
 3. **Generate a runner**: `pipelex build runner your_pipe.plx` - See [Build Runner](runner.md)
 4. **Generate structures**: `pipelex build structures ./` - See [Build Structures](structures.md)
+5. **Generate input template**: `pipelex build inputs your_pipe.plx` - See [Build Inputs](inputs.md)
+6. **View output structure**: `pipelex build output your_pipe.plx` - See [Build Output](output.md)
 
 ## Related Documentation
 
 - [Pipe Builder Deep Dive](../../pipe-builder.md) - How the builder works under the hood
 - [Design and Run Pipelines](../../../6-build-reliable-ai-workflows/pipes/index.md)
+- [Build Inputs](inputs.md) - Generate example input JSON
+- [Build Output](output.md) - Generate example output JSON
 - [Pipe Operators](../../../6-build-reliable-ai-workflows/pipes/pipe-operators/index.md)
 - [Pipe Controllers](../../../6-build-reliable-ai-workflows/pipes/pipe-controllers/index.md)
 

--- a/docs/home/9-tools/cli/build/runner.md
+++ b/docs/home/9-tools/cli/build/runner.md
@@ -10,12 +10,13 @@ pipelex build runner <TARGET> [OPTIONS]
 
 **Arguments:**
 
-- `TARGET` - Either a bundle file path (`.plx`) or a library directory
+- `TARGET` - Bundle file path (`.plx`)
 
 **Options:**
 
-- `--pipe` - Pipe code to use (**mandatory** for library directory, **mandatory** for `.plx` without `main_pipe`)
+- `--pipe` - Pipe code to use (optional if the `.plx` declares a `main_pipe`)
 - `--output`, `-o` - Path to save the generated Python file (defaults to target's directory)
+- `--library-dirs`, `-L` - Directories to search for pipe definitions. Can be specified multiple times.
 
 ## Examples
 
@@ -31,10 +32,10 @@ pipelex build runner my_bundle.plx
 pipelex build runner my_bundle.plx --pipe my_pipe
 ```
 
-**Generate runner from a library directory (--pipe is mandatory):**
+**With additional library directories:**
 
 ```bash
-pipelex build runner ./my_library/ --pipe my_pipe
+pipelex build runner my_bundle.plx -L ./shared_pipes/ -L ./common/
 ```
 
 **Custom output path:**
@@ -73,5 +74,7 @@ After generating the runner file:
 
 - [Build Pipe](pipe.md) - Generate pipelines from natural language
 - [Build Structures](structures.md) - Generate Pydantic models separately
+- [Build Inputs](inputs.md) - Generate example input JSON for a pipe
+- [Build Output](output.md) - Generate example output JSON for a pipe
 - [Run Command](../run.md) - Run pipes directly from CLI
 

--- a/docs/home/9-tools/cli/build/structures.md
+++ b/docs/home/9-tools/cli/build/structures.md
@@ -87,5 +87,7 @@ class CandidateProfile(StructuredContent):
 
 - [Build Pipe](pipe.md) - Generate pipelines from natural language
 - [Build Runner](runner.md) - Generate Python runner scripts
+- [Build Inputs](inputs.md) - Generate example input JSON for a pipe
+- [Build Output](output.md) - Generate example output JSON for a pipe
 - [Concepts](../../../6-build-reliable-ai-workflows/concepts/define_your_concepts.md) - Understanding concept definitions
 

--- a/pipelex/builder/builder_loop.py
+++ b/pipelex/builder/builder_loop.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import TYPE_CHECKING, cast
 
 from pipelex import builder, log
 from pipelex.builder.builder import (
@@ -7,6 +8,7 @@ from pipelex.builder.builder import (
     reconstruct_bundle_with_pipe_fixes,
 )
 from pipelex.builder.concept.concept_spec import ConceptSpec
+from pipelex.builder.pipe.pipe_condition_spec import PipeConditionSpec
 from pipelex.builder.pipe.pipe_sequence_spec import PipeSequenceSpec
 from pipelex.client.protocol import PipelineInputs
 from pipelex.config import get_config
@@ -21,6 +23,9 @@ from pipelex.pipeline.validate_bundle import ValidateBundleError, validate_bundl
 from pipelex.system.configuration.configs import PipelineExecutionConfig
 from pipelex.tools.misc.file_utils import get_incremental_file_path, save_text_to_path
 from pipelex.tools.misc.json_utils import save_as_json_to_path
+
+if TYPE_CHECKING:
+    from pipelex.pipe_controllers.condition.pipe_condition import PipeCondition
 
 
 class BuilderLoop:
@@ -200,29 +205,57 @@ class BuilderLoop:
 
                 case PipeValidationErrorType.INADEQUATE_OUTPUT_CONCEPT | PipeValidationErrorType.INADEQUATE_OUTPUT_MULTIPLICITY:
                     # Fix output concept/multiplicity mismatch for PipeSequence by updating to match last step's output
-                    if not isinstance(pipe_spec, PipeSequenceSpec):
-                        continue
+                    if isinstance(pipe_spec, PipeSequenceSpec):
+                        last_step = pipe_spec.steps[-1]
+                        last_step_pipe_code = last_step.pipe_code
 
-                    last_step = pipe_spec.steps[-1]
-                    last_step_pipe_code = last_step.pipe_code
+                        # Get the last step's pipe spec to retrieve its output
+                        last_step_pipe_spec = pipelex_bundle_spec.pipe.get(last_step_pipe_code)
+                        if not last_step_pipe_spec:
+                            continue
 
-                    # Get the last step's pipe spec to retrieve its output
-                    last_step_pipe_spec = pipelex_bundle_spec.pipe.get(last_step_pipe_code)
-                    if not last_step_pipe_spec:
-                        continue
+                        old_output = pipe_spec.output
+                        new_output = last_step_pipe_spec.output
 
-                    old_output = pipe_spec.output
-                    new_output = last_step_pipe_spec.output
+                        # Set the sequence output to match the last step's output
+                        pipe_spec.output = new_output
+                        fixed_pipes.append(pipe_spec)
+                        # TODO: return a structured report of what was done, let the caller decide if they want to print it or act on it
+                        error_kind = "concept" if val_error.error_type == PipeValidationErrorType.INADEQUATE_OUTPUT_CONCEPT else "multiplicity"
+                        log.info(
+                            f"🔧 Fixed output {error_kind} for pipe '{val_error.pipe_code}': output changed from '{old_output}' → \
+                                '{new_output}' (matching last step '{last_step_pipe_code}')"
+                        )
 
-                    # Set the sequence output to match the last step's output
-                    pipe_spec.output = new_output
-                    fixed_pipes.append(pipe_spec)
-                    # TODO: return a structured report of what was done, let the caller decide if they want to print it or act on it
-                    error_kind = "concept" if val_error.error_type == PipeValidationErrorType.INADEQUATE_OUTPUT_CONCEPT else "multiplicity"
-                    log.info(
-                        f"🔧 Fixed output {error_kind} for pipe '{val_error.pipe_code}': output changed from '{old_output}' → \
-                            '{new_output}' (matching last step '{last_step_pipe_code}')"
-                    )
+                    # Fix output concept for PipeCondition by checking mapped pipes' outputs
+                    elif isinstance(pipe_spec, PipeConditionSpec):
+                        # Get the PipeCondition instance to access mapped_pipe_codes
+                        pipe_condition = cast("PipeCondition", get_required_pipe(pipe_code=val_error.pipe_code))
+                        mapped_pipe_codes = pipe_condition.mapped_pipe_codes
+
+                        if not mapped_pipe_codes:
+                            # No mapped pipes (all special outcomes), any output is fine
+                            continue
+
+                        # Collect all unique output concept refs from mapped pipes
+                        mapped_output_refs: set[str] = set()
+                        for mapped_pipe_code in mapped_pipe_codes:
+                            mapped_pipe = get_required_pipe(pipe_code=mapped_pipe_code)
+                            mapped_output_refs.add(mapped_pipe.output.concept.concept_ref)
+
+                        old_output = pipe_spec.output
+
+                        # If all mapped pipes have same output, use that; otherwise use Anything
+                        if len(mapped_output_refs) == 1:
+                            new_output = next(iter(mapped_output_refs))
+                        else:
+                            new_output = "native.Anything"
+
+                        pipe_spec.output = new_output
+                        fixed_pipes.append(pipe_spec)
+                        log.info(
+                            f"🔧 Fixed output concept for PipeCondition '{val_error.pipe_code}': output changed from '{old_output}' → '{new_output}'"
+                        )
 
                 case (
                     PipeValidationErrorType.LLM_OUTPUT_CANNOT_BE_IMAGE

--- a/pipelex/builder/builder_loop.py
+++ b/pipelex/builder/builder_loop.py
@@ -229,9 +229,9 @@ class BuilderLoop:
 
                     # Fix output concept for PipeCondition by checking mapped pipes' outputs
                     elif isinstance(pipe_spec, PipeConditionSpec):
-                        # Get the PipeCondition instance to access mapped_pipe_codes
+                        # Get the PipeCondition instance to access pipe_dependencies()
                         pipe_condition = cast("PipeCondition", get_required_pipe(pipe_code=val_error.pipe_code))
-                        mapped_pipe_codes = pipe_condition.mapped_pipe_codes
+                        mapped_pipe_codes = pipe_condition.pipe_dependencies()
 
                         if not mapped_pipe_codes:
                             # No mapped pipes (all special outcomes), any output is fine

--- a/pipelex/builder/pipe/pipe_condition_spec.py
+++ b/pipelex/builder/pipe/pipe_condition_spec.py
@@ -1,6 +1,6 @@
 from typing import Literal
 
-from pydantic import Field, field_validator
+from pydantic import Field
 from pydantic.json_schema import SkipJsonSchema
 from rich.console import Group
 from rich.panel import Panel
@@ -30,11 +30,6 @@ class PipeConditionSpec(PipeSpec):
     jinja2_expression_template: str = Field(description="Jinja2 expression to evaluate.")
     outcomes: dict[str, str] = Field(..., description="Mapping `dict[str, str]` of condition to outcomes.")
     default_outcome: str | SpecialOutcome = Field(description="The fallback outcome if the expression result does not match any key in outcome map.")
-
-    @field_validator("output", mode="after")
-    @classmethod
-    def forced_output(cls, _: str) -> str:
-        return "native.Anything"
 
     @override
     def rendered_pretty(self, title: str | None = None, depth: int = 0) -> PrettyPrintable:

--- a/pipelex/builder/pipe/pipe_extract_spec.py
+++ b/pipelex/builder/pipe/pipe_extract_spec.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Literal
+from typing import Literal
 
 from pydantic import Field, field_validator
 from pydantic.json_schema import SkipJsonSchema
@@ -8,12 +8,8 @@ from typing_extensions import override
 
 from pipelex.builder.pipe.pipe_spec import PipeSpec
 from pipelex.builder.talents.extract_talent import ExtractTalent
-from pipelex.config import get_config
 from pipelex.pipe_operators.extract.pipe_extract_blueprint import PipeExtractBlueprint
 from pipelex.tools.misc.pretty import PrettyPrintable
-
-if TYPE_CHECKING:
-    from pipelex.cogt.extract.extract_setting import ExtractModelChoice
 
 
 class PipeExtractSpec(PipeSpec):
@@ -87,15 +83,15 @@ class PipeExtractSpec(PipeSpec):
         base_blueprint = super().to_blueprint()
 
         # Get extract choice from config-based mapping
-        mappings = get_config().pipelex.builder_config.talent_preset_mappings.extract
-        extract_model_choice: ExtractModelChoice = mappings[self.extract_talent]
+        # mappings = get_config().pipelex.builder_config.talent_preset_mappings.extract
+        # extract_model_choice: ExtractModelChoice = mappings[self.extract_talent]
 
         return PipeExtractBlueprint(
             source=None,
             description=base_blueprint.description,
             inputs=base_blueprint.inputs,
             output=base_blueprint.output,
-            model=extract_model_choice,
+            model=None,
             max_page_images=self.max_page_images,
             page_image_captions=self.page_image_captions,
             page_views=self.page_views,

--- a/pipelex/builder/pipe/pipe_extract_spec.py
+++ b/pipelex/builder/pipe/pipe_extract_spec.py
@@ -1,4 +1,4 @@
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 from pydantic import Field, field_validator
 from pydantic.json_schema import SkipJsonSchema
@@ -8,6 +8,11 @@ from typing_extensions import override
 
 from pipelex.builder.pipe.pipe_spec import PipeSpec
 from pipelex.builder.talents.extract_talent import ExtractTalent
+
+if TYPE_CHECKING:
+    from pipelex.cogt.extract.extract_setting import ExtractModelChoice
+
+from pipelex.config import get_config
 from pipelex.pipe_operators.extract.pipe_extract_blueprint import PipeExtractBlueprint
 from pipelex.tools.misc.pretty import PrettyPrintable
 
@@ -83,15 +88,15 @@ class PipeExtractSpec(PipeSpec):
         base_blueprint = super().to_blueprint()
 
         # Get extract choice from config-based mapping
-        # mappings = get_config().pipelex.builder_config.talent_preset_mappings.extract
-        # extract_model_choice: ExtractModelChoice = mappings[self.extract_talent]
+        mappings = get_config().pipelex.builder_config.talent_preset_mappings.extract
+        extract_model_choice: ExtractModelChoice = mappings[self.extract_talent]
 
         return PipeExtractBlueprint(
             source=None,
             description=base_blueprint.description,
             inputs=base_blueprint.inputs,
             output=base_blueprint.output,
-            model=None,
+            model=extract_model_choice,
             max_page_images=self.max_page_images,
             page_image_captions=self.page_image_captions,
             page_views=self.page_views,

--- a/pipelex/builder/runner_code.py
+++ b/pipelex/builder/runner_code.py
@@ -239,7 +239,7 @@ def generate_runner_code(pipe: PipeAbstract, output_multiplicity: bool = False, 
         input_entries: list[str] = []
         for var_name, input_req in pipe.inputs.root.items():
             is_multiple = _is_multiple(input_req.multiplicity)
-            result, _ = input_req.concept.generate_input_representation(
+            result, _ = input_req.concept.render_concept_representation(
                 output_format=ConceptRepresentationFormat.PYTHON,
                 is_multiple=is_multiple,
             )

--- a/pipelex/cli/commands/build/app.py
+++ b/pipelex/cli/commands/build/app.py
@@ -1,6 +1,7 @@
 import typer
 
 from pipelex.cli.commands.build.inputs_cmd import generate_inputs_cmd
+from pipelex.cli.commands.build.output_cmd import generate_output_cmd
 from pipelex.cli.commands.build.pipe_cmd import build_pipe_cmd
 from pipelex.cli.commands.build.runner_cmd import prepare_runner_cmd
 from pipelex.cli.commands.build.structures_cmd import build_structures_command
@@ -9,6 +10,7 @@ build_app = typer.Typer(help="Build working pipelines from natural language requ
 
 # Register commands explicitly
 build_app.command("inputs", help="Generate example input JSON for a pipe")(generate_inputs_cmd)
+build_app.command("output", help="Generate example output JSON for a pipe")(generate_output_cmd)
 build_app.command("pipe", help="Build a Pipelex bundle with one validation/fix loop correcting deterministic issues")(build_pipe_cmd)
 build_app.command("runner", help="Build the Python code to run a pipe with the necessary inputs")(prepare_runner_cmd)
 build_app.command("structures", help="Generate Python structure files from concept definitions in PLX files")(build_structures_command)

--- a/pipelex/cli/commands/build/inputs_cmd.py
+++ b/pipelex/cli/commands/build/inputs_cmd.py
@@ -15,6 +15,7 @@ from pipelex.cli.error_handlers import (
 from pipelex.core.interpreter.helpers import is_pipelex_file
 from pipelex.core.pipes.exceptions import PipeOperatorModelChoiceError
 from pipelex.core.pipes.inputs.exceptions import PipeInputError
+from pipelex.core.pipes.inputs.input_renderer import NoInputsRequiredError, render_inputs
 from pipelex.hub import get_required_pipe, get_telemetry_manager
 from pipelex.pipe_operators.exceptions import PipeOperatorModelAvailabilityError
 from pipelex.pipelex import PACKAGE_VERSION
@@ -84,14 +85,12 @@ async def _generate_inputs_core(
         typer.secho(f"❌ Error: Could not find pipe '{pipe_code}': {exc}", fg=typer.colors.RED)
         raise typer.Exit(1) from exc
 
-    # Check if pipe has any inputs
-    if not the_pipe.inputs.root:
-        typer.secho(f"No inputs required for pipe '{pipe_code}'.", fg=typer.colors.YELLOW)
-        raise typer.Exit(0)
-
     # Generate the input JSON
     try:
-        inputs_json_str = the_pipe.inputs.render_inputs(indent=2)
+        inputs_json_str = render_inputs(the_pipe, indent=2)
+    except NoInputsRequiredError as exc:
+        typer.secho(str(exc), fg=typer.colors.YELLOW)
+        raise typer.Exit(0) from exc
     except Exception as exc:
         typer.secho(f"❌ Error generating input JSON: {exc}", fg=typer.colors.RED)
         raise typer.Exit(1) from exc

--- a/pipelex/cli/commands/build/output_cmd.py
+++ b/pipelex/cli/commands/build/output_cmd.py
@@ -86,10 +86,11 @@ async def _generate_output_core(
         typer.secho(f"❌ Error: Could not find pipe '{pipe_code}': {exc}", fg=typer.colors.RED)
         raise typer.Exit(1) from exc
 
-    # Generate the output JSON
+    # Generate the output JSON (content only, no concept wrapper)
     try:
         output_dict = the_pipe.output.render_stuff_spec(ConceptRepresentationFormat.JSON)
-        output_json_str = json.dumps(output_dict, indent=2, ensure_ascii=False)
+        content = output_dict.get("content", output_dict)
+        output_json_str = json.dumps(content, indent=2, ensure_ascii=False)
     except Exception as exc:
         typer.secho(f"❌ Error generating output JSON: {exc}", fg=typer.colors.RED)
         raise typer.Exit(1) from exc

--- a/pipelex/cli/commands/build/output_cmd.py
+++ b/pipelex/cli/commands/build/output_cmd.py
@@ -1,5 +1,4 @@
 import asyncio
-import json
 from pathlib import Path
 from typing import Annotated
 
@@ -13,10 +12,10 @@ from pipelex.cli.error_handlers import (
     handle_model_availability_error,
     handle_model_choice_error,
 )
-from pipelex.core.concepts.concept_representation_generator import ConceptRepresentationFormat
 from pipelex.core.interpreter.helpers import is_pipelex_file
 from pipelex.core.pipes.exceptions import PipeOperatorModelChoiceError
 from pipelex.core.pipes.inputs.exceptions import PipeInputError
+from pipelex.core.pipes.output.output_renderer import render_output
 from pipelex.hub import get_required_pipe, get_telemetry_manager
 from pipelex.pipe_operators.exceptions import PipeOperatorModelAvailabilityError
 from pipelex.pipelex import PACKAGE_VERSION
@@ -86,11 +85,12 @@ async def _generate_output_core(
         typer.secho(f"❌ Error: Could not find pipe '{pipe_code}': {exc}", fg=typer.colors.RED)
         raise typer.Exit(1) from exc
 
-    # Generate the output JSON (content only, no concept wrapper)
+    # Generate the output JSON
     try:
-        output_dict = the_pipe.output.render_stuff_spec(ConceptRepresentationFormat.JSON)
-        content = output_dict.get("content", output_dict)
-        output_json_str = json.dumps(content, indent=2, ensure_ascii=False)
+        output_json_str = render_output(the_pipe)
+    except ValueError as exc:
+        typer.secho(str(exc), fg=typer.colors.YELLOW)
+        raise typer.Exit(0) from exc
     except Exception as exc:
         typer.secho(f"❌ Error generating output JSON: {exc}", fg=typer.colors.RED)
         raise typer.Exit(1) from exc

--- a/pipelex/cli/commands/build/output_cmd.py
+++ b/pipelex/cli/commands/build/output_cmd.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 from pathlib import Path
 from typing import Annotated
 
@@ -12,6 +13,7 @@ from pipelex.cli.error_handlers import (
     handle_model_availability_error,
     handle_model_choice_error,
 )
+from pipelex.core.concepts.concept_representation_generator import ConceptRepresentationFormat
 from pipelex.core.interpreter.helpers import is_pipelex_file
 from pipelex.core.pipes.exceptions import PipeOperatorModelChoiceError
 from pipelex.core.pipes.inputs.exceptions import PipeInputError
@@ -27,18 +29,18 @@ from pipelex.tools.misc.file_utils import (
 )
 
 COMMAND = "build"
-SUB_COMMAND_INPUTS = "inputs"
+SUB_COMMAND_OUTPUT = "output"
 
 
-async def _generate_inputs_core(
+async def _generate_output_core(
     pipe_code: str | None = None,
     bundle_path: Path | None = None,
     output_path: Path | None = None,
 ) -> None:
-    """Core logic for generating input JSON for a pipe.
+    """Core logic for generating output JSON for a pipe.
 
     Args:
-        pipe_code: The pipe code to generate inputs for.
+        pipe_code: The pipe code to generate output for.
         bundle_path: Path to the bundle file (.plx).
         output_path: Path to save the generated JSON file.
     """
@@ -51,7 +53,7 @@ async def _generate_inputs_core(
                 main_pipe_code = bundle_blueprint.main_pipe
                 if not main_pipe_code:
                     msg = (
-                        f"Bundle '{bundle_path}' does not declare a main_pipe. In order to build inputs for a bundle, "
+                        f"Bundle '{bundle_path}' does not declare a main_pipe. In order to build output for a bundle, "
                         "you must specify a main pipe in the bundle itself or specify a pipe code in the command line using the --pipe option."
                     )
                     typer.secho(
@@ -84,39 +86,35 @@ async def _generate_inputs_core(
         typer.secho(f"❌ Error: Could not find pipe '{pipe_code}': {exc}", fg=typer.colors.RED)
         raise typer.Exit(1) from exc
 
-    # Check if pipe has any inputs
-    if not the_pipe.inputs.root:
-        typer.secho(f"No inputs required for pipe '{pipe_code}'.", fg=typer.colors.YELLOW)
-        raise typer.Exit(0)
-
-    # Generate the input JSON
+    # Generate the output JSON
     try:
-        inputs_json_str = the_pipe.inputs.render_inputs(indent=2)
+        output_dict = the_pipe.output.render_stuff_spec(ConceptRepresentationFormat.JSON)
+        output_json_str = json.dumps(output_dict, indent=2, ensure_ascii=False)
     except Exception as exc:
-        typer.secho(f"❌ Error generating input JSON: {exc}", fg=typer.colors.RED)
+        typer.secho(f"❌ Error generating output JSON: {exc}", fg=typer.colors.RED)
         raise typer.Exit(1) from exc
 
     # Determine output path - use bundle's directory if bundle provided, otherwise results/
     if output_path:
         final_output_path = output_path
     elif bundle_path:
-        # Place inputs.json in the same directory as the PLX file
-        bundle_dir = bundle_path.parent
-        final_output_path = bundle_dir / "inputs.json"
+        # Place output.json in the same directory as the PLX file
+        bundle_dir = Path(bundle_path).parent
+        final_output_path = bundle_dir / "output.json"
     else:
-        final_output_path = Path("results/inputs.json")
+        final_output_path = Path("results/output.json")
 
     # Save the file
     try:
         ensure_directory_for_file_path(file_path=str(final_output_path))
-        save_text_to_path(text=inputs_json_str, path=str(final_output_path))
-        typer.secho(f"✅ Generated input JSON file: {final_output_path}", fg=typer.colors.GREEN)
+        save_text_to_path(text=output_json_str, path=str(final_output_path))
+        typer.secho(f"✅ Generated output JSON file: {final_output_path}", fg=typer.colors.GREEN)
     except Exception as exc:
         typer.secho(f"❌ Error saving file: {exc}", fg=typer.colors.RED)
         raise typer.Exit(1) from exc
 
 
-def generate_inputs_cmd(
+def generate_output_cmd(
     target: Annotated[
         str | None,
         typer.Argument(help="Pipe code or bundle file path (auto-detected)"),
@@ -140,17 +138,17 @@ def generate_inputs_cmd(
         ),
     ] = None,
 ) -> None:
-    """Generate example input JSON for a pipe.
+    """Generate example output JSON for a pipe.
 
-    The generated JSON file will include example values for all pipe inputs
-    based on their concept types.
+    The generated JSON file will show the expected output structure
+    based on the pipe's output concept type.
 
     Examples:
-        pipelex build inputs my_pipe
-        pipelex build inputs my_bundle.plx
-        pipelex build inputs my_bundle.plx --pipe my_pipe
-        pipelex build inputs my_pipe --output custom_inputs.json
-        pipelex build inputs my_pipe -L ./my_pipes
+        pipelex build output my_pipe
+        pipelex build output my_bundle.plx
+        pipelex build output my_bundle.plx --pipe my_pipe
+        pipelex build output my_pipe --output custom_output.json
+        pipelex build output my_pipe -L ./my_pipes
     """
     # Show help if nothing provided
     if target is None and pipe is None:
@@ -167,7 +165,7 @@ def generate_inputs_cmd(
         target_path = Path(target)
         if target_path.is_dir():
             typer.secho(
-                f"Failed to run: '{target}' is a directory. The inputs command requires a .plx file or a pipe code.",
+                f"Failed to run: '{target}' is a directory. The output command requires a .plx file or a pipe code.",
                 fg=typer.colors.RED,
                 err=True,
             )
@@ -193,15 +191,15 @@ def generate_inputs_cmd(
         typer.secho("Failed to run: no pipe code or bundle file specified", fg=typer.colors.RED, err=True)
         raise typer.Exit(1)
 
-    pipelex_instance = make_pipelex_for_cli(context=ErrorContext.VALIDATION_BEFORE_BUILD_INPUTS, library_dirs=library_dir)
+    pipelex_instance = make_pipelex_for_cli(context=ErrorContext.VALIDATION_BEFORE_BUILD_OUTPUT, library_dirs=library_dir)
 
     try:
         with get_telemetry_manager().telemetry_context():
             tag(name=EventProperty.INTEGRATION, value=IntegrationMode.CLI)
             tag(name=EventProperty.PIPELEX_VERSION, value=PACKAGE_VERSION)
-            tag(name=EventProperty.CLI_COMMAND, value=f"{COMMAND} {SUB_COMMAND_INPUTS}")
+            tag(name=EventProperty.CLI_COMMAND, value=f"{COMMAND} {SUB_COMMAND_OUTPUT}")
 
-            asyncio.run(_generate_inputs_core(pipe_code=pipe_code, bundle_path=bundle_path, output_path=output_path_path))
+            asyncio.run(_generate_output_core(pipe_code=pipe_code, bundle_path=bundle_path, output_path=output_path_path))
 
     except PipeOperatorModelChoiceError as exc:
         handle_model_choice_error(exc, context=ErrorContext.BUILD)

--- a/pipelex/cli/commands/build/pipe_cmd.py
+++ b/pipelex/cli/commands/build/pipe_cmd.py
@@ -271,7 +271,7 @@ def build_pipe_cmd(
                         typer.secho(f"✅ Generated {len(generated_structures)} structure(s) in: {structures_output_dir}", fg=typer.colors.GREEN)
 
                     # Generate inputs.json
-                    inputs_json_str = pipe.inputs.generate_json_string(indent=2)
+                    inputs_json_str = pipe.inputs.render_inputs(indent=2)
                     inputs_json_path = os.path.join(extras_output_dir, "inputs.json")
                     save_text_to_path(text=inputs_json_str, path=inputs_json_path)
                     typer.secho(f"✅ Inputs template saved to: {inputs_json_path}", fg=typer.colors.GREEN)

--- a/pipelex/cli/error_handlers.py
+++ b/pipelex/cli/error_handlers.py
@@ -36,6 +36,7 @@ class ErrorContext(StrEnum):
     VALIDATION_BEFORE_BUILD_PIPE = "Pre-validation (build pipe)"
     VALIDATION_BEFORE_BUILD_RUNNER = "Pre-validation (build runner)"
     VALIDATION_BEFORE_BUILD_INPUTS = "Pre-validation (build inputs)"
+    VALIDATION_BEFORE_BUILD_OUTPUT = "Pre-validation (build output)"
     KIT = "Kit operation"
 
 

--- a/pipelex/client/pipeline_response_factory.py
+++ b/pipelex/client/pipeline_response_factory.py
@@ -36,13 +36,10 @@ class PipelineResponseFactory:
     @staticmethod
     def make_from_pipe_output(
         pipe_output: PipeOutput,
-        status: str,
         pipeline_run_id: str = "",
         created_at: str = "",
         pipeline_state: PipelineState = PipelineState.COMPLETED,
         finished_at: str | None = None,
-        message: str | None = None,
-        error: str | None = None,
     ) -> PipelineResponse:
         """Create a PipelineResponse from a PipeOutput object.
 
@@ -52,9 +49,6 @@ class PipelineResponseFactory:
             created_at: Timestamp when the pipeline was created
             pipeline_state: Current state of the pipeline
             finished_at: Timestamp when the pipeline finished
-            status: Status of the API call
-            message: Optional message providing additional information
-            error: Optional error message
         Returns:
             PipelineResponse with the pipe output serialized to reduced format
 
@@ -69,9 +63,6 @@ class PipelineResponseFactory:
                 pipeline_run_id=pipe_output.pipeline_run_id,
             ),
             main_stuff_name=pipe_output.working_memory.aliases.get(MAIN_STUFF_NAME, MAIN_STUFF_NAME),
-            status=status,
-            message=message,
-            error=error,
         )
 
     @staticmethod

--- a/pipelex/client/pipeline_response_factory.py
+++ b/pipelex/client/pipeline_response_factory.py
@@ -61,6 +61,7 @@ class PipelineResponseFactory:
             pipe_output=DictPipeOutput(
                 working_memory=PipelineResponseFactory._serialize_working_memory_with_dict_stuffs(pipe_output.working_memory),
                 pipeline_run_id=pipe_output.pipeline_run_id,
+                graph_spec=pipe_output.graph_spec,
             ),
             main_stuff_name=pipe_output.working_memory.aliases.get(MAIN_STUFF_NAME, MAIN_STUFF_NAME),
         )

--- a/pipelex/client/pipeline_response_factory.py
+++ b/pipelex/client/pipeline_response_factory.py
@@ -43,7 +43,6 @@ class PipelineResponseFactory:
         finished_at: str | None = None,
         message: str | None = None,
         error: str | None = None,
-        pipe_structures: dict[str, Any] | None = None,
     ) -> PipelineResponse:
         """Create a PipelineResponse from a PipeOutput object.
 
@@ -56,7 +55,6 @@ class PipelineResponseFactory:
             status: Status of the API call
             message: Optional message providing additional information
             error: Optional error message
-            pipe_structures: Structure of the pipeline to execute
         Returns:
             PipelineResponse with the pipe output serialized to reduced format
 
@@ -70,7 +68,6 @@ class PipelineResponseFactory:
                 working_memory=PipelineResponseFactory._serialize_working_memory_with_dict_stuffs(pipe_output.working_memory),
                 pipeline_run_id=pipe_output.pipeline_run_id,
             ),
-            pipe_structures=pipe_structures,
             main_stuff_name=pipe_output.working_memory.aliases.get(MAIN_STUFF_NAME, MAIN_STUFF_NAME),
             status=status,
             message=message,

--- a/pipelex/client/protocol.py
+++ b/pipelex/client/protocol.py
@@ -113,7 +113,6 @@ class PipelineResponse(ApiResponse):
         finished_at (str | None): Timestamp when the pipeline finished, if completed
         pipe_output (DictPipeOutput | None): Output data from the pipeline execution (working_memory dict + pipeline_run_id)
         main_stuff_name (str | None): Name of the main stuff in the pipeline output
-        pipe_structures (dict[str, Any] | None): Structure of the pipeline to execute
 
     """
 
@@ -123,7 +122,6 @@ class PipelineResponse(ApiResponse):
     finished_at: str | None = None
     pipe_output: DictPipeOutput | None = None
     main_stuff_name: str | None = None
-    pipe_structures: dict[str, Any] | None = None
 
 
 @runtime_checkable

--- a/pipelex/client/protocol.py
+++ b/pipelex/client/protocol.py
@@ -39,32 +39,6 @@ StuffContentOrData = (
 PipelineInputs = dict[str, StuffContentOrData]  # Can include both dict and StuffContent
 
 
-class PipelineState(StrEnum):
-    """Enum representing the possible states of a pipe execution."""
-
-    RUNNING = "RUNNING"
-    COMPLETED = "COMPLETED"
-    FAILED = "FAILED"
-    CANCELLED = "CANCELLED"
-    ERROR = "ERROR"
-    STARTED = "STARTED"
-
-
-class ApiResponse(BaseModel):
-    """Base response class for Pipelex API calls.
-
-    Attributes:
-        status (str): Application-level status ("success", "error")
-        message (str | None): Optional message providing additional information
-        error (str | None): Optional error message when status is not "success"
-
-    """
-
-    status: str | None
-    message: str | None = None
-    error: str | None = None
-
-
 class PipelineRequestError(PipelexError):
     pass
 
@@ -103,7 +77,18 @@ class PipelineRequest(BaseModel):
         return values
 
 
-class PipelineResponse(ApiResponse):
+class PipelineState(StrEnum):
+    """Enum representing the possible states of a pipe execution."""
+
+    RUNNING = "RUNNING"
+    COMPLETED = "COMPLETED"
+    FAILED = "FAILED"
+    CANCELLED = "CANCELLED"
+    ERROR = "ERROR"
+    STARTED = "STARTED"
+
+
+class PipelineResponse(BaseModel):
     """Response for pipeline execution requests.
 
     Attributes:

--- a/pipelex/core/concepts/concept.py
+++ b/pipelex/core/concepts/concept.py
@@ -172,12 +172,12 @@ class Concept(BaseModel):
             raise PipelexUnexpectedError(msg)
         return search_for_nested_image_fields(content_class=structure_class)
 
-    def generate_input_representation(
+    def render_concept_representation(
         self,
         output_format: ConceptRepresentationFormat,
         is_multiple: bool = False,
     ) -> tuple[dict[str, Any], set[str]]:
-        """Generate a representation for this concept's input.
+        """Render a representation for this concept.
 
         Args:
             output_format: The format to generate (JSON or PYTHON)
@@ -188,11 +188,9 @@ class Concept(BaseModel):
             - For JSON: content is a dict (or list of dicts if is_multiple)
             - For Python: content is a class instantiation string (wrapping handled by caller)
         """
-        structure_class = self.get_structure_class()
-
         generator = ConceptRepresentationGenerator(output_format)
         # For inputs, we only want required fields (not optional ones)
-        result = generator.generate_representation(self.concept_ref, structure_class, include_optional=False)
+        result = generator.generate_representation(self.concept_ref, self.get_structure_class(), include_optional=False)
 
         # If multiple and JSON format, wrap content in a list
         # For Python format, the caller handles wrapping since content is a string

--- a/pipelex/core/pipes/inputs/exceptions.py
+++ b/pipelex/core/pipes/inputs/exceptions.py
@@ -43,3 +43,7 @@ class PipeRunInputsError(PipeRunError):
         self.variable_name = variable_name
         self.concept_code = concept_code
         super().__init__(message, run_mode, pipe_code)
+
+
+class NoInputsRequiredError(Exception):
+    """Raised when a pipe has no inputs."""

--- a/pipelex/core/pipes/inputs/input_renderer.py
+++ b/pipelex/core/pipes/inputs/input_renderer.py
@@ -1,0 +1,22 @@
+from pipelex.core.pipes.inputs.exceptions import NoInputsRequiredError
+from pipelex.core.pipes.pipe_abstract import PipeAbstract
+
+
+def render_inputs(the_pipe: PipeAbstract, indent: int = 2) -> str:
+    """Render a JSON representation of the pipe's inputs.
+
+    Args:
+        the_pipe: The pipe to render inputs for
+        indent: Number of spaces for indentation (default: 2)
+
+    Returns:
+        Formatted JSON string with the inputs representation
+
+    Raises:
+        NoInputsRequiredError: If the pipe has no inputs
+    """
+    if not the_pipe.inputs.root:
+        msg = f"No inputs required for pipe '{the_pipe.code}'."
+        raise NoInputsRequiredError(msg)
+
+    return the_pipe.inputs.render_inputs(indent=indent)

--- a/pipelex/core/pipes/inputs/input_stuff_specs.py
+++ b/pipelex/core/pipes/inputs/input_stuff_specs.py
@@ -132,30 +132,17 @@ class InputStuffSpecs(RootModel[PipeInputsRoot]):
     def is_empty(self) -> bool:
         return not bool(self.root)
 
-    def generate_json_representation(self) -> dict[str, Any]:
-        """Generate a JSON representation for all inputs.
-
-        Returns:
-            Dictionary with JSON representations for each input
-        """
-        json_inputs: dict[str, Any] = {}
-        for var_name, stuff_spec in self.root.items():
-            json_value, _ = stuff_spec.concept.generate_input_representation(
-                output_format=ConceptRepresentationFormat.JSON,
-                is_multiple=stuff_spec.is_multiple(),
-            )
-            json_inputs[var_name] = json_value
-
-        return json_inputs
-
-    def generate_json_string(self, indent: int = 2) -> str:
-        """Generate a JSON representation for all inputs as a formatted string.
+    def render_inputs(self, indent: int = 2) -> str:
+        """Render a JSON representation for all stuff specs as a formatted string.
 
         Args:
             indent: Number of spaces for indentation (default: 2)
 
         Returns:
-            Formatted JSON string
+            Formatted JSON string with all inputs
         """
-        json_inputs = self.generate_json_representation()
+        json_inputs: dict[str, Any] = {}
+        for var_name, stuff_spec in self.root.items():
+            json_inputs[var_name] = stuff_spec.render_stuff_spec(ConceptRepresentationFormat.JSON)
+
         return json.dumps(json_inputs, indent=indent, ensure_ascii=False)

--- a/pipelex/core/pipes/output/output_renderer.py
+++ b/pipelex/core/pipes/output/output_renderer.py
@@ -1,0 +1,134 @@
+import json
+from typing import Any
+
+from pipelex.core.concepts.concept_representation_generator import ConceptRepresentationFormat
+from pipelex.core.concepts.native.concept_native import NativeConceptCode
+from pipelex.core.pipes.pipe_abstract import PipeAbstract
+from pipelex.core.pipes.pipe_blueprint import PipeType
+from pipelex.hub import get_required_pipe
+
+
+def _collect_possible_outputs(the_pipe: PipeAbstract) -> list[dict[str, Any]]:
+    """Collect all possible outputs for a pipe with native.Anything output.
+
+    For PipeCondition, collects outputs from all mapped pipes.
+    For PipeSequence, looks at the last step to determine possible outputs.
+
+    Args:
+        the_pipe: The pipe to analyze
+
+    Returns:
+        A list of possible output dicts, each containing 'concept_ref' and 'content'
+    """
+    pipe_type = PipeType(the_pipe.type)
+
+    # Check if the pipe is a PipeCondition
+    match pipe_type:
+        case PipeType.PIPE_CONDITION:
+            mapped_pipe_codes: set[str] = getattr(the_pipe, "mapped_pipe_codes", set())
+
+            if not mapped_pipe_codes:
+                return []
+
+            possible_outputs: list[dict[str, Any]] = []
+            for mapped_pipe_code in mapped_pipe_codes:
+                mapped_pipe = get_required_pipe(pipe_code=mapped_pipe_code)
+                try:
+                    output_dict = mapped_pipe.output.render_stuff_spec(ConceptRepresentationFormat.JSON)
+                    content = output_dict.get("content", output_dict)
+                    possible_outputs.append(
+                        {
+                            "concept_ref": mapped_pipe.output.concept.concept_ref,
+                            "content": content,
+                        }
+                    )
+                except Exception:
+                    # If we can't render this pipe's output, add a placeholder
+                    possible_outputs.append(
+                        {
+                            "concept_ref": mapped_pipe.output.concept.concept_ref,
+                            "content": "<unable to render>",
+                        }
+                    )
+
+            return possible_outputs
+
+        case PipeType.PIPE_SEQUENCE:
+            sequential_sub_pipes: list[Any] = getattr(the_pipe, "sequential_sub_pipes", [])
+            if not sequential_sub_pipes:
+                return []
+
+            last_sub_pipe = sequential_sub_pipes[-1]
+            last_pipe_code: str = getattr(last_sub_pipe, "pipe_code", "")
+            if not last_pipe_code:
+                return []
+
+            last_pipe = get_required_pipe(pipe_code=last_pipe_code)
+
+            # If last pipe also has Anything output, recurse
+            if last_pipe.output.concept.code == NativeConceptCode.ANYTHING:
+                return _collect_possible_outputs(last_pipe)
+
+            # Otherwise render the last pipe's output
+            try:
+                output_dict = last_pipe.output.render_stuff_spec(ConceptRepresentationFormat.JSON)
+                content = output_dict.get("content", output_dict)
+                return [
+                    {
+                        "concept_ref": last_pipe.output.concept.concept_ref,
+                        "content": content,
+                    }
+                ]
+            except Exception:
+                return []
+
+        case (
+            PipeType.PIPE_FUNC
+            | PipeType.PIPE_IMG_GEN
+            | PipeType.PIPE_COMPOSE
+            | PipeType.PIPE_LLM
+            | PipeType.PIPE_EXTRACT
+            | PipeType.PIPE_BATCH
+            | PipeType.PIPE_PARALLEL
+        ):
+            return []
+
+
+def render_output(the_pipe: PipeAbstract, indent: int = 2) -> str:
+    """Render a JSON representation of the pipe's output.
+
+    For pipes with native.Anything output, shows all possible outputs from mapped pipes
+    with keys "output_option_1", "output_option_2", etc.
+
+    Args:
+        the_pipe: The pipe to render output for
+        indent: Number of spaces for indentation (default: 2)
+
+    Returns:
+        Formatted JSON string with the output representation
+
+    Raises:
+        ValueError: If the output cannot be rendered
+    """
+    # Check if output is native.Anything (has no specific shape)
+    if the_pipe.output.concept.code == NativeConceptCode.ANYTHING:
+        possible_outputs = _collect_possible_outputs(the_pipe)
+
+        if not possible_outputs:
+            msg = f"Output is '{NativeConceptCode.ANYTHING.concept_ref}' which has no specific shape and no possible outputs could be determined."
+            raise ValueError(msg)
+
+        # Build dict with "output_option_1", "output_option_2", etc.
+        # Each option includes "concept" and "content" fields
+        result: dict[str, Any] = {}
+        for idx, output_info in enumerate(possible_outputs, start=1):
+            result[f"output_option_{idx}"] = {
+                "concept": output_info["concept_ref"],
+                "content": output_info["content"],
+            }
+
+        return json.dumps(result, indent=indent, ensure_ascii=False)
+
+    # Normal output rendering - returns dict with "concept" and "content"
+    output_dict = the_pipe.output.render_stuff_spec(ConceptRepresentationFormat.JSON)
+    return json.dumps(output_dict, indent=indent, ensure_ascii=False)

--- a/pipelex/core/pipes/output/output_renderer.py
+++ b/pipelex/core/pipes/output/output_renderer.py
@@ -1,11 +1,15 @@
 import json
-from typing import Any
+from typing import TYPE_CHECKING, Any, cast
 
 from pipelex.core.concepts.concept_representation_generator import ConceptRepresentationFormat
 from pipelex.core.concepts.native.concept_native import NativeConceptCode
 from pipelex.core.pipes.pipe_abstract import PipeAbstract
 from pipelex.core.pipes.pipe_blueprint import PipeType
 from pipelex.hub import get_required_pipe
+
+if TYPE_CHECKING:
+    from pipelex.pipe_controllers.condition.pipe_condition import PipeCondition
+    from pipelex.pipe_controllers.sequence.pipe_sequence import PipeSequence
 
 
 def _collect_possible_outputs(the_pipe: PipeAbstract) -> list[dict[str, Any]]:
@@ -25,7 +29,8 @@ def _collect_possible_outputs(the_pipe: PipeAbstract) -> list[dict[str, Any]]:
     # Check if the pipe is a PipeCondition
     match pipe_type:
         case PipeType.PIPE_CONDITION:
-            mapped_pipe_codes: set[str] = getattr(the_pipe, "mapped_pipe_codes", set())
+            the_pipe = cast("PipeCondition", the_pipe)
+            mapped_pipe_codes = the_pipe.pipe_dependencies()
 
             if not mapped_pipe_codes:
                 return []
@@ -54,6 +59,7 @@ def _collect_possible_outputs(the_pipe: PipeAbstract) -> list[dict[str, Any]]:
             return possible_outputs
 
         case PipeType.PIPE_SEQUENCE:
+            the_pipe = cast("PipeSequence", the_pipe)
             sequential_sub_pipes: list[Any] = getattr(the_pipe, "sequential_sub_pipes", [])
             if not sequential_sub_pipes:
                 return []

--- a/pipelex/core/pipes/pipe_output.py
+++ b/pipelex/core/pipes/pipe_output.py
@@ -18,6 +18,7 @@ from pipelex.pipeline.pipeline_models import SpecialPipelineId
 
 class DictPipeOutput(BaseModel):
     working_memory: DictWorkingMemory
+    graph_spec: GraphSpec | None = None
     pipeline_run_id: str
 
 

--- a/pipelex/core/pipes/stuff_spec/stuff_spec.py
+++ b/pipelex/core/pipes/stuff_spec/stuff_spec.py
@@ -1,6 +1,9 @@
+from typing import Any
+
 from pydantic import BaseModel
 
 from pipelex.core.concepts.concept import Concept
+from pipelex.core.concepts.concept_representation_generator import ConceptRepresentationFormat
 from pipelex.core.pipes.variable_multiplicity import VariableMultiplicity
 
 
@@ -21,3 +24,19 @@ class StuffSpec(BaseModel):
         if isinstance(self.multiplicity, bool):
             return f"{self.concept.concept_ref}[]"
         return f"{self.concept.concept_ref}[{self.multiplicity}]"
+
+    def render_stuff_spec(self, output_format: ConceptRepresentationFormat) -> dict[str, Any]:
+        """Render a representation of this stuff spec.
+
+        Args:
+            output_format: The format to generate (JSON or PYTHON)
+
+        Returns:
+            Dictionary with concept and content structure,
+            wrapped in a list if multiplicity indicates multiple items.
+        """
+        json_value, _ = self.concept.render_concept_representation(
+            output_format=output_format,
+            is_multiple=self.is_multiple(),
+        )
+        return json_value

--- a/pipelex/pipe_controllers/condition/pipe_condition.py
+++ b/pipelex/pipe_controllers/condition/pipe_condition.py
@@ -4,7 +4,6 @@ from typing_extensions import override
 
 from pipelex import log
 from pipelex.cogt.templating.template_category import TemplateCategory
-from pipelex.core.concepts.concept_factory import ConceptFactory
 from pipelex.core.concepts.native.concept_native import NativeConceptCode
 from pipelex.core.memory.working_memory import WorkingMemory, WorkingMemoryStuffNotFoundError
 from pipelex.core.pipes.exceptions import PipeValidationError, PipeValidationErrorType
@@ -32,20 +31,17 @@ class PipeCondition(PipeController):
     default_outcome: str | SpecialOutcome
     add_alias_from_expression_to: str | None = None
 
-    @property
-    def mapped_pipe_codes(self) -> set[str]:
+    @override
+    def pipe_dependencies(self) -> set[str]:
         codes = set(self.outcome_map.values())
         if self.default_outcome:
             codes.add(self.default_outcome)
         return codes - set(SpecialOutcome.value_list())
 
     @override
-    def pipe_dependencies(self) -> set[str]:
-        return self.mapped_pipe_codes
-
-    @override
     def required_variables(self) -> set[str]:
         required_variables: set[str] = set()
+
         # Variables from the expression/expression_template
         full_paths = detect_jinja2_required_variables(
             template_category=TemplateCategory.EXPRESSION,
@@ -56,7 +52,9 @@ class PipeCondition(PipeController):
         # Variables from the outcomes map and default_outcome
         for pipe_code in self.pipe_dependencies():
             required_variables.update(get_required_pipe(pipe_code=pipe_code).required_variables())
-        return required_variables
+
+        # Exclude internal variables starting with `_`
+        return {var for var in required_variables if not var.startswith("_")}
 
     @override
     def needed_inputs(self, visited_pipes: set[str] | None = None) -> InputStuffSpecs:
@@ -72,26 +70,24 @@ class PipeCondition(PipeController):
 
         needed_inputs = InputStuffSpecsFactory.make_empty()
 
-        # Add the variables from the expression/expression_template
+        # Add the expression variables from self.inputs (with their declared concepts)
         full_paths = detect_jinja2_required_variables(
             template_category=TemplateCategory.EXPRESSION,
             template_source=self.expression,
         )
-        required_variables = {get_root_from_dotted_path(path) for path in full_paths}
-
-        for var_name in required_variables:
-            if not var_name.startswith("_"):  # exclude internal variables starting with `_`
-                # We don't know the concept code from just the variable name,
-                # so we'll use a generic placeholder that will be validated later
+        expression_variables = {get_root_from_dotted_path(path) for path in full_paths}
+        for var_name in expression_variables:
+            if not var_name.startswith("_"):
+                # Get the concept from declared inputs
+                stuff_spec = self.inputs.get_required_stuff_spec(variable_name=var_name)
                 needed_inputs.add_stuff_spec(
                     variable_name=var_name,
-                    concept=ConceptFactory.make_native_concept(
-                        native_concept_code=NativeConceptCode.ANYTHING,
-                    ),
+                    concept=stuff_spec.concept,
+                    multiplicity=stuff_spec.multiplicity,
                 )
 
         # Add the inputs needed by all possible target pipes
-        for pipe_code in self.mapped_pipe_codes:
+        for pipe_code in self.pipe_dependencies():
             pipe = get_required_pipe(pipe_code=pipe_code)
             # Use the centralized recursion detection
             pipe_needed_inputs = pipe.needed_inputs(visited_pipes_with_current)
@@ -124,7 +120,7 @@ class PipeCondition(PipeController):
         Special outcomes (CONTINUE/FAIL) do not influence the output validation - only actual pipes matter.
         When there are no mapped pipes (all special outcomes), any output is allowed.
         """
-        mapped_pipe_codes = self.mapped_pipe_codes
+        mapped_pipe_codes = self.pipe_dependencies()
         if not mapped_pipe_codes:
             # No actual pipes to validate against (all special outcomes)
             return
@@ -171,26 +167,28 @@ class PipeCondition(PipeController):
                 required_concept_codes=[NativeConceptCode.ANYTHING.concept_ref],
             )
 
-    # TODO: Restore this validation. The problem lies with needed_inputs that construct Anything concepts.
-    # @override
-    # async def _validate_before_run(
-    #     self,
-    #     job_metadata: JobMetadata,
-    #     working_memory: WorkingMemory,
-    #     pipe_run_params: PipeRunParams,
-    #     output_name: str | None = None,
-    # ):
-    #     evaluated_expression = await get_content_generator().make_templated_text(
-    #         context=working_memory.generate_context(),
-    #         template=self.expression,
-    #         template_category=TemplateCategory.EXPRESSION,
-    #     )
-    #     if not evaluated_expression or evaluated_expression == "None":
-    #         error_msg = f"PipeCondition '{self.code}': Conditional expression returned no result"
-    #         raise PipeRunError(
-    #             message=error_msg,
-    #             run_mode=pipe_run_params.run_mode,
-    #         )
+    @override
+    async def _validate_before_run(
+        self, job_metadata: JobMetadata, working_memory: WorkingMemory, pipe_run_params: PipeRunParams, output_name: str | None = None
+    ):
+        evaluated_expression = await get_content_generator().make_templated_text(
+            context=working_memory.generate_context(),
+            template=self.expression,
+            template_category=TemplateCategory.EXPRESSION,
+        )
+        if not evaluated_expression or evaluated_expression == "None":
+            error_msg = f"PipeCondition '{self.code}': Conditional expression returned no result"
+            raise PipeRunError(
+                pipe_code=self.code,
+                message=error_msg,
+                run_mode=pipe_run_params.run_mode,
+            )
+
+    @override
+    async def _validate_after_run(
+        self, job_metadata: JobMetadata, working_memory: WorkingMemory, pipe_run_params: PipeRunParams, output_name: str | None = None
+    ):
+        pass
 
     async def _evaluate_expression(
         self,
@@ -306,7 +304,7 @@ class PipeCondition(PipeController):
             raise PipeRunError(message=msg, run_mode=pipe_run_params.run_mode, pipe_code=self.code)
 
         # Here, it should launch the dry run of all the pipes in the outcomes map
-        for pipe_code in self.mapped_pipe_codes:
+        for pipe_code in self.pipe_dependencies():
             pipe = get_required_pipe(pipe_code=pipe_code)
             await pipe.run_pipe(
                 job_metadata=job_metadata,
@@ -314,15 +312,3 @@ class PipeCondition(PipeController):
                 pipe_run_params=pipe_run_params,
             )
         return PipeOutput(working_memory=working_memory)
-
-    @override
-    async def _validate_before_run(
-        self, job_metadata: JobMetadata, working_memory: WorkingMemory, pipe_run_params: PipeRunParams, output_name: str | None = None
-    ):
-        pass
-
-    @override
-    async def _validate_after_run(
-        self, job_metadata: JobMetadata, working_memory: WorkingMemory, pipe_run_params: PipeRunParams, output_name: str | None = None
-    ):
-        pass

--- a/pipelex/pipe_operators/llm/llm_prompt_blueprint.py
+++ b/pipelex/pipe_operators/llm/llm_prompt_blueprint.py
@@ -51,9 +51,9 @@ class LLMPromptBlueprint(BaseModel):
             required_variables.update(system_doc_ref_root_names)
 
         if self.prompt_blueprint:
-            required_variables.update(self.prompt_blueprint.required_variables())
+            required_variables.update(get_root_from_dotted_path(path) for path in self.prompt_blueprint.required_variables())
         if self.system_prompt_blueprint:
-            required_variables.update(self.system_prompt_blueprint.required_variables())
+            required_variables.update(get_root_from_dotted_path(path) for path in self.system_prompt_blueprint.required_variables())
         return {
             variable_name
             for variable_name in required_variables

--- a/tests/unit/pipelex/builder/test_runner_generator.py
+++ b/tests/unit/pipelex/builder/test_runner_generator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from typing import Any, cast
 from unittest.mock import MagicMock
 
@@ -16,12 +17,12 @@ from pipelex.core.pipes.stuff_spec.stuff_spec import StuffSpec
 
 
 class TestConceptGenerateInputRepresentationJson:
-    """Test Concept.generate_input_representation for JSON format."""
+    """Test Concept.render_concept_representation for JSON format."""
 
     def test_native_text_json(self) -> None:
         """Test JSON representation for native Text concept."""
         concept = ConceptFactory.make_native_concept(NativeConceptCode.TEXT)
-        result, _ = concept.generate_input_representation(ConceptRepresentationFormat.JSON)
+        result, _ = concept.render_concept_representation(ConceptRepresentationFormat.JSON)
         assert result["concept"] == "native.Text"
         assert "content" in result
         assert "text" in result["content"]
@@ -29,7 +30,7 @@ class TestConceptGenerateInputRepresentationJson:
     def test_native_image_json(self) -> None:
         """Test JSON representation for native Image concept."""
         concept = ConceptFactory.make_native_concept(NativeConceptCode.IMAGE)
-        result, _ = concept.generate_input_representation(ConceptRepresentationFormat.JSON)
+        result, _ = concept.render_concept_representation(ConceptRepresentationFormat.JSON)
         assert result["concept"] == "native.Image"
         assert "content" in result
         assert "url" in result["content"]
@@ -37,7 +38,7 @@ class TestConceptGenerateInputRepresentationJson:
     def test_native_number_json(self) -> None:
         """Test JSON representation for native Number concept."""
         concept = ConceptFactory.make_native_concept(NativeConceptCode.NUMBER)
-        result, _ = concept.generate_input_representation(ConceptRepresentationFormat.JSON)
+        result, _ = concept.render_concept_representation(ConceptRepresentationFormat.JSON)
         assert result["concept"] == "native.Number"
         assert "content" in result
         assert "number" in result["content"]
@@ -45,7 +46,7 @@ class TestConceptGenerateInputRepresentationJson:
     def test_native_document_json_with_multiplicity(self) -> None:
         """Test JSON representation for Document with multiplicity - content should be a list."""
         concept = ConceptFactory.make_native_concept(NativeConceptCode.DOCUMENT)
-        result, _ = concept.generate_input_representation(ConceptRepresentationFormat.JSON, is_multiple=True)
+        result, _ = concept.render_concept_representation(ConceptRepresentationFormat.JSON, is_multiple=True)
         assert result["concept"] == "native.Document"
         assert "content" in result
         # Content should be a list
@@ -56,12 +57,12 @@ class TestConceptGenerateInputRepresentationJson:
 
 
 class TestConceptGenerateInputRepresentationPython:
-    """Test Concept.generate_input_representation for Python format."""
+    """Test Concept.render_concept_representation for Python format."""
 
     def test_native_text_python(self) -> None:
         """Test Python representation for native Text concept."""
         concept = ConceptFactory.make_native_concept(NativeConceptCode.TEXT)
-        result, imports = concept.generate_input_representation(ConceptRepresentationFormat.PYTHON)
+        result, imports = concept.render_concept_representation(ConceptRepresentationFormat.PYTHON)
         assert result["concept"] == "native.Text"
         assert "TextContent" in result["content"]
         assert "TextContent" in imports
@@ -69,7 +70,7 @@ class TestConceptGenerateInputRepresentationPython:
     def test_native_image_python(self) -> None:
         """Test Python representation for native Image concept."""
         concept = ConceptFactory.make_native_concept(NativeConceptCode.IMAGE)
-        result, imports = concept.generate_input_representation(ConceptRepresentationFormat.PYTHON)
+        result, imports = concept.render_concept_representation(ConceptRepresentationFormat.PYTHON)
         assert result["concept"] == "native.Image"
         assert "ImageContent" in result["content"]
         assert "ImageContent" in imports
@@ -83,7 +84,7 @@ class TestConceptGenerateInputRepresentationPython:
             structure_class_name="TextContent",
             refines="native.Text",
         )
-        result, imports = concept.generate_input_representation(ConceptRepresentationFormat.PYTHON)
+        result, imports = concept.render_concept_representation(ConceptRepresentationFormat.PYTHON)
         assert result["concept"] == "test_domain.Question"
         assert "TextContent" in result["content"]
         assert "TextContent" in imports
@@ -91,27 +92,27 @@ class TestConceptGenerateInputRepresentationPython:
     def test_native_document_python_with_multiplicity(self) -> None:
         """Test Python representation for Document with multiplicity - for Python format, wrapping is handled by caller."""
         concept = ConceptFactory.make_native_concept(NativeConceptCode.DOCUMENT)
-        result, imports = concept.generate_input_representation(ConceptRepresentationFormat.PYTHON, is_multiple=True)
+        result, imports = concept.render_concept_representation(ConceptRepresentationFormat.PYTHON, is_multiple=True)
         # For Python format, is_multiple doesn't wrap content (caller handles it)
         assert result["concept"] == "native.Document"
         assert "DocumentContent" in result["content"]
         assert "DocumentContent" in imports
 
 
-class TestInputStuffSpecsGenerateJsonRepresentation:
-    """Test InputStuffSpecs.generate_json_representation method."""
+class TestInputStuffSpecsRenderInputsRepresentation:
+    """Test InputStuffSpecs.render_inputs method."""
 
     def test_empty_inputs(self) -> None:
         """Test JSON generation with no inputs."""
         inputs = InputStuffSpecs(root={})
-        result = inputs.generate_json_representation()
+        result = json.loads(inputs.render_inputs())
         assert result == {}
 
     def test_single_input(self) -> None:
         """Test JSON generation with a single input."""
         concept = ConceptFactory.make_native_concept(NativeConceptCode.TEXT)
         inputs = InputStuffSpecs(root={"message": StuffSpec(concept=concept)})
-        result = inputs.generate_json_representation()
+        result = json.loads(inputs.render_inputs())
         assert "message" in result
         assert result["message"]["concept"] == "native.Text"
 
@@ -125,21 +126,21 @@ class TestInputStuffSpecsGenerateJsonRepresentation:
                 "image_input": StuffSpec(concept=image_concept),
             }
         )
-        result = inputs.generate_json_representation()
+        result = json.loads(inputs.render_inputs())
         assert "text_input" in result
         assert "image_input" in result
         assert result["text_input"]["concept"] == "native.Text"
         assert result["image_input"]["concept"] == "native.Image"
 
 
-class TestInputStuffSpecsJsonWithMultiplicity:
-    """Test InputStuffSpecs.generate_json_representation with multiplicity - content is wrapped in list."""
+class TestInputStuffSpecsRenderWithMultiplicity:
+    """Test InputStuffSpecs.render_inputs with multiplicity - content is wrapped in list."""
 
     def test_single_item_no_multiplicity(self) -> None:
         """Test that single item (no multiplicity) has content as dict, not list."""
         concept = ConceptFactory.make_native_concept(NativeConceptCode.DOCUMENT)
         inputs = InputStuffSpecs(root={"document": StuffSpec(concept=concept, multiplicity=None)})
-        result = inputs.generate_json_representation()
+        result = json.loads(inputs.render_inputs())
         assert "document" in result
         # concept should be present
         assert result["document"]["concept"] == "native.Document"
@@ -152,7 +153,7 @@ class TestInputStuffSpecsJsonWithMultiplicity:
         """Test that multiplicity=True wraps content in list."""
         concept = ConceptFactory.make_native_concept(NativeConceptCode.DOCUMENT)
         inputs = InputStuffSpecs(root={"documents": StuffSpec(concept=concept, multiplicity=True)})
-        result = inputs.generate_json_representation()
+        result = json.loads(inputs.render_inputs())
         assert "documents" in result
         # concept should be at the top level
         assert result["documents"]["concept"] == "native.Document"
@@ -166,7 +167,7 @@ class TestInputStuffSpecsJsonWithMultiplicity:
         """Test that multiplicity=N (int > 1) wraps content in list."""
         concept = ConceptFactory.make_native_concept(NativeConceptCode.IMAGE)
         inputs = InputStuffSpecs(root={"images": StuffSpec(concept=concept, multiplicity=3)})
-        result = inputs.generate_json_representation()
+        result = json.loads(inputs.render_inputs())
         assert "images" in result
         # concept should be at the top level
         assert result["images"]["concept"] == "native.Image"
@@ -185,7 +186,7 @@ class TestInputStuffSpecsJsonWithMultiplicity:
                 "multiple_documents": StuffSpec(concept=document_concept, multiplicity=True),
             }
         )
-        result = inputs.generate_json_representation()
+        result = json.loads(inputs.render_inputs())
         # single_document content should be a dict
         assert isinstance(result["single_document"]["content"], dict)
         # multiple_documents content should be a list

--- a/tests/unit/pipelex/pipe_controllers/condition/test_pipe_condition_needed_inputs.py
+++ b/tests/unit/pipelex/pipe_controllers/condition/test_pipe_condition_needed_inputs.py
@@ -57,8 +57,8 @@ class TestPipeConditionNeededInputs:
 
         # The expression uses 'status', so it should be in needed inputs
         assert "status" in needed_inputs.root
-        # The concept for expression variables is Anything since we can't infer the type
-        assert needed_inputs.root["status"].concept.code == NativeConceptCode.ANYTHING
+        # The concept for expression variables comes from the declared inputs
+        assert needed_inputs.root["status"].concept.code == NativeConceptCode.TEXT
 
         concept_library.teardown()
 
@@ -858,7 +858,7 @@ class TestPipeConditionSpecialOutcomes:
         pipe_condition.validate_output_with_library()
 
     def test_mapped_pipe_codes_excludes_special_outcomes(self, load_empty_library: Callable[[], None]):
-        """Test that mapped_pipe_codes property excludes CONTINUE and FAIL."""
+        """Test that pipe_dependencies() property excludes CONTINUE and FAIL."""
         load_empty_library()
         domain_code = "test_domain"
         concept_library = get_concept_library()
@@ -906,9 +906,9 @@ class TestPipeConditionSpecialOutcomes:
             blueprint=pipe_condition_blueprint,
         )
 
-        # mapped_pipe_codes should only contain actual pipes, not special outcomes
-        assert pipe_condition.mapped_pipe_codes == {"real_pipe"}
-        assert SpecialOutcome.CONTINUE not in pipe_condition.mapped_pipe_codes
-        assert SpecialOutcome.FAIL not in pipe_condition.mapped_pipe_codes
+        # pipe_dependencies() should only contain actual pipes, not special outcomes
+        assert pipe_condition.pipe_dependencies() == {"real_pipe"}
+        assert SpecialOutcome.CONTINUE not in pipe_condition.pipe_dependencies()
+        assert SpecialOutcome.FAIL not in pipe_condition.pipe_dependencies()
 
         concept_library.teardown()

--- a/tests/unit/pipelex/pipe_operators/pipe_llm/test_llm_prompt_blueprint.py
+++ b/tests/unit/pipelex/pipe_operators/pipe_llm/test_llm_prompt_blueprint.py
@@ -1,0 +1,150 @@
+from pipelex.cogt.templating.template_blueprint import TemplateBlueprint
+from pipelex.cogt.templating.template_category import TemplateCategory
+from pipelex.pipe_operators.llm.llm_prompt_blueprint import LLMPromptBlueprint
+
+
+class TestLLMPromptBlueprintRequiredVariables:
+    """Test LLMPromptBlueprint.required_variables method."""
+
+    def test_required_variables_returns_root_names_for_dotted_paths_in_prompt(self):
+        """Test that dotted paths like user_profile.department are converted to root names like user_profile."""
+        prompt_template = """
+Process this marketing business document.
+@user_profile.department
+@doc_request.language
+
+Output: "MARKETING_BUSINESS_PROCESSED"
+"""
+        blueprint = LLMPromptBlueprint(
+            prompt_blueprint=TemplateBlueprint(
+                template=prompt_template,
+                category=TemplateCategory.LLM_PROMPT,
+            ),
+        )
+
+        required_vars = blueprint.required_variables()
+
+        assert "user_profile" in required_vars
+        assert "doc_request" in required_vars
+        # Should NOT contain dotted paths
+        assert "user_profile.department" not in required_vars
+        assert "doc_request.language" not in required_vars
+
+    def test_required_variables_returns_root_names_for_dotted_paths_in_system_prompt(self):
+        """Test that dotted paths in system_prompt are converted to root names."""
+        system_prompt_template = """
+You are processing documents for @organization.name in @organization.region.
+"""
+        blueprint = LLMPromptBlueprint(
+            system_prompt_blueprint=TemplateBlueprint(
+                template=system_prompt_template,
+                category=TemplateCategory.LLM_PROMPT,
+            ),
+        )
+
+        required_vars = blueprint.required_variables()
+
+        assert "organization" in required_vars
+        # Should NOT contain dotted paths
+        assert "organization.name" not in required_vars
+        assert "organization.region" not in required_vars
+
+    def test_required_variables_returns_root_names_for_both_prompts(self):
+        """Test that both prompt and system_prompt dotted paths are converted to root names."""
+        prompt_template = "@request.content"
+        system_prompt_template = "Context: @context.metadata.source"
+
+        blueprint = LLMPromptBlueprint(
+            prompt_blueprint=TemplateBlueprint(
+                template=prompt_template,
+                category=TemplateCategory.LLM_PROMPT,
+            ),
+            system_prompt_blueprint=TemplateBlueprint(
+                template=system_prompt_template,
+                category=TemplateCategory.LLM_PROMPT,
+            ),
+        )
+
+        required_vars = blueprint.required_variables()
+
+        assert "request" in required_vars
+        assert "context" in required_vars
+        # Should NOT contain dotted paths
+        assert "request.content" not in required_vars
+        assert "context.metadata.source" not in required_vars
+        assert "context.metadata" not in required_vars
+
+    def test_required_variables_handles_mix_of_root_and_dotted_paths(self):
+        """Test that both root variables and dotted paths are handled correctly."""
+        prompt_template = """
+Process @simple_var and @complex_object.nested.value
+Also use @another_object.field
+"""
+        blueprint = LLMPromptBlueprint(
+            prompt_blueprint=TemplateBlueprint(
+                template=prompt_template,
+                category=TemplateCategory.LLM_PROMPT,
+            ),
+        )
+
+        required_vars = blueprint.required_variables()
+
+        assert "simple_var" in required_vars
+        assert "complex_object" in required_vars
+        assert "another_object" in required_vars
+        # Should NOT contain dotted paths
+        assert "complex_object.nested.value" not in required_vars
+        assert "complex_object.nested" not in required_vars
+        assert "another_object.field" not in required_vars
+        # Should have exactly 3 variables
+        assert len(required_vars) == 3
+
+    def test_required_variables_deduplicates_same_root(self):
+        """Test that multiple dotted paths with same root are deduplicated."""
+        prompt_template = """
+Use @user.name and @user.email and @user.address.city
+"""
+        blueprint = LLMPromptBlueprint(
+            prompt_blueprint=TemplateBlueprint(
+                template=prompt_template,
+                category=TemplateCategory.LLM_PROMPT,
+            ),
+        )
+
+        required_vars = blueprint.required_variables()
+
+        assert "user" in required_vars
+        assert len(required_vars) == 1
+
+    def test_required_variables_excludes_internal_variables(self):
+        """Test that internal variables starting with _ are excluded."""
+        prompt_template = "@public_var and @_internal_var.field"
+
+        blueprint = LLMPromptBlueprint(
+            prompt_blueprint=TemplateBlueprint(
+                template=prompt_template,
+                category=TemplateCategory.LLM_PROMPT,
+            ),
+        )
+
+        required_vars = blueprint.required_variables()
+
+        assert "public_var" in required_vars
+        assert "_internal_var" not in required_vars
+
+    def test_required_variables_excludes_special_variables(self):
+        """Test that special variables preliminary_text and place_holder are excluded."""
+        prompt_template = "@data and @preliminary_text and @place_holder"
+
+        blueprint = LLMPromptBlueprint(
+            prompt_blueprint=TemplateBlueprint(
+                template=prompt_template,
+                category=TemplateCategory.LLM_PROMPT,
+            ),
+        )
+
+        required_vars = blueprint.required_variables()
+
+        assert "data" in required_vars
+        assert "preliminary_text" not in required_vars
+        assert "place_holder" not in required_vars


### PR DESCRIPTION
 - **`pipelex build output` CLI Command**: New command to generate example output JSON for a pipe, complementing the existing `pipelex build inputs` command. Shows the expected output structure based on the pipe's output concept type, with multiplicity support.
 - **PipeCondition Output Auto-Fix in Builder Loop**: The pipe builder now automatically fixes `PipeCondition` output concept errors during validation. If all mapped pipes have the same output, the `PipeCondition` output is set to that concept; otherwise it's set to `native.Anything`.