### PR TITLE
Build-PipeCompose-2: Improve builder loop

### DIFF
--- a/pipelex/builder/builder_loop.py
+++ b/pipelex/builder/builder_loop.py
@@ -332,27 +332,7 @@ class BuilderLoop:
             pipe_spec = pipelex_bundle_spec.pipe.get(pipe_code)
             if pipe_spec is None:
                 continue
-
-            # Output
-            output_parse = parse_concept_with_multiplicity(pipe_spec.output)
-            bare_output = self._extract_local_bare_code(concept_ref_or_code=output_parse.concept_ref_or_code, domain=domain)
-            if bare_output is not None:
-                referenced_concepts.add(bare_output)
-
-            # Inputs
-            if pipe_spec.inputs:
-                for input_concept_str in pipe_spec.inputs.values():
-                    input_parse = parse_concept_with_multiplicity(input_concept_str)
-                    bare_input = self._extract_local_bare_code(concept_ref_or_code=input_parse.concept_ref_or_code, domain=domain)
-                    if bare_input is not None:
-                        referenced_concepts.add(bare_input)
-
-            # PipeParallel combined_output
-            if isinstance(pipe_spec, PipeParallelSpec) and pipe_spec.combined_output:
-                combined_parse = parse_concept_with_multiplicity(pipe_spec.combined_output)
-                bare_combined = self._extract_local_bare_code(concept_ref_or_code=combined_parse.concept_ref_or_code, domain=domain)
-                if bare_combined is not None:
-                    referenced_concepts.add(bare_combined)
+            referenced_concepts.update(self._collect_concept_refs_from_pipe_spec(pipe_spec=pipe_spec, domain=domain))
 
         # Step D: Collect transitive concept references from concept definitions
         if pipelex_bundle_spec.concept:
@@ -363,27 +343,11 @@ class BuilderLoop:
                     concept_spec_or_name = pipelex_bundle_spec.concept.get(concept_code)
                     if not isinstance(concept_spec_or_name, ConceptSpec):
                         continue
-
-                    # Check refines
-                    if concept_spec_or_name.refines:
-                        bare_ref = self._extract_local_bare_code(concept_ref_or_code=concept_spec_or_name.refines, domain=domain)
-                        if bare_ref is not None and bare_ref not in referenced_concepts and bare_ref in pipelex_bundle_spec.concept:
+                    new_refs = self._collect_concept_refs_from_concept_spec(concept_spec=concept_spec_or_name, domain=domain)
+                    for bare_ref in new_refs:
+                        if bare_ref not in referenced_concepts and bare_ref in pipelex_bundle_spec.concept:
                             referenced_concepts.add(bare_ref)
                             changed = True
-
-                    # Check structure fields
-                    if concept_spec_or_name.structure:
-                        for field_spec in concept_spec_or_name.structure.values():
-                            if field_spec.concept_ref:
-                                bare_ref = self._extract_local_bare_code(concept_ref_or_code=field_spec.concept_ref, domain=domain)
-                                if bare_ref is not None and bare_ref not in referenced_concepts and bare_ref in pipelex_bundle_spec.concept:
-                                    referenced_concepts.add(bare_ref)
-                                    changed = True
-                            if field_spec.item_concept_ref:
-                                bare_ref = self._extract_local_bare_code(concept_ref_or_code=field_spec.item_concept_ref, domain=domain)
-                                if bare_ref is not None and bare_ref not in referenced_concepts and bare_ref in pipelex_bundle_spec.concept:
-                                    referenced_concepts.add(bare_ref)
-                                    changed = True
 
         # Step E: Remove unused concepts
         if pipelex_bundle_spec.concept:
@@ -416,6 +380,79 @@ class BuilderLoop:
         return None
 
     @staticmethod
