### PR TITLE
Properly Resolving library dirs in all CLIs

### DIFF
--- a/pipelex/cli/commands/show_cmd.py
+++ b/pipelex/cli/commands/show_cmd.py
@@ -229,7 +229,7 @@ def show_pipe_cmd(
         )
         raise typer.Exit(1)
 
-    library_dirs = [Path(lib_dir) for lib_dir in library_dir] if library_dir else [Path.cwd()]
+    library_dirs = [Path(lib_dir) for lib_dir in library_dir] if library_dir else None
     make_pipelex_for_cli(context=ErrorContext.VALIDATION_BEFORE_SHOW_PIPE, library_dirs=library_dirs)
 
     try:

--- a/pipelex/cli/commands/show_cmd.py
+++ b/pipelex/cli/commands/show_cmd.py
@@ -24,6 +24,7 @@ from pipelex.hub import (
     get_required_pipe,
     get_secrets_provider,
     get_telemetry_manager,
+    resolve_library_dirs,
     set_current_library,
 )
 from pipelex.pipelex import Pipelex
@@ -235,7 +236,10 @@ def show_pipe_cmd(
         library_manager = get_library_manager()
         library_id, _ = library_manager.open_library()
         set_current_library(library_id=library_id)
-        library_manager.load_libraries(library_id=library_id, library_dirs=library_dirs)
+        effective_dirs, _ = resolve_library_dirs(library_dirs)
+
+        if effective_dirs:
+            library_manager.load_libraries(library_id=library_id, library_dirs=effective_dirs)
 
         with get_telemetry_manager().telemetry_context():
             tag(name=EventProperty.INTEGRATION, value=IntegrationMode.CLI)

--- a/pipelex/cli/commands/validate_cmd.py
+++ b/pipelex/cli/commands/validate_cmd.py
@@ -9,6 +9,7 @@ import typer
 from posthog import tag
 from rich.traceback import Traceback
 
+from pipelex import log
 from pipelex.cli.cli_factory import make_pipelex_for_cli
 from pipelex.cli.error_handlers import (
     ErrorContext,
@@ -18,7 +19,14 @@ from pipelex.cli.error_handlers import (
 )
 from pipelex.core.interpreter.helpers import is_pipelex_file
 from pipelex.core.pipes.exceptions import PipeOperatorModelChoiceError
-from pipelex.hub import get_console, get_library_manager, get_required_pipe, get_telemetry_manager, set_current_library
+from pipelex.hub import (
+    get_console,
+    get_library_manager,
+    get_required_pipe,
+    get_telemetry_manager,
+    resolve_library_dirs,
+    set_current_library,
+)
 from pipelex.pipe_operators.exceptions import PipeOperatorModelAvailabilityError
 from pipelex.pipe_run.dry_run import dry_run_pipe, dry_run_pipes
 from pipelex.pipelex import Pipelex
@@ -30,7 +38,9 @@ from pipelex.tools.misc.package_utils import get_package_version
 COMMAND = "validate"
 
 
-def do_validate_all_libraries_and_dry_run(library_dirs: list[Path] | None = None) -> None:
+def do_validate_all_libraries_and_dry_run(
+    library_dirs: list[Path] | None = None,
+) -> None:
     try:
         with get_telemetry_manager().telemetry_context():
             tag(name=EventProperty.INTEGRATION, value=IntegrationMode.CLI)
@@ -40,7 +50,11 @@ def do_validate_all_libraries_and_dry_run(library_dirs: list[Path] | None = None
             library_manager = get_library_manager()
             library_id, library = library_manager.open_library()
             set_current_library(library_id=library_id)
-            library_manager.load_libraries(library_id=library_id, library_dirs=library_dirs)
+            effective_dirs, source_label = resolve_library_dirs(library_dirs)
+            if effective_dirs:
+                library_manager.load_libraries(library_id=library_id, library_dirs=effective_dirs)
+            else:
+                log.info(f"No library directories to load ({source_label})")
 
             pipes = library.pipe_library.get_pipes()
             if library_dirs:
@@ -70,7 +84,10 @@ def validate_cmd(
     ] = None,
     bundle: Annotated[
         str | None,
-        typer.Option("--bundle", help="Bundle file path (.plx) - validates all pipes in the bundle"),
+        typer.Option(
+            "--bundle",
+            help="Bundle file path (.plx) - validates all pipes in the bundle",
+        ),
     ] = None,
     validate_all: Annotated[
         bool,
@@ -103,7 +120,10 @@ def validate_cmd(
             )
             raise typer.Exit(1)
         try:
-            make_pipelex_for_cli(context=ErrorContext.VALIDATION, library_dirs=[Path(lib_dir) for lib_dir in library_dir] if library_dir else None)
+            make_pipelex_for_cli(
+                context=ErrorContext.VALIDATION,
+                library_dirs=[Path(lib_dir) for lib_dir in library_dir] if library_dir else None,
+            )
             do_validate_all_libraries_and_dry_run(library_dirs=[Path(lib_dir) for lib_dir in library_dir] if library_dir else None)
         finally:
             Pipelex.teardown_if_needed()
@@ -152,17 +172,32 @@ def validate_cmd(
         pipe_code = pipe
 
     if not pipe_code and not bundle_path:
-        typer.secho("Failed to validate: no pipe code or bundle file specified", fg=typer.colors.RED, err=True)
+        typer.secho(
+            "Failed to validate: no pipe code or bundle file specified",
+            fg=typer.colors.RED,
+            err=True,
+        )
         raise typer.Exit(1)
 
-    async def validate_pipe(pipe_code: str | None = None, bundle_path: Path | None = None, library_dirs: list[Path] | None = None):
+    async def validate_pipe(
+        pipe_code: str | None = None,
+        bundle_path: Path | None = None,
+        library_dirs: list[Path] | None = None,
+    ):
         if bundle_path:
             try:
                 await validate_bundle(plx_file_path=bundle_path, library_dirs=library_dirs)
-                typer.secho(f"✅ Successfully validated bundle '{bundle_path}'", fg=typer.colors.GREEN)
+                typer.secho(
+                    f"✅ Successfully validated bundle '{bundle_path}'",
+                    fg=typer.colors.GREEN,
+                )
             except FileNotFoundError as exc:
                 get_console().print(Traceback())
-                typer.secho(f"Failed to load bundle '{bundle_path}':", fg=typer.colors.RED, err=True)
+                typer.secho(
+                    f"Failed to load bundle '{bundle_path}':",
+                    fg=typer.colors.RED,
+                    err=True,
+                )
                 raise typer.Exit(1) from exc
             except ValidateBundleError as bundle_error:
                 handle_validate_bundle_error(bundle_error, bundle_path=bundle_path)
@@ -171,7 +206,10 @@ def validate_cmd(
             library_manager = get_library_manager()
             library_id, _ = library_manager.open_library()
             set_current_library(library_id=library_id)
-            library_manager.load_libraries(library_id=library_id, library_dirs=library_dirs)
+            effective_dirs, _ = resolve_library_dirs(library_dirs)
+
+            if effective_dirs:
+                library_manager.load_libraries(library_id=library_id, library_dirs=effective_dirs)
 
             pipe = get_required_pipe(pipe_code=pipe_code)
             get_telemetry_manager().track_event(EventName.PIPE_DRY_RUN, properties={EventProperty.PIPE_TYPE: pipe.type})
@@ -181,7 +219,11 @@ def validate_cmd(
             )
             typer.secho(f"✅ Successfully validated pipe '{pipe_code}'", fg=typer.colors.GREEN)
         else:
-            typer.secho("Failed to validate: no pipe code or bundle specified", fg=typer.colors.RED, err=True)
+            typer.secho(
+                "Failed to validate: no pipe code or bundle specified",
+                fg=typer.colors.RED,
+                err=True,
+            )
             raise typer.Exit(1)
 
     make_pipelex_for_cli(context=ErrorContext.VALIDATION)
@@ -195,7 +237,13 @@ def validate_cmd(
             else:
                 tag(name=EventProperty.CLI_COMMAND, value=f"{COMMAND} pipe")
 
-            asyncio.run(validate_pipe(pipe_code=pipe_code, bundle_path=bundle_path, library_dirs=library_dirs))
+            asyncio.run(
+                validate_pipe(
+                    pipe_code=pipe_code,
+                    bundle_path=bundle_path,
+                    library_dirs=library_dirs,
+                )
+            )
     except PipeOperatorModelChoiceError as exc:
         handle_model_choice_error(exc, context=ErrorContext.VALIDATION)
     except PipeOperatorModelAvailabilityError as exc:

--- a/pipelex/cli/commands/which_cmd.py
+++ b/pipelex/cli/commands/which_cmd.py
@@ -96,6 +96,8 @@ def which_cmd(
 
         if effective_dirs:
             library_manager.load_libraries(library_id=library_id, library_dirs=effective_dirs)
+        else:
+            log.info(f"No library directories to load ({source_label})")
 
         with get_telemetry_manager().telemetry_context():
             tag(name=EventProperty.INTEGRATION, value=IntegrationMode.CLI)

--- a/pipelex/libraries/library_manager.py
+++ b/pipelex/libraries/library_manager.py
@@ -17,11 +17,6 @@ from pipelex.core.domains.domain_blueprint import DomainBlueprint
 from pipelex.core.domains.domain_factory import DomainFactory
 from pipelex.core.interpreter.exceptions import PipelexInterpreterError
 from pipelex.core.interpreter.interpreter import PipelexInterpreter
-from pipelex.core.pipes.handle_pipe_errors import (
-    categorize_pipe_factory_error,
-    categorize_pipe_validation_error,
-    categorize_pipe_validation_with_libraries_error,
-)
 from pipelex.core.pipes.pipe_abstract import PipeAbstract
 from pipelex.core.pipes.pipe_factory import PipeFactory
 from pipelex.core.stuffs.structured_content import StructuredContent

--- a/pipelex/libraries/library_manager.py
+++ b/pipelex/libraries/library_manager.py
@@ -142,8 +142,7 @@ class LibraryManager(LibraryManagerAbstract):
             raise LibraryError(msg)
 
         if not library_dirs:
-            log.info("No library directories to load")
-            return []
+            library_dirs = []
 
         all_dirs: list[Path] = []
         all_plx_paths: list[Path] = []

--- a/pipelex/libraries/library_manager.py
+++ b/pipelex/libraries/library_manager.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from kajson.kajson_manager import KajsonManager
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 from typing_extensions import override
 
 from pipelex import log
@@ -17,9 +17,15 @@ from pipelex.core.domains.domain_blueprint import DomainBlueprint
 from pipelex.core.domains.domain_factory import DomainFactory
 from pipelex.core.interpreter.exceptions import PipelexInterpreterError
 from pipelex.core.interpreter.interpreter import PipelexInterpreter
+from pipelex.core.pipes.handle_pipe_errors import (
+    categorize_pipe_factory_error,
+    categorize_pipe_validation_error,
+    categorize_pipe_validation_with_libraries_error,
+)
 from pipelex.core.pipes.pipe_abstract import PipeAbstract
 from pipelex.core.pipes.pipe_factory import PipeFactory
 from pipelex.core.stuffs.structured_content import StructuredContent
+from pipelex.core.validation import report_validation_error
 from pipelex.hub import get_current_library
 from pipelex.libraries.exceptions import (
     LibraryError,
@@ -141,7 +147,8 @@ class LibraryManager(LibraryManagerAbstract):
             raise LibraryError(msg)
 
         if not library_dirs:
-            library_dirs = [Path()]
+            log.info("No library directories to load")
+            return []
 
         all_dirs: list[Path] = []
         all_plx_paths: list[Path] = []
@@ -187,7 +194,7 @@ class LibraryManager(LibraryManagerAbstract):
         log.debug(f"Auto-registered {num_registered} StructuredContent classes from loaded modules")
 
         # Load PLX files into the specific library
-
+        log.debug(f"Loading plx files from: {[str(p) for p in valid_plx_paths]}")
         return self._load_plx_files_into_library(library_id=library_id, valid_plx_paths=valid_plx_paths)
 
     @override
@@ -277,12 +284,20 @@ class LibraryManager(LibraryManagerAbstract):
                         domain_code=blueprint.domain,
                         concept_code=concept_code,
                     )
-                    ref_to_entry[concept_ref] = (blueprint.domain, concept_code, concept_blueprint)
+                    ref_to_entry[concept_ref] = (
+                        blueprint.domain,
+                        concept_code,
+                        concept_blueprint,
+                    )
 
         # Step 2: Build dependency graph and topologically sort using graphlib
         sorter: TopologicalSorter[str] = TopologicalSorter()
 
-        for concept_ref, (domain_code, _concept_code, concept_blueprint) in ref_to_entry.items():
+        for concept_ref, (
+            domain_code,
+            _concept_code,
+            concept_blueprint,
+        ) in ref_to_entry.items():
             dependencies: set[str] = set()
 
             if not isinstance(concept_blueprint, str) and concept_blueprint.refines:
@@ -364,7 +379,14 @@ class LibraryManager(LibraryManagerAbstract):
                 resolved_path = plx_file_path
             library.loaded_plx_paths.append(resolved_path)
 
-        return self.load_from_blueprints(library_id=library_id, blueprints=blueprints)
+        try:
+            return self.load_from_blueprints(library_id=library_id, blueprints=blueprints)
+        except ValidationError as validation_error:
+            validation_error_msg = report_validation_error(category="plx", validation_error=validation_error)
+            msg = f"Could not load blueprints from {[str(pth) for pth in valid_plx_paths]} because of: {validation_error_msg}"
+            raise LibraryError(
+                message=msg,
+            ) from validation_error
 
     def _remove_pipes_from_blueprint(self, blueprint: PipelexBundleBlueprint) -> None:
         library = self.get_current_library()

--- a/pipelex/pipe_controllers/condition/pipe_condition.py
+++ b/pipelex/pipe_controllers/condition/pipe_condition.py
@@ -140,7 +140,7 @@ class PipeCondition(PipeController):
         if all_outputs_same:
             # All mapped pipes have the same output - PipeCondition MUST use that same output
             expected_output_ref = next(iter(mapped_output_refs))
-            if self.output.concept.concept_ref != expected_output_ref:
+            if self.output.concept.concept_ref not in {expected_output_ref, NativeConceptCode.ANYTHING.concept_ref}:
                 msg = (
                     f"All mapped pipes of PipeCondition '{self.code}' have the same output concept "
                     f"'{expected_output_ref}', but PipeCondition declares output '{self.output.concept.concept_ref}'. "

--- a/pipelex/pipeline/validate_bundle.py
+++ b/pipelex/pipeline/validate_bundle.py
@@ -111,6 +111,8 @@ async def validate_bundle(
                 library_id=library_id,
                 library_dirs=effective_dirs,
             )
+        else:
+            log.verbose(f"No library directories to load ({source_label})")
         if blueprints is not None:
             loaded_blueprints = blueprints
             loaded_pipes = library_manager.load_from_blueprints(library_id=library_id, blueprints=blueprints)

--- a/tests/unit/pipelex/pipe_controllers/condition/test_pipe_condition_needed_inputs.py
+++ b/tests/unit/pipelex/pipe_controllers/condition/test_pipe_condition_needed_inputs.py
@@ -355,6 +355,7 @@ class TestPipeConditionOutputValidation:
 
         concept_library.teardown()
 
+    @pytest.mark.xfail(reason="Anything output is allowed until we enable the pipe builder to auto-fix")
     def test_validate_output_all_pipes_same_output_anything_not_allowed(self, load_empty_library: Callable[[], None]):
         """Test that using Anything output when all mapped pipes have the same output raises an error."""
         load_empty_library()


### PR DESCRIPTION
- Resolving library dirs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes library directory resolution and loading across CLI commands, and tightens error reporting.
> 
> - CLIs (`show pipe`, `validate`, `which`) now use `resolve_library_dirs(...)`; only load when `effective_dirs` exist and log when none. `show` no longer defaults to `cwd` when no `--library-dir` is provided.
> - `LibraryManager.load_libraries(...)`: stop defaulting to `Path()`; use empty list, add debug for PLX paths, and wrap Pydantic `ValidationError` into `LibraryError` using `report_validation_error` for clearer messages.
> - `validate_bundle(...)`: logs when no library directories are resolved before validation.
> - `PipeCondition.validate_output_with_library(...)`: allows `native.Anything` when all mapped pipes share the same output (test added/xfail adjusted).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc38ca224231e03254c1d82c170d646216d6bdf8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->