### PR TITLE
Add silent agent-test Makefile target

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,12 +29,12 @@
 
 ### Running Tests
 
-   After you're finished making code changes, you must always run tests using `make test-xdist`.
+   After you're finished making code changes, you must always run tests using `make agent-test`.
 
    ```bash
-   make test-xdist
-   # If the current system doesn't have the `make` command, lookup the "test-xdist" target in the Makefile and run the command manually.
-   # If some test failes, re-run it with `-s -vv` to see more details
+   make agent-test
+   # If the current system doesn't have the `make` command, lookup the "agent-test" target in the Makefile and run the command manually.
+   # Zero output on success; full output on failure.
    ```
 
 ### Running Tests with Prints
@@ -97,7 +97,7 @@ This document outlines the core coding standards, best practices, and quality co
 
     - When defining enums related to string values, always inherit from `StrEnum`
     - When you need the enum value as a string, don't use `str(enum_var)` or `enum_var.value`, just use `enum_var` itself, that is the point of using StrEnum!
-    - Never test equality to an enum value: use match/case, even to single out 1 case out of 10 cases. To avoid heavy match/case code in awkward places, add methods to the enum class such as `is_foobar()`. This is to avoid bugs: when new enum values are added we want the linter to complain. Use the `|` operator to group cases
+    - Never test equality to an enum value: use match/case, even to single out 1 case out of 10 cases. To avoid heavy match/case code in awkward places, add @property methods to the enum class such as `is_foobar()`. This is to avoid bugs: when new enum values are added we want the linter to complain. Use the `|` operator to group cases
     - As our match/case constructs over enums are always exhaustive, NEVER add a default `case _: ...`. Otherwise, you won't pass linting.
     - `StrEnum` must be imported from `pipelex.types` (handles python retrocompatibility):
     ```python

--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,7 @@ make codex-tests              - Run tests for Codex (exit on first failure) (no 
 make gha-tests		          - Run tests for github actions (exit on first failure) (no inference, no gha_disabled)
 make test                     - Run unit tests (no inference)
 make test-xdist               - Run unit tests with xdist (no inference)
+make agent-test               - Run unit tests, silent on success, output on failure (for AI agents)
 make t                        - Shorthand -> test-xdist
 make test-quiet               - Run unit tests without prints (no inference)
 make tq                       - Shorthand -> test-quiet
@@ -141,7 +142,7 @@ export HELP
 	test test-xdist t test-quiet tq test-with-prints tp test-inference ti \
 	test-llm tl test-img-gen tg test-extract te codex-tests gha-tests \
 	run-all-tests run-manual-trigger-gha-tests run-gha_disabled-tests \
-	validate v check c cc agent-check \
+	validate v check c cc agent-check agent-test \
 	merge-check-ruff-lint merge-check-ruff-format merge-check-mypy merge-check-pyright \
 	li check-unused-imports fix-unused-imports check-TODOs check-uv \
 	docs docs-check docs-serve-versioned docs-list docs-deploy docs-deploy-stable docs-deploy-specific-version docs-delete \
@@ -574,6 +575,16 @@ test-pipelex-api: env
 
 ta: test-pipelex-api
 	@echo "> done: ta = test-pipelex-api"
+
+agent-test: env
+	@echo "• Running unit tests..."
+	@tmpfile=$$(mktemp); \
+	$(VENV_PYTEST) -n auto -m $(USUAL_PYTEST_MARKERS) -o log_level=WARNING --tb=short -q > "$$tmpfile" 2>&1; \
+	exit_code=$$?; \
+	if [ $$exit_code -ne 0 ]; then grep -vE '\[\s*[0-9]+%\]\s*$$' "$$tmpfile"; fi; \
+	rm -f "$$tmpfile"; \
+	if [ $$exit_code -eq 0 ]; then echo "• All tests passed."; fi; \
+	exit $$exit_code
 
 cov: env
 	$(call PRINT_TITLE,"Unit testing with coverage")

--- a/pipelex/kit/agent_rules/commands.md
+++ b/pipelex/kit/agent_rules/commands.md
@@ -27,12 +27,12 @@
 
 ## Running Tests
 
-   After you're finished making code changes, you must always run tests using `make test-xdist`.
+   After you're finished making code changes, you must always run tests using `make agent-test`.
 
    ```bash
-   make test-xdist
-   # If the current system doesn't have the `make` command, lookup the "test-xdist" target in the Makefile and run the command manually.
-   # If some test failes, re-run it with `-s -vv` to see more details
+   make agent-test
+   # If the current system doesn't have the `make` command, lookup the "agent-test" target in the Makefile and run the command manually.
+   # Zero output on success; full output on failure.
    ```
 
 ## Running Tests with Prints


### PR DESCRIPTION
## Summary

- Add `agent-test` Makefile target that produces zero output on success and filtered failure output (no progress dots) on failure, saving ~20K tokens of context window for AI agents
- Update agent rules template and CLAUDE.md to reference `make agent-test` instead of `make test-xdist`
- Add target to `.PHONY` list and help text

## Test plan

- [x] Run `make agent-test` — produces only "Running unit tests..." and "All tests passed." on success
- [x] Introduce a deliberate test failure — shows failure details without progress dot lines
- [x] Verify `make rules` regenerates CLAUDE.md with updated instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Makefile + documentation-only changes that don’t affect runtime behavior; main risk is minor confusion if the new test output format hides useful context.
> 
> **Overview**
> Adds a new `make agent-test` target that runs the usual unit test suite in parallel while **suppressing output on success** and printing **filtered failure output** (hiding pytest progress lines), making test runs more concise for agent-driven workflows.
> 
> Updates the Makefile help and `.PHONY` declarations, and switches the agent command docs (`CLAUDE.md` and `pipelex/kit/agent_rules/commands.md`) to recommend `make agent-test` instead of `make test-xdist`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1109736425cbfc45c93a3cb7cb56e35aa71f84da. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->