+    def _collect_concept_refs_from_pipe_spec(pipe_spec: PipeSpecUnion, domain: str) -> set[str]:
+        """Collect local bare concept codes referenced by a single pipe spec.
+
+        Scans output, inputs, and (for PipeParallelSpec) combined_output.
+
+        Args:
+            pipe_spec: The pipe spec to scan
+            domain: The bundle's domain for locality filtering
+
+        Returns:
+            Set of bare concept codes referenced by this pipe spec
+        """
+        refs: set[str] = set()
+
+        # Output
+        output_parse = parse_concept_with_multiplicity(pipe_spec.output)
+        bare_output = BuilderLoop._extract_local_bare_code(concept_ref_or_code=output_parse.concept_ref_or_code, domain=domain)
+        if bare_output is not None:
+            refs.add(bare_output)
+
+        # Inputs
+        if pipe_spec.inputs:
+            for input_concept_str in pipe_spec.inputs.values():
+                input_parse = parse_concept_with_multiplicity(input_concept_str)
+                bare_input = BuilderLoop._extract_local_bare_code(concept_ref_or_code=input_parse.concept_ref_or_code, domain=domain)
+                if bare_input is not None:
+                    refs.add(bare_input)
+
+        # PipeParallel combined_output
+        if isinstance(pipe_spec, PipeParallelSpec) and pipe_spec.combined_output:
+            combined_parse = parse_concept_with_multiplicity(pipe_spec.combined_output)
+            bare_combined = BuilderLoop._extract_local_bare_code(concept_ref_or_code=combined_parse.concept_ref_or_code, domain=domain)
+            if bare_combined is not None:
+                refs.add(bare_combined)
+
+        return refs
+
+    @staticmethod
+    def _collect_concept_refs_from_concept_spec(concept_spec: ConceptSpec, domain: str) -> set[str]:
+        """Collect local bare concept codes referenced by a single concept spec.
+
+        Scans refines, and structure fields' concept_ref and item_concept_ref.
+
+        Args:
+            concept_spec: The concept spec to scan
+            domain: The bundle's domain for locality filtering
+
+        Returns:
+            Set of bare concept codes referenced by this concept spec
+        """
+        refs: set[str] = set()
+
+        # Refines
+        if concept_spec.refines:
+            bare_ref = BuilderLoop._extract_local_bare_code(concept_ref_or_code=concept_spec.refines, domain=domain)
+            if bare_ref is not None:
+                refs.add(bare_ref)
+
+        # Structure fields
+        if concept_spec.structure:
+            for field_spec in concept_spec.structure.values():
+                if field_spec.concept_ref:
+                    bare_ref = BuilderLoop._extract_local_bare_code(concept_ref_or_code=field_spec.concept_ref, domain=domain)
+                    if bare_ref is not None:
+                        refs.add(bare_ref)
+                if field_spec.item_concept_ref:
+                    bare_ref = BuilderLoop._extract_local_bare_code(concept_ref_or_code=field_spec.item_concept_ref, domain=domain)
+                    if bare_ref is not None:
+                        refs.add(bare_ref)
+
+        return refs
+
+    @staticmethod
     def _collect_local_bare_concept_codes(pipelex_bundle_spec: PipelexBundleSpec) -> set[str]:
         """Collect bare concept codes referenced locally from pipe specs and concept definitions.
 
@@ -431,34 +468,17 @@ class BuilderLoop:
         domain = pipelex_bundle_spec.domain
         referenced: set[str] = set()
 
-        def _add_if_local(concept_ref_or_code: str) -> None:
-            bare_code = BuilderLoop._extract_local_bare_code(concept_ref_or_code=concept_ref_or_code, domain=domain)
-            if bare_code is not None:
-                referenced.add(bare_code)
-
         # Scan pipe specs
         if pipelex_bundle_spec.pipe:
             for pipe_spec in pipelex_bundle_spec.pipe.values():
-                _add_if_local(parse_concept_with_multiplicity(pipe_spec.output).concept_ref_or_code)
-                if pipe_spec.inputs:
-                    for input_concept_str in pipe_spec.inputs.values():
-                        _add_if_local(parse_concept_with_multiplicity(input_concept_str).concept_ref_or_code)
-                if isinstance(pipe_spec, PipeParallelSpec) and pipe_spec.combined_output:
-                    _add_if_local(parse_concept_with_multiplicity(pipe_spec.combined_output).concept_ref_or_code)
+                referenced.update(BuilderLoop._collect_concept_refs_from_pipe_spec(pipe_spec=pipe_spec, domain=domain))
 
         # Scan concept definitions
         if pipelex_bundle_spec.concept:
             for concept_spec_or_name in pipelex_bundle_spec.concept.values():
                 if not isinstance(concept_spec_or_name, ConceptSpec):
                     continue
-                if concept_spec_or_name.refines:
-                    _add_if_local(concept_spec_or_name.refines)
-                if concept_spec_or_name.structure:
-                    for field_spec in concept_spec_or_name.structure.values():
-                        if field_spec.concept_ref:
-                            _add_if_local(field_spec.concept_ref)
-                        if field_spec.item_concept_ref:
-                            _add_if_local(field_spec.item_concept_ref)
+                referenced.update(BuilderLoop._collect_concept_refs_from_concept_spec(concept_spec=concept_spec_or_name, domain=domain))
 
         return referenced
 

--- a/pipelex/builder/builder_loop.py
+++ b/pipelex/builder/builder_loop.py
@@ -286,6 +286,8 @@ class BuilderLoop:
         if not pipelex_bundle_spec.pipe:
             return pipelex_bundle_spec
 
+        domain = pipelex_bundle_spec.domain
+
         # Step A: Find all reachable pipes by walking the call graph from main_pipe
         reachable_pipes: set[str] = set()
         to_visit: list[str] = [pipelex_bundle_spec.main_pipe]
@@ -295,11 +297,12 @@ class BuilderLoop:
             pipe_code = to_visit.pop()
             if pipe_code in reachable_pipes:
                 continue
-            reachable_pipes.add(pipe_code)
 
             pipe_spec = pipelex_bundle_spec.pipe.get(pipe_code)
             if pipe_spec is None:
+                log.warning(f"Pipe '{pipe_code}' is referenced but not found in bundle spec pipes")
                 continue
+            reachable_pipes.add(pipe_code)
 
             sub_pipe_codes: list[str] = []
             if isinstance(pipe_spec, PipeSequenceSpec):
@@ -332,24 +335,24 @@ class BuilderLoop:
 
             # Output
             output_parse = parse_concept_with_multiplicity(pipe_spec.output)
-            output_concept = output_parse.concept_ref_or_code
-            bare_output = output_concept.split(".")[-1] if "." in output_concept else output_concept
-            referenced_concepts.add(bare_output)
+            bare_output = self._extract_local_bare_code(concept_ref_or_code=output_parse.concept_ref_or_code, domain=domain)
+            if bare_output is not None:
+                referenced_concepts.add(bare_output)
 
             # Inputs
             if pipe_spec.inputs:
                 for input_concept_str in pipe_spec.inputs.values():
                     input_parse = parse_concept_with_multiplicity(input_concept_str)
-                    input_concept = input_parse.concept_ref_or_code
-                    bare_input = input_concept.split(".")[-1] if "." in input_concept else input_concept
-                    referenced_concepts.add(bare_input)
+                    bare_input = self._extract_local_bare_code(concept_ref_or_code=input_parse.concept_ref_or_code, domain=domain)
+                    if bare_input is not None:
+                        referenced_concepts.add(bare_input)
 
             # PipeParallel combined_output
             if isinstance(pipe_spec, PipeParallelSpec) and pipe_spec.combined_output:
                 combined_parse = parse_concept_with_multiplicity(pipe_spec.combined_output)
-                combined_concept = combined_parse.concept_ref_or_code
-                bare_combined = combined_concept.split(".")[-1] if "." in combined_concept else combined_concept
-                referenced_concepts.add(bare_combined)
+                bare_combined = self._extract_local_bare_code(concept_ref_or_code=combined_parse.concept_ref_or_code, domain=domain)
+                if bare_combined is not None:
+                    referenced_concepts.add(bare_combined)
 
         # Step D: Collect transitive concept references from concept definitions
         if pipelex_bundle_spec.concept:
@@ -363,10 +366,8 @@ class BuilderLoop:
 
                     # Check refines
                     if concept_spec_or_name.refines:
-                        bare_ref = (
-                            concept_spec_or_name.refines.split(".")[-1] if "." in concept_spec_or_name.refines else concept_spec_or_name.refines
-                        )
-                        if bare_ref not in referenced_concepts and bare_ref in pipelex_bundle_spec.concept:
+                        bare_ref = self._extract_local_bare_code(concept_ref_or_code=concept_spec_or_name.refines, domain=domain)
+                        if bare_ref is not None and bare_ref not in referenced_concepts and bare_ref in pipelex_bundle_spec.concept:
                             referenced_concepts.add(bare_ref)
                             changed = True
 
@@ -374,15 +375,13 @@ class BuilderLoop:
                     if concept_spec_or_name.structure:
                         for field_spec in concept_spec_or_name.structure.values():
                             if field_spec.concept_ref:
-                                bare_ref = field_spec.concept_ref.split(".")[-1] if "." in field_spec.concept_ref else field_spec.concept_ref
-                                if bare_ref not in referenced_concepts and bare_ref in pipelex_bundle_spec.concept:
+                                bare_ref = self._extract_local_bare_code(concept_ref_or_code=field_spec.concept_ref, domain=domain)
+                                if bare_ref is not None and bare_ref not in referenced_concepts and bare_ref in pipelex_bundle_spec.concept:
                                     referenced_concepts.add(bare_ref)
                                     changed = True
                             if field_spec.item_concept_ref:
-                                bare_ref = (
-                                    field_spec.item_concept_ref.split(".")[-1] if "." in field_spec.item_concept_ref else field_spec.item_concept_ref
-                                )
-                                if bare_ref not in referenced_concepts and bare_ref in pipelex_bundle_spec.concept:
+                                bare_ref = self._extract_local_bare_code(concept_ref_or_code=field_spec.item_concept_ref, domain=domain)
+                                if bare_ref is not None and bare_ref not in referenced_concepts and bare_ref in pipelex_bundle_spec.concept:
                                     referenced_concepts.add(bare_ref)
                                     changed = True
 
@@ -394,6 +393,27 @@ class BuilderLoop:
                 log.info(f"🧹 Removed unused concept '{concept_code}'")
 
         return pipelex_bundle_spec
+
+    @staticmethod
+    def _extract_local_bare_code(concept_ref_or_code: str, domain: str) -> str | None:
+        """Extract a bare concept code only if the reference is local.
+
+        A reference is considered local if it has no domain prefix or if
+        its domain prefix matches the bundle domain.
+
+        Args:
+            concept_ref_or_code: A concept reference like "Document", "my_domain.Document", or "external.Document"
+            domain: The bundle's domain
+
+        Returns:
+            The bare concept code if local, or None if external
+        """
+        if "." not in concept_ref_or_code:
+            return concept_ref_or_code
+        prefix, bare_code = concept_ref_or_code.rsplit(".", maxsplit=1)
+        if prefix == domain:
+            return bare_code
+        return None
 
     @staticmethod
     def _collect_local_bare_concept_codes(pipelex_bundle_spec: PipelexBundleSpec) -> set[str]:
@@ -412,8 +432,8 @@ class BuilderLoop:
         referenced: set[str] = set()
 
         def _add_if_local(concept_ref_or_code: str) -> None:
-            if "." not in concept_ref_or_code or concept_ref_or_code.split(".", maxsplit=1)[0] == domain:
-                bare_code = concept_ref_or_code.rsplit(".", maxsplit=1)[-1] if "." in concept_ref_or_code else concept_ref_or_code
+            bare_code = BuilderLoop._extract_local_bare_code(concept_ref_or_code=concept_ref_or_code, domain=domain)
+            if bare_code is not None:
                 referenced.add(bare_code)
 
         # Scan pipe specs

--- a/pipelex/builder/builder_loop.py
+++ b/pipelex/builder/builder_loop.py
@@ -222,6 +222,13 @@ class BuilderLoop:
                         log.info(f"🔧 Setting output of PipeParallel '{pipe_code}' to 'Anything'")
                         pipe_spec.output = "Anything"
 
+        # Recompute undeclared: some concepts may no longer be referenced after PipeParallel fixes
+        still_referenced = self._collect_local_bare_concept_codes(pipelex_bundle_spec=pipelex_bundle_spec)
+        no_longer_referenced = undeclared - still_referenced
+        if no_longer_referenced:
+            log.info(f"🔧 Concepts no longer referenced after PipeParallel fixes: {', '.join(sorted(no_longer_referenced))}")
+            undeclared -= no_longer_referenced
+
         # Step 4: Create remaining undeclared concepts via pipeline
         if undeclared:
             # Build context for the LLM
@@ -387,6 +394,53 @@ class BuilderLoop:
                 log.info(f"🧹 Removed unused concept '{concept_code}'")
 
         return pipelex_bundle_spec
+
+    @staticmethod
+    def _collect_local_bare_concept_codes(pipelex_bundle_spec: PipelexBundleSpec) -> set[str]:
+        """Collect bare concept codes referenced locally from pipe specs and concept definitions.
+
+        Only includes references whose domain prefix is absent or matches the bundle domain.
+        This is used to determine which concepts are still actively referenced after spec mutations.
+
+        Args:
+            pipelex_bundle_spec: The bundle spec to scan
+
+        Returns:
+            Set of bare concept codes (without domain prefix) that are referenced
+        """
+        domain = pipelex_bundle_spec.domain
+        referenced: set[str] = set()
+
+        def _add_if_local(concept_ref_or_code: str) -> None:
+            if "." not in concept_ref_or_code or concept_ref_or_code.split(".", maxsplit=1)[0] == domain:
+                bare_code = concept_ref_or_code.rsplit(".", maxsplit=1)[-1] if "." in concept_ref_or_code else concept_ref_or_code
+                referenced.add(bare_code)
+
+        # Scan pipe specs
+        if pipelex_bundle_spec.pipe:
+            for pipe_spec in pipelex_bundle_spec.pipe.values():
+                _add_if_local(parse_concept_with_multiplicity(pipe_spec.output).concept_ref_or_code)
+                if pipe_spec.inputs:
+                    for input_concept_str in pipe_spec.inputs.values():
+                        _add_if_local(parse_concept_with_multiplicity(input_concept_str).concept_ref_or_code)
+                if isinstance(pipe_spec, PipeParallelSpec) and pipe_spec.combined_output:
+                    _add_if_local(parse_concept_with_multiplicity(pipe_spec.combined_output).concept_ref_or_code)
+
+        # Scan concept definitions
+        if pipelex_bundle_spec.concept:
+            for concept_spec_or_name in pipelex_bundle_spec.concept.values():
+                if not isinstance(concept_spec_or_name, ConceptSpec):
+                    continue
+                if concept_spec_or_name.refines:
+                    _add_if_local(concept_spec_or_name.refines)
+                if concept_spec_or_name.structure:
+                    for field_spec in concept_spec_or_name.structure.values():
+                        if field_spec.concept_ref:
+                            _add_if_local(field_spec.concept_ref)
+                        if field_spec.item_concept_ref:
+                            _add_if_local(field_spec.item_concept_ref)
+
+        return referenced
 
     def _fix_bundle_validation_error(
         self,

--- a/pipelex/builder/builder_loop.py
+++ b/pipelex/builder/builder_loop.py
@@ -11,6 +11,7 @@ from pipelex.builder.builder import (
 from pipelex.builder.builder_errors import PipeBuilderError
 from pipelex.builder.concept.concept_spec import ConceptSpec, ConceptStructureSpecFieldType
 from pipelex.builder.exceptions import PipelexBundleSpecBlueprintError
+from pipelex.builder.pipe.pipe_batch_spec import PipeBatchSpec
 from pipelex.builder.pipe.pipe_compose_spec import PipeComposeSpec
 from pipelex.builder.pipe.pipe_condition_spec import PipeConditionSpec
 from pipelex.builder.pipe.pipe_parallel_spec import PipeParallelSpec
@@ -24,6 +25,7 @@ from pipelex.core.pipes.variable_multiplicity import format_concept_with_multipl
 from pipelex.graph.graphspec import GraphSpec
 from pipelex.hub import get_required_pipe
 from pipelex.language.plx_factory import PlxFactory
+from pipelex.pipe_controllers.condition.special_outcome import SpecialOutcome
 from pipelex.pipeline.execute import execute_pipeline
 from pipelex.pipeline.validate_bundle import ValidateBundleError, validate_bundle
 from pipelex.system.configuration.configs import PipelineExecutionConfig
@@ -194,7 +196,6 @@ class BuilderLoop:
         log.info(f"🔍 Found {len(undeclared)} undeclared concept(s): {', '.join(sorted(undeclared))}")
 
         # Step 3: Fix PipeParallel combined_output deterministically (no pipeline needed)
-        fixed_pipe_parallel_concepts: set[str] = set()
         if pipelex_bundle_spec.pipe:
             for pipe_code, pipe_spec in pipelex_bundle_spec.pipe.items():
                 if not isinstance(pipe_spec, PipeParallelSpec):
@@ -212,7 +213,6 @@ class BuilderLoop:
                 if pipe_spec.add_each_output:
                     log.info(f"🔧 Removing undeclared combined_output '{pipe_spec.combined_output}' from PipeParallel '{pipe_code}'")
                     pipe_spec.combined_output = None
-                    fixed_pipe_parallel_concepts.add(bare_combined)
 
                     # Also fix output if it references an undeclared concept
                     output_parse = parse_concept_with_multiplicity(pipe_spec.output)
@@ -221,9 +221,6 @@ class BuilderLoop:
                     if bare_output in undeclared:
                         log.info(f"🔧 Setting output of PipeParallel '{pipe_code}' to 'Anything'")
                         pipe_spec.output = "Anything"
-                        fixed_pipe_parallel_concepts.add(bare_output)
-
-        undeclared -= fixed_pipe_parallel_concepts
 
         # Step 4: Create remaining undeclared concepts via pipeline
         if undeclared:
@@ -263,6 +260,131 @@ class BuilderLoop:
             for concept_spec in generated_concepts_list.items:
                 pipelex_bundle_spec.concept[concept_spec.the_concept_code] = concept_spec
                 log.info(f"🔧 Added generated concept '{concept_spec.the_concept_code}' to bundle")
+
+        return self._prune_unreachable_specs(pipelex_bundle_spec=pipelex_bundle_spec)
+
+    def _prune_unreachable_specs(self, pipelex_bundle_spec: PipelexBundleSpec) -> PipelexBundleSpec:
+        """Remove unreachable pipes and unused concepts from the bundle spec.
+
+        Walks the call graph from main_pipe to find all reachable pipes, removes
+        unreachable ones, then collects all concept references from reachable pipes
+        and concept definitions (transitively) to remove unused concepts.
+
+        Args:
+            pipelex_bundle_spec: The bundle spec to prune (modified in place)
+
+        Returns:
+            The pruned bundle spec
+        """
+        if not pipelex_bundle_spec.pipe:
+            return pipelex_bundle_spec
+
+        # Step A: Find all reachable pipes by walking the call graph from main_pipe
+        reachable_pipes: set[str] = set()
+        to_visit: list[str] = [pipelex_bundle_spec.main_pipe]
+        special_outcome_values = SpecialOutcome.value_list()
+
+        while to_visit:
+            pipe_code = to_visit.pop()
+            if pipe_code in reachable_pipes:
+                continue
+            reachable_pipes.add(pipe_code)
+
+            pipe_spec = pipelex_bundle_spec.pipe.get(pipe_code)
+            if pipe_spec is None:
+                continue
+
+            sub_pipe_codes: list[str] = []
+            if isinstance(pipe_spec, PipeSequenceSpec):
+                sub_pipe_codes = [step.pipe_code for step in pipe_spec.steps]
+            elif isinstance(pipe_spec, PipeParallelSpec):
+                sub_pipe_codes = [parallel.pipe_code for parallel in pipe_spec.parallels]
+            elif isinstance(pipe_spec, PipeBatchSpec):
+                sub_pipe_codes = [pipe_spec.branch_pipe_code]
+            elif isinstance(pipe_spec, PipeConditionSpec):
+                for outcome_value in pipe_spec.outcomes.values():
+                    if outcome_value not in special_outcome_values:
+                        sub_pipe_codes.append(outcome_value)
+                if pipe_spec.default_outcome not in special_outcome_values:
+                    sub_pipe_codes.append(pipe_spec.default_outcome)
+
+            to_visit.extend(sub_pipe_codes)
+
+        # Step B: Remove unreachable pipes
+        unreachable = set(pipelex_bundle_spec.pipe.keys()) - reachable_pipes
+        for pipe_code in unreachable:
+            del pipelex_bundle_spec.pipe[pipe_code]
+            log.info(f"🧹 Removed unreachable pipe '{pipe_code}'")
+
+        # Step C: Collect all concept references from reachable pipes
+        referenced_concepts: set[str] = set()
+        for pipe_code in reachable_pipes:
+            pipe_spec = pipelex_bundle_spec.pipe.get(pipe_code)
+            if pipe_spec is None:
+                continue
+
+            # Output
+            output_parse = parse_concept_with_multiplicity(pipe_spec.output)
+            output_concept = output_parse.concept_ref_or_code
+            bare_output = output_concept.split(".")[-1] if "." in output_concept else output_concept
+            referenced_concepts.add(bare_output)
+
+            # Inputs
+            if pipe_spec.inputs:
+                for input_concept_str in pipe_spec.inputs.values():
+                    input_parse = parse_concept_with_multiplicity(input_concept_str)
+                    input_concept = input_parse.concept_ref_or_code
+                    bare_input = input_concept.split(".")[-1] if "." in input_concept else input_concept
+                    referenced_concepts.add(bare_input)
+
+            # PipeParallel combined_output
+            if isinstance(pipe_spec, PipeParallelSpec) and pipe_spec.combined_output:
+                combined_parse = parse_concept_with_multiplicity(pipe_spec.combined_output)
+                combined_concept = combined_parse.concept_ref_or_code
+                bare_combined = combined_concept.split(".")[-1] if "." in combined_concept else combined_concept
+                referenced_concepts.add(bare_combined)
+
+        # Step D: Collect transitive concept references from concept definitions
+        if pipelex_bundle_spec.concept:
+            changed = True
+            while changed:
+                changed = False
+                for concept_code in list(referenced_concepts):
+                    concept_spec_or_name = pipelex_bundle_spec.concept.get(concept_code)
+                    if not isinstance(concept_spec_or_name, ConceptSpec):
+                        continue
+
+                    # Check refines
+                    if concept_spec_or_name.refines:
+                        bare_ref = (
+                            concept_spec_or_name.refines.split(".")[-1] if "." in concept_spec_or_name.refines else concept_spec_or_name.refines
+                        )
+                        if bare_ref not in referenced_concepts and bare_ref in pipelex_bundle_spec.concept:
+                            referenced_concepts.add(bare_ref)
+                            changed = True
+
+                    # Check structure fields
+                    if concept_spec_or_name.structure:
+                        for field_spec in concept_spec_or_name.structure.values():
+                            if field_spec.concept_ref:
+                                bare_ref = field_spec.concept_ref.split(".")[-1] if "." in field_spec.concept_ref else field_spec.concept_ref
+                                if bare_ref not in referenced_concepts and bare_ref in pipelex_bundle_spec.concept:
+                                    referenced_concepts.add(bare_ref)
+                                    changed = True
+                            if field_spec.item_concept_ref:
+                                bare_ref = (
+                                    field_spec.item_concept_ref.split(".")[-1] if "." in field_spec.item_concept_ref else field_spec.item_concept_ref
+                                )
+                                if bare_ref not in referenced_concepts and bare_ref in pipelex_bundle_spec.concept:
+                                    referenced_concepts.add(bare_ref)
+                                    changed = True
+
+        # Step E: Remove unused concepts
+        if pipelex_bundle_spec.concept:
+            unused = set(pipelex_bundle_spec.concept.keys()) - referenced_concepts
+            for concept_code in unused:
+                del pipelex_bundle_spec.concept[concept_code]
+                log.info(f"🧹 Removed unused concept '{concept_code}'")
 
         return pipelex_bundle_spec
 

--- a/tests/unit/pipelex/builder/test_builder_loop_prune.py
+++ b/tests/unit/pipelex/builder/test_builder_loop_prune.py
@@ -7,13 +7,14 @@ from pipelex.builder.bundle_spec import PipelexBundleSpec
 from pipelex.builder.concept.concept_spec import ConceptSpec, ConceptStructureSpec, ConceptStructureSpecFieldType
 from pipelex.builder.pipe.pipe_llm_spec import PipeLLMSpec
 from pipelex.builder.pipe.pipe_sequence_spec import PipeSequenceSpec
+from pipelex.builder.pipe.pipe_spec_union import PipeSpecUnion
 from pipelex.builder.pipe.sub_pipe_spec import SubPipeSpec
 
 
 def _make_bundle_for_prune(
     domain: str = "my_domain",
     main_pipe: str = "main_sequence",
-    pipes: dict[str, PipeLLMSpec | PipeSequenceSpec] | None = None,
+    pipes: dict[str, PipeSpecUnion] | None = None,
     concepts: dict[str, ConceptSpec | str] | None = None,
 ) -> PipelexBundleSpec:
     """Create a minimal PipelexBundleSpec for testing _prune_unreachable_specs."""
@@ -60,7 +61,7 @@ class TestBuilderLoopPruneUnreachableSpecs:
                     description="Main",
                     type="PipeSequence",
                     pipe_category="PipeController",
-                    inputs=None,
+                    inputs={},
                     output="Text",
                     steps=[SubPipeSpec(pipe_code="generate_text", result="text_output")],
                 ),
@@ -103,7 +104,7 @@ class TestBuilderLoopPruneUnreachableSpecs:
                     description="Generate report",
                     type="PipeLLM",
                     pipe_category="PipeOperator",
-                    inputs=None,
+                    inputs={},
                     output="my_domain.Report",
                     llm_talent="data-retrieval",
                     prompt="Generate a report",
@@ -137,7 +138,7 @@ class TestBuilderLoopPruneUnreachableSpecs:
                     description="Generate summary",
                     type="PipeLLM",
                     pipe_category="PipeOperator",
-                    inputs=None,
+                    inputs={},
                     output="Summary",
                     llm_talent="data-retrieval",
                     prompt="Generate a summary",
@@ -170,7 +171,7 @@ class TestBuilderLoopPruneUnreachableSpecs:
                     description="Generate result",
                     type="PipeLLM",
                     pipe_category="PipeOperator",
-                    inputs=None,
+                    inputs={},
                     output="Result",
                     llm_talent="data-retrieval",
                     prompt="Generate a result",
@@ -211,7 +212,7 @@ class TestBuilderLoopPruneUnreachableSpecs:
                     description="Generate derived",
                     type="PipeLLM",
                     pipe_category="PipeOperator",
-                    inputs=None,
+                    inputs={},
                     output="Derived",
                     llm_talent="data-retrieval",
                     prompt="Generate derived content",
@@ -250,7 +251,7 @@ class TestBuilderLoopPruneUnreachableSpecs:
                     description="Generate container",
                     type="PipeLLM",
                     pipe_category="PipeOperator",
-                    inputs=None,
+                    inputs={},
                     output="Container",
                     llm_talent="data-retrieval",
                     prompt="Generate container",
@@ -300,7 +301,7 @@ class TestBuilderLoopPruneUnreachableSpecs:
                     description="Main",
                     type="PipeSequence",
                     pipe_category="PipeController",
-                    inputs=None,
+                    inputs={},
                     output="Text",
                     steps=[
                         SubPipeSpec(pipe_code="existing_pipe", result="result"),
@@ -312,7 +313,7 @@ class TestBuilderLoopPruneUnreachableSpecs:
                     description="Existing pipe",
                     type="PipeLLM",
                     pipe_category="PipeOperator",
-                    inputs=None,
+                    inputs={},
                     output="Text",
                     llm_talent="data-retrieval",
                     prompt="Generate text",
@@ -339,7 +340,7 @@ class TestBuilderLoopPruneUnreachableSpecs:
                     description="Main",
                     type="PipeSequence",
                     pipe_category="PipeController",
-                    inputs=None,
+                    inputs={},
                     output="Text",
                     steps=[SubPipeSpec(pipe_code="missing_pipe", result="result")],
                 ),
@@ -348,7 +349,7 @@ class TestBuilderLoopPruneUnreachableSpecs:
                     description="Orphan pipe",
                     type="PipeLLM",
                     pipe_category="PipeOperator",
-                    inputs=None,
+                    inputs={},
                     output="Text",
                     llm_talent="data-retrieval",
                     prompt="Orphan",

--- a/tests/unit/pipelex/builder/test_builder_loop_prune.py
+++ b/tests/unit/pipelex/builder/test_builder_loop_prune.py
@@ -1,0 +1,366 @@
+import logging
+
+import pytest
+
+from pipelex.builder.builder_loop import BuilderLoop
+from pipelex.builder.bundle_spec import PipelexBundleSpec
+from pipelex.builder.concept.concept_spec import ConceptSpec, ConceptStructureSpec, ConceptStructureSpecFieldType
+from pipelex.builder.pipe.pipe_llm_spec import PipeLLMSpec
+from pipelex.builder.pipe.pipe_sequence_spec import PipeSequenceSpec
+from pipelex.builder.pipe.sub_pipe_spec import SubPipeSpec
+
+
+def _make_bundle_for_prune(
+    domain: str = "my_domain",
+    main_pipe: str = "main_sequence",
+    pipes: dict[str, PipeLLMSpec | PipeSequenceSpec] | None = None,
+    concepts: dict[str, ConceptSpec | str] | None = None,
+) -> PipelexBundleSpec:
+    """Create a minimal PipelexBundleSpec for testing _prune_unreachable_specs."""
+    return PipelexBundleSpec.model_construct(
+        domain=domain,
+        main_pipe=main_pipe,
+        concept=concepts or {},
+        pipe=pipes or {},
+    )
+
+
+class TestBuilderLoopPruneUnreachableSpecs:
+    """Tests for _prune_unreachable_specs and _extract_local_bare_code in BuilderLoop."""
+
+    # --- Tests for _extract_local_bare_code ---
+
+    @pytest.mark.parametrize(
+        ("concept_ref", "domain", "expected"),
+        [
+            ("Doc", "my_domain", "Doc"),
+            ("my_domain.Doc", "my_domain", "Doc"),
+            ("external.Doc", "my_domain", None),
+            ("other_lib.Foo", "my_domain", None),
+            ("my_domain.nested.Thing", "my_domain", None),
+        ],
+    )
+    def test_extract_local_bare_code(self, concept_ref: str, domain: str, expected: str | None) -> None:
+        """Verify _extract_local_bare_code returns bare code for local refs and None for external."""
+        result = BuilderLoop._extract_local_bare_code(concept_ref_or_code=concept_ref, domain=domain)  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+        assert result == expected
+
+    # --- Tests for domain filtering ---
+
+    def test_prune_external_ref_does_not_keep_local(self) -> None:
+        """An external reference like 'external.Document' should not prevent local 'Document' from being pruned."""
+        builder_loop = BuilderLoop()
+
+        bundle = _make_bundle_for_prune(
+            domain="my_domain",
+            main_pipe="main_sequence",
+            pipes={
+                "main_sequence": PipeSequenceSpec.model_construct(
+                    pipe_code="main_sequence",
+                    description="Main",
+                    type="PipeSequence",
+                    pipe_category="PipeController",
+                    inputs=None,
+                    output="Text",
+                    steps=[SubPipeSpec(pipe_code="generate_text", result="text_output")],
+                ),
+                "generate_text": PipeLLMSpec.model_construct(
+                    pipe_code="generate_text",
+                    description="Generate text",
+                    type="PipeLLM",
+                    pipe_category="PipeOperator",
+                    inputs={"doc": "external.Document"},
+                    output="Text",
+                    llm_talent="data-retrieval",
+                    prompt="Process @doc",
+                ),
+            },
+            concepts={
+                "Document": ConceptSpec(
+                    the_concept_code="Document",
+                    description="A local document concept that should be pruned",
+                    refines="Text",
+                ),
+            },
+        )
+
+        result = builder_loop._prune_unreachable_specs(pipelex_bundle_spec=bundle)  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+
+        # Document should be pruned because 'external.Document' is an external ref
+        assert result.concept is not None
+        assert "Document" not in result.concept
+
+    def test_prune_keeps_same_domain_prefixed(self) -> None:
+        """A same-domain prefixed reference like 'my_domain.Report' should keep local 'Report'."""
+        builder_loop = BuilderLoop()
+
+        bundle = _make_bundle_for_prune(
+            domain="my_domain",
+            main_pipe="generate_report",
+            pipes={
+                "generate_report": PipeLLMSpec.model_construct(
+                    pipe_code="generate_report",
+                    description="Generate report",
+                    type="PipeLLM",
+                    pipe_category="PipeOperator",
+                    inputs=None,
+                    output="my_domain.Report",
+                    llm_talent="data-retrieval",
+                    prompt="Generate a report",
+                ),
+            },
+            concepts={
+                "Report": ConceptSpec(
+                    the_concept_code="Report",
+                    description="A report concept",
+                    refines="Text",
+                ),
+            },
+        )
+
+        result = builder_loop._prune_unreachable_specs(pipelex_bundle_spec=bundle)  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+
+        # Report should NOT be pruned because 'my_domain.Report' is a local ref
+        assert result.concept is not None
+        assert "Report" in result.concept
+
+    def test_prune_keeps_unprefixed_local(self) -> None:
+        """An unprefixed reference like 'Summary' should keep local 'Summary'."""
+        builder_loop = BuilderLoop()
+
+        bundle = _make_bundle_for_prune(
+            domain="my_domain",
+            main_pipe="generate_summary",
+            pipes={
+                "generate_summary": PipeLLMSpec.model_construct(
+                    pipe_code="generate_summary",
+                    description="Generate summary",
+                    type="PipeLLM",
+                    pipe_category="PipeOperator",
+                    inputs=None,
+                    output="Summary",
+                    llm_talent="data-retrieval",
+                    prompt="Generate a summary",
+                ),
+            },
+            concepts={
+                "Summary": ConceptSpec(
+                    the_concept_code="Summary",
+                    description="A summary concept",
+                    refines="Text",
+                ),
+            },
+        )
+
+        result = builder_loop._prune_unreachable_specs(pipelex_bundle_spec=bundle)  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+
+        assert result.concept is not None
+        assert "Summary" in result.concept
+
+    def test_prune_transitive_external_ref(self) -> None:
+        """A concept refining an external ref should not keep the local concept with the same bare name."""
+        builder_loop = BuilderLoop()
+
+        bundle = _make_bundle_for_prune(
+            domain="my_domain",
+            main_pipe="generate_result",
+            pipes={
+                "generate_result": PipeLLMSpec.model_construct(
+                    pipe_code="generate_result",
+                    description="Generate result",
+                    type="PipeLLM",
+                    pipe_category="PipeOperator",
+                    inputs=None,
+                    output="Result",
+                    llm_talent="data-retrieval",
+                    prompt="Generate a result",
+                ),
+            },
+            concepts={
+                "Result": ConceptSpec(
+                    the_concept_code="Result",
+                    description="A result concept",
+                    refines="external.Info",
+                ),
+                "Info": ConceptSpec(
+                    the_concept_code="Info",
+                    description="A local info concept that should be pruned",
+                    refines="Text",
+                ),
+            },
+        )
+
+        result = builder_loop._prune_unreachable_specs(pipelex_bundle_spec=bundle)  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+
+        assert result.concept is not None
+        # Result should be kept (referenced by pipe output)
+        assert "Result" in result.concept
+        # Info should be pruned because 'external.Info' is external
+        assert "Info" not in result.concept
+
+    def test_prune_transitive_local_ref(self) -> None:
+        """A concept refining a local concept should keep that concept."""
+        builder_loop = BuilderLoop()
+
+        bundle = _make_bundle_for_prune(
+            domain="my_domain",
+            main_pipe="generate_derived",
+            pipes={
+                "generate_derived": PipeLLMSpec.model_construct(
+                    pipe_code="generate_derived",
+                    description="Generate derived",
+                    type="PipeLLM",
+                    pipe_category="PipeOperator",
+                    inputs=None,
+                    output="Derived",
+                    llm_talent="data-retrieval",
+                    prompt="Generate derived content",
+                ),
+            },
+            concepts={
+                "Derived": ConceptSpec(
+                    the_concept_code="Derived",
+                    description="A derived concept",
+                    refines="Base",
+                ),
+                "Base": ConceptSpec(
+                    the_concept_code="Base",
+                    description="A base concept",
+                    refines="Text",
+                ),
+            },
+        )
+
+        result = builder_loop._prune_unreachable_specs(pipelex_bundle_spec=bundle)  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+
+        assert result.concept is not None
+        assert "Derived" in result.concept
+        assert "Base" in result.concept
+
+    def test_prune_transitive_structure_external_ref(self) -> None:
+        """A concept with a structure field referencing an external concept should not keep the local bare name."""
+        builder_loop = BuilderLoop()
+
+        bundle = _make_bundle_for_prune(
+            domain="my_domain",
+            main_pipe="generate_container",
+            pipes={
+                "generate_container": PipeLLMSpec.model_construct(
+                    pipe_code="generate_container",
+                    description="Generate container",
+                    type="PipeLLM",
+                    pipe_category="PipeOperator",
+                    inputs=None,
+                    output="Container",
+                    llm_talent="data-retrieval",
+                    prompt="Generate container",
+                ),
+            },
+            concepts={
+                "Container": ConceptSpec(
+                    the_concept_code="Container",
+                    description="A container",
+                    structure={
+                        "items": ConceptStructureSpec(
+                            the_field_name="items",
+                            description="Items list",
+                            type=ConceptStructureSpecFieldType.LIST,
+                            item_type="concept",
+                            item_concept_ref="other_lib.Widget",
+                        ),
+                    },
+                ),
+                "Widget": ConceptSpec(
+                    the_concept_code="Widget",
+                    description="A local widget that should be pruned",
+                    refines="Text",
+                ),
+            },
+        )
+
+        result = builder_loop._prune_unreachable_specs(pipelex_bundle_spec=bundle)  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+
+        assert result.concept is not None
+        assert "Container" in result.concept
+        # Widget should be pruned because 'other_lib.Widget' is external
+        assert "Widget" not in result.concept
+
+    # --- Tests for pipe lookup masking ---
+
+    def test_prune_warns_missing_pipe(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A sequence referencing a non-existent pipe should log a warning and not crash."""
+        builder_loop = BuilderLoop()
+
+        bundle = _make_bundle_for_prune(
+            domain="my_domain",
+            main_pipe="main_sequence",
+            pipes={
+                "main_sequence": PipeSequenceSpec.model_construct(
+                    pipe_code="main_sequence",
+                    description="Main",
+                    type="PipeSequence",
+                    pipe_category="PipeController",
+                    inputs=None,
+                    output="Text",
+                    steps=[
+                        SubPipeSpec(pipe_code="existing_pipe", result="result"),
+                        SubPipeSpec(pipe_code="missing_pipe", result="other_result"),
+                    ],
+                ),
+                "existing_pipe": PipeLLMSpec.model_construct(
+                    pipe_code="existing_pipe",
+                    description="Existing pipe",
+                    type="PipeLLM",
+                    pipe_category="PipeOperator",
+                    inputs=None,
+                    output="Text",
+                    llm_talent="data-retrieval",
+                    prompt="Generate text",
+                ),
+            },
+            concepts={},
+        )
+
+        with caplog.at_level(logging.WARNING):
+            builder_loop._prune_unreachable_specs(pipelex_bundle_spec=bundle)  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+
+        assert any("missing_pipe" in record.message and "not found" in record.message for record in caplog.records)
+
+    def test_prune_missing_pipe_not_in_reachable(self) -> None:
+        """A non-existent pipe referenced by a sequence should not be in reachable_pipes, allowing orphan pipes to be pruned."""
+        builder_loop = BuilderLoop()
+
+        bundle = _make_bundle_for_prune(
+            domain="my_domain",
+            main_pipe="main_sequence",
+            pipes={
+                "main_sequence": PipeSequenceSpec.model_construct(
+                    pipe_code="main_sequence",
+                    description="Main",
+                    type="PipeSequence",
+                    pipe_category="PipeController",
+                    inputs=None,
+                    output="Text",
+                    steps=[SubPipeSpec(pipe_code="missing_pipe", result="result")],
+                ),
+                "orphan_pipe": PipeLLMSpec.model_construct(
+                    pipe_code="orphan_pipe",
+                    description="Orphan pipe",
+                    type="PipeLLM",
+                    pipe_category="PipeOperator",
+                    inputs=None,
+                    output="Text",
+                    llm_talent="data-retrieval",
+                    prompt="Orphan",
+                ),
+            },
+            concepts={},
+        )
+
+        result = builder_loop._prune_unreachable_specs(pipelex_bundle_spec=bundle)  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+
+        # orphan_pipe should be pruned since it's not reachable from main
+        assert result.pipe is not None
+        assert "orphan_pipe" not in result.pipe
+        # main_sequence should remain
+        assert "main_sequence" in result.pipe


