### PR TITLE
Speed up test suite by skipping telemetry teardown

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+SHELL := /bin/bash
+.SHELLFLAGS := -o pipefail -c
+
 ifeq ($(wildcard .env),.env)
 include .env
 export

--- a/Makefile
+++ b/Makefile
@@ -131,6 +131,15 @@ make li                       - Shorthand -> lock install
 make test-count               - Count the number of tests
 make check-test-badge         - Check if the test count matches the badge value
 
+make test-durations           - Show slowest tests with xdist (TOP=30, MIN=0.5)
+make td                       - Shorthand -> test-durations
+make test-durations-serial    - Show slowest tests without xdist (TOP=30, MIN=0.5)
+make tds                      - Shorthand -> test-durations-serial
+make test-time                - Timed test run with xdist (wall clock)
+make tt                       - Shorthand -> test-time
+make test-time-serial         - Timed test run without xdist (wall clock)
+make tts                      - Shorthand -> test-time-serial
+
 endef
 export HELP
 
@@ -143,6 +152,7 @@ export HELP
 	test-llm tl test-img-gen tg test-extract te codex-tests gha-tests \
 	run-all-tests run-manual-trigger-gha-tests run-gha_disabled-tests \
 	validate v check c cc agent-check agent-test \
+	test-durations td test-durations-serial tds test-time tt test-time-serial tts \
 	merge-check-ruff-lint merge-check-ruff-format merge-check-mypy merge-check-pyright \
 	li check-unused-imports fix-unused-imports check-TODOs check-uv \
 	docs docs-check docs-serve-versioned docs-list docs-deploy docs-deploy-stable docs-deploy-specific-version docs-delete \
@@ -585,6 +595,41 @@ agent-test: env
 	rm -f "$$tmpfile"; \
 	if [ $$exit_code -eq 0 ]; then echo "• All tests passed."; fi; \
 	exit $$exit_code
