### PR TITLE
fix/pipe-func-error-catching-and-validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
  - **StructuredContent.rendered_html()**: Now recursively calls `rendered_html()` on nested `StuffContent` fields instead of using json2html conversion. Also skips `None` values and uses HTML table format.
 
 ### Fixed
+ - **Helpful Error for `get_stuff_as(ListContent[T])`**: When users incorrectly call `get_stuff_as("name", ListContent[Something])` instead of `get_stuff_as_list("name", Something)`, the error message now explicitly suggests using `get_stuff_as_list()`.
  - **PipeFunc `ListContent[T]` Validation**: Fixed validation rejecting valid `ListContent[T]` return types for array outputs (`T[]`). Previously, a function returning `ListContent[Expense]` would fail validation for `output = "Expense[]"` with a misleading error. The validation now correctly extracts and validates the generic type parameter from Pydantic's metadata.
  - **PipeFunc Class Name Matching**: Fixed validation failing when the return type class and concept structure class are logically the same but loaded from different contexts. The validation now uses class name matching as a fallback, allowing `ListContent[Expense]` to match `Expense[]` even if the `Expense` class objects differ.
  - Fixed `PipeImgGen` not properly converting `ImageContent` to custom subclasses (e.g., `Receipt(ImageContent)`). The pipe now uses `smart_dump()` before `model_validate()` to correctly instantiate the output concept's structure class.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   - **Nested concepts in inline structures**: You can now define nested structures for your concepts in your `.plx` files. Learn more here: [Nested Concepts in Inline Structures](https://docs.pipelex.com/home/6-build-reliable-ai-workflows/concepts/inline-structures).
 
 ### Added
+ - **PipeFunc Execution Error Context**: When a `@pipe_func` function fails during execution, the error message now includes detailed context: the function name, actual input values from working memory, expected output type, and the original error with its type. This makes debugging PipeFunc errors much easier.
  - **`pipelex build output` CLI Command**: New command to generate example output JSON for a pipe, complementing the existing `pipelex build inputs` command. Shows the expected output structure based on the pipe's output concept type, with multiplicity support. For pipes with `native.Anything` output (e.g., `PipeCondition` with different mapped pipe outputs), displays all possible outputs from mapped pipes.
  - **Telemetry System**: Introduced anonymous usage tracking and exception capture for CLI commands (`graph render`), reporting to both user-configured and Pipelex analytics endpoints.
  - **PipeExtract Operator Validation**: Added strict input validation that raises configuration errors for incompatible input types or when document-specific parameters are used with image inputs.
@@ -14,6 +15,7 @@
  - **PipeFunc Return Type Validation**: Added validation to ensure that a `PipeFunc` function's return type matches the output concept's structure class.
 
 ### Changed
+ - **`pipelex run --dry-run`**: No longer pretty prints the main_stuff output, matching the expected behavior for dry runs where no actual inference occurs.
  - **`pipelex build structures` Command**: Now uses a lightweight loading mechanism that only processes domains and concepts, skipping pipe loading and validation entirely. This fixes the chicken-and-egg problem where structure generation would fail due to pipe validation errors before the structures were even created. Added `--force` / `-f` flag to regenerate all structures without checking if classes already exist.
  - **Test Profile System**: Refactored integration tests to use a new configuration system (`.pipelex/test_profiles.toml`) with `dev`, `ci`, and `full` profiles for controlling which AI models are used in parametrized tests, replacing runtime filtering and hardcoded model lists.
  - **`pipelex run --graph` Flag**: Now acts as an override for `pipelex.toml` settings instead of defaulting to `true`.
@@ -25,6 +27,8 @@
  - **StructuredContent.rendered_html()**: Now recursively calls `rendered_html()` on nested `StuffContent` fields instead of using json2html conversion. Also skips `None` values and uses HTML table format.
 
 ### Fixed
