### PR TITLE
Add unit tests for model deck reference validation

### DIFF
--- a/pipelex/cogt/models/model_deck.py
+++ b/pipelex/cogt/models/model_deck.py
@@ -726,10 +726,7 @@ class ModelDeck(ConfigModel):
         # For direct handles (HANDLE kind), try inference_models first
         if inference_model := self.inference_models.get(ref.name):
             if inference_model.model_type != model_type:
-                log.warning(
-                    f"Model handle '{ref.name}' has type '{inference_model.model_type}' "
-                    f"but was requested as '{model_type}'. Skipping."
-                )
+                log.warning(f"Model handle '{ref.name}' has type '{inference_model.model_type}' but was requested as '{model_type}'. Skipping.")
                 return None
             return inference_model
         # Then try aliases (without prefix)

--- a/pipelex/cogt/models/model_deck.py
+++ b/pipelex/cogt/models/model_deck.py
@@ -567,9 +567,8 @@ class ModelDeck(ConfigModel):
                     pass
 
     def validate_inference_models(self):
-        for model_handle in self.inference_models:
-            # model_type doesn't matter here since we're validating direct inference models (not aliases/waterfalls)
-            self.get_required_inference_model(model_handle=model_handle, model_type=ModelType.LLM)
+        for model_handle, model_spec in self.inference_models.items():
+            self.get_required_inference_model(model_handle=model_handle, model_type=model_spec.model_type)
 
     def _get_enabled_backends(self) -> set[str]:
         """Return the set of backend names that have at least one model enabled."""
@@ -726,6 +725,12 @@ class ModelDeck(ConfigModel):
 
         # For direct handles (HANDLE kind), try inference_models first
         if inference_model := self.inference_models.get(ref.name):
+            if inference_model.model_type != model_type:
+                log.warning(
+                    f"Model handle '{ref.name}' has type '{inference_model.model_type}' "
+                    f"but was requested as '{model_type}'. Skipping."
+                )
+                return None
             return inference_model
         # Then try aliases (without prefix)
         if alias := aliases.get(ref.name):

--- a/tests/unit/pipelex/cogt/models/model_deck_validation_utils.py
+++ b/tests/unit/pipelex/cogt/models/model_deck_validation_utils.py
@@ -1,0 +1,147 @@
+"""Shared validation utilities for model deck testing.
+
+These utilities validate model deck references (aliases, presets, waterfalls)
+and are used by multiple test modules.
+"""
+
+from pipelex.cogt.model_backends.model_type import ModelType
+from pipelex.cogt.models.model_reference import ModelReference, ModelReferenceKind
+
+
+def find_invalid_alias_targets(
+    aliases: dict[str, str],
+    all_aliases: dict[str, str],
+    all_waterfalls: dict[str, list[str]],
+    known_model_handles: dict[str, ModelType],
+    expected_model_type: ModelType,
+) -> list[tuple[str, str, str]]:
+    """Find aliases that reference invalid targets.
+
+    Args:
+        aliases: The aliases dict to validate
+        all_aliases: All available aliases for this model type
+        all_waterfalls: All available waterfalls for this model type
+        known_model_handles: Mapping of model handle -> ModelType
+        expected_model_type: The expected model type for this deck (LLM, TEXT_EXTRACTOR, IMG_GEN)
+
+    Returns:
+        List of (alias_name, target_value, reason) tuples for invalid references
+    """
+    invalid_refs: list[tuple[str, str, str]] = []
+
+    for alias_name, target_value in aliases.items():
+        ref = ModelReference.parse(target_value)
+
+        match ref.kind:
+            case ModelReferenceKind.ALIAS:
+                if ref.name not in all_aliases:
+                    invalid_refs.append((alias_name, target_value, f"alias '{ref.name}' not found"))
+            case ModelReferenceKind.WATERFALL:
+                if ref.name not in all_waterfalls:
+                    invalid_refs.append((alias_name, target_value, f"waterfall '{ref.name}' not found"))
+            case ModelReferenceKind.PRESET:
+                invalid_refs.append((alias_name, target_value, "aliases cannot reference presets ($ prefix)"))
+            case ModelReferenceKind.HANDLE:
+                if ref.name not in known_model_handles:
+                    invalid_refs.append((alias_name, target_value, f"model handle '{ref.name}' not found in backends"))
+                elif known_model_handles[ref.name] != expected_model_type:
+                    actual_type = known_model_handles[ref.name]
+                    invalid_refs.append(
+                        (alias_name, target_value, f"model handle '{ref.name}' has type '{actual_type}' but expected '{expected_model_type}'")
+                    )
+
+    return invalid_refs
+
+
+def find_invalid_waterfall_entries(
+    waterfalls: dict[str, list[str]],
+    all_aliases: dict[str, str],
+    known_model_handles: dict[str, ModelType],
+    expected_model_type: ModelType,
+) -> list[tuple[str, int, str, str]]:
+    """Find waterfall entries that reference invalid targets.
+
+    Args:
+        waterfalls: The waterfalls dict to validate
+        all_aliases: All available aliases for this model type
+        known_model_handles: Mapping of model handle -> ModelType
+        expected_model_type: The expected model type for this deck (LLM, TEXT_EXTRACTOR, IMG_GEN)
+
+    Returns:
+        List of (waterfall_name, index, entry_value, reason) tuples for invalid entries
+    """
+    invalid_refs: list[tuple[str, int, str, str]] = []
+
+    for waterfall_name, entries in waterfalls.items():
+        for index, entry_value in enumerate(entries):
+            ref = ModelReference.parse(entry_value)
+
+            match ref.kind:
+                case ModelReferenceKind.ALIAS:
+                    if ref.name not in all_aliases:
+                        invalid_refs.append((waterfall_name, index, entry_value, f"alias '{ref.name}' not found"))
+                case ModelReferenceKind.WATERFALL:
+                    invalid_refs.append((waterfall_name, index, entry_value, "waterfalls cannot contain other waterfalls (~ prefix)"))
+                case ModelReferenceKind.PRESET:
+                    invalid_refs.append((waterfall_name, index, entry_value, "waterfalls cannot contain presets ($ prefix)"))
+                case ModelReferenceKind.HANDLE:
+                    if ref.name not in known_model_handles:
+                        invalid_refs.append((waterfall_name, index, entry_value, f"model handle '{ref.name}' not found in backends"))
+                    elif known_model_handles[ref.name] != expected_model_type:
+                        actual_type = known_model_handles[ref.name]
+                        invalid_refs.append(
+                            (
+                                waterfall_name,
+                                index,
+                                entry_value,
+                                f"model handle '{ref.name}' has type '{actual_type}' but expected '{expected_model_type}'",
+                            )
+                        )
+
+    return invalid_refs
+
+
+def find_circular_aliases(
+    aliases: dict[str, str],
+) -> list[tuple[str, list[str]]]:
+    """Find circular alias chains.
+
+    Args:
+        aliases: The aliases dict to check for cycles
+
+    Returns:
+        List of (starting_alias, cycle_path) tuples for detected cycles
+    """
+    cycles: list[tuple[str, list[str]]] = []
+
+    for start_alias in aliases:
+        visited: list[str] = []
+        current = start_alias
+
+        while current in aliases:
+            if current in visited:
+                cycle_start_idx = visited.index(current)
+                cycle_path = [*visited[cycle_start_idx:], current]
+                if start_alias in cycle_path:
+                    cycles.append((start_alias, cycle_path))
+                break
+
+            visited.append(current)
+            target = aliases[current]
+            ref = ModelReference.parse(target)
+
+            if ref.kind == ModelReferenceKind.ALIAS:
+                current = ref.name
+            else:
+                break
+
+    unique_cycles: list[tuple[str, list[str]]] = []
+    seen_cycles: set[frozenset[str]] = set()
+
+    for start_alias, cycle_path in cycles:
+        cycle_set = frozenset(cycle_path)
+        if cycle_set not in seen_cycles:
+            seen_cycles.add(cycle_set)
+            unique_cycles.append((start_alias, cycle_path))
+
+    return unique_cycles