### PR DESCRIPTION
## Summary

- Remove the flawed `fixed_pipe_parallel_concepts` optimization in `_fix_undeclared_concept_references` that prematurely removed concepts from the undeclared set even when referenced elsewhere, wasting a fix-loop iteration
- Add `_prune_unreachable_specs` method that walks the call graph from `main_pipe` to remove unreachable pipes and transitively unused concepts after all fixes are applied
- New method handles all controller pipe types: `PipeSequence`, `PipeParallel`, `PipeBatch`, and `PipeCondition` (filtering `SpecialOutcome` values)

## Test plan

- [x] `make agent-check` — all linting, formatting, pyright, and mypy pass
- [x] `make agent-test` — full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the builder auto-fix loop and now deletes unreachable pipes/concepts; incorrect reachability or reference collection could remove needed specs and break generated bundles.
> 
> **Overview**
> Improves `_fix_undeclared_concept_references` by **recomputing** which undeclared concepts are still referenced after `PipeParallel` `combined_output`/`output` fixes, avoiding prematurely skipping concept generation.
> 
> Adds `_prune_unreachable_specs`, which walks the pipe call graph from `main_pipe` (covering `PipeSequence`, `PipeParallel`, `PipeBatch`, and `PipeCondition` while ignoring `SpecialOutcome`s) to remove unreachable pipes and then prune unused concepts via local-only reference collection (including transitive refs through `refines` and structure fields). New unit tests cover domain filtering, transitive concept retention/pruning, missing-pipe warnings, and orphan-pipe cleanup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7c25f114b3d0dfb6cff24dc78dedd536d036b916. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->