+ - **PipeFunc `ListContent[T]` Validation**: Fixed validation rejecting valid `ListContent[T]` return types for array outputs (`T[]`). Previously, a function returning `ListContent[Expense]` would fail validation for `output = "Expense[]"` with a misleading error. The validation now correctly extracts and validates the generic type parameter from Pydantic's metadata.
+ - **PipeFunc Class Name Matching**: Fixed validation failing when the return type class and concept structure class are logically the same but loaded from different contexts. The validation now uses class name matching as a fallback, allowing `ListContent[Expense]` to match `Expense[]` even if the `Expense` class objects differ.
  - Fixed `PipeImgGen` not properly converting `ImageContent` to custom subclasses (e.g., `Receipt(ImageContent)`). The pipe now uses `smart_dump()` before `model_validate()` to correctly instantiate the output concept's structure class.
  - Corrected output directory creation logic in `pipelex run` to properly respect the `--no-graph` flag and configuration settings.
  - Fixed a bug when trying to print HTML content in a TextContent object.

--- a/pipelex/cli/commands/run_cmd.py
+++ b/pipelex/cli/commands/run_cmd.py
@@ -250,8 +250,8 @@ def run_cmd(
             typer.secho(f"Failed to execute pipeline: {exc}", fg=typer.colors.RED, err=True)
             raise typer.Exit(1) from exc
 
-        # Pretty print main_stuff unless disabled
-        if not no_pretty_print:
+        # Pretty print main_stuff unless disabled or in dry run mode
+        if not no_pretty_print and not dry_run:
             title = f"Final output of pipe [red]{pipe_code}[/red]"
             pipe_output.main_stuff.pretty_print_stuff(title=title)
             # TODO: no_pretty_print should also disable the pretty printing of each pipe operator step

--- a/pipelex/core/stuffs/stuff.py
+++ b/pipelex/core/stuffs/stuff.py
@@ -1,5 +1,5 @@
 # pyright: reportImportCycles=false
-from typing import Any, cast
+from typing import Any, cast, get_args, get_origin
 
 from kajson import kajson
 from pydantic import ConfigDict, ValidationError
@@ -118,6 +118,33 @@ class Stuff(PrettyRenderable, CustomBaseModel):
             ) from exc
 
         actual_type = type(content)
+
+        # Check if user is trying to use ListContent[Something] - suggest get_stuff_as_list() instead
+        origin = get_origin(content_type)
+        if origin is None:
+            # For Pydantic generics, check __pydantic_generic_metadata__
+            pydantic_metadata: dict[str, Any] | None = getattr(content_type, "__pydantic_generic_metadata__", None)
+            if pydantic_metadata is not None:
+                origin = pydantic_metadata.get("origin")
+
+        if origin is not None and issubclass(origin, ListContent):
+            # User passed ListContent[Something] - extract the item type and suggest the correct method
+            type_args = get_args(content_type)
+            if not type_args:
+                pydantic_metadata = getattr(content_type, "__pydantic_generic_metadata__", None)
+                if pydantic_metadata is not None:
+                    type_args = pydantic_metadata.get("args", ())
+
+            if type_args:
+                item_type_name = type_args[0].__name__
+                msg = (
+                    f"Cannot use ListContent[{item_type_name}] with get_stuff_as() or content_as(). "
+                    f'Use get_stuff_as_list("<name>", {item_type_name}) instead.'
+                )
+            else:
+                msg = 'Cannot use ListContent[...] with get_stuff_as() or content_as(). Use get_stuff_as_list("<name>", ItemType) instead.'
+            raise StuffContentTypeError(message=msg, expected_type=content_type.__name__, actual_type=actual_type.__name__)
+
         msg = f"Content is of type '{actual_type}', instead of the expected '{content_type}'"
         raise StuffContentTypeError(message=msg, expected_type=content_type.__name__, actual_type=actual_type.__name__)
 