--- a/tests/unit/pipelex/cogt/models/model_deck_validation_utils.py
+++ b/tests/unit/pipelex/cogt/models/model_deck_validation_utils.py
@@ -135,10 +135,19 @@ def find_circular_aliases(
             target = aliases[current]
             ref = ModelReference.parse(target)
 
-            if ref.kind == ModelReferenceKind.ALIAS:
-                current = ref.name
-            else:
-                break
+            match ref.kind:
+                case ModelReferenceKind.ALIAS:
+                    # Explicit alias reference (@name or alias:name)
+                    current = ref.name
+                case ModelReferenceKind.HANDLE:
+                    # Unprefixed reference - follow if it's an alias key (matches runtime behavior)
+                    if ref.name in aliases:
+                        current = ref.name
+                    else:
+                        break
+                case ModelReferenceKind.WATERFALL | ModelReferenceKind.PRESET:
+                    # Waterfalls and presets don't continue the alias chain
+                    break
 
     unique_cycles: list[tuple[str, list[str]]] = []
     seen_cycles: set[frozenset[str]] = set()

--- a/tests/unit/pipelex/cogt/models/model_deck_validation_utils.py
+++ b/tests/unit/pipelex/cogt/models/model_deck_validation_utils.py
@@ -73,6 +73,11 @@ def find_invalid_waterfall_entries(
     invalid_refs: list[tuple[str, int, str, str]] = []
 
     for waterfall_name, entries in waterfalls.items():
+        # Empty waterfalls cause IndexError at runtime (fallback_list[0])
+        if not entries:
+            invalid_refs.append((waterfall_name, -1, "", "waterfall cannot be empty"))
+            continue
+
         for index, entry_value in enumerate(entries):
             ref = ModelReference.parse(entry_value)
 

--- a/tests/unit/pipelex/cogt/models/test_model_deck.py
+++ b/tests/unit/pipelex/cogt/models/test_model_deck.py
@@ -196,6 +196,27 @@ class TestModelDeckGetOptionalInferenceModel:
         # Assert - cycle detection returns None instead of causing RecursionError
         assert result is None
 
+    def test_model_type_mismatch_returns_none(self):
+        """Test that requesting a model with wrong model_type returns None."""
+        # Arrange - create a TEXT_EXTRACTOR model
+        extractor_spec = InferenceModelSpec(
+            backend_name="test_backend",
+            name="mistral-extractor",
+            sdk="test_sdk",
+            model_type=ModelType.TEXT_EXTRACTOR,
+            model_id="mistral-extractor-id",
+            costs={CostCategory.INPUT: 0.001, CostCategory.OUTPUT: 0.002},
+            max_tokens=1000,
+            max_prompt_images=None,
+        )
+        model_deck = self._create_test_model_deck(inference_models={"mistral-extractor": extractor_spec})
+
+        # Act - request it as LLM
+        result = model_deck.get_optional_inference_model("mistral-extractor", model_type=ModelType.LLM)
+
+        # Assert - should return None due to model_type mismatch
+        assert result is None
+
     def test_complex_waterfall_scenario(self):
         # Arrange
         model_spec = self._create_test_model_spec("claude-3")

--- a/tests/unit/pipelex/cogt/models/test_model_deck_references.py
+++ b/tests/unit/pipelex/cogt/models/test_model_deck_references.py
@@ -9,6 +9,7 @@ import pytest
 from pipelex.cogt.extract.extract_setting import ExtractSetting
 from pipelex.cogt.img_gen.img_gen_setting import ImgGenSetting
 from pipelex.cogt.llm.llm_setting import LLMSetting
+from pipelex.cogt.model_backends.model_type import ModelType
 from pipelex.cogt.models.model_deck import (
     ModelDeckBlueprint,
 )
@@ -19,6 +20,11 @@ from pipelex.system.configuration.configs import ConfigPaths
 from pipelex.system.pipelex_service.remote_config_fetcher import RemoteConfigFetcher
 from pipelex.tools.misc.file_utils import find_files_in_dir
 from pipelex.tools.misc.toml_utils import load_toml_from_path_if_exists
+from tests.unit.pipelex.cogt.models.model_deck_validation_utils import (
+    find_circular_aliases,
+    find_invalid_alias_targets,
+    find_invalid_waterfall_entries,
+)
 
 
 class TestModelDeckReferences:
@@ -31,14 +37,17 @@ class TestModelDeckReferences:
         return load_model_deck_blueprint(model_deck_paths=model_deck_paths)
 
     @pytest.fixture(scope="class")
-    def all_known_model_handles(self) -> set[str]:
-        """Collect all valid model handles from local backends + Pipelex Gateway.
+    def all_known_model_handles(self) -> dict[str, ModelType]:
+        """Collect all valid model handles with their types from local backends + Pipelex Gateway.
 
         Sources:
         1. Local backend TOML files (.pipelex/inference/backends/*.toml)
         2. Pipelex Gateway remote config (uses session-level cache from conftest.py)
+
+        Returns:
+            Mapping of model_handle -> ModelType
         """
-        known_handles: set[str] = set()
+        known_handles: dict[str, ModelType] = {}
 
         # 1. Parse local backend TOML files
         known_handles.update(self._get_local_backend_models())
@@ -46,7 +55,9 @@ class TestModelDeckReferences:
         # 2. Get gateway models from cached remote config
         remote_config = RemoteConfigFetcher.fetch_remote_config()  # Uses cached version
         gateway_specs = remote_config.backend_model_specs
-        known_handles.update(gateway_specs.keys())
+        for model_name, spec in gateway_specs.items():
+            if isinstance(spec, dict) and "model_type" in spec:
+                known_handles[model_name] = ModelType(spec["model_type"])
 
         return known_handles
 
@@ -54,74 +65,45 @@ class TestModelDeckReferences:
     # Helper methods
     # ============================================================
 
-    def _get_local_backend_models(self) -> set[str]:
-        """Parse all local backend TOML files to collect model handles.
+    def _get_local_backend_models(self) -> dict[str, ModelType]:
+        """Parse all local backend TOML files to collect model handles with their types.
 
         Model names are the top-level keys in each backend TOML file,
         excluding the 'defaults' section which contains shared config.
+        Model types are determined from the model's 'model_type' field or the defaults section.
+
+        Returns:
+            Mapping of model_handle -> ModelType
         """
-        known_handles: set[str] = set()
+        known_handles: dict[str, ModelType] = {}
         backends_dir = ConfigPaths.BACKENDS_DIR_PATH
 
         toml_files = find_files_in_dir(backends_dir, pattern="*.toml", is_recursive=False)
         for toml_path in toml_files:
             backend_data = load_toml_from_path_if_exists(str(toml_path))
             if backend_data:
+                # Get default model_type from defaults section if present
+                defaults = backend_data.get("defaults", {})
+                default_model_type_str = defaults.get("model_type")
+
                 # Model names are top-level keys except "defaults"
                 for key in backend_data:
                     if key != "defaults":
-                        known_handles.add(key)
+                        model_config = backend_data[key]
+                        # Model can override the default model_type
+                        model_type_str = model_config.get("model_type", default_model_type_str)
+                        if model_type_str:
+                            known_handles[key] = ModelType(model_type_str)
 
         return known_handles
-
-    def _find_invalid_alias_targets(
-        self,
-        aliases: dict[str, str],
-        all_aliases: dict[str, str],
-        all_waterfalls: dict[str, list[str]],
-        known_model_handles: set[str],
-    ) -> list[tuple[str, str, str]]:
-        """Find aliases that reference invalid targets.
-
-        Args:
-            aliases: The aliases dict to validate
-            all_aliases: All available aliases for this model type
-            all_waterfalls: All available waterfalls for this model type
-            known_model_handles: Set of valid direct model handles
-
-        Returns:
-            List of (alias_name, target_value, reason) tuples for invalid references
-        """
-        invalid_refs: list[tuple[str, str, str]] = []
-
-        for alias_name, target_value in aliases.items():
-            ref = ModelReference.parse(target_value)
-
-            match ref.kind:
-                case ModelReferenceKind.ALIAS:
-                    # Alias can point to another alias
-                    if ref.name not in all_aliases:
-                        invalid_refs.append((alias_name, target_value, f"alias '{ref.name}' not found"))
-                case ModelReferenceKind.WATERFALL:
-                    # Alias can point to a waterfall
-                    if ref.name not in all_waterfalls:
-                        invalid_refs.append((alias_name, target_value, f"waterfall '{ref.name}' not found"))
-                case ModelReferenceKind.PRESET:
-                    # Alias should NOT point to a preset
-                    invalid_refs.append((alias_name, target_value, "aliases cannot reference presets ($ prefix)"))
-                case ModelReferenceKind.HANDLE:
-                    # Validate direct handle exists in known models
-                    if ref.name not in known_model_handles:
-                        invalid_refs.append((alias_name, target_value, f"model handle '{ref.name}' not found in backends"))
-
-        return invalid_refs
 
     def _find_invalid_preset_references(
         self,
         presets: dict[str, LLMSetting] | dict[str, ExtractSetting] | dict[str, ImgGenSetting],
         all_aliases: dict[str, str],
         all_waterfalls: dict[str, list[str]],
-        known_model_handles: set[str],
+        known_model_handles: dict[str, ModelType],
+        expected_model_type: ModelType,
     ) -> list[tuple[str, str, str]]:
         """Find presets that reference invalid model targets.
 
@@ -129,7 +111,8 @@ class TestModelDeckReferences:
             presets: The presets dict to validate
             all_aliases: All available aliases for this model type
             all_waterfalls: All available waterfalls for this model type
-            known_model_handles: Set of valid direct model handles
+            known_model_handles: Mapping of model handle -> ModelType
+            expected_model_type: The expected model type for this deck (LLM, TEXT_EXTRACTOR, IMG_GEN)
 
         Returns:
             List of (preset_name, model_value, reason) tuples for invalid references
@@ -142,113 +125,23 @@ class TestModelDeckReferences:
 
             match ref.kind:
                 case ModelReferenceKind.ALIAS:
-                    # Preset can use an alias
                     if ref.name not in all_aliases:
                         invalid_refs.append((preset_name, model_value, f"alias '{ref.name}' not found"))
                 case ModelReferenceKind.WATERFALL:
-                    # Preset can use a waterfall
                     if ref.name not in all_waterfalls:
                         invalid_refs.append((preset_name, model_value, f"waterfall '{ref.name}' not found"))
                 case ModelReferenceKind.PRESET:
-                    # Preset should NOT reference another preset
                     invalid_refs.append((preset_name, model_value, "presets cannot reference other presets ($ prefix)"))
                 case ModelReferenceKind.HANDLE:
-                    # Validate direct handle exists in known models
                     if ref.name not in known_model_handles:
                         invalid_refs.append((preset_name, model_value, f"model handle '{ref.name}' not found in backends"))
+                    elif known_model_handles[ref.name] != expected_model_type:
+                        actual_type = known_model_handles[ref.name]
+                        invalid_refs.append(
+                            (preset_name, model_value, f"model handle '{ref.name}' has type '{actual_type}' but expected '{expected_model_type}'")
+                        )
 
         return invalid_refs
-
-    def _find_invalid_waterfall_entries(
-        self,
-        waterfalls: dict[str, list[str]],
-        all_aliases: dict[str, str],
-        known_model_handles: set[str],
-    ) -> list[tuple[str, int, str, str]]:
-        """Find waterfall entries that reference invalid targets.
-
-        Args:
-            waterfalls: The waterfalls dict to validate
-            all_aliases: All available aliases for this model type
-            known_model_handles: Set of valid direct model handles
-
-        Returns:
-            List of (waterfall_name, index, entry_value, reason) tuples for invalid entries
-        """
-        invalid_refs: list[tuple[str, int, str, str]] = []
-
-        for waterfall_name, entries in waterfalls.items():
-            for index, entry_value in enumerate(entries):
-                ref = ModelReference.parse(entry_value)
-
-                match ref.kind:
-                    case ModelReferenceKind.ALIAS:
-                        # Waterfall can contain aliases
-                        if ref.name not in all_aliases:
-                            invalid_refs.append((waterfall_name, index, entry_value, f"alias '{ref.name}' not found"))
-                    case ModelReferenceKind.WATERFALL:
-                        # Waterfall should NOT contain other waterfalls
-                        invalid_refs.append((waterfall_name, index, entry_value, "waterfalls cannot contain other waterfalls (~ prefix)"))
-                    case ModelReferenceKind.PRESET:
-                        # Waterfall should NOT contain presets
-                        invalid_refs.append((waterfall_name, index, entry_value, "waterfalls cannot contain presets ($ prefix)"))
-                    case ModelReferenceKind.HANDLE:
-                        # Validate direct handle exists in known models
-                        if ref.name not in known_model_handles:
-                            invalid_refs.append((waterfall_name, index, entry_value, f"model handle '{ref.name}' not found in backends"))
-
-        return invalid_refs
-
-    def _find_circular_aliases(
-        self,
-        aliases: dict[str, str],
-    ) -> list[tuple[str, list[str]]]:
-        """Find circular alias chains.
-
-        Args:
-            aliases: The aliases dict to check for cycles
-
-        Returns:
-            List of (starting_alias, cycle_path) tuples for detected cycles
-        """
-        cycles: list[tuple[str, list[str]]] = []
-
-        for start_alias in aliases:
-            visited: list[str] = []
-            current = start_alias
-
-            while current in aliases:
-                if current in visited:
-                    # Found a cycle
-                    cycle_start_idx = visited.index(current)
-                    cycle_path = [*visited[cycle_start_idx:], current]
-                    # Only report if this cycle starts with our starting alias
-                    if start_alias in cycle_path:
-                        cycles.append((start_alias, cycle_path))
-                    break
-
-                visited.append(current)
-                target = aliases[current]
-                ref = ModelReference.parse(target)
-
-                # Only follow alias references
-                if ref.kind == ModelReferenceKind.ALIAS:
-                    current = ref.name
-                else:
-                    # Not an alias reference, chain ends
-                    break
-
-        # Deduplicate cycles (same cycle can be found from different starting points)
-        unique_cycles: list[tuple[str, list[str]]] = []
-        seen_cycles: set[frozenset[str]] = set()
-
-        for start_alias, cycle_path in cycles:
-            cycle_set = frozenset(cycle_path)
-            if cycle_set not in seen_cycles:
-                seen_cycles.add(cycle_set)
-                unique_cycles.append((start_alias, cycle_path))
-
-        return unique_cycles
 
     # ============================================================
     # LLM Tests
@@ -257,16 +150,17 @@ class TestModelDeckReferences:
     def test_llm_aliases_reference_valid_targets(
         self,
         model_deck_blueprint: ModelDeckBlueprint,
-        all_known_model_handles: set[str],
+        all_known_model_handles: dict[str, ModelType],
     ):
         """Verify LLM aliases point to valid targets (other aliases, waterfalls, or direct handles)."""
         llm_deck = model_deck_blueprint.llm
 
-        invalid_refs = self._find_invalid_alias_targets(
+        invalid_refs = find_invalid_alias_targets(
             aliases=llm_deck.aliases,
             all_aliases=llm_deck.aliases,
             all_waterfalls=llm_deck.waterfalls,
             known_model_handles=all_known_model_handles,
+            expected_model_type=ModelType.LLM,
         )
 
         if invalid_refs:
@@ -278,7 +172,7 @@ class TestModelDeckReferences:
     def test_llm_presets_reference_valid_models(
         self,
         model_deck_blueprint: ModelDeckBlueprint,
-        all_known_model_handles: set[str],
+        all_known_model_handles: dict[str, ModelType],
     ):
         """Verify LLM preset model fields use valid aliases, waterfalls, or direct handles."""
         llm_deck = model_deck_blueprint.llm
@@ -288,6 +182,7 @@ class TestModelDeckReferences:
             all_aliases=llm_deck.aliases,
             all_waterfalls=llm_deck.waterfalls,
             known_model_handles=all_known_model_handles,
+            expected_model_type=ModelType.LLM,
         )
 
         if invalid_refs:
@@ -299,15 +194,16 @@ class TestModelDeckReferences:
     def test_llm_waterfalls_contain_valid_models(
         self,
         model_deck_blueprint: ModelDeckBlueprint,
-        all_known_model_handles: set[str],
+        all_known_model_handles: dict[str, ModelType],
     ):
         """Verify LLM waterfall entries are valid aliases or direct model handles."""
         llm_deck = model_deck_blueprint.llm
 
-        invalid_refs = self._find_invalid_waterfall_entries(
+        invalid_refs = find_invalid_waterfall_entries(
             waterfalls=llm_deck.waterfalls,
             all_aliases=llm_deck.aliases,
             known_model_handles=all_known_model_handles,
+            expected_model_type=ModelType.LLM,
         )
 
         if invalid_refs:
@@ -320,7 +216,7 @@ class TestModelDeckReferences:
         """Detect LLM alias chains that form cycles."""
         llm_deck = model_deck_blueprint.llm
 
-        cycles = self._find_circular_aliases(aliases=llm_deck.aliases)
+        cycles = find_circular_aliases(aliases=llm_deck.aliases)
 
         if cycles:
             error_lines = ["Circular LLM alias references detected:"]
@@ -336,16 +232,17 @@ class TestModelDeckReferences:
     def test_extract_aliases_reference_valid_targets(
         self,
         model_deck_blueprint: ModelDeckBlueprint,
-        all_known_model_handles: set[str],
+        all_known_model_handles: dict[str, ModelType],
     ):
         """Verify Extract aliases point to valid targets (other aliases, waterfalls, or direct handles)."""
         extract_deck = model_deck_blueprint.extract
 
-        invalid_refs = self._find_invalid_alias_targets(
+        invalid_refs = find_invalid_alias_targets(
             aliases=extract_deck.aliases,
             all_aliases=extract_deck.aliases,
             all_waterfalls=extract_deck.waterfalls,
             known_model_handles=all_known_model_handles,
+            expected_model_type=ModelType.TEXT_EXTRACTOR,
         )
 
         if invalid_refs:
@@ -357,7 +254,7 @@ class TestModelDeckReferences:
     def test_extract_presets_reference_valid_models(
         self,
         model_deck_blueprint: ModelDeckBlueprint,
-        all_known_model_handles: set[str],
+        all_known_model_handles: dict[str, ModelType],
     ):
         """Verify Extract preset model fields use valid aliases, waterfalls, or direct handles."""
         extract_deck = model_deck_blueprint.extract
@@ -367,6 +264,7 @@ class TestModelDeckReferences:
             all_aliases=extract_deck.aliases,
             all_waterfalls=extract_deck.waterfalls,
             known_model_handles=all_known_model_handles,
+            expected_model_type=ModelType.TEXT_EXTRACTOR,
         )
 
         if invalid_refs:
@@ -378,15 +276,16 @@ class TestModelDeckReferences:
     def test_extract_waterfalls_contain_valid_models(
         self,
         model_deck_blueprint: ModelDeckBlueprint,
-        all_known_model_handles: set[str],
+        all_known_model_handles: dict[str, ModelType],
     ):
         """Verify Extract waterfall entries are valid aliases or direct model handles."""
         extract_deck = model_deck_blueprint.extract
 
-        invalid_refs = self._find_invalid_waterfall_entries(
+        invalid_refs = find_invalid_waterfall_entries(
             waterfalls=extract_deck.waterfalls,
             all_aliases=extract_deck.aliases,
             known_model_handles=all_known_model_handles,
+            expected_model_type=ModelType.TEXT_EXTRACTOR,
         )
 
         if invalid_refs:
@@ -399,7 +298,7 @@ class TestModelDeckReferences:
         """Detect Extract alias chains that form cycles."""
         extract_deck = model_deck_blueprint.extract
 
-        cycles = self._find_circular_aliases(aliases=extract_deck.aliases)
+        cycles = find_circular_aliases(aliases=extract_deck.aliases)
 
         if cycles:
             error_lines = ["Circular Extract alias references detected:"]
@@ -415,16 +314,17 @@ class TestModelDeckReferences:
     def test_img_gen_aliases_reference_valid_targets(
         self,
         model_deck_blueprint: ModelDeckBlueprint,
-        all_known_model_handles: set[str],
+        all_known_model_handles: dict[str, ModelType],
     ):
         """Verify ImgGen aliases point to valid targets (other aliases, waterfalls, or direct handles)."""
         img_gen_deck = model_deck_blueprint.img_gen
 
-        invalid_refs = self._find_invalid_alias_targets(
+        invalid_refs = find_invalid_alias_targets(
             aliases=img_gen_deck.aliases,
             all_aliases=img_gen_deck.aliases,
             all_waterfalls=img_gen_deck.waterfalls,
             known_model_handles=all_known_model_handles,
+            expected_model_type=ModelType.IMG_GEN,
         )
 
         if invalid_refs:
@@ -436,7 +336,7 @@ class TestModelDeckReferences:
     def test_img_gen_presets_reference_valid_models(
         self,
         model_deck_blueprint: ModelDeckBlueprint,
-        all_known_model_handles: set[str],
+        all_known_model_handles: dict[str, ModelType],
     ):
         """Verify ImgGen preset model fields use valid aliases, waterfalls, or direct handles."""
         img_gen_deck = model_deck_blueprint.img_gen
@@ -446,6 +346,7 @@ class TestModelDeckReferences:
             all_aliases=img_gen_deck.aliases,
             all_waterfalls=img_gen_deck.waterfalls,
             known_model_handles=all_known_model_handles,
+            expected_model_type=ModelType.IMG_GEN,
         )
 
         if invalid_refs:
@@ -457,15 +358,16 @@ class TestModelDeckReferences:
     def test_img_gen_waterfalls_contain_valid_models(
         self,
         model_deck_blueprint: ModelDeckBlueprint,
-        all_known_model_handles: set[str],
+        all_known_model_handles: dict[str, ModelType],
     ):
         """Verify ImgGen waterfall entries are valid aliases or direct model handles."""
         img_gen_deck = model_deck_blueprint.img_gen
 
-        invalid_refs = self._find_invalid_waterfall_entries(
+        invalid_refs = find_invalid_waterfall_entries(
             waterfalls=img_gen_deck.waterfalls,
             all_aliases=img_gen_deck.aliases,
             known_model_handles=all_known_model_handles,
+            expected_model_type=ModelType.IMG_GEN,
         )
 
         if invalid_refs:
@@ -478,7 +380,7 @@ class TestModelDeckReferences:
         """Detect ImgGen alias chains that form cycles."""
         img_gen_deck = model_deck_blueprint.img_gen
 
-        cycles = self._find_circular_aliases(aliases=img_gen_deck.aliases)
+        cycles = find_circular_aliases(aliases=img_gen_deck.aliases)
 
         if cycles:
             error_lines = ["Circular ImgGen alias references detected:"]

--- a/tests/unit/pipelex/cogt/models/test_model_deck_references.py
+++ b/tests/unit/pipelex/cogt/models/test_model_deck_references.py
@@ -153,246 +153,139 @@ class TestModelDeckReferences:
         return invalid_refs
 
     # ============================================================
-    # LLM Tests
+    # Parameterized validation tests
     # ============================================================
 
-    def test_llm_aliases_reference_valid_targets(
+    def _get_deck_for_model_type(
+        self,
+        model_deck_blueprint: ModelDeckBlueprint,
+        model_type: ModelType,
+    ):
+        """Get the appropriate deck from the blueprint based on model type."""
+        match model_type:
+            case ModelType.LLM:
+                return model_deck_blueprint.llm
+            case ModelType.TEXT_EXTRACTOR:
+                return model_deck_blueprint.extract
+            case ModelType.IMG_GEN:
+                return model_deck_blueprint.img_gen
+
+    @pytest.mark.parametrize(
+        ("model_type", "deck_name"),
+        [
+            (ModelType.LLM, "LLM"),
+            (ModelType.TEXT_EXTRACTOR, "Extract"),
+            (ModelType.IMG_GEN, "ImgGen"),
+        ],
+    )
+    def test_aliases_reference_valid_targets(
         self,
         model_deck_blueprint: ModelDeckBlueprint,
         all_known_model_handles: dict[str, ModelType],
+        model_type: ModelType,
+        deck_name: str,
     ):
-        """Verify LLM aliases point to valid targets (other aliases, waterfalls, or direct handles)."""
-        llm_deck = model_deck_blueprint.llm
+        """Verify aliases point to valid targets (other aliases, waterfalls, or direct handles)."""
+        deck = self._get_deck_for_model_type(model_deck_blueprint, model_type)
 
         invalid_refs = find_invalid_alias_targets(
-            aliases=llm_deck.aliases,
-            all_aliases=llm_deck.aliases,
-            all_waterfalls=llm_deck.waterfalls,
+            aliases=deck.aliases,
+            all_aliases=deck.aliases,
+            all_waterfalls=deck.waterfalls,
             known_model_handles=all_known_model_handles,
-            expected_model_type=ModelType.LLM,
+            expected_model_type=model_type,
         )
 
         if invalid_refs:
-            error_lines = ["Invalid LLM alias references found:"]
+            error_lines = [f"Invalid {deck_name} alias references found:"]
             for alias_name, target_value, reason in invalid_refs:
                 error_lines.append(f"  - '{alias_name}' -> '{target_value}': {reason}")
             pytest.fail("\n".join(error_lines))
 
-    def test_llm_presets_reference_valid_models(
+    @pytest.mark.parametrize(
+        ("model_type", "deck_name"),
+        [
+            (ModelType.LLM, "LLM"),
+            (ModelType.TEXT_EXTRACTOR, "Extract"),
+            (ModelType.IMG_GEN, "ImgGen"),
+        ],
+    )
+    def test_presets_reference_valid_models(
         self,
         model_deck_blueprint: ModelDeckBlueprint,
         all_known_model_handles: dict[str, ModelType],
+        model_type: ModelType,
+        deck_name: str,
     ):
-        """Verify LLM preset model fields use valid aliases, waterfalls, or direct handles."""
-        llm_deck = model_deck_blueprint.llm
+        """Verify preset model fields use valid aliases, waterfalls, or direct handles."""
+        deck = self._get_deck_for_model_type(model_deck_blueprint, model_type)
 
         invalid_refs = self._find_invalid_preset_references(
-            presets=llm_deck.presets,
-            all_aliases=llm_deck.aliases,
-            all_waterfalls=llm_deck.waterfalls,
+            presets=deck.presets,
+            all_aliases=deck.aliases,
+            all_waterfalls=deck.waterfalls,
             known_model_handles=all_known_model_handles,
-            expected_model_type=ModelType.LLM,
+            expected_model_type=model_type,
         )
 
         if invalid_refs:
-            error_lines = ["Invalid LLM preset model references found:"]
+            error_lines = [f"Invalid {deck_name} preset model references found:"]
             for preset_name, model_value, reason in invalid_refs:
                 error_lines.append(f"  - preset '{preset_name}' model='{model_value}': {reason}")
             pytest.fail("\n".join(error_lines))
 
-    def test_llm_waterfalls_contain_valid_models(
+    @pytest.mark.parametrize(
+        ("model_type", "deck_name"),
+        [
+            (ModelType.LLM, "LLM"),
+            (ModelType.TEXT_EXTRACTOR, "Extract"),
+            (ModelType.IMG_GEN, "ImgGen"),
+        ],
+    )
+    def test_waterfalls_contain_valid_models(
         self,
         model_deck_blueprint: ModelDeckBlueprint,
         all_known_model_handles: dict[str, ModelType],
+        model_type: ModelType,
+        deck_name: str,
     ):
-        """Verify LLM waterfall entries are valid aliases or direct model handles."""
-        llm_deck = model_deck_blueprint.llm
+        """Verify waterfall entries are valid aliases or direct model handles."""
+        deck = self._get_deck_for_model_type(model_deck_blueprint, model_type)
 
         invalid_refs = find_invalid_waterfall_entries(
-            waterfalls=llm_deck.waterfalls,
-            all_aliases=llm_deck.aliases,
+            waterfalls=deck.waterfalls,
+            all_aliases=deck.aliases,
             known_model_handles=all_known_model_handles,
-            expected_model_type=ModelType.LLM,
+            expected_model_type=model_type,
         )
 
         if invalid_refs:
-            error_lines = ["Invalid LLM waterfall entries found:"]
+            error_lines = [f"Invalid {deck_name} waterfall entries found:"]
             for waterfall_name, index, entry_value, reason in invalid_refs:
                 error_lines.append(f"  - waterfall '{waterfall_name}'[{index}]='{entry_value}': {reason}")
             pytest.fail("\n".join(error_lines))
 
-    def test_llm_aliases_no_circular_references(self, model_deck_blueprint: ModelDeckBlueprint):
-        """Detect LLM alias chains that form cycles."""
-        llm_deck = model_deck_blueprint.llm
+    @pytest.mark.parametrize(
+        ("model_type", "deck_name"),
+        [
+            (ModelType.LLM, "LLM"),
+            (ModelType.TEXT_EXTRACTOR, "Extract"),
+            (ModelType.IMG_GEN, "ImgGen"),
+        ],
+    )
+    def test_aliases_no_circular_references(
+        self,
+        model_deck_blueprint: ModelDeckBlueprint,
+        model_type: ModelType,
+        deck_name: str,
+    ):
+        """Detect alias chains that form cycles."""
+        deck = self._get_deck_for_model_type(model_deck_blueprint, model_type)
 
-        cycles = find_circular_aliases(aliases=llm_deck.aliases)
+        cycles = find_circular_aliases(aliases=deck.aliases)
 
         if cycles:
-            error_lines = ["Circular LLM alias references detected:"]
-            for _start_alias, cycle_path in cycles:
-                cycle_str = " -> ".join(cycle_path)
-                error_lines.append(f"  - {cycle_str}")
-            pytest.fail("\n".join(error_lines))
-
-    # ============================================================
-    # Extract Tests
-    # ============================================================
-
-    def test_extract_aliases_reference_valid_targets(
-        self,
-        model_deck_blueprint: ModelDeckBlueprint,
-        all_known_model_handles: dict[str, ModelType],
-    ):
-        """Verify Extract aliases point to valid targets (other aliases, waterfalls, or direct handles)."""
-        extract_deck = model_deck_blueprint.extract
-
-        invalid_refs = find_invalid_alias_targets(
-            aliases=extract_deck.aliases,
-            all_aliases=extract_deck.aliases,
-            all_waterfalls=extract_deck.waterfalls,
-            known_model_handles=all_known_model_handles,
-            expected_model_type=ModelType.TEXT_EXTRACTOR,
-        )
-
-        if invalid_refs:
-            error_lines = ["Invalid Extract alias references found:"]
-            for alias_name, target_value, reason in invalid_refs:
-                error_lines.append(f"  - '{alias_name}' -> '{target_value}': {reason}")
-            pytest.fail("\n".join(error_lines))
-
-    def test_extract_presets_reference_valid_models(
-        self,
-        model_deck_blueprint: ModelDeckBlueprint,
-        all_known_model_handles: dict[str, ModelType],
-    ):
-        """Verify Extract preset model fields use valid aliases, waterfalls, or direct handles."""
-        extract_deck = model_deck_blueprint.extract
-
-        invalid_refs = self._find_invalid_preset_references(
-            presets=extract_deck.presets,
-            all_aliases=extract_deck.aliases,
-            all_waterfalls=extract_deck.waterfalls,
-            known_model_handles=all_known_model_handles,
-            expected_model_type=ModelType.TEXT_EXTRACTOR,
-        )
-
-        if invalid_refs:
-            error_lines = ["Invalid Extract preset model references found:"]
-            for preset_name, model_value, reason in invalid_refs:
-                error_lines.append(f"  - preset '{preset_name}' model='{model_value}': {reason}")
-            pytest.fail("\n".join(error_lines))
-
-    def test_extract_waterfalls_contain_valid_models(
-        self,
-        model_deck_blueprint: ModelDeckBlueprint,
-        all_known_model_handles: dict[str, ModelType],
-    ):
-        """Verify Extract waterfall entries are valid aliases or direct model handles."""
-        extract_deck = model_deck_blueprint.extract
-
-        invalid_refs = find_invalid_waterfall_entries(
-            waterfalls=extract_deck.waterfalls,
-            all_aliases=extract_deck.aliases,
-            known_model_handles=all_known_model_handles,
-            expected_model_type=ModelType.TEXT_EXTRACTOR,
-        )
-
-        if invalid_refs:
-            error_lines = ["Invalid Extract waterfall entries found:"]
-            for waterfall_name, index, entry_value, reason in invalid_refs:
-                error_lines.append(f"  - waterfall '{waterfall_name}'[{index}]='{entry_value}': {reason}")
-            pytest.fail("\n".join(error_lines))
-
-    def test_extract_aliases_no_circular_references(self, model_deck_blueprint: ModelDeckBlueprint):
-        """Detect Extract alias chains that form cycles."""
-        extract_deck = model_deck_blueprint.extract
-
-        cycles = find_circular_aliases(aliases=extract_deck.aliases)
-
-        if cycles:
-            error_lines = ["Circular Extract alias references detected:"]
-            for _start_alias, cycle_path in cycles:
-                cycle_str = " -> ".join(cycle_path)
-                error_lines.append(f"  - {cycle_str}")
-            pytest.fail("\n".join(error_lines))
-
-    # ============================================================
-    # ImgGen Tests
-    # ============================================================
-
-    def test_img_gen_aliases_reference_valid_targets(
-        self,
-        model_deck_blueprint: ModelDeckBlueprint,
-        all_known_model_handles: dict[str, ModelType],
-    ):
-        """Verify ImgGen aliases point to valid targets (other aliases, waterfalls, or direct handles)."""
-        img_gen_deck = model_deck_blueprint.img_gen
-
-        invalid_refs = find_invalid_alias_targets(
-            aliases=img_gen_deck.aliases,
-            all_aliases=img_gen_deck.aliases,
-            all_waterfalls=img_gen_deck.waterfalls,
-            known_model_handles=all_known_model_handles,
-            expected_model_type=ModelType.IMG_GEN,
-        )
-
-        if invalid_refs:
-            error_lines = ["Invalid ImgGen alias references found:"]
-            for alias_name, target_value, reason in invalid_refs:
-                error_lines.append(f"  - '{alias_name}' -> '{target_value}': {reason}")
-            pytest.fail("\n".join(error_lines))
-
-    def test_img_gen_presets_reference_valid_models(
-        self,
-        model_deck_blueprint: ModelDeckBlueprint,
-        all_known_model_handles: dict[str, ModelType],
-    ):
-        """Verify ImgGen preset model fields use valid aliases, waterfalls, or direct handles."""
-        img_gen_deck = model_deck_blueprint.img_gen
-
-        invalid_refs = self._find_invalid_preset_references(
-            presets=img_gen_deck.presets,
-            all_aliases=img_gen_deck.aliases,
-            all_waterfalls=img_gen_deck.waterfalls,
-            known_model_handles=all_known_model_handles,
-            expected_model_type=ModelType.IMG_GEN,
-        )
-
-        if invalid_refs:
-            error_lines = ["Invalid ImgGen preset model references found:"]
-            for preset_name, model_value, reason in invalid_refs:
-                error_lines.append(f"  - preset '{preset_name}' model='{model_value}': {reason}")
-            pytest.fail("\n".join(error_lines))
-
-    def test_img_gen_waterfalls_contain_valid_models(
-        self,
-        model_deck_blueprint: ModelDeckBlueprint,
-        all_known_model_handles: dict[str, ModelType],
-    ):
-        """Verify ImgGen waterfall entries are valid aliases or direct model handles."""
-        img_gen_deck = model_deck_blueprint.img_gen
-
-        invalid_refs = find_invalid_waterfall_entries(
-            waterfalls=img_gen_deck.waterfalls,
-            all_aliases=img_gen_deck.aliases,
-            known_model_handles=all_known_model_handles,
-            expected_model_type=ModelType.IMG_GEN,
-        )
-
-        if invalid_refs:
-            error_lines = ["Invalid ImgGen waterfall entries found:"]
-            for waterfall_name, index, entry_value, reason in invalid_refs:
-                error_lines.append(f"  - waterfall '{waterfall_name}'[{index}]='{entry_value}': {reason}")
-            pytest.fail("\n".join(error_lines))
-
-    def test_img_gen_aliases_no_circular_references(self, model_deck_blueprint: ModelDeckBlueprint):
-        """Detect ImgGen alias chains that form cycles."""
-        img_gen_deck = model_deck_blueprint.img_gen
-
-        cycles = find_circular_aliases(aliases=img_gen_deck.aliases)
-
-        if cycles:
-            error_lines = ["Circular ImgGen alias references detected:"]
+            error_lines = [f"Circular {deck_name} alias references detected:"]
             for _start_alias, cycle_path in cycles:
                 cycle_str = " -> ".join(cycle_path)
                 error_lines.append(f"  - {cycle_str}")

--- a/tests/unit/pipelex/cogt/models/test_model_deck_references.py
+++ b/tests/unit/pipelex/cogt/models/test_model_deck_references.py
@@ -1,0 +1,488 @@
+"""Tests for validating model deck references (aliases, presets, waterfalls).
+
+This test suite systematically validates that model deck references point to valid targets,
+preventing configuration errors from being discovered at runtime.
+"""
+
+import pytest
+
+from pipelex.cogt.extract.extract_setting import ExtractSetting
+from pipelex.cogt.img_gen.img_gen_setting import ImgGenSetting
+from pipelex.cogt.llm.llm_setting import LLMSetting
+from pipelex.cogt.models.model_deck import (
+    ModelDeckBlueprint,
+)
+from pipelex.cogt.models.model_deck_loader import load_model_deck_blueprint
+from pipelex.cogt.models.model_manager import ModelManager
+from pipelex.cogt.models.model_reference import ModelReference, ModelReferenceKind
+from pipelex.system.configuration.configs import ConfigPaths
+from pipelex.system.pipelex_service.remote_config_fetcher import RemoteConfigFetcher
+from pipelex.tools.misc.file_utils import find_files_in_dir
+from pipelex.tools.misc.toml_utils import load_toml_from_path_if_exists
+
+
+class TestModelDeckReferences:
+    """Validate that model deck references point to valid targets."""
+
+    @pytest.fixture(scope="class")
+    def model_deck_blueprint(self) -> ModelDeckBlueprint:
+        """Load actual model deck blueprint from TOML files."""
+        model_deck_paths = ModelManager.get_model_deck_paths(deck_dir_path=ConfigPaths.MODEL_DECKS_DIR_PATH)
+        return load_model_deck_blueprint(model_deck_paths=model_deck_paths)
+
+    @pytest.fixture(scope="class")
+    def all_known_model_handles(self) -> set[str]:
+        """Collect all valid model handles from local backends + Pipelex Gateway.
+
+        Sources:
+        1. Local backend TOML files (.pipelex/inference/backends/*.toml)
+        2. Pipelex Gateway remote config (uses session-level cache from conftest.py)
+        """
+        known_handles: set[str] = set()
+
+        # 1. Parse local backend TOML files
+        known_handles.update(self._get_local_backend_models())
+
+        # 2. Get gateway models from cached remote config
+        remote_config = RemoteConfigFetcher.fetch_remote_config()  # Uses cached version
+        gateway_specs = remote_config.backend_model_specs
+        known_handles.update(gateway_specs.keys())
+
+        return known_handles
+
+    # ============================================================
+    # Helper methods
+    # ============================================================
+
+    def _get_local_backend_models(self) -> set[str]:
+        """Parse all local backend TOML files to collect model handles.
+
+        Model names are the top-level keys in each backend TOML file,
+        excluding the 'defaults' section which contains shared config.
+        """
+        known_handles: set[str] = set()
+        backends_dir = ConfigPaths.BACKENDS_DIR_PATH
+
+        toml_files = find_files_in_dir(backends_dir, pattern="*.toml", is_recursive=False)
+        for toml_path in toml_files:
+            backend_data = load_toml_from_path_if_exists(str(toml_path))
+            if backend_data:
+                # Model names are top-level keys except "defaults"
+                for key in backend_data:
+                    if key != "defaults":
+                        known_handles.add(key)
+
+        return known_handles
+
+    def _find_invalid_alias_targets(
+        self,
+        aliases: dict[str, str],
+        all_aliases: dict[str, str],
+        all_waterfalls: dict[str, list[str]],
+        known_model_handles: set[str],
+    ) -> list[tuple[str, str, str]]:
+        """Find aliases that reference invalid targets.
+
+        Args:
+            aliases: The aliases dict to validate
+            all_aliases: All available aliases for this model type
+            all_waterfalls: All available waterfalls for this model type
+            known_model_handles: Set of valid direct model handles
+
+        Returns:
+            List of (alias_name, target_value, reason) tuples for invalid references
+        """
+        invalid_refs: list[tuple[str, str, str]] = []
+
+        for alias_name, target_value in aliases.items():
+            ref = ModelReference.parse(target_value)
+
+            match ref.kind:
+                case ModelReferenceKind.ALIAS:
+                    # Alias can point to another alias
+                    if ref.name not in all_aliases:
+                        invalid_refs.append((alias_name, target_value, f"alias '{ref.name}' not found"))
+                case ModelReferenceKind.WATERFALL:
+                    # Alias can point to a waterfall
+                    if ref.name not in all_waterfalls:
+                        invalid_refs.append((alias_name, target_value, f"waterfall '{ref.name}' not found"))
+                case ModelReferenceKind.PRESET:
+                    # Alias should NOT point to a preset
+                    invalid_refs.append((alias_name, target_value, "aliases cannot reference presets ($ prefix)"))
+                case ModelReferenceKind.HANDLE:
+                    # Validate direct handle exists in known models
+                    if ref.name not in known_model_handles:
+                        invalid_refs.append((alias_name, target_value, f"model handle '{ref.name}' not found in backends"))
+
+        return invalid_refs
+
+    def _find_invalid_preset_references(
+        self,
+        presets: dict[str, LLMSetting] | dict[str, ExtractSetting] | dict[str, ImgGenSetting],
+        all_aliases: dict[str, str],
+        all_waterfalls: dict[str, list[str]],
+        known_model_handles: set[str],
+    ) -> list[tuple[str, str, str]]:
+        """Find presets that reference invalid model targets.
+
+        Args:
+            presets: The presets dict to validate
+            all_aliases: All available aliases for this model type
+            all_waterfalls: All available waterfalls for this model type
+            known_model_handles: Set of valid direct model handles
+
+        Returns:
+            List of (preset_name, model_value, reason) tuples for invalid references
+        """
+        invalid_refs: list[tuple[str, str, str]] = []
+
+        for preset_name, preset_setting in presets.items():
+            model_value = preset_setting.model
+            ref = ModelReference.parse(model_value)
+
+            match ref.kind:
+                case ModelReferenceKind.ALIAS:
+                    # Preset can use an alias
+                    if ref.name not in all_aliases:
+                        invalid_refs.append((preset_name, model_value, f"alias '{ref.name}' not found"))
+                case ModelReferenceKind.WATERFALL:
+                    # Preset can use a waterfall
+                    if ref.name not in all_waterfalls:
+                        invalid_refs.append((preset_name, model_value, f"waterfall '{ref.name}' not found"))
+                case ModelReferenceKind.PRESET:
+                    # Preset should NOT reference another preset
+                    invalid_refs.append((preset_name, model_value, "presets cannot reference other presets ($ prefix)"))
+                case ModelReferenceKind.HANDLE:
+                    # Validate direct handle exists in known models
+                    if ref.name not in known_model_handles:
+                        invalid_refs.append((preset_name, model_value, f"model handle '{ref.name}' not found in backends"))
+
+        return invalid_refs
+
+    def _find_invalid_waterfall_entries(
+        self,
+        waterfalls: dict[str, list[str]],
+        all_aliases: dict[str, str],
+        known_model_handles: set[str],
+    ) -> list[tuple[str, int, str, str]]:
+        """Find waterfall entries that reference invalid targets.
+
+        Args:
+            waterfalls: The waterfalls dict to validate
+            all_aliases: All available aliases for this model type
+            known_model_handles: Set of valid direct model handles
+
+        Returns:
+            List of (waterfall_name, index, entry_value, reason) tuples for invalid entries
+        """
+        invalid_refs: list[tuple[str, int, str, str]] = []
+
+        for waterfall_name, entries in waterfalls.items():
+            for index, entry_value in enumerate(entries):
+                ref = ModelReference.parse(entry_value)
+
+                match ref.kind:
+                    case ModelReferenceKind.ALIAS:
+                        # Waterfall can contain aliases
+                        if ref.name not in all_aliases:
+                            invalid_refs.append((waterfall_name, index, entry_value, f"alias '{ref.name}' not found"))
+                    case ModelReferenceKind.WATERFALL:
+                        # Waterfall should NOT contain other waterfalls
+                        invalid_refs.append((waterfall_name, index, entry_value, "waterfalls cannot contain other waterfalls (~ prefix)"))
+                    case ModelReferenceKind.PRESET:
+                        # Waterfall should NOT contain presets
+                        invalid_refs.append((waterfall_name, index, entry_value, "waterfalls cannot contain presets ($ prefix)"))
+                    case ModelReferenceKind.HANDLE:
+                        # Validate direct handle exists in known models
+                        if ref.name not in known_model_handles:
+                            invalid_refs.append((waterfall_name, index, entry_value, f"model handle '{ref.name}' not found in backends"))
+
+        return invalid_refs
+
+    def _find_circular_aliases(
+        self,
+        aliases: dict[str, str],
+    ) -> list[tuple[str, list[str]]]:
+        """Find circular alias chains.
+
+        Args:
+            aliases: The aliases dict to check for cycles
+
+        Returns:
+            List of (starting_alias, cycle_path) tuples for detected cycles
+        """
+        cycles: list[tuple[str, list[str]]] = []
+
+        for start_alias in aliases:
+            visited: list[str] = []
+            current = start_alias
+
+            while current in aliases:
+                if current in visited:
+                    # Found a cycle
+                    cycle_start_idx = visited.index(current)
+                    cycle_path = [*visited[cycle_start_idx:], current]
+                    # Only report if this cycle starts with our starting alias
+                    if start_alias in cycle_path:
+                        cycles.append((start_alias, cycle_path))
+                    break
+
+                visited.append(current)
+                target = aliases[current]
+                ref = ModelReference.parse(target)
+
+                # Only follow alias references
+                if ref.kind == ModelReferenceKind.ALIAS:
+                    current = ref.name
+                else:
+                    # Not an alias reference, chain ends
+                    break
+
+        # Deduplicate cycles (same cycle can be found from different starting points)
+        unique_cycles: list[tuple[str, list[str]]] = []
+        seen_cycles: set[frozenset[str]] = set()
+
+        for start_alias, cycle_path in cycles:
+            cycle_set = frozenset(cycle_path)
+            if cycle_set not in seen_cycles:
+                seen_cycles.add(cycle_set)
+                unique_cycles.append((start_alias, cycle_path))
+
+        return unique_cycles
+
+    # ============================================================
+    # LLM Tests
+    # ============================================================
+
+    def test_llm_aliases_reference_valid_targets(
+        self,
+        model_deck_blueprint: ModelDeckBlueprint,
+        all_known_model_handles: set[str],
+    ):
+        """Verify LLM aliases point to valid targets (other aliases, waterfalls, or direct handles)."""
+        llm_deck = model_deck_blueprint.llm
+
+        invalid_refs = self._find_invalid_alias_targets(
+            aliases=llm_deck.aliases,
+            all_aliases=llm_deck.aliases,
+            all_waterfalls=llm_deck.waterfalls,
+            known_model_handles=all_known_model_handles,
+        )
+
+        if invalid_refs:
+            error_lines = ["Invalid LLM alias references found:"]
+            for alias_name, target_value, reason in invalid_refs:
+                error_lines.append(f"  - '{alias_name}' -> '{target_value}': {reason}")
+            pytest.fail("\n".join(error_lines))
+
+    def test_llm_presets_reference_valid_models(
+        self,
+        model_deck_blueprint: ModelDeckBlueprint,
+        all_known_model_handles: set[str],
+    ):
+        """Verify LLM preset model fields use valid aliases, waterfalls, or direct handles."""
+        llm_deck = model_deck_blueprint.llm
+
+        invalid_refs = self._find_invalid_preset_references(
+            presets=llm_deck.presets,
+            all_aliases=llm_deck.aliases,
+            all_waterfalls=llm_deck.waterfalls,
+            known_model_handles=all_known_model_handles,
+        )
+
+        if invalid_refs:
+            error_lines = ["Invalid LLM preset model references found:"]
+            for preset_name, model_value, reason in invalid_refs:
+                error_lines.append(f"  - preset '{preset_name}' model='{model_value}': {reason}")
+            pytest.fail("\n".join(error_lines))
+
+    def test_llm_waterfalls_contain_valid_models(
+        self,
+        model_deck_blueprint: ModelDeckBlueprint,
+        all_known_model_handles: set[str],
+    ):
+        """Verify LLM waterfall entries are valid aliases or direct model handles."""
+        llm_deck = model_deck_blueprint.llm
+
+        invalid_refs = self._find_invalid_waterfall_entries(
+            waterfalls=llm_deck.waterfalls,
+            all_aliases=llm_deck.aliases,
+            known_model_handles=all_known_model_handles,
+        )
+
+        if invalid_refs:
+            error_lines = ["Invalid LLM waterfall entries found:"]
+            for waterfall_name, index, entry_value, reason in invalid_refs:
+                error_lines.append(f"  - waterfall '{waterfall_name}'[{index}]='{entry_value}': {reason}")
+            pytest.fail("\n".join(error_lines))
+
+    def test_llm_aliases_no_circular_references(self, model_deck_blueprint: ModelDeckBlueprint):
+        """Detect LLM alias chains that form cycles."""
+        llm_deck = model_deck_blueprint.llm
+
+        cycles = self._find_circular_aliases(aliases=llm_deck.aliases)
+
+        if cycles:
+            error_lines = ["Circular LLM alias references detected:"]
+            for _start_alias, cycle_path in cycles:
+                cycle_str = " -> ".join(cycle_path)
+                error_lines.append(f"  - {cycle_str}")
+            pytest.fail("\n".join(error_lines))
+
+    # ============================================================
+    # Extract Tests
+    # ============================================================
+
+    def test_extract_aliases_reference_valid_targets(
+        self,
+        model_deck_blueprint: ModelDeckBlueprint,
+        all_known_model_handles: set[str],
+    ):
+        """Verify Extract aliases point to valid targets (other aliases, waterfalls, or direct handles)."""
+        extract_deck = model_deck_blueprint.extract
+
+        invalid_refs = self._find_invalid_alias_targets(
+            aliases=extract_deck.aliases,
+            all_aliases=extract_deck.aliases,
+            all_waterfalls=extract_deck.waterfalls,
+            known_model_handles=all_known_model_handles,
+        )
+
+        if invalid_refs:
+            error_lines = ["Invalid Extract alias references found:"]
+            for alias_name, target_value, reason in invalid_refs:
+                error_lines.append(f"  - '{alias_name}' -> '{target_value}': {reason}")
+            pytest.fail("\n".join(error_lines))
+
+    def test_extract_presets_reference_valid_models(
+        self,
+        model_deck_blueprint: ModelDeckBlueprint,
+        all_known_model_handles: set[str],
+    ):
+        """Verify Extract preset model fields use valid aliases, waterfalls, or direct handles."""
+        extract_deck = model_deck_blueprint.extract
+
+        invalid_refs = self._find_invalid_preset_references(
+            presets=extract_deck.presets,
+            all_aliases=extract_deck.aliases,
+            all_waterfalls=extract_deck.waterfalls,
+            known_model_handles=all_known_model_handles,
+        )
+
+        if invalid_refs:
+            error_lines = ["Invalid Extract preset model references found:"]
+            for preset_name, model_value, reason in invalid_refs:
+                error_lines.append(f"  - preset '{preset_name}' model='{model_value}': {reason}")
+            pytest.fail("\n".join(error_lines))
+
+    def test_extract_waterfalls_contain_valid_models(
+        self,
+        model_deck_blueprint: ModelDeckBlueprint,
+        all_known_model_handles: set[str],
+    ):
+        """Verify Extract waterfall entries are valid aliases or direct model handles."""
+        extract_deck = model_deck_blueprint.extract
+
+        invalid_refs = self._find_invalid_waterfall_entries(
+            waterfalls=extract_deck.waterfalls,
+            all_aliases=extract_deck.aliases,
+            known_model_handles=all_known_model_handles,
+        )
+
+        if invalid_refs:
+            error_lines = ["Invalid Extract waterfall entries found:"]
+            for waterfall_name, index, entry_value, reason in invalid_refs:
+                error_lines.append(f"  - waterfall '{waterfall_name}'[{index}]='{entry_value}': {reason}")
+            pytest.fail("\n".join(error_lines))
+
+    def test_extract_aliases_no_circular_references(self, model_deck_blueprint: ModelDeckBlueprint):
+        """Detect Extract alias chains that form cycles."""
+        extract_deck = model_deck_blueprint.extract
+
+        cycles = self._find_circular_aliases(aliases=extract_deck.aliases)
+
+        if cycles:
+            error_lines = ["Circular Extract alias references detected:"]
+            for _start_alias, cycle_path in cycles:
+                cycle_str = " -> ".join(cycle_path)
+                error_lines.append(f"  - {cycle_str}")
+            pytest.fail("\n".join(error_lines))
+
+    # ============================================================
+    # ImgGen Tests
+    # ============================================================
+
+    def test_img_gen_aliases_reference_valid_targets(
+        self,
+        model_deck_blueprint: ModelDeckBlueprint,
+        all_known_model_handles: set[str],
+    ):
+        """Verify ImgGen aliases point to valid targets (other aliases, waterfalls, or direct handles)."""
+        img_gen_deck = model_deck_blueprint.img_gen
+
+        invalid_refs = self._find_invalid_alias_targets(
+            aliases=img_gen_deck.aliases,
+            all_aliases=img_gen_deck.aliases,
+            all_waterfalls=img_gen_deck.waterfalls,
+            known_model_handles=all_known_model_handles,
+        )
+
+        if invalid_refs:
+            error_lines = ["Invalid ImgGen alias references found:"]
+            for alias_name, target_value, reason in invalid_refs:
+                error_lines.append(f"  - '{alias_name}' -> '{target_value}': {reason}")
+            pytest.fail("\n".join(error_lines))
+
+    def test_img_gen_presets_reference_valid_models(
+        self,
+        model_deck_blueprint: ModelDeckBlueprint,
+        all_known_model_handles: set[str],
+    ):
+        """Verify ImgGen preset model fields use valid aliases, waterfalls, or direct handles."""
+        img_gen_deck = model_deck_blueprint.img_gen
+
+        invalid_refs = self._find_invalid_preset_references(
+            presets=img_gen_deck.presets,
+            all_aliases=img_gen_deck.aliases,
+            all_waterfalls=img_gen_deck.waterfalls,
+            known_model_handles=all_known_model_handles,
+        )
+
+        if invalid_refs:
+            error_lines = ["Invalid ImgGen preset model references found:"]
+            for preset_name, model_value, reason in invalid_refs:
+                error_lines.append(f"  - preset '{preset_name}' model='{model_value}': {reason}")
+            pytest.fail("\n".join(error_lines))
+
+    def test_img_gen_waterfalls_contain_valid_models(
+        self,
+        model_deck_blueprint: ModelDeckBlueprint,
+        all_known_model_handles: set[str],
+    ):
+        """Verify ImgGen waterfall entries are valid aliases or direct model handles."""
+        img_gen_deck = model_deck_blueprint.img_gen
+
+        invalid_refs = self._find_invalid_waterfall_entries(
+            waterfalls=img_gen_deck.waterfalls,
+            all_aliases=img_gen_deck.aliases,
+            known_model_handles=all_known_model_handles,
+        )
+
+        if invalid_refs:
+            error_lines = ["Invalid ImgGen waterfall entries found:"]
+            for waterfall_name, index, entry_value, reason in invalid_refs:
+                error_lines.append(f"  - waterfall '{waterfall_name}'[{index}]='{entry_value}': {reason}")
+            pytest.fail("\n".join(error_lines))
+
+    def test_img_gen_aliases_no_circular_references(self, model_deck_blueprint: ModelDeckBlueprint):
+        """Detect ImgGen alias chains that form cycles."""
+        img_gen_deck = model_deck_blueprint.img_gen
+
+        cycles = self._find_circular_aliases(aliases=img_gen_deck.aliases)
+
+        if cycles:
+            error_lines = ["Circular ImgGen alias references detected:"]
+            for _start_alias, cycle_path in cycles:
+                cycle_str = " -> ".join(cycle_path)
+                error_lines.append(f"  - {cycle_str}")
+            pytest.fail("\n".join(error_lines))

--- a/tests/unit/pipelex/cogt/models/test_model_deck_references.py
+++ b/tests/unit/pipelex/cogt/models/test_model_deck_references.py
@@ -55,12 +55,18 @@ class TestModelDeckReferences:
         # 2. Get gateway models from cached remote config
         remote_config = RemoteConfigFetcher.fetch_remote_config()  # Uses cached version
         gateway_specs = remote_config.backend_model_specs
+
+        # Get default model_type from gateway defaults section (same pattern as local backends)
+        gateway_defaults = gateway_specs.get("defaults", {})
+        gateway_default_model_type_str = gateway_defaults.get("model_type") if isinstance(gateway_defaults, dict) else None
+
         for model_name, spec in gateway_specs.items():
-            if isinstance(spec, dict) and "model_type" in spec:
-                known_handles[model_name] = ModelType(spec["model_type"])
-            elif model_name not in known_handles:
-                # Gateway models without explicit model_type default to LLM (most common type)
-                known_handles[model_name] = ModelType.LLM
+            if model_name == "defaults":
+                continue  # Skip the defaults section itself
+            if isinstance(spec, dict):
+                model_type_str = spec.get("model_type", gateway_default_model_type_str)
+                if model_type_str:
+                    known_handles[model_name] = ModelType(model_type_str)
 
         return known_handles
 

--- a/tests/unit/pipelex/cogt/models/test_model_deck_references.py
+++ b/tests/unit/pipelex/cogt/models/test_model_deck_references.py
@@ -58,6 +58,9 @@ class TestModelDeckReferences:
         for model_name, spec in gateway_specs.items():
             if isinstance(spec, dict) and "model_type" in spec:
                 known_handles[model_name] = ModelType(spec["model_type"])
+            elif model_name not in known_handles:
+                # Gateway models without explicit model_type default to LLM (most common type)
+                known_handles[model_name] = ModelType.LLM
 
         return known_handles
 

--- a/tests/unit/pipelex/cogt/models/test_model_deck_references.py
+++ b/tests/unit/pipelex/cogt/models/test_model_deck_references.py
@@ -4,6 +4,8 @@ This test suite systematically validates that model deck references point to val
 preventing configuration errors from being discovered at runtime.
 """
 
+from typing import cast
+
 import pytest
 
 from pipelex.cogt.extract.extract_setting import ExtractSetting
@@ -58,13 +60,17 @@ class TestModelDeckReferences:
 
         # Get default model_type from gateway defaults section (same pattern as local backends)
         gateway_defaults = gateway_specs.get("defaults", {})
-        gateway_default_model_type_str = gateway_defaults.get("model_type") if isinstance(gateway_defaults, dict) else None
+        gateway_default_model_type_str: str | None = None
+        if isinstance(gateway_defaults, dict):
+            typed_defaults = cast("dict[str, str]", gateway_defaults)
+            gateway_default_model_type_str = typed_defaults.get("model_type")
 
         for model_name, spec in gateway_specs.items():
             if model_name == "defaults":
                 continue  # Skip the defaults section itself
             if isinstance(spec, dict):
-                model_type_str = spec.get("model_type", gateway_default_model_type_str)
+                typed_spec = cast("dict[str, str]", spec)
+                model_type_str: str | None = typed_spec.get("model_type") or gateway_default_model_type_str
                 if model_type_str:
                     known_handles[model_name] = ModelType(model_type_str)
 

--- a/tests/unit/pipelex/cogt/models/test_model_deck_validation_helpers.py
+++ b/tests/unit/pipelex/cogt/models/test_model_deck_validation_helpers.py
@@ -196,6 +196,26 @@ class TestModelDeckValidationHelpers:
         assert invalid_refs[0][1] == 1  # index of bad entry (dall-e-3)
         assert "has type 'img_gen' but expected 'llm'" in invalid_refs[0][3]
 
+    def test_detects_empty_waterfall(
+        self,
+        valid_aliases: dict[str, str],
+        known_model_handles: dict[str, ModelType],
+    ):
+        """Empty waterfall is detected (would cause IndexError at runtime)."""
+        bad_waterfalls = {"empty-waterfall": []}
+
+        invalid_refs = find_invalid_waterfall_entries(
+            waterfalls=bad_waterfalls,
+            all_aliases=valid_aliases,
+            known_model_handles=known_model_handles,
+            expected_model_type=ModelType.LLM,
+        )
+
+        assert len(invalid_refs) == 1
+        assert invalid_refs[0][0] == "empty-waterfall"
+        assert invalid_refs[0][1] == -1  # special index for empty waterfall
+        assert "cannot be empty" in invalid_refs[0][3]
+
     # ============================================================
     # Circular reference tests
     # ============================================================

--- a/tests/unit/pipelex/cogt/models/test_model_deck_validation_helpers.py
+++ b/tests/unit/pipelex/cogt/models/test_model_deck_validation_helpers.py
@@ -1,0 +1,243 @@
+"""Tests for model deck validation helper methods with intentionally bad data.
+
+These tests verify that the validation logic correctly detects invalid references.
+"""
+
+import pytest
+
+from pipelex.cogt.models.model_reference import ModelReference, ModelReferenceKind
+
+
+class TestModelDeckValidationHelpers:
+    """Test validation helper methods with synthetic bad data."""
+
+    # ============================================================
+    # Test data fixtures
+    # ============================================================
+
+    @pytest.fixture
+    def known_model_handles(self) -> set[str]:
+        """A small set of valid model handles for testing."""
+        return {"gpt-4o", "claude-3-opus", "gemini-pro"}
+
+    @pytest.fixture
+    def valid_aliases(self) -> dict[str, str]:
+        """Valid aliases pointing to known handles."""
+        return {
+            "smart": "gpt-4o",
+            "default": "@smart",
+        }
+
+    @pytest.fixture
+    def valid_waterfalls(self) -> dict[str, list[str]]:
+        """Valid waterfalls containing known handles and aliases."""
+        return {
+            "fallback": ["gpt-4o", "claude-3-opus"],
+        }
+
+    # ============================================================
+    # Helper method implementations (copied from main test for isolation)
+    # ============================================================
+
+    def _find_invalid_alias_targets(
+        self,
+        aliases: dict[str, str],
+        all_aliases: dict[str, str],
+        all_waterfalls: dict[str, list[str]],
+        known_model_handles: set[str],
+    ) -> list[tuple[str, str, str]]:
+        """Find aliases that reference invalid targets."""
+        invalid_refs: list[tuple[str, str, str]] = []
+
+        for alias_name, target_value in aliases.items():
+            ref = ModelReference.parse(target_value)
+
+            match ref.kind:
+                case ModelReferenceKind.ALIAS:
+                    if ref.name not in all_aliases:
+                        invalid_refs.append((alias_name, target_value, f"alias '{ref.name}' not found"))
+                case ModelReferenceKind.WATERFALL:
+                    if ref.name not in all_waterfalls:
+                        invalid_refs.append((alias_name, target_value, f"waterfall '{ref.name}' not found"))
+                case ModelReferenceKind.PRESET:
+                    invalid_refs.append((alias_name, target_value, "aliases cannot reference presets ($ prefix)"))
+                case ModelReferenceKind.HANDLE:
+                    if ref.name not in known_model_handles:
+                        invalid_refs.append((alias_name, target_value, f"model handle '{ref.name}' not found in backends"))
+
+        return invalid_refs
+
+    def _find_invalid_waterfall_entries(
+        self,
+        waterfalls: dict[str, list[str]],
+        all_aliases: dict[str, str],
+        known_model_handles: set[str],
+    ) -> list[tuple[str, int, str, str]]:
+        """Find waterfall entries that reference invalid targets."""
+        invalid_refs: list[tuple[str, int, str, str]] = []
+
+        for waterfall_name, entries in waterfalls.items():
+            for index, entry_value in enumerate(entries):
+                ref = ModelReference.parse(entry_value)
+
+                match ref.kind:
+                    case ModelReferenceKind.ALIAS:
+                        if ref.name not in all_aliases:
+                            invalid_refs.append((waterfall_name, index, entry_value, f"alias '{ref.name}' not found"))
+                    case ModelReferenceKind.WATERFALL:
+                        invalid_refs.append((waterfall_name, index, entry_value, "waterfalls cannot contain other waterfalls (~ prefix)"))
+                    case ModelReferenceKind.PRESET:
+                        invalid_refs.append((waterfall_name, index, entry_value, "waterfalls cannot contain presets ($ prefix)"))
+                    case ModelReferenceKind.HANDLE:
+                        if ref.name not in known_model_handles:
+                            invalid_refs.append((waterfall_name, index, entry_value, f"model handle '{ref.name}' not found in backends"))
+
+        return invalid_refs
+
+    def _find_circular_aliases(
+        self,
+        aliases: dict[str, str],
+    ) -> list[tuple[str, list[str]]]:
+        """Find circular alias chains."""
+        cycles: list[tuple[str, list[str]]] = []
+
+        for start_alias in aliases:
+            visited: list[str] = []
+            current = start_alias
+
+            while current in aliases:
+                if current in visited:
+                    cycle_start_idx = visited.index(current)
+                    cycle_path = [*visited[cycle_start_idx:], current]
+                    if start_alias in cycle_path:
+                        cycles.append((start_alias, cycle_path))
+                    break
+
+                visited.append(current)
+                target = aliases[current]
+                ref = ModelReference.parse(target)
+
+                if ref.kind == ModelReferenceKind.ALIAS:
+                    current = ref.name
+                else:
+                    break
+
+        unique_cycles: list[tuple[str, list[str]]] = []
+        seen_cycles: set[frozenset[str]] = set()
+
+        for start_alias, cycle_path in cycles:
+            cycle_set = frozenset(cycle_path)
+            if cycle_set not in seen_cycles:
+                seen_cycles.add(cycle_set)
+                unique_cycles.append((start_alias, cycle_path))
+
+        return unique_cycles
+
+    # ============================================================
+    # Alias validation tests
+    # ============================================================
+
+    def test_detects_alias_pointing_to_unknown_handle(
+        self,
+        valid_aliases: dict[str, str],
+        valid_waterfalls: dict[str, list[str]],
+        known_model_handles: set[str],
+    ):
+        """Alias pointing to non-existent model handle is detected."""
+        bad_aliases = {"broken": "nonexistent-model"}
+
+        invalid_refs = self._find_invalid_alias_targets(
+            aliases=bad_aliases,
+            all_aliases=valid_aliases,
+            all_waterfalls=valid_waterfalls,
+            known_model_handles=known_model_handles,
+        )
+
+        assert len(invalid_refs) == 1
+        assert invalid_refs[0][0] == "broken"
+        assert "not found in backends" in invalid_refs[0][2]
+
+    def test_detects_alias_pointing_to_preset(
+        self,
+        valid_aliases: dict[str, str],
+        valid_waterfalls: dict[str, list[str]],
+        known_model_handles: set[str],
+    ):
+        """Alias pointing to a preset ($ prefix) is detected as invalid."""
+        bad_aliases = {"broken": "$some_preset"}
+
+        invalid_refs = self._find_invalid_alias_targets(
+            aliases=bad_aliases,
+            all_aliases=valid_aliases,
+            all_waterfalls=valid_waterfalls,
+            known_model_handles=known_model_handles,
+        )
+
+        assert len(invalid_refs) == 1
+        assert "cannot reference presets" in invalid_refs[0][2]
+
+    # ============================================================
+    # Waterfall validation tests
+    # ============================================================
+
+    def test_detects_waterfall_containing_another_waterfall(
+        self,
+        valid_aliases: dict[str, str],
+        known_model_handles: set[str],
+    ):
+        """Waterfall containing another waterfall (~ prefix) is detected."""
+        bad_waterfalls = {"broken": ["gpt-4o", "~other_waterfall"]}
+
+        invalid_refs = self._find_invalid_waterfall_entries(
+            waterfalls=bad_waterfalls,
+            all_aliases=valid_aliases,
+            known_model_handles=known_model_handles,
+        )
+
+        assert len(invalid_refs) == 1
+        assert invalid_refs[0][1] == 1  # index of bad entry
+        assert "cannot contain other waterfalls" in invalid_refs[0][3]
+
+    def test_detects_waterfall_containing_preset(
+        self,
+        valid_aliases: dict[str, str],
+        known_model_handles: set[str],
+    ):
+        """Waterfall containing a preset ($ prefix) is detected."""
+        bad_waterfalls = {"broken": ["$some_preset"]}
+
+        invalid_refs = self._find_invalid_waterfall_entries(
+            waterfalls=bad_waterfalls,
+            all_aliases=valid_aliases,
+            known_model_handles=known_model_handles,
+        )
+
+        assert len(invalid_refs) == 1
+        assert "cannot contain presets" in invalid_refs[0][3]
+
+    # ============================================================
+    # Circular reference tests
+    # ============================================================
+
+    def test_detects_simple_circular_alias(self):
+        """Direct circular reference (A -> A) is detected."""
+        circular_aliases = {"loop": "@loop"}
+
+        cycles = self._find_circular_aliases(aliases=circular_aliases)
+
+        assert len(cycles) == 1
+        assert "loop" in cycles[0][1]
+
+    def test_detects_indirect_circular_alias(self):
+        """Indirect circular reference (A -> B -> A) is detected."""
+        circular_aliases = {
+            "alpha": "@beta",
+            "beta": "@alpha",
+        }
+
+        cycles = self._find_circular_aliases(aliases=circular_aliases)
+
+        assert len(cycles) >= 1
+        cycle_members = set(cycles[0][1])
+        assert "alpha" in cycle_members
+        assert "beta" in cycle_members

--- a/tests/unit/pipelex/cogt/models/test_model_deck_validation_helpers.py
+++ b/tests/unit/pipelex/cogt/models/test_model_deck_validation_helpers.py
@@ -242,3 +242,49 @@ class TestModelDeckValidationHelpers:
         cycle_members = set(cycles[0][1])
         assert "alpha" in cycle_members
         assert "beta" in cycle_members
+
+    def test_detects_unprefixed_circular_alias(self):
+        """Unprefixed circular reference (A -> B -> A without @ prefix) is detected.
+
+        This tests the fix for the issue where cycles like {"alpha": "beta", "beta": "alpha"}
+        without @ prefixes would not be detected by validation, even though they cause issues
+        at runtime. The runtime code follows unprefixed alias references when the target string
+        exists as a key in the aliases dict.
+        """
+        circular_aliases = {
+            "alpha": "beta",
+            "beta": "alpha",
+        }
+
+        cycles = find_circular_aliases(aliases=circular_aliases)
+
+        assert len(cycles) >= 1
+        cycle_members = set(cycles[0][1])
+        assert "alpha" in cycle_members
+        assert "beta" in cycle_members
+
+    def test_detects_mixed_prefix_circular_alias(self):
+        """Circular reference with mixed prefixes (A -> @B -> C -> A) is detected."""
+        circular_aliases = {
+            "alpha": "@beta",
+            "beta": "gamma",
+            "gamma": "alpha",
+        }
+
+        cycles = find_circular_aliases(aliases=circular_aliases)
+
+        assert len(cycles) >= 1
+        cycle_members = set(cycles[0][1])
+        assert "alpha" in cycle_members
+        assert "beta" in cycle_members
+        assert "gamma" in cycle_members
+
+    def test_no_cycle_when_unprefixed_target_is_not_alias_key(self):
+        """Unprefixed reference to a non-alias key does not create a cycle."""
+        aliases = {
+            "alpha": "gpt-4o",  # gpt-4o is not an alias key, so no cycle
+        }
+
+        cycles = find_circular_aliases(aliases=aliases)
+
+        assert len(cycles) == 0

--- a/tests/unit/pipelex/cogt/models/test_model_deck_validation_helpers.py
+++ b/tests/unit/pipelex/cogt/models/test_model_deck_validation_helpers.py
@@ -5,7 +5,12 @@ These tests verify that the validation logic correctly detects invalid reference
 
 import pytest
 
-from pipelex.cogt.models.model_reference import ModelReference, ModelReferenceKind
+from pipelex.cogt.model_backends.model_type import ModelType
+from tests.unit.pipelex.cogt.models.model_deck_validation_utils import (
+    find_circular_aliases,
+    find_invalid_alias_targets,
+    find_invalid_waterfall_entries,
+)
 
 
 class TestModelDeckValidationHelpers:
@@ -16,9 +21,15 @@ class TestModelDeckValidationHelpers:
     # ============================================================
 
     @pytest.fixture
-    def known_model_handles(self) -> set[str]:
-        """A small set of valid model handles for testing."""
-        return {"gpt-4o", "claude-3-opus", "gemini-pro"}
+    def known_model_handles(self) -> dict[str, ModelType]:
+        """A small set of valid model handles with their types for testing."""
+        return {
+            "gpt-4o": ModelType.LLM,
+            "claude-3-opus": ModelType.LLM,
+            "gemini-pro": ModelType.LLM,
+            "mistral-ocr": ModelType.TEXT_EXTRACTOR,
+            "dall-e-3": ModelType.IMG_GEN,
+        }
 
     @pytest.fixture
     def valid_aliases(self) -> dict[str, str]:
@@ -36,104 +47,6 @@ class TestModelDeckValidationHelpers:
         }
 
     # ============================================================
-    # Helper method implementations (copied from main test for isolation)
-    # ============================================================
-
-    def _find_invalid_alias_targets(
-        self,
-        aliases: dict[str, str],
-        all_aliases: dict[str, str],
-        all_waterfalls: dict[str, list[str]],
-        known_model_handles: set[str],
-    ) -> list[tuple[str, str, str]]:
-        """Find aliases that reference invalid targets."""
-        invalid_refs: list[tuple[str, str, str]] = []
-
-        for alias_name, target_value in aliases.items():
-            ref = ModelReference.parse(target_value)
-
-            match ref.kind:
-                case ModelReferenceKind.ALIAS:
-                    if ref.name not in all_aliases:
-                        invalid_refs.append((alias_name, target_value, f"alias '{ref.name}' not found"))
-                case ModelReferenceKind.WATERFALL:
-                    if ref.name not in all_waterfalls:
-                        invalid_refs.append((alias_name, target_value, f"waterfall '{ref.name}' not found"))
-                case ModelReferenceKind.PRESET:
-                    invalid_refs.append((alias_name, target_value, "aliases cannot reference presets ($ prefix)"))
-                case ModelReferenceKind.HANDLE:
-                    if ref.name not in known_model_handles:
-                        invalid_refs.append((alias_name, target_value, f"model handle '{ref.name}' not found in backends"))
-
-        return invalid_refs
-
-    def _find_invalid_waterfall_entries(
-        self,
-        waterfalls: dict[str, list[str]],
-        all_aliases: dict[str, str],
-        known_model_handles: set[str],
-    ) -> list[tuple[str, int, str, str]]:
-        """Find waterfall entries that reference invalid targets."""
-        invalid_refs: list[tuple[str, int, str, str]] = []
-
-        for waterfall_name, entries in waterfalls.items():
-            for index, entry_value in enumerate(entries):
-                ref = ModelReference.parse(entry_value)
-
-                match ref.kind:
-                    case ModelReferenceKind.ALIAS:
-                        if ref.name not in all_aliases:
-                            invalid_refs.append((waterfall_name, index, entry_value, f"alias '{ref.name}' not found"))
-                    case ModelReferenceKind.WATERFALL:
-                        invalid_refs.append((waterfall_name, index, entry_value, "waterfalls cannot contain other waterfalls (~ prefix)"))
-                    case ModelReferenceKind.PRESET:
-                        invalid_refs.append((waterfall_name, index, entry_value, "waterfalls cannot contain presets ($ prefix)"))
-                    case ModelReferenceKind.HANDLE:
-                        if ref.name not in known_model_handles:
-                            invalid_refs.append((waterfall_name, index, entry_value, f"model handle '{ref.name}' not found in backends"))
-
-        return invalid_refs
-
-    def _find_circular_aliases(
-        self,
-        aliases: dict[str, str],
-    ) -> list[tuple[str, list[str]]]:
-        """Find circular alias chains."""
-        cycles: list[tuple[str, list[str]]] = []
-
-        for start_alias in aliases:
-            visited: list[str] = []
-            current = start_alias
-
-            while current in aliases:
-                if current in visited:
-                    cycle_start_idx = visited.index(current)
-                    cycle_path = [*visited[cycle_start_idx:], current]
-                    if start_alias in cycle_path:
-                        cycles.append((start_alias, cycle_path))
-                    break
-
-                visited.append(current)
-                target = aliases[current]
-                ref = ModelReference.parse(target)
-
-                if ref.kind == ModelReferenceKind.ALIAS:
-                    current = ref.name
-                else:
-                    break
-
-        unique_cycles: list[tuple[str, list[str]]] = []
-        seen_cycles: set[frozenset[str]] = set()
-
-        for start_alias, cycle_path in cycles:
-            cycle_set = frozenset(cycle_path)
-            if cycle_set not in seen_cycles:
-                seen_cycles.add(cycle_set)
-                unique_cycles.append((start_alias, cycle_path))
-
-        return unique_cycles
-
-    # ============================================================
     # Alias validation tests
     # ============================================================
 
@@ -141,16 +54,17 @@ class TestModelDeckValidationHelpers:
         self,
         valid_aliases: dict[str, str],
         valid_waterfalls: dict[str, list[str]],
-        known_model_handles: set[str],
+        known_model_handles: dict[str, ModelType],
     ):
         """Alias pointing to non-existent model handle is detected."""
         bad_aliases = {"broken": "nonexistent-model"}
 
-        invalid_refs = self._find_invalid_alias_targets(
+        invalid_refs = find_invalid_alias_targets(
             aliases=bad_aliases,
             all_aliases=valid_aliases,
             all_waterfalls=valid_waterfalls,
             known_model_handles=known_model_handles,
+            expected_model_type=ModelType.LLM,
         )
 
         assert len(invalid_refs) == 1
@@ -161,20 +75,65 @@ class TestModelDeckValidationHelpers:
         self,
         valid_aliases: dict[str, str],
         valid_waterfalls: dict[str, list[str]],
-        known_model_handles: set[str],
+        known_model_handles: dict[str, ModelType],
     ):
         """Alias pointing to a preset ($ prefix) is detected as invalid."""
         bad_aliases = {"broken": "$some_preset"}
 
-        invalid_refs = self._find_invalid_alias_targets(
+        invalid_refs = find_invalid_alias_targets(
             aliases=bad_aliases,
             all_aliases=valid_aliases,
             all_waterfalls=valid_waterfalls,
             known_model_handles=known_model_handles,
+            expected_model_type=ModelType.LLM,
         )
 
         assert len(invalid_refs) == 1
         assert "cannot reference presets" in invalid_refs[0][2]
+
+    def test_detects_alias_pointing_to_wrong_model_type(
+        self,
+        valid_aliases: dict[str, str],
+        valid_waterfalls: dict[str, list[str]],
+        known_model_handles: dict[str, ModelType],
+    ):
+        """Alias pointing to a model with wrong type is detected (e.g., LLM alias -> IMG_GEN model)."""
+        # LLM alias pointing to an IMG_GEN model
+        bad_aliases = {"llm-alias": "dall-e-3"}
+
+        invalid_refs = find_invalid_alias_targets(
+            aliases=bad_aliases,
+            all_aliases=valid_aliases,
+            all_waterfalls=valid_waterfalls,
+            known_model_handles=known_model_handles,
+            expected_model_type=ModelType.LLM,
+        )
+
+        assert len(invalid_refs) == 1
+        assert invalid_refs[0][0] == "llm-alias"
+        assert "has type 'img_gen' but expected 'llm'" in invalid_refs[0][2]
+
+    def test_detects_extract_alias_pointing_to_llm_model(
+        self,
+        valid_aliases: dict[str, str],
+        valid_waterfalls: dict[str, list[str]],
+        known_model_handles: dict[str, ModelType],
+    ):
+        """Extract alias pointing to an LLM model is detected."""
+        # TEXT_EXTRACTOR alias pointing to an LLM model
+        bad_aliases = {"extractor-alias": "gpt-4o"}
+
+        invalid_refs = find_invalid_alias_targets(
+            aliases=bad_aliases,
+            all_aliases=valid_aliases,
+            all_waterfalls=valid_waterfalls,
+            known_model_handles=known_model_handles,
+            expected_model_type=ModelType.TEXT_EXTRACTOR,
+        )
+
+        assert len(invalid_refs) == 1
+        assert invalid_refs[0][0] == "extractor-alias"
+        assert "has type 'llm' but expected 'text_extractor'" in invalid_refs[0][2]
 
     # ============================================================
     # Waterfall validation tests
@@ -183,15 +142,16 @@ class TestModelDeckValidationHelpers:
     def test_detects_waterfall_containing_another_waterfall(
         self,
         valid_aliases: dict[str, str],
-        known_model_handles: set[str],
+        known_model_handles: dict[str, ModelType],
     ):
         """Waterfall containing another waterfall (~ prefix) is detected."""
         bad_waterfalls = {"broken": ["gpt-4o", "~other_waterfall"]}
 
-        invalid_refs = self._find_invalid_waterfall_entries(
+        invalid_refs = find_invalid_waterfall_entries(
             waterfalls=bad_waterfalls,
             all_aliases=valid_aliases,
             known_model_handles=known_model_handles,
+            expected_model_type=ModelType.LLM,
         )
 
         assert len(invalid_refs) == 1
@@ -201,19 +161,40 @@ class TestModelDeckValidationHelpers:
     def test_detects_waterfall_containing_preset(
         self,
         valid_aliases: dict[str, str],
-        known_model_handles: set[str],
+        known_model_handles: dict[str, ModelType],
     ):
         """Waterfall containing a preset ($ prefix) is detected."""
         bad_waterfalls = {"broken": ["$some_preset"]}
 
-        invalid_refs = self._find_invalid_waterfall_entries(
+        invalid_refs = find_invalid_waterfall_entries(
             waterfalls=bad_waterfalls,
             all_aliases=valid_aliases,
             known_model_handles=known_model_handles,
+            expected_model_type=ModelType.LLM,
         )
 
         assert len(invalid_refs) == 1
         assert "cannot contain presets" in invalid_refs[0][3]
+
+    def test_detects_waterfall_containing_wrong_model_type(
+        self,
+        valid_aliases: dict[str, str],
+        known_model_handles: dict[str, ModelType],
+    ):
+        """Waterfall containing a model with wrong type is detected."""
+        # LLM waterfall containing an IMG_GEN model
+        bad_waterfalls = {"broken": ["gpt-4o", "dall-e-3"]}
+
+        invalid_refs = find_invalid_waterfall_entries(
+            waterfalls=bad_waterfalls,
+            all_aliases=valid_aliases,
+            known_model_handles=known_model_handles,
+            expected_model_type=ModelType.LLM,
+        )
+
+        assert len(invalid_refs) == 1
+        assert invalid_refs[0][1] == 1  # index of bad entry (dall-e-3)
+        assert "has type 'img_gen' but expected 'llm'" in invalid_refs[0][3]
 
     # ============================================================
     # Circular reference tests
@@ -223,7 +204,7 @@ class TestModelDeckValidationHelpers:
         """Direct circular reference (A -> A) is detected."""
         circular_aliases = {"loop": "@loop"}
 
-        cycles = self._find_circular_aliases(aliases=circular_aliases)
+        cycles = find_circular_aliases(aliases=circular_aliases)
 
         assert len(cycles) == 1
         assert "loop" in cycles[0][1]
@@ -235,7 +216,7 @@ class TestModelDeckValidationHelpers:
             "beta": "@alpha",
         }
 
-        cycles = self._find_circular_aliases(aliases=circular_aliases)
+        cycles = find_circular_aliases(aliases=circular_aliases)
 
         assert len(cycles) >= 1
         cycle_members = set(cycles[0][1])

--- a/tests/unit/pipelex/cogt/models/test_model_deck_validation_helpers.py
+++ b/tests/unit/pipelex/cogt/models/test_model_deck_validation_helpers.py
@@ -202,7 +202,7 @@ class TestModelDeckValidationHelpers:
         known_model_handles: dict[str, ModelType],
     ):
         """Empty waterfall is detected (would cause IndexError at runtime)."""
-        bad_waterfalls = {"empty-waterfall": []}
+        bad_waterfalls: dict[str, list[str]] = {"empty-waterfall": []}
 
         invalid_refs = find_invalid_waterfall_entries(
             waterfalls=bad_waterfalls,

--- a/tests/unit/pipelex/core/stuffs/document_content/test_document_content_renders.py
+++ b/tests/unit/pipelex/core/stuffs/document_content/test_document_content_renders.py
@@ -4,7 +4,6 @@ from pipelex.core.stuffs.document_content import DocumentContent
 from tests.unit.pipelex.core.stuffs.document_content.test_data import TestData
 
 
-@pytest.mark.asyncio(loop_scope="class")
 class TestDocumentContentRenders:
     """Tests for DocumentContent render methods."""
 
@@ -38,24 +37,28 @@ class TestDocumentContentRenders:
         content = DocumentContent(url=TestData.SAMPLE_URL)
         assert content.rendered_for_prompt() == TestData.EXPECTED_RENDERED_FOR_PROMPT
 
+    @pytest.mark.asyncio
     async def test_rendered_plain_async(self):
         """Verify async rendered_plain returns the same as sync version."""
         content = DocumentContent(url=TestData.SAMPLE_URL)
         result = await content.rendered_plain_async()
         assert result == TestData.EXPECTED_RENDERED_PLAIN
 
+    @pytest.mark.asyncio
     async def test_rendered_markdown_async(self):
         """Verify async rendered_markdown returns the same as sync version."""
         content = DocumentContent(url=TestData.SAMPLE_URL)
         result = await content.rendered_markdown_async()
         assert result == TestData.EXPECTED_RENDERED_MARKDOWN
 
+    @pytest.mark.asyncio
     async def test_rendered_html_async(self):
         """Verify async rendered_html returns the same as sync version."""
         content = DocumentContent(url=TestData.SAMPLE_URL)
         result = await content.rendered_html_async()
         assert result == TestData.EXPECTED_RENDERED_HTML
 
+    @pytest.mark.asyncio
     async def test_rendered_json_async(self):
         """Verify async rendered_json returns the same as sync version."""
         content = DocumentContent(url=TestData.SAMPLE_URL)

--- a/tests/unit/pipelex/core/stuffs/dynamic_content/test_dynamic_content_renders.py
+++ b/tests/unit/pipelex/core/stuffs/dynamic_content/test_dynamic_content_renders.py
@@ -3,7 +3,6 @@ import pytest
 from tests.unit.pipelex.core.stuffs.dynamic_content.test_data import SampleDynamicContent, TestData
 
 
-@pytest.mark.asyncio(loop_scope="class")
 class TestDynamicContentRenders:
     """Tests for DynamicContent render methods."""
 
@@ -25,12 +24,14 @@ class TestDynamicContentRenders:
         result = content.rendered_for_prompt()
         assert result == TestData.EXPECTED_RENDERED_FOR_PROMPT
 
+    @pytest.mark.asyncio
     async def test_rendered_markdown_async(self):
         """Verify async rendered_markdown returns the same as sync version."""
         content = SampleDynamicContent(name=TestData.SAMPLE_NAME, value=TestData.SAMPLE_VALUE)
         result = await content.rendered_markdown_async()
         assert result == TestData.EXPECTED_RENDERED_MARKDOWN
 
+    @pytest.mark.asyncio
     async def test_rendered_html_async(self):
         """Verify async rendered_html returns the same as sync version."""
         content = SampleDynamicContent(name=TestData.SAMPLE_NAME, value=TestData.SAMPLE_VALUE)

--- a/tests/unit/pipelex/core/stuffs/html_content/test_html_content_renders.py
+++ b/tests/unit/pipelex/core/stuffs/html_content/test_html_content_renders.py
@@ -4,7 +4,6 @@ from pipelex.core.stuffs.html_content import HtmlContent
 from tests.unit.pipelex.core.stuffs.html_content.test_data import TestData
 
 
-@pytest.mark.asyncio(loop_scope="class")
 class TestHtmlContentRenders:
     """Tests for HtmlContent render methods."""
 
@@ -38,24 +37,28 @@ class TestHtmlContentRenders:
         content = HtmlContent(inner_html=TestData.SAMPLE_INNER_HTML, css_class=TestData.SAMPLE_CSS_CLASS)
         assert content.rendered_for_prompt() == TestData.EXPECTED_RENDERED_FOR_PROMPT
 
+    @pytest.mark.asyncio
     async def test_rendered_plain_async(self):
         """Verify async rendered_plain returns the same as sync version."""
         content = HtmlContent(inner_html=TestData.SAMPLE_INNER_HTML, css_class=TestData.SAMPLE_CSS_CLASS)
         result = await content.rendered_plain_async()
         assert result == TestData.EXPECTED_RENDERED_PLAIN
 
+    @pytest.mark.asyncio
     async def test_rendered_markdown_async(self):
         """Verify async rendered_markdown returns the same as sync version."""
         content = HtmlContent(inner_html=TestData.SAMPLE_INNER_HTML, css_class=TestData.SAMPLE_CSS_CLASS)
         result = await content.rendered_markdown_async()
         assert result == TestData.EXPECTED_RENDERED_MARKDOWN
 
+    @pytest.mark.asyncio
     async def test_rendered_html_async(self):
         """Verify async rendered_html returns the same as sync version."""
         content = HtmlContent(inner_html=TestData.SAMPLE_INNER_HTML, css_class=TestData.SAMPLE_CSS_CLASS)
         result = await content.rendered_html_async()
         assert result == TestData.EXPECTED_RENDERED_HTML
 
+    @pytest.mark.asyncio
     async def test_rendered_json_async(self):
         """Verify async rendered_json returns the same as sync version."""
         content = HtmlContent(inner_html=TestData.SAMPLE_INNER_HTML, css_class=TestData.SAMPLE_CSS_CLASS)

--- a/tests/unit/pipelex/core/stuffs/image_content/test_image_content_renders.py
+++ b/tests/unit/pipelex/core/stuffs/image_content/test_image_content_renders.py
@@ -4,7 +4,6 @@ from pipelex.core.stuffs.image_content import ImageContent
 from tests.unit.pipelex.core.stuffs.image_content.test_data import TestData
 
 
-@pytest.mark.asyncio(loop_scope="class")
 class TestImageContentRenders:
     """Tests for ImageContent render methods."""
 
@@ -43,24 +42,28 @@ class TestImageContentRenders:
         content = ImageContent(url=TestData.SAMPLE_URL)
         assert content.rendered_for_prompt() == TestData.EXPECTED_RENDERED_FOR_PROMPT
 
+    @pytest.mark.asyncio
     async def test_rendered_plain_async(self):
         """Verify async rendered_plain returns the same as sync version."""
         content = ImageContent(url=TestData.SAMPLE_URL)
         result = await content.rendered_plain_async()
         assert result == TestData.EXPECTED_RENDERED_PLAIN
 
+    @pytest.mark.asyncio
     async def test_rendered_markdown_async(self):
         """Verify async rendered_markdown returns the same as sync version."""
         content = ImageContent(url=TestData.SAMPLE_URL)
         result = await content.rendered_markdown_async()
         assert result == TestData.EXPECTED_RENDERED_MARKDOWN
 
+    @pytest.mark.asyncio
     async def test_rendered_html_async(self):
         """Verify async rendered_html returns the same as sync version."""
         content = ImageContent(url=TestData.SAMPLE_URL)
         result = await content.rendered_html_async()
         assert result == TestData.EXPECTED_RENDERED_HTML
 
+    @pytest.mark.asyncio
     async def test_rendered_json_async(self):
         """Verify async rendered_json returns the same as sync version."""
         content = ImageContent(url=TestData.SAMPLE_URL)

--- a/tests/unit/pipelex/core/stuffs/json_content/test_json_content_renders.py
+++ b/tests/unit/pipelex/core/stuffs/json_content/test_json_content_renders.py
@@ -4,7 +4,6 @@ from pipelex.core.stuffs.json_content import JSONContent
 from tests.unit.pipelex.core.stuffs.json_content.test_data import TestData
 
 
-@pytest.mark.asyncio(loop_scope="class")
 class TestJSONContentRenders:
     """Tests for JSONContent render methods."""
 
@@ -29,18 +28,21 @@ class TestJSONContentRenders:
         # JSONContent overrides rendered_for_prompt to return JSON format
         assert content.rendered_for_prompt() == TestData.EXPECTED_RENDERED_FOR_PROMPT
 
+    @pytest.mark.asyncio
     async def test_rendered_plain_async(self):
         """Verify async rendered_plain returns the same as sync version."""
         content = JSONContent(json_obj=TestData.SAMPLE_JSON_OBJ)
         result = await content.rendered_plain_async()
         assert result == TestData.EXPECTED_RENDERED_PLAIN
 
+    @pytest.mark.asyncio
     async def test_rendered_markdown_async(self):
         """Verify async rendered_markdown returns the same as sync version."""
         content = JSONContent(json_obj=TestData.SAMPLE_JSON_OBJ)
         result = await content.rendered_markdown_async()
         assert result == TestData.EXPECTED_RENDERED_MARKDOWN
 
+    @pytest.mark.asyncio
     async def test_rendered_json_async(self):
         """Verify async rendered_json returns the same as sync version."""
         content = JSONContent(json_obj=TestData.SAMPLE_JSON_OBJ)

--- a/tests/unit/pipelex/core/stuffs/list_content/test_list_content_renders.py
+++ b/tests/unit/pipelex/core/stuffs/list_content/test_list_content_renders.py
@@ -11,7 +11,6 @@ if TYPE_CHECKING:
     from pipelex.core.stuffs.text_content import TextContent
 
 
-@pytest.mark.asyncio(loop_scope="class")
 class TestListContentRenders:
     """Tests for ListContent render methods."""
 
@@ -40,12 +39,14 @@ class TestListContentRenders:
         content: ListContent[TextContent] = ListContent(items=[])
         assert content.rendered_markdown() == TestData.EXPECTED_RENDERED_EMPTY
 
+    @pytest.mark.asyncio
     async def test_rendered_plain_async(self):
         """Verify async rendered_plain returns the same as sync version."""
         content: ListContent[TextContent] = ListContent(items=TestData.SAMPLE_TEXT_ITEMS)
         result = await content.rendered_plain_async()
         assert result == TestData.EXPECTED_RENDERED_PLAIN
 
+    @pytest.mark.asyncio
     async def test_rendered_markdown_async(self):
         """Verify async rendered_markdown returns the same as sync version."""
         content: ListContent[TextContent] = ListContent(items=TestData.SAMPLE_TEXT_ITEMS)

--- a/tests/unit/pipelex/core/stuffs/mermaid_content/test_mermaid_content_renders.py
+++ b/tests/unit/pipelex/core/stuffs/mermaid_content/test_mermaid_content_renders.py
@@ -4,7 +4,6 @@ from pipelex.core.stuffs.mermaid_content import MermaidContent
 from tests.unit.pipelex.core.stuffs.mermaid_content.test_data import TestData
 
 
-@pytest.mark.asyncio(loop_scope="class")
 class TestMermaidContentRenders:
     """Tests for MermaidContent render methods."""
 
@@ -33,24 +32,28 @@ class TestMermaidContentRenders:
         content = MermaidContent(mermaid_code=TestData.SAMPLE_MERMAID_CODE, mermaid_url=TestData.SAMPLE_MERMAID_URL)
         assert content.rendered_for_prompt() == TestData.EXPECTED_RENDERED_FOR_PROMPT
 
+    @pytest.mark.asyncio
     async def test_rendered_plain_async(self):
         """Verify async rendered_plain returns the same as sync version."""
         content = MermaidContent(mermaid_code=TestData.SAMPLE_MERMAID_CODE, mermaid_url=TestData.SAMPLE_MERMAID_URL)
         result = await content.rendered_plain_async()
         assert result == TestData.EXPECTED_RENDERED_PLAIN
 
+    @pytest.mark.asyncio
     async def test_rendered_markdown_async(self):
         """Verify async rendered_markdown returns the same as sync version."""
         content = MermaidContent(mermaid_code=TestData.SAMPLE_MERMAID_CODE, mermaid_url=TestData.SAMPLE_MERMAID_URL)
         result = await content.rendered_markdown_async()
         assert result == TestData.EXPECTED_RENDERED_MARKDOWN
 
+    @pytest.mark.asyncio
     async def test_rendered_html_async(self):
         """Verify async rendered_html returns the same as sync version."""
         content = MermaidContent(mermaid_code=TestData.SAMPLE_MERMAID_CODE, mermaid_url=TestData.SAMPLE_MERMAID_URL)
         result = await content.rendered_html_async()
         assert result == TestData.EXPECTED_RENDERED_HTML
 
+    @pytest.mark.asyncio
     async def test_rendered_json_async(self):
         """Verify async rendered_json returns the same as sync version."""
         content = MermaidContent(mermaid_code=TestData.SAMPLE_MERMAID_CODE, mermaid_url=TestData.SAMPLE_MERMAID_URL)

--- a/tests/unit/pipelex/core/stuffs/number_content/test_number_content_renders.py
+++ b/tests/unit/pipelex/core/stuffs/number_content/test_number_content_renders.py
@@ -4,7 +4,6 @@ from pipelex.core.stuffs.number_content import NumberContent
 from tests.unit.pipelex.core.stuffs.number_content.test_data import TestData
 
 
-@pytest.mark.asyncio(loop_scope="class")
 class TestNumberContentRenders:
     """Tests for NumberContent render methods."""
 
@@ -58,24 +57,28 @@ class TestNumberContentRenders:
         content = NumberContent(number=TestData.SAMPLE_FLOAT)
         assert content.rendered_for_prompt() == TestData.EXPECTED_RENDERED_FOR_PROMPT_FLOAT
 
+    @pytest.mark.asyncio
     async def test_rendered_plain_async_int(self):
         """Verify async rendered_plain returns the same as sync version for integer."""
         content = NumberContent(number=TestData.SAMPLE_INT)
         result = await content.rendered_plain_async()
         assert result == TestData.EXPECTED_RENDERED_PLAIN_INT
 
+    @pytest.mark.asyncio
     async def test_rendered_markdown_async_int(self):
         """Verify async rendered_markdown returns the same as sync version for integer."""
         content = NumberContent(number=TestData.SAMPLE_INT)
         result = await content.rendered_markdown_async()
         assert result == TestData.EXPECTED_RENDERED_MARKDOWN_INT
 
+    @pytest.mark.asyncio
     async def test_rendered_html_async_int(self):
         """Verify async rendered_html returns the same as sync version for integer."""
         content = NumberContent(number=TestData.SAMPLE_INT)
         result = await content.rendered_html_async()
         assert result == TestData.EXPECTED_RENDERED_HTML_INT
 
+    @pytest.mark.asyncio
     async def test_rendered_json_async_int(self):
         """Verify async rendered_json returns the same as sync version for integer."""
         content = NumberContent(number=TestData.SAMPLE_INT)

--- a/tests/unit/pipelex/core/stuffs/page_content/test_page_content_renders.py
+++ b/tests/unit/pipelex/core/stuffs/page_content/test_page_content_renders.py
@@ -6,7 +6,6 @@ from pipelex.core.stuffs.text_content import TextContent
 from tests.unit.pipelex.core.stuffs.page_content.test_data import TestData
 
 
-@pytest.mark.asyncio(loop_scope="class")
 class TestPageContentRenders:
     """Tests for PageContent render methods."""
 
@@ -40,6 +39,7 @@ class TestPageContentRenders:
         result = content.rendered_html()
         assert result == TestData.EXPECTED_RENDERED_HTML
 
+    @pytest.mark.asyncio
     async def test_rendered_markdown_async(self):
         """Verify async rendered_markdown returns the same as sync version."""
         text_and_images = TextAndImagesContent(
@@ -50,6 +50,7 @@ class TestPageContentRenders:
         result = await content.rendered_markdown_async()
         assert result == TestData.EXPECTED_RENDERED_MARKDOWN
 
+    @pytest.mark.asyncio
     async def test_rendered_html_async(self):
         """Verify async rendered_html returns the same as sync version."""
         text_and_images = TextAndImagesContent(

--- a/tests/unit/pipelex/core/stuffs/structured_content/test_structured_content_renders.py
+++ b/tests/unit/pipelex/core/stuffs/structured_content/test_structured_content_renders.py
@@ -3,7 +3,6 @@ import pytest
 from tests.unit.pipelex.core.stuffs.structured_content.test_data import SampleStructuredContent, TestData
 
 
-@pytest.mark.asyncio(loop_scope="class")
 class TestStructuredContentRenders:
     """Tests for StructuredContent render methods."""
 
@@ -46,12 +45,14 @@ class TestStructuredContentRenders:
         result = content.rendered_html()
         assert result == TestData.EXPECTED_RENDERED_HTML_FULL
 
+    @pytest.mark.asyncio
     async def test_rendered_markdown_async(self):
         """Verify async rendered_markdown returns the same as sync version."""
         content = SampleStructuredContent(name=TestData.SAMPLE_NAME, value=TestData.SAMPLE_VALUE)
         result = await content.rendered_markdown_async()
         assert result == TestData.EXPECTED_RENDERED_MARKDOWN_MINIMAL
 
+    @pytest.mark.asyncio
     async def test_rendered_html_async(self):
         """Verify async rendered_html returns the same as sync version."""
         content = SampleStructuredContent(name=TestData.SAMPLE_NAME, value=TestData.SAMPLE_VALUE)

--- a/tests/unit/pipelex/core/stuffs/text_and_images_content/test_text_and_images_content_renders.py
+++ b/tests/unit/pipelex/core/stuffs/text_and_images_content/test_text_and_images_content_renders.py
@@ -4,7 +4,6 @@ from pipelex.core.stuffs.text_and_images_content import TextAndImagesContent
 from tests.unit.pipelex.core.stuffs.text_and_images_content.test_data import TestData
 
 
-@pytest.mark.asyncio(loop_scope="class")
 class TestTextAndImagesContentRenders:
     """Tests for TextAndImagesContent render methods."""
 
@@ -34,18 +33,21 @@ class TestTextAndImagesContentRenders:
         result = content.rendered_html()
         assert result == TestData.EXPECTED_RENDERED_HTML
 
+    @pytest.mark.asyncio
     async def test_rendered_plain_async(self):
         """Verify async rendered_plain returns the same as sync version."""
         content = TextAndImagesContent(text=TestData.SAMPLE_TEXT, images=None)
         result = await content.rendered_plain_async()
         assert result == TestData.EXPECTED_RENDERED_PLAIN
 
+    @pytest.mark.asyncio
     async def test_rendered_markdown_async(self):
         """Verify async rendered_markdown returns the same as sync version."""
         content = TextAndImagesContent(text=TestData.SAMPLE_TEXT, images=None)
         result = await content.rendered_markdown_async()
         assert result == TestData.EXPECTED_RENDERED_MARKDOWN
 
+    @pytest.mark.asyncio
     async def test_rendered_html_async(self):
         """Verify async rendered_html returns the same as sync version."""
         content = TextAndImagesContent(text=TestData.SAMPLE_TEXT, images=None)

--- a/tests/unit/pipelex/core/stuffs/text_content/test_text_content_renders.py
+++ b/tests/unit/pipelex/core/stuffs/text_content/test_text_content_renders.py
@@ -4,7 +4,6 @@ from pipelex.core.stuffs.text_content import TextContent
 from tests.unit.pipelex.core.stuffs.text_content.test_data import TestData
 
 
-@pytest.mark.asyncio(loop_scope="class")
 class TestTextContentRenders:
     """Tests for TextContent render methods."""
 
@@ -43,24 +42,28 @@ class TestTextContentRenders:
         content = TextContent(text=TestData.SAMPLE_TEXT)
         assert content.rendered_for_prompt() == TestData.EXPECTED_RENDERED_FOR_PROMPT
 
+    @pytest.mark.asyncio
     async def test_rendered_plain_async(self):
         """Verify async rendered_plain returns the same as sync version."""
         content = TextContent(text=TestData.SAMPLE_TEXT)
         result = await content.rendered_plain_async()
         assert result == TestData.EXPECTED_RENDERED_PLAIN
 
+    @pytest.mark.asyncio
     async def test_rendered_markdown_async(self):
         """Verify async rendered_markdown returns the same as sync version."""
         content = TextContent(text=TestData.SAMPLE_TEXT)
         result = await content.rendered_markdown_async()
         assert result == TestData.EXPECTED_RENDERED_MARKDOWN
 
+    @pytest.mark.asyncio
     async def test_rendered_html_async(self):
         """Verify async rendered_html returns the same as sync version."""
         content = TextContent(text=TestData.SAMPLE_TEXT)
         result = await content.rendered_html_async()
         assert result == TestData.EXPECTED_RENDERED_HTML
 
+    @pytest.mark.asyncio
     async def test_rendered_json_async(self):
         """Verify async rendered_json returns the same as sync version."""
         content = TextContent(text=TestData.SAMPLE_TEXT)


### PR DESCRIPTION
## Summary
- Add comprehensive test suite for validating model deck references (aliases, presets, waterfalls)
- Tests cover LLM, Extract, and ImgGen model types
- Validates that references point to valid targets and detects circular alias chains
- Prevents configuration errors from being discovered at runtime

## Test plan
- [x] Run `make test-xdist` to verify all new tests pass
- [ ] Review test coverage for edge cases in model deck configurations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds comprehensive validation and tests for model deck references and tightens type checks in inference resolution.
> 
> - New `tests/.../model_deck_validation_utils.py` helpers and parameterized suites validating `aliases`, `presets`, and `waterfalls` (detect unknown targets, wrong `ModelType`, empty waterfalls, and circular aliases)
> - Extend `tests/.../test_model_deck.py` with type-mismatch case and prefixed reference scenarios; new `test_model_deck_references.py` covers real blueprint/backends + gateway models
> - Model changes: `validate_inference_models` now uses each spec’s `model_type`; `get_optional_inference_model` skips and warns on `model_type` mismatch
> - Test housekeeping: replace class-level `@pytest.mark.asyncio(loop_scope="class")` with per-test `@pytest.mark.asyncio` across content render tests
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a6b7996eccc7e68e7f76e3c35fc28c4a4dc2ce8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->