### PR TITLE
Tweaks2: run pipeline directory

### DIFF
--- a/docs/home/1-releases/chicago.md
+++ b/docs/home/1-releases/chicago.md
@@ -102,7 +102,7 @@ Broad support for open-source AI:
 ## Getting Started
 
 ```bash
-pip install pipelex
+pip install pipelex --pre
 ```
 
 Then run `pipelex init` to configure your environment and obtain your Gateway API key at [app.pipelex.com](https://app.pipelex.com/).

--- a/pipelex/builder/conventions.py
+++ b/pipelex/builder/conventions.py
@@ -1,0 +1,8 @@
+"""Conventions for builder output file names.
+
+These constants define the standard file names produced by the builder
+and expected by the runner when auto-detecting from a directory.
+"""
+
+DEFAULT_BUNDLE_FILE_NAME = "bundle.plx"
+DEFAULT_INPUTS_FILE_NAME = "inputs.json"

--- a/pipelex/cli/agent_cli/commands/build_core.py
+++ b/pipelex/cli/agent_cli/commands/build_core.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel
 from pipelex import log
 from pipelex.builder.builder_errors import PipeBuilderError
 from pipelex.builder.builder_loop import BuilderLoop
+from pipelex.builder.conventions import DEFAULT_INPUTS_FILE_NAME
 from pipelex.config import get_config
 from pipelex.hub import get_required_pipe
 from pipelex.language.plx_factory import PlxFactory
@@ -142,7 +143,7 @@ async def build_pipe_core(
         try:
             pipe = get_required_pipe(pipe_code=main_pipe_code)
             inputs_json_str = pipe.inputs.render_inputs(indent=2)
-            inputs_file_path = Path(extras_output_dir) / "inputs.json"
+            inputs_file_path = Path(extras_output_dir) / DEFAULT_INPUTS_FILE_NAME
             save_text_to_path(text=inputs_json_str, path=str(inputs_file_path))
         except Exception as exc:
             log.warning(f"Could not generate inputs.json: {exc}")

--- a/pipelex/cli/commands/build/inputs_cmd.py
+++ b/pipelex/cli/commands/build/inputs_cmd.py
@@ -6,6 +6,7 @@ import click
 import typer
 from posthog import tag
 
+from pipelex.builder.conventions import DEFAULT_INPUTS_FILE_NAME
 from pipelex.cli.cli_factory import make_pipelex_for_cli
 from pipelex.cli.error_handlers import (
     ErrorContext,
@@ -101,9 +102,9 @@ async def _generate_inputs_core(
     elif bundle_path:
         # Place inputs.json in the same directory as the PLX file
         bundle_dir = bundle_path.parent
-        final_output_path = bundle_dir / "inputs.json"
+        final_output_path = bundle_dir / DEFAULT_INPUTS_FILE_NAME
     else:
-        final_output_path = Path("results/inputs.json")
+        final_output_path = Path("results") / DEFAULT_INPUTS_FILE_NAME
 
     # Save the file
     try:

--- a/pipelex/cli/commands/build/pipe_cmd.py
+++ b/pipelex/cli/commands/build/pipe_cmd.py
@@ -10,6 +10,7 @@ from posthog import tag
 from pipelex import log
 from pipelex.builder.builder_errors import PipeBuilderError
 from pipelex.builder.builder_loop import BuilderLoop
+from pipelex.builder.conventions import DEFAULT_INPUTS_FILE_NAME
 from pipelex.builder.runner_code import generate_runner_code
 from pipelex.cli.cli_factory import make_pipelex_for_cli
 from pipelex.cli.commands.build.structures_cmd import generate_structures_from_blueprints
@@ -272,7 +273,7 @@ def build_pipe_cmd(
 
                     # Generate inputs.json
                     inputs_json_str = pipe.inputs.render_inputs(indent=2)
-                    inputs_json_path = os.path.join(extras_output_dir, "inputs.json")
+                    inputs_json_path = os.path.join(extras_output_dir, DEFAULT_INPUTS_FILE_NAME)
                     save_text_to_path(text=inputs_json_str, path=inputs_json_path)
                     typer.secho(f"✅ Inputs template saved to: {inputs_json_path}", fg=typer.colors.GREEN)
 

--- a/pipelex/cli/commands/run_cmd.py
+++ b/pipelex/cli/commands/run_cmd.py
@@ -284,7 +284,8 @@ def run_cmd(
                     raise typer.Exit(1) from json_type_error_exc
 
         # Execute pipeline
-        typer.secho(f"\n🚀 Executing {source_description}...\n", fg=typer.colors.GREEN, bold=True)
+        inputs_description = f" with inputs '{inputs}'" if inputs and not inputs.startswith("{") else ""
+        typer.secho(f"\n🚀 Executing {source_description}{inputs_description}...\n", fg=typer.colors.GREEN, bold=True)
 
         # Determine pipe run mode
         pipe_run_mode = PipeRunMode.DRY if dry_run else None

--- a/pipelex/cli/commands/run_cmd.py
+++ b/pipelex/cli/commands/run_cmd.py
@@ -10,6 +10,7 @@ import typer
 from posthog import tag
 
 from pipelex import log
+from pipelex.builder.conventions import DEFAULT_BUNDLE_FILE_NAME, DEFAULT_INPUTS_FILE_NAME
 from pipelex.cli.cli_factory import make_pipelex_for_cli
 from pipelex.cli.error_handlers import (
     ErrorContext,
@@ -41,7 +42,7 @@ COMMAND = "run"
 def run_cmd(
     target: Annotated[
         str | None,
-        typer.Argument(help="Pipe code or bundle file path (auto-detected)"),
+        typer.Argument(help="Pipe code, bundle file path (.plx), or pipeline directory (auto-detected)"),
     ] = None,
     pipe: Annotated[
         str | None,
@@ -105,6 +106,7 @@ def run_cmd(
     """Execute a pipeline from a specific bundle file (or not), specifying its pipe code or not.
     If the bundle is provided, it will run its main pipe unless you specify a pipe code.
     If the pipe code is provided, you don't need to provide a bundle file if it's already part of the imported packages.
+    If a directory is provided, it auto-detects bundle.plx and inputs.json inside it.
 
     Examples:
         pipelex run my_pipe
@@ -112,6 +114,8 @@ def run_cmd(
         pipelex run --bundle my_bundle.plx --pipe my_pipe
         pipelex run --pipe my_pipe --inputs data.json
         pipelex run my_bundle.plx --inputs data.json
+        pipelex run pipeline_01/
+        pipelex run pipeline_01/ --pipe my_pipe
         pipelex run my_pipe --working-memory-path results.json --no-pretty-print
         pipelex run my_pipe --no-save-working-memory --no-save-main-stuff
         pipelex run my_pipe --no-graph                  # Disable graph generation
@@ -142,7 +146,63 @@ def run_cmd(
 
     # Determine source:
     if target:
-        if is_pipelex_file(Path(target)):
+        target_path = Path(target)
+        if target_path.is_dir():
+            # Directory mode: auto-detect bundle and inputs
+            if bundle:
+                typer.secho(
+                    "Failed to run: cannot use option --bundle when passing a pipeline directory as target",
+                    fg=typer.colors.RED,
+                    err=True,
+                )
+                raise typer.Exit(1)
+
+            # Find .plx: try default name first, then fall back to single .plx
+            bundle_file = target_path / DEFAULT_BUNDLE_FILE_NAME
+            if bundle_file.is_file():
+                bundle_path = str(bundle_file)
+            else:
+                plx_files = list(target_path.glob("*.plx"))
+                if len(plx_files) == 0:
+                    typer.secho(
+                        f"Failed to run: no .plx bundle file found in directory '{target}'",
+                        fg=typer.colors.RED,
+                        err=True,
+                    )
+                    raise typer.Exit(1)
+                if len(plx_files) > 1:
+                    plx_names = ", ".join(plx_file.name for plx_file in plx_files)
+                    typer.secho(
+                        f"Failed to run: multiple .plx files found in '{target}' ({plx_names}) "
+                        f"and no '{DEFAULT_BUNDLE_FILE_NAME}'. "
+                        f"Pass the .plx file directly, e.g.: pipelex run {target_path / plx_files[0].name}",
+                        fg=typer.colors.RED,
+                        err=True,
+                    )
+                    raise typer.Exit(1)
+                bundle_path = str(plx_files[0])
+
+            # Auto-detect inputs if --inputs not explicitly provided
+            inputs_file = target_path / DEFAULT_INPUTS_FILE_NAME
+            if not inputs and inputs_file.is_file():
+                inputs = str(inputs_file)
+                typer.echo(f"Auto-detected inputs: {inputs}")
+
+            # Add directory as library dir (prepend to user-supplied list)
+            target_dir_str = str(target_path)
+            if library_dir is None:
+                library_dir = [target_dir_str]
+            elif target_dir_str not in library_dir:
+                library_dir = [target_dir_str, *library_dir]
+
+            # Consume --pipe if provided
+            if pipe:
+                pipe_code = pipe
+                pipe = None  # prevent double-assignment below
+
+            typer.echo(f"Auto-detected bundle: {bundle_path}")
+
+        elif is_pipelex_file(target_path):
             bundle_path = target
             if bundle:
                 typer.secho(


### PR DESCRIPTION
## Summary
- Allow `pipelex run pipeline_01/` to auto-detect `bundle.plx`, `inputs.json`, and use the directory as a library dir — replacing verbose `--bundle ... --inputs ... --library-dir ...` invocations
- Extract shared file naming constants (`DEFAULT_BUNDLE_FILE_NAME`, `DEFAULT_INPUTS_FILE_NAME`) into `pipelex/builder/conventions.py` so builder and runner reference a single source of truth
- Graceful fallback: if no `bundle.plx` exists, uses a single `.plx` file in the directory; clear error messages for ambiguous or empty directories

## Test plan
- [x] `make agent-check` passes (ruff, pyright, mypy)
- [x] `make agent-test` passes
- [x] Manual: `pipelex run <dir-with-bundle-and-inputs>/` auto-detects both files
- [x] Manual: `pipelex run <dir-with-bundle-only>/` runs without inputs
- [x] Manual: `pipelex run <empty-dir>/` shows "no .plx" error
- [x] Manual: `pipelex run <dir>/ --bundle x.plx` shows mutual exclusivity error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk due to new CLI argument parsing/auto-detection paths that can change which bundle/inputs are selected and how `library_dir` is constructed.
> 
> **Overview**
> `pipelex run` now accepts a pipeline directory as the positional `target`, auto-detecting `bundle.plx` (or a single `.plx` fallback), optionally auto-loading `inputs.json`, and prepending the directory to `--library-dir` for resolution.
> 
> Shared builder/runner output filenames are centralized in new `pipelex/builder/conventions.py` and used across build commands and the agent build core to avoid hardcoded `inputs.json` strings. CLI messaging/docs were updated (including showing inputs file in the execution banner), and the Chicago release doc now recommends `pip install pipelex --pre`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fae4884c7e589a214641b416ec07a68c54a7cc7e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->