--- a/pipelex/pipe_operators/func/pipe_func.py
+++ b/pipelex/pipe_operators/func/pipe_func.py
@@ -1,6 +1,6 @@
 import asyncio
 import inspect
-from typing import Literal, cast, get_type_hints
+from typing import Literal, cast, get_args, get_origin, get_type_hints
 
 from kajson.kajson_manager import KajsonManager
 from pydantic import field_validator
@@ -77,7 +77,7 @@ class PipeFunc(PipeOperator[PipeFuncOutput]):
     @override
     def validate_output_with_library(self):
         function = func_registry.get_required_function(self.function_name)
-        return_type = get_type_hints(function).get("return")
+        return_type: type[StuffContent] | None = get_type_hints(function).get("return")
         if return_type is None:
             msg = (
                 f"PipeFunc '{self.code}' failed to validate output with library: The return type of the function is None. "
@@ -108,15 +108,67 @@ class PipeFunc(PipeOperator[PipeFuncOutput]):
                 f"Concept structure class '{self.output.concept.structure_class_name}' not found in registry."
             )
             raise TypeError(msg)
-        # TODO: To revive this test, the cli `build strucutres` command should only validate the concepts and not the pipes.
-        # More info here: tests/integration/pipelex/pipes/operator/pipe_func/test_pipe_func_validation_errors.py:367
-        # if return_type != concept_structure_class:
-        #     msg = (
-        #         f"PipeFunc '{self.code}' output concept expects structure class '{self.output.concept.structure_class_name}', "
-        #         f"but the function '{self.function_name}' return type is '{return_type.__name__}'. "
-        #         f"The return type of your function should be '{self.output.concept.structure_class_name}' or a subclass of it."
-        #     )
-        #     raise TypeError(msg)
+
+        # When multiplicity is set (e.g., output = "Expense[]"), the return type should be ListContent[T]
+        # where T matches the concept's structure class
+        if self.output.multiplicity:
+            # We already validated that return_type is a subclass of ListContent above.
+            # Now check that the generic parameter matches the concept's structure class.
+            type_args: tuple[type, ...] | None = None
+
+            # Try standard typing module first
+            origin = get_origin(return_type)
+            if origin is not None:
+                type_args = get_args(return_type)
+            else:
+                # For Pydantic generics (e.g., ListContent[MyItem]), use Pydantic's metadata
+                return_type_for_metadata = cast("type", return_type)
+                pydantic_metadata: dict[str, tuple[type, ...]] | None = getattr(return_type_for_metadata, "__pydantic_generic_metadata__", None)
+                if pydantic_metadata is not None:
+                    type_args = pydantic_metadata.get("args")
+
+            if type_args:
+                item_type = type_args[0]
+                # Check if item type matches the concept's structure class:
+                # 1. Same class object
+                # 2. Subclass relationship
+                # 3. Same class name (for cases where the class is defined in different modules but represents the same concept)
+                is_same_class = item_type == concept_structure_class
+                is_subclass = not is_same_class and issubclass(item_type, concept_structure_class)
+                is_same_name = item_type.__name__ == self.output.concept.structure_class_name
+
+                # Debug logging
+                log.verbose(
+                    f"PipeFunc '{self.code}' ListContent validation: "
+                    f"item_type={item_type.__module__}.{item_type.__name__}, "
+                    f"concept_structure_class={concept_structure_class.__module__}.{concept_structure_class.__name__}, "
+                    f"is_same_class={is_same_class}, is_subclass={is_subclass}, is_same_name={is_same_name}"
+                )
+
+                if not (is_same_class or is_subclass or is_same_name):
+                    msg = (
+                        f"PipeFunc '{self.code}' output concept expects structure class '{self.output.concept.structure_class_name}' "
+                        f"(from {concept_structure_class.__module__}.{concept_structure_class.__name__}), "
+                        f"but the function '{self.function_name}' return type is 'ListContent[{item_type.__name__}]' "
+                        f"(from {item_type.__module__}.{item_type.__name__}). "
+                        f"The item type of your ListContent should be '{self.output.concept.structure_class_name}' or a subclass of it."
+                    )
+                    raise TypeError(msg)
+            # If no type_args found, return_type is raw ListContent without generic parameter - we already validated it's a ListContent subclass
+        else:
+            # No multiplicity - return type must match the concept's structure class
+            # Same checks as above: same class, subclass, or same name
+            is_same_class = return_type == concept_structure_class
+            is_subclass = not is_same_class and issubclass(return_type, concept_structure_class)
+            is_same_name = return_type.__name__ == self.output.concept.structure_class_name
+
+            if not (is_same_class or is_subclass or is_same_name):
+                msg = (
+                    f"PipeFunc '{self.code}' output concept expects structure class '{self.output.concept.structure_class_name}', "
+                    f"but the function '{self.function_name}' return type is '{return_type.__name__}'. "
+                    f"The return type of your function should be '{self.output.concept.structure_class_name}' or a subclass of it."
+                )
+                raise TypeError(msg)
 
     @override
     async def _live_run_operator_pipe(
@@ -129,10 +181,31 @@ class PipeFunc(PipeOperator[PipeFuncOutput]):
         log.verbose(f"Running PipeFunc with function '{self.function_name}'")
         function = func_registry.get_required_function(self.function_name)
 
-        if inspect.iscoroutinefunction(function):
-            func_output_object = await function(working_memory=working_memory)
-        else:
-            func_output_object = await asyncio.to_thread(function, working_memory=working_memory)
+        try:
+            if inspect.iscoroutinefunction(function):
+                func_output_object = await function(working_memory=working_memory)
+            else:
+                func_output_object = await asyncio.to_thread(function, working_memory=working_memory)
+        except Exception as exc:
+            # Build informative error message with actual input values from working memory
+            inputs_lines: list[str] = []
+            for input_name in self.inputs.root:
+                try:
+                    stuff = working_memory.get_stuff(name=input_name)
+                    inputs_lines.append(f"    {input_name} = {stuff.content!r}")
+                except Exception:
+                    inputs_lines.append(f"    {input_name} = <not found in working memory>")
+
+            inputs_desc = "\n".join(inputs_lines) if inputs_lines else "    none"
+            output_desc = self.output.to_bundle_representation()
+            msg = (
+                f"PipeFunc '{self.code}' failed during execution.\n"
+                f"  Function: {self.function_name}\n"
+                f"  Inputs:\n{inputs_desc}\n"
+                f"  Expected output: {output_desc}\n"
+                f"  Error: {type(exc).__name__}: {exc}"
+            )
+            raise PipeRunError(message=msg, run_mode=pipe_run_params.run_mode, pipe_code=self.code) from exc
 
         the_content: StuffContent
         if isinstance(func_output_object, StuffContent):
@@ -171,6 +244,10 @@ class PipeFunc(PipeOperator[PipeFuncOutput]):
         output_name: str | None = None,
     ) -> PipeFuncOutput:
         function = func_registry.get_required_function(self.function_name)
