### PR TITLE
html issues

### DIFF
--- a/pipelex/core/concepts/concept_factory.py
+++ b/pipelex/core/concepts/concept_factory.py
@@ -112,6 +112,13 @@ class ConceptFactory:
                     description="A document",
                     structure_class_name=structure_class_name,
                 )
+            case NativeConceptCode.HTML:
+                return Concept(
+                    code=native_concept_code,
+                    domain_code=SpecialDomain.NATIVE,
+                    description="HTML content",
+                    structure_class_name=structure_class_name,
+                )
             case NativeConceptCode.TEXT_AND_IMAGES:
                 return Concept(
                     code=native_concept_code,

--- a/pipelex/core/concepts/native/concept_native.py
+++ b/pipelex/core/concepts/native/concept_native.py
@@ -3,6 +3,7 @@ from pipelex.core.concepts.validation import is_concept_ref_or_code_valid
 from pipelex.core.domains.domain import SpecialDomain
 from pipelex.core.stuffs.document_content import DocumentContent
 from pipelex.core.stuffs.dynamic_content import DynamicContent
+from pipelex.core.stuffs.html_content import HtmlContent
 from pipelex.core.stuffs.image_content import ImageContent
 from pipelex.core.stuffs.json_content import JSONContent
 from pipelex.core.stuffs.number_content import NumberContent
@@ -17,6 +18,7 @@ class NativeConceptCode(StrEnum):
     TEXT = "Text"
     IMAGE = "Image"
     DOCUMENT = "Document"
+    HTML = "Html"
     TEXT_AND_IMAGES = "TextAndImages"
     NUMBER = "Number"
     IMG_GEN_PROMPT = "ImgGenPrompt"
@@ -52,6 +54,8 @@ class NativeConceptCode(StrEnum):
                 return ImageContent
             case NativeConceptCode.DOCUMENT:
                 return DocumentContent
+            case NativeConceptCode.HTML:
+                return HtmlContent
             case NativeConceptCode.TEXT_AND_IMAGES:
                 return TextAndImagesContent
             case NativeConceptCode.NUMBER:
@@ -108,6 +112,7 @@ class NativeConceptCode(StrEnum):
                 NativeConceptCode.DYNAMIC
                 | NativeConceptCode.IMAGE
                 | NativeConceptCode.DOCUMENT
+                | NativeConceptCode.HTML
                 | NativeConceptCode.TEXT_AND_IMAGES
                 | NativeConceptCode.NUMBER
                 | NativeConceptCode.IMG_GEN_PROMPT
@@ -129,6 +134,7 @@ class NativeConceptCode(StrEnum):
                 NativeConceptCode.TEXT
                 | NativeConceptCode.IMAGE
                 | NativeConceptCode.DOCUMENT
+                | NativeConceptCode.HTML
                 | NativeConceptCode.TEXT_AND_IMAGES
                 | NativeConceptCode.NUMBER
                 | NativeConceptCode.IMG_GEN_PROMPT

--- a/pipelex/core/stuffs/html_content.py
+++ b/pipelex/core/stuffs/html_content.py
@@ -26,6 +26,9 @@ class HtmlContent(StuffContent):
 
     @override
     def rendered_html(self) -> str:
+        # If no css_class is provided, return raw inner_html without wrapping
+        if not self.css_class:
+            return self.inner_html
         template_source = '<div class="{{ css_class|e }}">{{ inner_html | safe }}</div>'
         return render_jinja2_sync(
             template_source=template_source,

--- a/pipelex/core/stuffs/text_content.py
+++ b/pipelex/core/stuffs/text_content.py
@@ -26,8 +26,12 @@ class TextContent(StuffContent):
 
     @override
     def rendered_html(self) -> str:
-        # Escape HTML special characters so text displays literally in browsers
-        return html.escape(self.text)
+        # If text looks like HTML, return it as-is (trusted HTML content from templates)
+        # Otherwise, escape HTML special characters so text displays literally in browsers
+        if self._looks_like_html():
+            return self.text
+        else:
+            return html.escape(self.text)
 
     @override
     def rendered_markdown(self, level: int = 1, is_pretty: bool = False) -> str:

--- a/pipelex/core/stuffs/text_content.py
+++ b/pipelex/core/stuffs/text_content.py
@@ -26,12 +26,9 @@ class TextContent(StuffContent):
 
     @override
     def rendered_html(self) -> str:
-        # If text looks like HTML, return it as-is (trusted HTML content from templates)
-        # Otherwise, escape HTML special characters so text displays literally in browsers
-        if self._looks_like_html():
-            return self.text
-        else:
-            return html.escape(self.text)
+        # Always escape HTML special characters so text displays literally in browsers.
+        # If you need to render trusted HTML content, use HtmlContent instead.
+        return html.escape(self.text)
 
     @override
     def rendered_markdown(self, level: int = 1, is_pretty: bool = False) -> str:
@@ -41,7 +38,6 @@ class TextContent(StuffContent):
     def rendered_json(self) -> str:
         return json.dumps({"text": self.text})
 
-    # TODO: This should not exist: In PipeCompose, if the category is HTML, the user should be recommended to use HtmlContent instead.
     def _looks_like_html(self) -> bool:
         """Check if the text content appears to be HTML."""
         return bool(HTML_PATTERN.match(self.text))

--- a/pipelex/pipe_operators/compose/pipe_compose.py
+++ b/pipelex/pipe_operators/compose/pipe_compose.py
@@ -14,6 +14,7 @@ from pipelex.core.pipes.exceptions import PipeValidationError, PipeValidationErr
 from pipelex.core.pipes.inputs.input_stuff_specs import InputStuffSpecs
 from pipelex.core.pipes.inputs.input_stuff_specs_factory import InputStuffSpecsFactory
 from pipelex.core.pipes.pipe_output import PipeOutput
+from pipelex.core.stuffs.html_content import HtmlContent
 from pipelex.core.stuffs.stuff_content import StuffContent
 from pipelex.core.stuffs.stuff_factory import StuffFactory
 from pipelex.hub import get_class_registry, get_concept_library, get_content_generator, get_native_concept
@@ -108,16 +109,23 @@ class PipeCompose(PipeOperator[PipeComposeOutput]):
         if self.is_construct_mode:
             return
 
-        # In template mode, output must be Text-compatible
-        if not get_concept_library().is_compatible(
+        # In template mode, output must be Text-compatible or Html-compatible
+        concept_library = get_concept_library()
+        is_text_compatible = concept_library.is_compatible(
             tested_concept=self.output.concept,
             wanted_concept=get_native_concept(native_concept=NativeConceptCode.TEXT),
             strict=True,
-        ):
+        )
+        is_html_compatible = concept_library.is_compatible(
+            tested_concept=self.output.concept,
+            wanted_concept=get_native_concept(native_concept=NativeConceptCode.HTML),
+            strict=True,
+        )
+        if not (is_text_compatible or is_html_compatible):
             msg = (
-                f"The output of a PipeCompose in template mode must be strictly compatible with the Text concept. "
+                f"The output of a PipeCompose in template mode must be strictly compatible with the Text or Html concept. "
                 f"In the pipe '{self.code}' the output is '{self.output.concept.concept_ref}'. "
-                "Make sure this concept refines the native Text concept, or use construct mode for StructuredContent."
+                "Make sure this concept refines the native Text or Html concept, or use construct mode for StructuredContent."
             )
             raise PipeValidationError(
                 message=msg,
@@ -125,7 +133,7 @@ class PipeCompose(PipeOperator[PipeComposeOutput]):
                 domain_code=self.domain_code,
                 pipe_code=self.code,
                 provided_concept_code=self.output.concept.concept_ref,
-                required_concept_codes=[NativeConceptCode.TEXT.concept_ref],
+                required_concept_codes=[NativeConceptCode.TEXT.concept_ref, NativeConceptCode.HTML.concept_ref],
             )
 
     @override
@@ -164,7 +172,7 @@ class PipeCompose(PipeOperator[PipeComposeOutput]):
         output_name: str | None,
         content_generator: ContentGeneratorProtocol,
     ) -> PipeComposeOutput:
-        """Run PipeCompose in template mode (produces Text output)."""
+        """Run PipeCompose in template mode (produces Text or Html output)."""
         if self.template is None:
             msg = "Template is required for template mode"
             raise ValueError(msg)
@@ -184,12 +192,17 @@ class PipeCompose(PipeOperator[PipeComposeOutput]):
         log.verbose(f"Jinja2 rendered text:\n{jinja2_text}")
         assert isinstance(jinja2_text, str)
 
-        # Get the structure class from the registry (might be a subclass of TextContent)
+        # Get the structure class from the registry (might be a subclass of TextContent or HtmlContent)
         structure_class = get_class_registry().get_required_subclass(
             name=self.output.concept.structure_class_name,
             base_class=StuffContent,
         )
-        the_content = structure_class(text=jinja2_text)
+
+        # Construct content based on the structure class type
+        if issubclass(structure_class, HtmlContent):
+            the_content = structure_class(inner_html=jinja2_text, css_class="")
+        else:
+            the_content = structure_class(text=jinja2_text)
 
         output_stuff = StuffFactory.make_stuff(concept=self.output.concept, content=the_content, name=output_name)
 


### PR DESCRIPTION
- Don't escape text when it looks like html. Support Html as Native concept.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new native content type and changes `PipeCompose` template-mode output validation/construction, which may affect existing pipelines expecting `TextContent` semantics and HTML escaping behavior.
> 
> **Overview**
> Introduces a new native `Html` concept wired through `NativeConceptCode`, `ConceptFactory`, and a dedicated `HtmlContent` structure class.
> 
> Updates `PipeCompose` template mode to allow outputs strictly compatible with `native.Html` (in addition to `native.Text`) and to instantiate `HtmlContent` subclasses using `inner_html` rather than `text`. Adjusts rendering behavior so `TextContent` always escapes HTML, while `HtmlContent.rendered_html()` can return raw `inner_html` when no `css_class` is provided.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6bc522eb222d87c1a9891b84a7c05366f1c6d9a1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->