### PR TITLE
Fix/runner number content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
  - Fixed a bug when trying to print HTML content in a TextContent object.
  - Fixed the Pipelex CLI for generating structures, inputs, runner files.
  - Fixed PipeLLM with list output (e.g., `output = "Item[]"`) not producing `ListContent` when run inside a nested PipeSequence with `batch_over`.
+ - Fixed `pipelex build runner` generating string placeholders (e.g., `"number_int | float"`) instead of numeric values for Number concepts with `int | float` union type fields.
 
 ### Removed
  - **`pipelex kit` Command**: The kit commands have been removed from the main CLI. They are now internal tools for Pipelex contributors only, available via `pipelex-dev kit rules`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
  - Fixed the Pipelex CLI for generating structures, inputs, runner files.
  - Fixed `@pipe_func` decorated functions showing "function not found" instead of explaining why the function is ineligible (e.g., missing return type annotation).
  - Fixed PipeLLM with list output (e.g., `output = "Item[]"`) not producing `ListContent` when run inside a nested PipeSequence with `batch_over`.
- - Fixed `pipelex build runner` generating string placeholders (e.g., `"number_int | float"`) instead of numeric values for Number concepts with `int | float` union type fields.
+ - Fixed `pipelex build runner` and `pipelex build inputs` generating string placeholders (e.g., `"number_int | float"`) instead of numeric values for Number concepts with `int | float` union type fields.
 
 ### Removed
  - **`pipelex kit` Command**: The kit commands have been removed from the main CLI. They are now internal tools for Pipelex contributors only, available via `pipelex-dev kit rules`.

--- a/README.md
+++ b/README.md
@@ -408,3 +408,5 @@ This project is licensed under the [MIT license](LICENSE). Runtime dependencies 
 "Pipelex" is a trademark of Evotis S.A.S.
 
 © 2025 Evotis S.A.S.
+
+test-auto-merge

--- a/README.md
+++ b/README.md
@@ -408,5 +408,3 @@ This project is licensed under the [MIT license](LICENSE). Runtime dependencies 
 "Pipelex" is a trademark of Evotis S.A.S.
 
 © 2025 Evotis S.A.S.
-
-test-auto-merge

--- a/pipelex/core/concepts/concept_representation_generator.py
+++ b/pipelex/core/concepts/concept_representation_generator.py
@@ -5,7 +5,8 @@ It supports two output formats: JSON (dict) and Python (class instantiation stri
 """
 
 import inspect
-from typing import Any, cast, get_args, get_origin
+import types
+from typing import Any, Union, cast, get_args, get_origin
 
 from pydantic import BaseModel
 
@@ -268,7 +269,7 @@ class ConceptRepresentationGenerator:
         """Generate a value for basic Python types.
 
         Args:
-            actual_type: The type (str, int, float, bool, or unknown)
+            actual_type: The type (str, int, float, bool, union types, or unknown)
             field_name: Name of the field (used for generating placeholder)
 
         Returns:
@@ -283,6 +284,18 @@ class ConceptRepresentationGenerator:
         elif actual_type is bool:
             return False
         else:
+            # Handle union types like int | float (used by NumberContent)
+            origin = get_origin(actual_type)
+            if origin is Union or origin is types.UnionType:
+                union_args = get_args(actual_type)
+                # Filter out NoneType (already handled by _unwrap_optional)
+                non_none_args = [arg for arg in union_args if arg is not type(None)]
+                if non_none_args:
+                    # Check if it's a numeric union (int | float or float | int)
+                    if set(non_none_args) == {int, float}:
+                        return 1  # Return a sensible default for number types
+                    # For other unions, try to generate a value for the first type
+                    return self._generate_basic_value(non_none_args[0], field_name)
             type_name = getattr(actual_type, "__name__", str(actual_type))
             return f"{field_name}_{type_name}"
 

--- a/tests/unit/pipelex/core/concepts/test_concept_representation_generator.py
+++ b/tests/unit/pipelex/core/concepts/test_concept_representation_generator.py
@@ -136,6 +136,20 @@ class TestGenerateFieldValueBasicTypes:
         result = generator.generate_field_value(bool, "active")
         assert result is False
 
+    def test_int_or_float_union_field(self) -> None:
+        """Int | float union field generates a numeric value (1), not a string placeholder."""
+        generator = ConceptRepresentationGenerator(ConceptRepresentationFormat.JSON)
+        result = generator.generate_field_value(int | float, "number")
+        assert isinstance(result, (int, float)), f"Expected int or float, got {type(result)}: {result}"
+        assert result == 1
+
+    def test_float_or_int_union_field(self) -> None:
+        """Float | int union field generates a numeric value (1), not a string placeholder."""
+        generator = ConceptRepresentationGenerator(ConceptRepresentationFormat.JSON)
+        result = generator.generate_field_value(float | int, "amount")
+        assert isinstance(result, (int, float)), f"Expected int or float, got {type(result)}: {result}"
+        assert result == 1
+
 
 # =============================================================================
 # Tests for generate_field_value - complex types
@@ -558,3 +572,40 @@ class TestSchemaRepresentationWithMultiple:
         items_schema = result["content"]["items"]
         assert items_schema["type"] == "object"
         assert "properties" in items_schema
+
+
+# =============================================================================
+# Tests for NumberContent (native Number concept)
+# =============================================================================
+
+
+class TestNumberContentRepresentation:
+    """Test that NumberContent generates proper numeric values, not string placeholders.
+
+    NumberContent has a field 'number: int | float' which is a union type.
+    The generator should produce a numeric value (1), not 'number_int | float'.
+    """
+
+    def test_number_content_json_representation(self) -> None:
+        """NumberContent generates proper numeric value in JSON format."""
+        from pipelex.core.stuffs.number_content import NumberContent  # noqa: PLC0415
+
+        generator = ConceptRepresentationGenerator(ConceptRepresentationFormat.JSON)
+        result = generator.generate_class_representation(NumberContent)
+
+        assert isinstance(result, dict)
+        assert "number" in result
+        assert isinstance(result["number"], (int, float)), f"Expected numeric value, got {type(result['number'])}: {result['number']}"
+        assert result["number"] == 1
+
+    def test_number_content_python_representation(self) -> None:
+        """NumberContent generates proper numeric value in Python format."""
+        from pipelex.core.stuffs.number_content import NumberContent  # noqa: PLC0415
+
+        generator = ConceptRepresentationGenerator(ConceptRepresentationFormat.PYTHON)
+        result = generator.generate_class_representation(NumberContent)
+
+        # Should be "NumberContent(number=1)" not "NumberContent(number=\"number_int | float\")"
+        assert isinstance(result, str)
+        assert "number=1" in result, f"Expected 'number=1' in result, got: {result}"
+        assert "number_int" not in result, f"Should not contain string placeholder: {result}"


### PR DESCRIPTION
 - Fixed `pipelex build runner` and `pipelex build inputs` generating string placeholders (e.g., `"number_int | float"`) instead of numeric values for Number concepts with `int | float` union type fields.