+        log.info(
+            f"🚨 For your information, the dry run of PipeFunc '{self.code}' is not actually running the python function \
+            but only validating the inputs and return type."
+        )
         return_type = get_type_hints(function).get("return")
         if return_type is None:
             msg = f"Dry run of {self.type} '{self.code}' failed: The return type of the function is None. It should be a subclass of StuffContent."

--- a/pipelex/pipe_operators/func/pipe_func.py
+++ b/pipelex/pipe_operators/func/pipe_func.py
@@ -200,9 +200,8 @@ class PipeFunc(PipeOperator[PipeFuncOutput]):
             output_desc = self.output.to_bundle_representation()
             msg = (
                 f"PipeFunc '{self.code}' failed during execution.\n"
-                f"  Function: {self.function_name}\n"
-                f"  Inputs:\n{inputs_desc}\n"
                 f"  Expected output: {output_desc}\n"
+                f"  Inputs:\n{inputs_desc}\n\n"
                 f"  Error: {type(exc).__name__}: {exc}"
             )
             raise PipeRunError(message=msg, run_mode=pipe_run_params.run_mode, pipe_code=self.code) from exc

--- a/tests/integration/pipelex/pipes/operator/pipe_func/test_pipe_func_validation_errors.py
+++ b/tests/integration/pipelex/pipes/operator/pipe_func/test_pipe_func_validation_errors.py
@@ -357,13 +357,6 @@ class TestPipeFuncValidationErrors:
                 f"Error should mention '{expected_error_substring}' to explain the specific issue. Got: {error_message}"
             )
 