+
+##########################################################################################
+### TEST DIAGNOSTICS
+##########################################################################################
+
+TOP ?= 30
+MIN ?= 0.5
+
+test-durations: env
+	$(call PRINT_TITLE,"Slowest tests - xdist - top=$(TOP) min=$(MIN)s")
+	$(VENV_PYTEST) -n auto -m $(USUAL_PYTEST_MARKERS) -o log_level=WARNING --durations=$(TOP) --durations-min=$(MIN) --tb=no -q
+
+td: test-durations
+	@echo "> done: td = test-durations"
+
+test-durations-serial: env
+	$(call PRINT_TITLE,"Slowest tests - serial - top=$(TOP) min=$(MIN)s")
+	$(VENV_PYTEST) -p no:xdist -m $(USUAL_PYTEST_MARKERS) -o log_level=WARNING --durations=$(TOP) --durations-min=$(MIN) --tb=no -q
+
+tds: test-durations-serial
+	@echo "> done: tds = test-durations-serial"
+
+test-time: env
+	$(call PRINT_TITLE,"Timed test run - xdist")
+	@time $(VENV_PYTEST) -n auto -m $(USUAL_PYTEST_MARKERS) -o log_level=WARNING --tb=no -q --no-header 2>&1 | tail -1
+
+tt: test-time
+	@echo "> done: tt = test-time"
+
+test-time-serial: env
+	$(call PRINT_TITLE,"Timed test run - serial")
+	@time $(VENV_PYTEST) -p no:xdist -m $(USUAL_PYTEST_MARKERS) -o log_level=WARNING --tb=no -q --no-header 2>&1 | tail -1
+
+tts: test-time-serial
+	@echo "> done: tts = test-time-serial"
 
 cov: env
 	$(call PRINT_TITLE,"Unit testing with coverage")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,8 @@ from pipelex.system.pipelex_service.pipelex_service_config import (
 from pipelex.system.pipelex_service.remote_config import RemoteConfig
 from pipelex.system.pipelex_service.remote_config_fetcher import RemoteConfigFetcher
 from pipelex.system.runtime import IntegrationMode, runtime_manager
+from pipelex.system.telemetry.telemetry_manager import TelemetryManager
+from pipelex.system.telemetry.telemetry_manager_abstract import TelemetryManagerAbstract
 
 pytest_plugins = [
     "pipelex.test_extras.shared_pytest_plugins",
@@ -52,9 +54,24 @@ def _cached_load_pipelex_service_config(config_dir: str) -> PipelexServiceConfig
     return _pipelex_service_config_cache[config_dir]
 
 
+def _fast_telemetry_teardown(self: TelemetryManager) -> None:
+    """Skip expensive OTel/PostHog shutdown during tests (~0.49s per call).
+
+    Preserves exception capture cleanup (restores sys.excepthook) and
+    singleton clearing. Skips TracerProvider.shutdown() and PostHog
+    client.shutdown() which flush queues and join threads.
+    """
+    if self._exception_capture:  # pyright: ignore[reportPrivateUsage]
+        try:
+            self._exception_capture.close()  # pyright: ignore[reportPrivateUsage]
+        except Exception as exc:
+            log.debug(f"Error closing exception capture: {exc}")
+    TelemetryManagerAbstract.clear_instance()
+
+
 @pytest.fixture(scope="session", autouse=True)
 def cache_configs_for_session(session_mocker: MockerFixture):
-    """Cache configurations for the entire test session to avoid repeated fetches and flaky tests."""
+    """Cache configurations and optimize teardown for the entire test session."""
     # Cache remote config to avoid repeated network fetches
     session_mocker.patch.object(RemoteConfigFetcher, "fetch_remote_config", _cached_fetch_remote_config)
     # Cache pipelex service config to avoid flaky tests from concurrent file reads
@@ -62,6 +79,8 @@ def cache_configs_for_session(session_mocker: MockerFixture):
         "pipelex.pipelex.load_pipelex_service_config_if_exists",
         _cached_load_pipelex_service_config,
     )
+    # Skip expensive telemetry shutdown (OTel + PostHog flush) during tests
+    session_mocker.patch.object(TelemetryManager, "teardown", _fast_telemetry_teardown)
 
 
 def _get_test_integration_mode() -> IntegrationMode:


### PR DESCRIPTION
## Summary

- **Patch `TelemetryManager.teardown`** at session scope to skip expensive OTel TracerProvider flush and PostHog client shutdown (~0.49s per module × 677 modules)
- Preserve exception capture cleanup (`sys.excepthook` restore) and singleton clearing
- **Add diagnostic Make targets** for benchmarking: `make td`, `make tds`, `make tt`, `make tts` (with `TOP=N` and `MIN=X` params)

**Results:** Serial 263s → 114s (57% faster). Xdist 16 cores 58s → 52s (10% faster).

## Test plan

- [x] `make agent-check` passes (lint, pyright, mypy)
- [x] `make agent-test` passes (3288 passed, 2 skipped, 2 xfailed — identical to before)
- [x] `make td TOP=5 MIN=1.0` works correctly
- [x] Verify on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes test-only behavior by bypassing telemetry shutdown/flush, which could mask issues that only appear during real teardown (e.g., background thread/queue cleanup). Production telemetry behavior is unchanged.
> 
> **Overview**
> Speeds up the test suite by patching `TelemetryManager.teardown` at session scope in `tests/conftest.py` to **skip OpenTelemetry tracer provider shutdown and PostHog client flush** during tests, while still closing exception capture and clearing the telemetry singleton.
> 
> Adds new Makefile *test diagnostics* targets to surface slow tests and wall-clock timing: `test-durations`/`test-durations-serial` (with `TOP`/`MIN` knobs) and `test-time`/`test-time-serial`, plus shorthands (`td`, `tds`, `tt`, `tts`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bbc34f3fad9aad6f6e5b30e8088476457e5ee819. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->