-    @pytest.mark.xfail(
-        reason="This test will fail because the building of the structures of the concepts are actually validating the pipes as well. \
-        So when you validate a pipe, it will validate the pipe func but it will not have created the structure for the pipe func, and this test \
-            will fail because the output of the pipe func function is not matching the output concept. (chicken and egg paradox). \
-            So first, we need to make sure thatwhen we call this the structure build structure command it only \
-                validates the concepts and not the pipes."
-    )
     async def test_pipe_func_return_type_must_match_concept_structure_class(self):
         """Test that the function's return type must exactly match the output concept's structure class.
 
@@ -426,3 +419,169 @@ output = "Text"
             assert "TextContent" in error_message or "structure class" in error_message.lower(), (
                 f"Error should mention the expected structure class 'TextContent' or 'structure class'. Got: {error_message}"
             )
+
+    async def test_pipe_func_list_content_with_array_output_validates_successfully(self):
+        """Test that ListContent[T] return type validates successfully with T[] output.
+
+        When a PipeFunc's output concept has array notation (e.g., "Text[]"),
+        the function should be allowed to return ListContent[TextContent].
+        """
+        # Function that returns ListContent[TextContent] for Text[] output
+        func_code = """
+from pipelex.core.memory.working_memory import WorkingMemory
+from pipelex.core.stuffs.list_content import ListContent
+from pipelex.core.stuffs.text_content import TextContent
+from pipelex.system.registries.func_registry import pipe_func
+
+
+@pipe_func()
+async def func_returns_list_content(working_memory: WorkingMemory) -> ListContent[TextContent]:
+    return ListContent(items=[TextContent(text="test1"), TextContent(text="test2")])
+"""
+        # PLX file with array output notation using built-in Text concept
+        plx_content = """
+domain = "test_pipe_func_validation"
+description = "Test bundle for ListContent validation"
+
+[pipe.test_list_content_pipe]
+type = "PipeFunc"
+description = "Test pipe with array output"
+function_name = "func_returns_list_content"
+output = "Text[]"
+"""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+
+            # Create the .plx file
+            plx_file = temp_path / "test_bundle.plx"
+            plx_file.write_text(plx_content)
+
+            # Create the .py file with the function
+            py_file = temp_path / "my_funcs.py"
+            py_file.write_text(func_code)
+
+            # Validate the bundle - should succeed
+            result = await validate_bundle(
+                plx_file_path=plx_file,
+                library_dirs=[temp_path],
+            )
+
+            assert result is not None
+            assert len(result.pipes) > 0
+
+    async def test_pipe_func_list_content_with_wrong_item_type_fails_validation(self):
+        """Test that ListContent[WrongType] fails validation when output expects DifferentType[].
+
+        When a PipeFunc's output concept expects "Text[]" (TextContent) but the function returns
+        ListContent[StructuredContent subclass], validation should fail with a clear error message.
+        """
+        func_code = """
+from pipelex.core.memory.working_memory import WorkingMemory
+from pipelex.core.stuffs.list_content import ListContent
+from pipelex.core.stuffs.structured_content import StructuredContent
+from pipelex.system.registries.func_registry import pipe_func
+
+
+class WrongItem(StructuredContent):
+    different_field: int
+
+
+@pipe_func()
+async def func_returns_wrong_list_content(working_memory: WorkingMemory) -> ListContent[WrongItem]:
+    return ListContent(items=[WrongItem(different_field=42)])
+"""
+        # PLX file expects Text[] (TextContent) but function returns ListContent[WrongItem]
+        plx_content = """
+domain = "test_pipe_func_validation"
+description = "Test bundle for ListContent validation error"
+
+[pipe.test_wrong_list_content_pipe]
+type = "PipeFunc"
+description = "Test pipe with mismatched list item type"
+function_name = "func_returns_wrong_list_content"
+output = "Text[]"
+"""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+
+            # Create the .plx file
+            plx_file = temp_path / "test_bundle.plx"
+            plx_file.write_text(plx_content)
+
+            # Create the .py file with the function
+            py_file = temp_path / "my_funcs.py"
+            py_file.write_text(func_code)
+
+            # Validate the bundle - should fail with clear error about item type mismatch
+            with pytest.raises((ValidateBundleError, LibraryError, TypeError)) as exc_info:
+                await validate_bundle(
+                    plx_file_path=plx_file,
+                    library_dirs=[temp_path],
+                )
+
+            error = exc_info.value
+            error_message = str(error)
+
+            # The error should mention the function name
+            assert "func_returns_wrong_list_content" in error_message, f"Error should mention the function name. Got: {error_message}"
+
+            # The error should mention the expected item type (TextContent) or ListContent
+            assert "TextContent" in error_message or "ListContent" in error_message, (
+                f"Error should mention 'TextContent' or 'ListContent'. Got: {error_message}"
+            )
+
+    async def test_pipe_func_array_output_requires_list_content_return_type(self):
+        """Test that array output (T[]) requires ListContent return type.
+
+        When a PipeFunc's output has array notation (e.g., "Text[]") but the function
+        returns a non-ListContent type (e.g., TextContent), validation should fail
+        with a clear error message explaining that ListContent is required.
+        """
+        # Function that returns TextContent (not ListContent) for Text[] output
+        func_code = """
+from pipelex.core.memory.working_memory import WorkingMemory
+from pipelex.core.stuffs.text_content import TextContent
+from pipelex.system.registries.func_registry import pipe_func
+
+
+@pipe_func()
+async def func_returns_single_instead_of_list(working_memory: WorkingMemory) -> TextContent:
+    return TextContent(text="single item - should be a list!")
+"""
+        # PLX file expects Text[] (array) but function returns single TextContent
+        plx_content = """
+domain = "test_pipe_func_validation"
+description = "Test bundle for ListContent requirement"
+
+[pipe.test_array_requires_list_content]
+type = "PipeFunc"
+description = "Test pipe with array output expecting ListContent"
+function_name = "func_returns_single_instead_of_list"
+output = "Text[]"
+"""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+
+            # Create the .plx file
+            plx_file = temp_path / "test_bundle.plx"
+            plx_file.write_text(plx_content)
+
+            # Create the .py file with the function
+            py_file = temp_path / "my_funcs.py"
+            py_file.write_text(func_code)
+
+            # Validate the bundle - should fail because return type is not ListContent
+            with pytest.raises((ValidateBundleError, LibraryError, TypeError)) as exc_info:
+                await validate_bundle(
+                    plx_file_path=plx_file,
+                    library_dirs=[temp_path],
+                )
+
+            error = exc_info.value
+            error_message = str(error)
+
+            # The error should mention the function name
+            assert "func_returns_single_instead_of_list" in error_message, f"Error should mention the function name. Got: {error_message}"
+
+            # The error should explicitly mention ListContent is required
+            assert "ListContent" in error_message, f"Error should mention that 'ListContent' is required for array output. Got: {error_message}"

--- a/tests/unit/pipelex/core/stuffs/test_stuff_verify_content_type.py
+++ b/tests/unit/pipelex/core/stuffs/test_stuff_verify_content_type.py
@@ -1,0 +1,53 @@
+import pytest
+
+from pipelex.core.stuffs.exceptions import StuffContentTypeError
+from pipelex.core.stuffs.list_content import ListContent
+from pipelex.core.stuffs.stuff import Stuff
+from pipelex.core.stuffs.text_content import TextContent
+
+
+class TestVerifyContentType:
+    def test_verify_content_type_with_list_content_generic_raises_helpful_error(self):
+        """Test that passing ListContent[Something] raises a helpful error suggesting get_stuff_as_list().
+
+        This is the bug scenario: content is plain ListContent (like what WorkingMemory stores)
+        but the user expects ListContent[Something].
+        """
+        # This is how content is typically stored in WorkingMemory - as plain ListContent (untyped)
+        items = [TextContent(text="hello"), TextContent(text="world")]
+        content = ListContent(items=items)  # type: ignore[var-annotated]
+
+        with pytest.raises(StuffContentTypeError) as exc_info:
+            Stuff.verify_content_type(content=content, content_type=ListContent[TextContent])
+
+        error_message = str(exc_info.value)
+        assert "Cannot use ListContent[TextContent]" in error_message
+        assert "get_stuff_as_list" in error_message
+
+    def test_verify_content_type_with_plain_list_content_works(self):
+        """Plain ListContent (without generic parameter) should work fine."""
+        content = ListContent[TextContent](items=[TextContent(text="hello")])
+
+        result = Stuff.verify_content_type(content=content, content_type=ListContent)  # pyright: ignore[reportUnknownVariableType]
+
+        assert isinstance(result, ListContent)
+
+    def test_verify_content_type_with_matching_type_works(self):
+        """Direct type match should work."""
+        content = TextContent(text="hello")
+
+        result = Stuff.verify_content_type(content=content, content_type=TextContent)
+
+        assert isinstance(result, TextContent)
+        assert result.text == "hello"
+
+    def test_verify_content_type_with_mismatched_type_raises_error(self):
+        """Mismatched types should raise StuffContentTypeError."""
+        content = TextContent(text="hello")
+
+        with pytest.raises(StuffContentTypeError) as exc_info:
+            Stuff.verify_content_type(content=content, content_type=ListContent)
+
+        error_message = str(exc_info.value)
+        assert "TextContent" in error_message
+        assert "ListContent" in error_message


### PR DESCRIPTION
- **PipeFunc Execution Error Context**: When a `@pipe_func` function fails during execution, the error message now includes detailed context: the function name, actual input values from working memory, expected output type, and the original error with its type. This makes debugging PipeFunc errors much easier.
 - **`pipelex run --dry-run`**: No longer pretty prints the main_stuff output, matching the expected behavior for dry runs where no actual inference occurs.
 - **PipeFunc `ListContent[T]` Validation**: Fixed validation rejecting valid `ListContent[T]` return types for array outputs (`T[]`). Previously, a function returning `ListContent[Expense]` would fail validation for `output = "Expense[]"` with a misleading error. The validation now correctly extracts and validates the generic type parameter from Pydantic's metadata.
 - **PipeFunc Class Name Matching**: Fixed validation failing when the return type class and concept structure class are logically the same but loaded from different contexts. The validation now uses class name matching as a fallback, allowing `ListContent[Expense]` to match `Expense[]` even if the `Expense` class objects differ.
 
 - **Helpful Error for `get_stuff_as(ListContent[T])`**: When users incorrectly call `get_stuff_as("name", ListContent[Something])` instead of `get_stuff_as_list("name", Something)`, the error message now explicitly suggests using `get_stuff_as_list()`.
