### PR TITLE
Centralize graph outputs, add agent CLI graph command, and overhaul skills docs

### DIFF
--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -14,6 +14,39 @@ Create new Pipelex workflow bundles through an adaptive, phase-based approach. T
 3. **Visualization**: Present ASCII graphs at overview and detail levels
 4. **Iterative**: Refine at each phase before proceeding
 
+## Automated Alternative
+
+Before starting the manual 9-phase process, consider the automated build:
+
+```bash
+pipelex-agent build "Given a theme, write a Haiku"
+```
+
+**JSON output on success:**
+```json
+{
+  "output_dir": "pipelex-wip/pipeline_01",
+  "plx_file": "pipelex-wip/pipeline_01/bundle.plx",
+  "main_pipe_code": "write_haiku",
+  "domain": "haiku_writing",
+  "pipe_inputs": {"theme": "Text"},
+  "pipe_output": "Haiku"
+}
+```
+
+Key output fields:
+- `plx_file` — path to the generated .plx bundle
+- `pipe_inputs` — maps input variable names to their concept types
+- `pipe_output` — the output concept type
+
+**When to use which:**
+- **Automated** — simple to moderate workflows, fast iteration, starting point for refinement
+- **Manual (below)** — complex workflows, custom controller logic, precise prompt engineering, full control
+
+Recommended approach: start with `pipelex-agent build`, then refine with /edit and /fix skills.
+
+---
+
 ## Prerequisites
 
 Check CLI availability:
@@ -526,4 +559,5 @@ inputs = {
 
 ## Reference
 
-See [Pipelex Language Reference](../shared/pipelex-reference.md) for complete syntax documentation.
+- [Pipelex Agent Guide](../shared/pipelex-agent-guide.md) for CLI philosophy and error type reference
+- [Pipelex Language Reference](../shared/pipelex-reference.md) for complete syntax documentation

--- a/.claude/skills/check/SKILL.md
+++ b/.claude/skills/check/SKILL.md
@@ -10,31 +10,100 @@ Validate and review Pipelex workflow bundles without making changes.
 ## Workflow
 
 **Prerequisite**: Check CLI availability:
-1. Try `pipelex --version`
-2. If not found, try `uv run pipelex --version`
+1. Try `pipelex-agent --version`
+2. If not found, try `uv run pipelex-agent --version`
 3. If neither works, guide install: `pip install pipelex` or `uv add pipelex`
 
-Use whichever method works. Always add `--no-logo` to commands.
+Use whichever method works for all subsequent commands.
 
-1. **Read the .plx file** - Load and parse the workflow
+1. **Read the .plx file** — Load and parse the workflow
 
 2. **Run CLI validation**:
-   - Execute `pipelex --no-logo validate <file>.plx`
-   - Capture all validation errors
+   ```bash
+   pipelex-agent validate <file>.plx
+   ```
 
-3. **Analyze for additional issues**:
+   **Success output:**
+   ```json
+   {
+     "success": true,
+     "bundle_path": "my_bundle.plx",
+     "validated_pipes": [
+       {"pipe_code": "main_workflow", "status": "SUCCESS"},
+       {"pipe_code": "summarize", "status": "SUCCESS"}
+     ],
+     "total_pipes": 2
+   }
+   ```
+
+   **Validation failure output:**
+   ```json
+   {
+     "error": true,
+     "error_type": "ValidateBundleError",
+     "message": "Bundle validation failed",
+     "hint": "Check the 'validation_errors' array for specific issues to fix",
+     "validation_errors": [
+       {
+         "error_type": "missing_input_variable",
+         "pipe_code": "summarize_document",
+         "message": "Missing input variable(s): context."
+       }
+     ]
+   }
+   ```
+
+   **Model error output:**
+   ```json
+   {
+     "error": true,
+     "error_type": "PipeOperatorModelChoiceError",
+     "message": "No model found for preset '$writing-creative'",
+     "hint": "Run 'pipelex-agent doctor' to check available models and routing configuration",
+     "pipe_code": "summarize",
+     "model_type": "llm",
+     "model_choice": "$writing-creative"
+   }
+   ```
+
+3. **Parse the JSON output**:
+   - If `success: true` — all pipes validated, report clean status
+   - If `error_type: "ValidateBundleError"` — iterate through `validation_errors` array
+   - If `error_type: "PipeOperatorModelChoiceError"` or `"PipeOperatorModelAvailabilityError"` — model/config issue, suggest `pipelex-agent doctor`
+
+4. **Cross-domain validation** — when the bundle references pipes from other domains:
+   ```bash
+   pipelex-agent validate <file>.plx --library-dir path/to/bundles/
+   ```
+
+5. **Analyze for additional issues** (manual review beyond CLI validation):
    - Unused concepts (defined but never referenced)
    - Unreachable pipes (not in main_pipe execution path)
    - Missing descriptions on pipes or concepts
    - Inconsistent naming conventions
    - Potential prompt issues (missing variables, unclear instructions)
 
-4. **Report findings by severity**:
-   - **Errors**: Validation failures that prevent execution
-   - **Warnings**: Issues that may cause problems
+6. **Report findings by severity**:
+   - **Errors**: Validation failures from CLI (with `error_type` and `pipe_code`)
+   - **Warnings**: Issues that may cause problems (e.g., model availability)
    - **Suggestions**: Improvements for maintainability
 
-5. **Do NOT make changes** - This skill is read-only
+7. **Do NOT make changes** — This skill is read-only
+
+## Validation Error Types
+
+| Error Type | Meaning |
+|------------|---------|
+| `missing_input_variable` | Pipe prompt references a variable not in `inputs` |
+| `extraneous_input_variable` | Pipe declares an input never used |
+| `input_stuff_spec_mismatch` | Input concept type doesn't match sub-pipe expectation |
+| `inadequate_output_concept` | Output concept doesn't match connected pipes |
+| `inadequate_output_multiplicity` | Output single/list mismatch |
+| `circular_dependency_error` | Pipe references form a cycle |
+| `llm_output_cannot_be_image` | PipeLLM cannot output Image directly |
+| `img_gen_input_not_text_compatible` | PipeImgGen needs text-compatible input |
+| `invalid_pipe_code_syntax` | Pipe code doesn't follow snake_case |
+| `unknown_concept` | Referenced concept not defined in bundle |
 
 ## Native Concepts
 
@@ -50,7 +119,9 @@ These are built-in and should NOT be flagged as undefined:
 - Variable references in prompts
 - Cross-domain references
 - Naming convention compliance
+- Model preset resolution (dry run)
 
 ## Reference
 
-See [Pipelex Language Reference](../shared/pipelex-reference.md) for complete syntax documentation.
+- [Pipelex Agent Guide](../shared/pipelex-agent-guide.md) for CLI philosophy and error type reference
+- [Pipelex Language Reference](../shared/pipelex-reference.md) for complete syntax documentation

--- a/.claude/skills/edit/SKILL.md
+++ b/.claude/skills/edit/SKILL.md
@@ -10,11 +10,11 @@ Modify existing Pipelex workflow bundles.
 ## Workflow
 
 **Prerequisite**: Check CLI availability:
-1. Try `pipelex --version`
-2. If not found, try `uv run pipelex --version`
+1. Try `pipelex-agent --version`
+2. If not found, try `uv run pipelex-agent --version`
 3. If neither works, guide install: `pip install pipelex` or `uv add pipelex`
 
-Use whichever method works. Always add `--no-logo` to commands.
+Use whichever method works for all subsequent commands.
 
 1. **Read the existing .plx file** - Understand current structure before making changes
 
@@ -31,11 +31,11 @@ Use whichever method works. Always add `--no-logo` to commands.
    - Maintain POSIX standard (empty line at end, no trailing whitespace)
 
 4. **Validate after editing**:
-   - Run `pipelex --no-logo validate <file>.plx`
+   - Run `pipelex-agent validate <file>.plx`
    - Fix any errors introduced by changes
 
 5. **Regenerate inputs if needed**:
-   - If inputs changed, run `pipelex --no-logo build inputs <file>.plx`
+   - If inputs changed, run `pipelex-agent inputs <file>.plx`
    - Update existing inputs.json if present
 
 ## Native Concepts
@@ -53,4 +53,5 @@ These are built-in and do NOT need definitions:
 
 ## Reference
 
-See [Pipelex Language Reference](../shared/pipelex-reference.md) for complete syntax documentation.
+- [Pipelex Agent Guide](../shared/pipelex-agent-guide.md) for CLI philosophy and error type reference
+- [Pipelex Language Reference](../shared/pipelex-reference.md) for complete syntax documentation

--- a/.claude/skills/fix/SKILL.md
+++ b/.claude/skills/fix/SKILL.md
@@ -10,52 +10,120 @@ Automatically fix issues in Pipelex workflow bundles.
 ## Workflow
 
 **Prerequisite**: Check CLI availability:
-1. Try `pipelex --version`
-2. If not found, try `uv run pipelex --version`
+1. Try `pipelex-agent --version`
+2. If not found, try `uv run pipelex-agent --version`
 3. If neither works, guide install: `pip install pipelex` or `uv add pipelex`
 
-Use whichever method works. Always add `--no-logo` to commands.
+Use whichever method works for all subsequent commands.
 
-1. **Read the .plx file and validate**:
-   - Run `pipelex --no-logo validate <file>.plx`
-   - Identify all errors and warnings
+### Step 1: Validate and Identify Errors
 
-2. **Apply fixes for common issues**:
-   - **missing_input_variable**: Add missing input to parent pipe's `inputs`
-   - **Multi-line inputs**: Reformat to single line
-   - **Undefined concept references**: Create concept definition or fix typo
-   - **Invalid pipe ordering**: Reorder pipes (controllers first)
-   - **Missing required fields**: Add with sensible defaults
-   - **Naming convention violations**: Rename to follow conventions
+```bash
+pipelex-agent validate <file>.plx
+```
 
-3. **Re-validate after each fix**:
-   - Run validation again
-   - Continue fixing until no errors remain
+Parse the JSON output:
+- If `success: true` — nothing to fix, report clean status
+- If `error_type: "ValidateBundleError"` — iterate through `validation_errors` array and fix each
+- If `error_type: "PipeOperatorModelChoiceError"` or `"PipeOperatorModelAvailabilityError"` — this is a model/config issue, not a .plx fix (see "Model & Config Errors" below)
 
-4. **Report what was fixed**:
-   - List all changes made
-   - Show any remaining warnings or suggestions
-   - Confirm validation passes
+### Step 2: Fix .plx Validation Errors
 
-5. **Iterate if needed**:
-   - Some fixes may reveal new issues
-   - Continue until validation passes completely
+Use the `error_type` field from each validation error to determine the fix:
+
+| Error Type | Fix Strategy |
+|------------|-------------|
+| `missing_input_variable` | Add the missing variable(s) to the parent pipe's `inputs` line. The `message` field names the variables. |
+| `extraneous_input_variable` | Remove the unused variable(s) from the pipe's `inputs` line. |
+| `input_stuff_spec_mismatch` | Correct the concept type in `inputs` to match what the sub-pipe expects. |
+| `inadequate_output_concept` | Change the `output` field to the correct concept type. |
+| `inadequate_output_multiplicity` | Add or remove `[]` from the output concept (e.g., `Text` vs `Text[]`). |
+| `circular_dependency_error` | Restructure the workflow to break the cycle — usually requires rethinking the pipe graph. |
+| `llm_output_cannot_be_image` | Use PipeImgGen instead of PipeLLM for image generation. |
+| `img_gen_input_not_text_compatible` | Ensure PipeImgGen input is text-based (use `ImgGenPrompt`). |
+| `invalid_pipe_code_syntax` | Rename the pipe to valid snake_case. |
+| `unknown_concept` | Add the concept definition to the bundle, or fix the typo in the reference. |
+
+### Step 3: Fix TOML Formatting Issues
+
+These aren't always reported by validation but cause problems:
+
+**Multi-line inputs** — must be on a single line:
+```toml
+# WRONG
+inputs = {
+    a = "A",
+    b = "B"
+}
+
+# CORRECT
+inputs = { a = "A", b = "B" }
+```
+
+**Pipe ordering** — controllers before sub-pipes:
+```toml
+# CORRECT: main pipe first, then sub-pipes in execution order
+[pipe.main_workflow]
+type = "PipeSequence"
+steps = [
+    { pipe = "step_one", result = "intermediate" },
+    { pipe = "step_two", result = "final" }
+]
+
+[pipe.step_one]
+...
+
+[pipe.step_two]
+...
+```
+
+**Missing required fields** — add with sensible defaults:
+- `description` on every pipe and concept
+- `type` on every pipe
+- `output` on every pipe
+
+### Step 4: Re-validate
+
+After applying fixes, re-validate:
+
+```bash
+pipelex-agent validate <file>.plx
+```
+
+Continue the fix-validate loop until `success: true` is returned. Some fixes reveal new issues — for example, fixing a `missing_input_variable` may expose an `input_stuff_spec_mismatch` on the newly added input.
+
+### Step 5: Report Results
+
+- List all changes made (which pipes were modified and how)
+- Show the final validation result
+- Flag any remaining warnings or suggestions
+
+## Model & Config Errors
+
+These errors indicate issues with the Pipelex configuration, not the .plx file itself:
+
+| Error Type | What To Do |
+|------------|-----------|
+| `PipeOperatorModelChoiceError` | The model preset (e.g., `$writing-creative`) doesn't resolve. Run `pipelex-agent doctor` to check routing configuration. |
+| `PipeOperatorModelAvailabilityError` | The model is configured but not reachable (missing API key, service down). Run `pipelex-agent doctor` to verify API keys. |
+
+These cannot be fixed by editing the .plx file. Run `pipelex-agent doctor` which will auto-fix configuration issues when possible.
+
+## Cross-Domain Validation
+
+When the bundle references pipes/concepts from other domains:
+```bash
+pipelex-agent validate <file>.plx --library-dir path/to/bundles/
+```
+
+If validation fails with "unknown concept" errors for concepts that exist in other bundles, the `--library-dir` flag is missing.
 
 ## Native Concepts
 
 These are built-in and do NOT need definitions:
 `Text`, `Image`, `PDF`, `Document`, `TextAndImages`, `Number`, `Page`, `JSON`, `ImgGenPrompt`, `Html`
 
-## Common Fixes
-
-| Error | Fix |
-|-------|-----|
-| `missing_input_variable` | Add variable to parent pipe's inputs |
-| Multi-line inputs block | Reformat to `inputs = { a = "A", b = "B" }` |
-| Undefined concept | Create definition or fix reference (unless it's a native concept) |
-| Missing description | Add descriptive text |
-| Wrong pipe order | Move controller pipes before sub-pipes |
-
 ## Reference
 
-See [Pipelex Language Reference](../shared/pipelex-reference.md) for complete syntax documentation.
+- [Pipelex Agent Guide](../shared/pipelex-agent-guide.md) for CLI philosophy and error type reference
+- [Pipelex Language Reference](../shared/pipelex-reference.md) for complete syntax documentation

--- a/.claude/skills/run/SKILL.md
+++ b/.claude/skills/run/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: run
+description: Run Pipelex workflows and interpret results. Use when executing a pipeline, user says "run this workflow", "execute the pipeline", "test this .plx file", or wants to see pipeline output.
+---
+
+# Run Pipelex Workflow
+
+Execute Pipelex pipelines and interpret their JSON output.
+
+## Workflow
+
+**Prerequisite**: Check CLI availability:
+1. Try `pipelex-agent --version`
+2. If not found, try `uv run pipelex-agent --version`
+3. If neither works, guide install: `pip install pipelex` or `uv add pipelex`
+
+Use whichever method works for all subsequent commands.
+
+### Step 1: Identify the Target
+
+Determine what to run:
+
+| Target | Command |
+|--------|---------|
+| Bundle file (main pipe) | `pipelex-agent run bundle.plx` |
+| Specific pipe in a bundle | `pipelex-agent run bundle.plx --pipe my_pipe` |
+| Pipe by code from library | `pipelex-agent run my_pipe` |
+| Pipe from a library directory | `pipelex-agent run my_pipe -L ./my_pipes/` |
+
+### Step 2: Prepare Inputs
+
+Get the input schema for the target:
+
+```bash
+pipelex-agent inputs bundle.plx
+```
+
+**Output:**
+```json
+{
+  "success": true,
+  "pipe_code": "process_document",
+  "inputs": {
+    "document": {
+      "concept": "native.Document",
+      "content": {"url": "url_value"}
+    },
+    "context": {
+      "concept": "native.Text",
+      "content": {"text": "text_value"}
+    }
+  }
+}
+```
+
+Fill in the `content` fields with actual values. For complex inputs, use the /synthesize-inputs skill.
+
+### Step 3: Choose Run Mode
+
+| Mode | Command | Use When |
+|------|---------|----------|
+| **Dry run + mock inputs** | `pipelex-agent run bundle.plx --dry-run --mock-inputs` | Quick structural validation, no real data needed |
+| **Dry run with real inputs** | `pipelex-agent run bundle.plx --dry-run --inputs data.json` | Validate input shapes without making API calls |
+| **Full run from file** | `pipelex-agent run bundle.plx --inputs data.json` | Production execution with inputs from a file |
+| **Full run inline** | `pipelex-agent run bundle.plx --inputs '{"theme": ...}'` | Quick execution without creating an input file |
+| **Full run + graph** | `pipelex-agent run bundle.plx --inputs data.json --graph` | Execute and generate execution graph HTML visualizations |
+
+**Cross-domain runs** — when the bundle references pipes from other bundles:
+```bash
+pipelex-agent run bundle.plx --inputs data.json -L ./shared_pipes/
+```
+
+### Inline JSON for Inputs
+
+The `--inputs` flag accepts both file paths and inline JSON. The CLI auto-detects: if the value starts with `{`, it is parsed as JSON directly. This is the fastest path — no file creation needed for simple inputs.
+
+```bash
+# Inline JSON
+pipelex-agent run bundle.plx --inputs '{"theme": {"concept": "native.Text", "content": {"text": "nature"}}}'
+
+# File path
+pipelex-agent run bundle.plx --inputs pipelex-wip/inputs/data.json
+```
+
+### Step 4: Interpret Output
+
+**Success output:**
+```json
+{
+  "success": true,
+  "pipe_code": "process_document",
+  "dry_run": false,
+  "main_stuff": {
+    "json": { ... },
+    "markdown": "...",
+    "html": "..."
+  },
+  "working_memory": { ... }
+}
+```
+
+Key fields:
+- `main_stuff.json` — the pipeline's final output as structured JSON (best for programmatic use)
+- `main_stuff.markdown` — human-readable markdown rendering of the output
+- `main_stuff.html` — HTML rendering of the output
+- `working_memory` — full state of all intermediate variables (useful for debugging)
+
+### Step 5: Handle Errors
+
+**Error output:**
+```json
+{
+  "error": true,
+  "error_type": "PipelineExecutionError",
+  "message": "Pipeline failed at pipe 'analyze_document'",
+  "pipe_code": "analyze_document",
+  "pipe_stack": ["process_all", "analyze_document"]
+}
+```
+
+| Error Type | Recovery |
+|------------|----------|
+| `ValidateBundleError` | Fix the .plx file — use /fix skill, check `validation_errors` array |
+| `PipeOperatorModelChoiceError` | Run `pipelex-agent doctor` — model preset doesn't resolve |
+| `PipeOperatorModelAvailabilityError` | Run `pipelex-agent doctor` — API key or service issue |
+| `PipelineExecutionError` | Check `pipe_code` and `pipe_stack` for which pipe failed |
+| `FileNotFoundError` | Check that the bundle file and input file paths are correct |
+| `JSONDecodeError` | Fix the JSON syntax in your inline inputs or input file |
+| `ArgumentError` | Check command flags — e.g., `--mock-inputs` requires `--dry-run` |
+
+For model/config issues, always try `pipelex-agent doctor` first.
+
+### Execution Graphs
+
+Add `--graph` to generate visual execution graphs alongside the run output:
+
+```bash
+pipelex-agent run bundle.plx --inputs data.json --graph
+```
+
+When `--graph` is set, the success JSON includes a `graph_files` field with paths to the generated files:
+
+```json
+{
+  "success": true,
+  "pipe_code": "main_pipe",
+  "graph_files": {
+    "graphspec_json": "pipelex-wip/graphspec.json",
+    "mermaidflow_html": "pipelex-wip/mermaidflow.html",
+    "reactflow_html": "pipelex-wip/reactflow.html"
+  },
+  ...
+}
+```
+
+To re-render an existing `graphspec.json` later (e.g., with different format options):
+
+```bash
+pipelex-agent graph graphspec.json
+pipelex-agent graph graphspec.json --format mermaidflow -o ./output/
+```
+
+## Reference
+
+- [Pipelex Agent Guide](../shared/pipelex-agent-guide.md) for CLI philosophy and error type reference
+- [Pipelex Language Reference](../shared/pipelex-reference.md) for .plx syntax documentation

--- a/.claude/skills/shared/pipelex-agent-guide.md
+++ b/.claude/skills/shared/pipelex-agent-guide.md
@@ -1,0 +1,283 @@
+# Pipelex Agent Guide
+
+Strategy and reference for agents working with Pipelex programmatically.
+
+## Agent CLI
+
+Agents must use `pipelex-agent` exclusively. It outputs structured JSON (stdout=success, stderr=error with exit code 1).
+
+There is also a `pipelex` CLI for human use — agents should not call it themselves, but can suggest it to the user when helpful:
+
+- `pipelex doctor` — interactive config diagnostics (richer than `pipelex-agent doctor`)
+- `pipelex show <pipe_or_concept>` — visual inspection of a pipe or concept
+- `pipelex init config` — interactive first-time setup
+
+**CLI availability check:**
+1. Try `pipelex-agent --version`
+2. If not found, try `uv run pipelex-agent --version`
+3. Use whichever works for all subsequent commands (either bare `pipelex-agent` or `uv run pipelex-agent`)
+
+## Two Approaches to Building
+
+### Automated Build
+
+Use `pipelex-agent build` to generate a complete workflow from a natural-language prompt:
+
+```bash
+pipelex-agent build "Given a theme, write a Haiku"
+```
+
+**JSON output on success:**
+```json
+{
+  "output_dir": "pipelex-wip/pipeline_01",
+  "plx_file": "pipelex-wip/pipeline_01/bundle.plx",
+  "main_pipe_code": "write_haiku",
+  "domain": "haiku_writing",
+  "pipe_inputs": {"theme": "Text"},
+  "pipe_output": "Haiku"
+}
+```
+
+Key fields:
+- `pipe_inputs` — maps input variable names to their concept types
+- `pipe_output` — the output concept type
+- `plx_file` — path to the generated .plx bundle
+
+### Manual Build (the /build skill)
+
+A 9-phase guided process: requirements → plan → concepts → structure → flow → review → pipes → assemble → validate. Use when you need full control over every detail.
+
+### Recommended Approach
+
+Start with automated build, then refine manually using /edit and /fix if the result needs adjustments.
+
+## The Iterative Development Loop
+
+```
+                 ┌──────────────────────────────────┐
+                 │                                   │
+                 ▼                                   │
+    ┌────────────────────┐                           │
+    │  Build or Edit     │                           │
+    │  (.plx file)       │                           │
+    └─────────┬──────────┘                           │
+              │                                      │
+              ▼                                      │
+    ┌────────────────────┐     ┌──────────────┐      │
+    │  Validate          │────►│  Fix errors  │──────┘
+    │  pipelex-agent     │ err │  /fix skill  │
+    │  validate file.plx │     └──────────────┘
+    └─────────┬──────────┘
+              │ ok
+              ▼
+    ┌────────────────────┐
+    │  Run               │
+    │  pipelex-agent     │
+    │  run file.plx      │
+    └─────────┬──────────┘
+              │
+              ▼
+    ┌────────────────────┐
+    │  Inspect output    │
+    │  Refine if needed  │──────────────────────────►(loop back to Edit)
+    └────────────────────┘
+```
+
+## Understanding JSON Output
+
+### Success Format
+
+All `pipelex-agent` commands output JSON to **stdout** on success:
+
+```json
+{
+  "success": true,
+  "pipe_code": "my_pipe",
+  ...command-specific fields...
+}
+```
+
+### Error Format
+
+On failure, JSON is printed to **stderr** and the process exits with code 1:
+
+```json
+{
+  "error": true,
+  "error_type": "ValidateBundleError",
+  "message": "Human-readable error description",
+  "hint": "Run 'pipelex-agent doctor' to check available models and routing configuration",
+  ...error-specific fields...
+}
+```
+
+Fields:
+- `error_type` — error class name for programmatic matching
+- `message` — human-readable description
+- `hint` — (optional) suggested recovery action, auto-added for known error types
+- Additional fields vary by error type (e.g., `validation_errors`, `pipe_code`, `model_handle`)
+
+## Validation Error Structure
+
+When `pipelex-agent validate` reports a `ValidateBundleError`, the JSON includes a `validation_errors` array:
+
+```json
+{
+  "error": true,
+  "error_type": "ValidateBundleError",
+  "message": "Bundle validation failed",
+  "hint": "Check the 'validation_errors' array for specific issues to fix",
+  "validation_errors": [
+    {
+      "error_type": "missing_input_variable",
+      "pipe_code": "summarize_document",
+      "message": "Missing input variable(s): context."
+    }
+  ]
+}
+```
+
+Each item in `validation_errors` has:
+- `error_type` — one of the validation error types below
+- `pipe_code` — which pipe has the issue (may be null for bundle-level errors)
+- `message` — description of the specific problem
+
+## Error Type Reference
+
+### Validation Error Types (in .plx files)
+
+| Error Type | Meaning | Fix Strategy |
+|------------|---------|--------------|
+| `missing_input_variable` | A pipe's prompt references a variable not declared in its `inputs` | Add the missing variable to the pipe's `inputs` line |
+| `extraneous_input_variable` | A pipe declares an input that is never referenced in its prompt or sub-pipes | Remove the unused variable from `inputs` |
+| `input_stuff_spec_mismatch` | Input concept type doesn't match what the sub-pipe expects | Correct the concept type in `inputs` |
+| `inadequate_output_concept` | Output concept doesn't match what connected pipes expect | Fix the `output` field to the correct concept |
+| `inadequate_output_multiplicity` | Output multiplicity (single vs list) doesn't match | Add/remove `[]` from the output concept |
+| `circular_dependency_error` | Pipe references create a cycle | Restructure the workflow to break the cycle |
+| `llm_output_cannot_be_image` | PipeLLM cannot output Image type directly | Use PipeImgGen for image generation instead |
+| `img_gen_input_not_text_compatible` | PipeImgGen input must be text-compatible | Ensure the input to PipeImgGen is text-based (use ImgGenPrompt) |
+| `invalid_pipe_code_syntax` | Pipe code doesn't follow snake_case convention | Rename the pipe to valid snake_case |
+| `unknown_concept` | A concept referenced in a pipe is not defined in the bundle | Add the concept definition to the bundle, or fix the typo |
+| `unknown_validation_error` | Uncategorized validation issue | Read the `message` field for details |
+
+### Runtime Error Types (when running pipelines)
+
+| Error Type | Meaning | Fix Strategy |
+|------------|---------|--------------|
+| `PipeOperatorModelChoiceError` | The model preset in the pipe doesn't resolve to an available model | Run `pipelex-agent doctor` — check routing configuration |
+| `PipeOperatorModelAvailabilityError` | The resolved model is not available (missing API key, service down) | Run `pipelex-agent doctor` — verify API keys and model availability |
+| `PipelineExecutionError` | Pipeline failed during execution | Check `pipe_code` and `pipe_stack` in the error JSON for context |
+| `BuildPipeError` | Automated build failed | Check `failure_memory_path` in error JSON for debugging details |
+
+## Inline JSON for Inputs
+
+The `--inputs` flag on `pipelex-agent run` accepts **both** file paths and inline JSON. The CLI auto-detects: if the value starts with `{`, it is parsed as JSON directly.
+
+```bash
+# File path
+pipelex-agent run bundle.plx --inputs pipelex-wip/inputs/data.json
+
+# Inline JSON (no file creation needed)
+pipelex-agent run bundle.plx --inputs '{"theme": {"concept": "native.Text", "content": {"text": "nature"}}}'
+```
+
+Inline JSON is the fastest path for agents — skip file creation for simple inputs.
+
+## Working Directory Convention
+
+All generated files go into `pipelex-wip/`:
+
+```
+pipelex-wip/
+  pipeline_01/          # Automated build output
+    bundle.plx
+  pipeline_02/
+    bundle.plx
+  inputs/               # Synthesized input files
+    test_input.json
+  test-files/           # Generated test files (images, PDFs)
+    photo.jpg
+```
+
+## Using the Doctor Command
+
+When you encounter model-related errors (`PipeOperatorModelChoiceError`, `PipeOperatorModelAvailabilityError`), run the doctor:
+
+```bash
+pipelex-agent doctor
+```
+
+The doctor checks:
+- Configuration health
+- Available models and routing
+- API key validity
+
+It auto-fixes issues when possible. Run it before debugging model errors manually.
+
+## Generating Visualizations
+
+Agents can generate execution graph visualizations for human review using two methods:
+
+### Standalone: `pipelex-agent graph`
+
+Render an existing `graphspec.json` (produced by a previous run) into HTML:
+
+```bash
+pipelex-agent graph graphspec.json
+pipelex-agent graph graphspec.json --format mermaidflow
+pipelex-agent graph graphspec.json -o ./output/ --format reactflow
+```
+
+**JSON output on success:**
+```json
+{
+  "success": true,
+  "output_dir": "path/to/dir",
+  "files": {
+    "mermaidflow_html": "path/to/mermaidflow.html",
+    "reactflow_html": "path/to/reactflow.html"
+  },
+  "node_count": 5
+}
+```
+
+Options:
+- `--format` / `-f` — `mermaidflow`, `reactflow`, or `both` (default: `both`)
+- `--out` / `-o` — output directory (default: same directory as input file)
+
+### Inline: `pipelex-agent run --graph`
+
+Generate graphs during a pipeline run:
+
+```bash
+pipelex-agent run bundle.plx --inputs data.json --graph
+```
+
+When `--graph` is set, the success JSON includes an additional `graph_files` field:
+```json
+{
+  "success": true,
+  "pipe_code": "main_pipe",
+  "graph_files": {
+    "graphspec_json": "pipelex-wip/graphspec.json",
+    "mermaidflow_html": "pipelex-wip/mermaidflow.html",
+    "reactflow_html": "pipelex-wip/reactflow.html"
+  },
+  ...
+}
+```
+
+## Agent CLI Command Reference
+
+| Command | Purpose | Example |
+|---------|---------|---------|
+| `build` | Generate a pipeline from a prompt | `pipelex-agent build "process invoices"` |
+| `run` | Execute a pipeline | `pipelex-agent run bundle.plx --inputs data.json` |
+| `validate` | Validate a bundle or pipe | `pipelex-agent validate bundle.plx` |
+| `inputs` | Generate example input JSON | `pipelex-agent inputs bundle.plx` |
+| `concept` | Structure a concept from JSON spec | `pipelex-agent concept --spec '{...}'` |
+| `pipe` | Structure a pipe from JSON spec | `pipelex-agent pipe --type PipeLLM --spec '{...}'` |
+| `assemble` | Assemble a .plx bundle from parts | `pipelex-agent assemble --domain my_domain ...` |
+| `graph` | Render graphspec.json to HTML | `pipelex-agent graph graphspec.json` |
+| `doctor` | Check config health and auto-fix | `pipelex-agent doctor` |

--- a/.claude/skills/shared/pipelex-reference.md
+++ b/.claude/skills/shared/pipelex-reference.md
@@ -396,10 +396,10 @@ When a bundle references pipes/concepts from other domains, use `--library-dir` 
 
 ```bash
 # Single file won't resolve cross-domain references
-pipelex --no-logo validate my_bundle.plx  # May fail
+pipelex-agent validate my_bundle.plx  # May fail
 
 # Load entire directory to resolve references
-pipelex --no-logo validate my_bundle.plx --library-dir path/to/bundles/
+pipelex-agent validate my_bundle.plx --library-dir path/to/bundles/
 ```
 
 ## Model Configuration
@@ -416,31 +416,54 @@ model = "$writing-creative"
 
 ## CLI Commands
 
-**Before running commands**, check pipelex availability:
-1. Try `pipelex --version` (works if globally installed or venv is activated)
-2. If not found, try `uv run pipelex --version` (works with project venv + uv)
+**Before running commands**, check CLI availability:
+1. Try `pipelex-agent --version`
+2. If not found, try `uv run pipelex-agent --version`
 3. If neither works: "Pipelex CLI not found. Install with `pip install pipelex` or `uv add pipelex`"
 
-Use whichever method works. Prefix all subsequent commands the same way (either bare `pipelex` or `uv run pipelex`).
+Use whichever method works. Prefix all subsequent commands the same way.
 
-**Always use `--no-logo`** to avoid wasting tokens on ASCII art output.
+Agents must use `pipelex-agent` exclusively. It outputs structured JSON (stdout=success, stderr=error). There is also a `pipelex` CLI for human use — agents should not call it themselves, but can suggest it to the user (e.g., `pipelex doctor` for interactive config diagnostics, `pipelex show <name>` to visually inspect a pipe or concept).
 
 ```bash
-# Generate example input JSON
-pipelex --no-logo build inputs my_bundle.plx
-pipelex --no-logo build inputs my_bundle.plx --pipe specific_pipe
-
 # Validate a bundle
-pipelex --no-logo validate my_bundle.plx
+pipelex-agent validate my_bundle.plx
+pipelex-agent validate my_bundle.plx --library-dir path/to/bundles/
+
+# Generate example input JSON
+pipelex-agent inputs my_bundle.plx
+pipelex-agent inputs my_bundle.plx --pipe specific_pipe
+
+# Run with inputs (file path or inline JSON)
+pipelex-agent run my_bundle.plx --inputs inputs.json
+pipelex-agent run my_bundle.plx --inputs '{"theme": {"concept": "native.Text", "content": {"text": "nature"}}}'
+pipelex-agent run my_bundle.plx --pipe specific_pipe --inputs inputs.json
 
 # Dry run (no API calls, validates logic)
-pipelex --no-logo run my_bundle.plx --dry-run
-pipelex --no-logo run my_bundle.plx --dry-run --mock-inputs
+pipelex-agent run my_bundle.plx --dry-run --mock-inputs
 
-# Run with inputs
-pipelex --no-logo run my_bundle.plx --inputs inputs.json
-pipelex --no-logo run my_bundle.plx --pipe specific_pipe --inputs inputs.json
+# Run with execution graph generation
+pipelex-agent run my_bundle.plx --inputs data.json --graph
+
+# Build a pipeline from a prompt
+pipelex-agent build "Given a theme, write a Haiku"
+
+# Render a graphspec.json to HTML visualizations
+pipelex-agent graph graphspec.json
+pipelex-agent graph graphspec.json --format mermaidflow -o ./output/
+
+# Structure concepts and pipes from JSON specs
+pipelex-agent concept --spec '{"the_concept_code": "Summary", "description": "A text summary", "refines": "Text"}'
+pipelex-agent pipe --type PipeLLM --spec '{"pipe_code": "summarize", "description": "Summarize text", "inputs": {"text": "Text"}, "output": "Summary", "llm_talent": "creative-writer", "prompt": "@text"}'
+
+# Assemble a bundle from TOML parts
+pipelex-agent assemble --domain my_domain --main-pipe main_workflow --output bundle.plx --concepts concepts.toml --pipes pipes.toml
+
+# Check configuration health
+pipelex-agent doctor
 ```
+
+The `--inputs` flag accepts both file paths and inline JSON. If the value starts with `{`, it is parsed as JSON directly — no file creation needed for simple inputs.
 
 ## Common Errors
 

--- a/.claude/skills/synthesize-inputs/SKILL.md
+++ b/.claude/skills/synthesize-inputs/SKILL.md
@@ -92,7 +92,7 @@ First, create an input file (e.g., `pipelex-wip/inputs/image_request.json`):
 
 Then run:
 ```bash
-pipelex run pipelex/builder/synthetic_inputs/synthesize_image.plx --inputs pipelex-wip/inputs/image_request.json
+pipelex-agent run pipelex/builder/synthetic_inputs/synthesize_image.plx --inputs pipelex-wip/inputs/image_request.json
 ```
 
 **Image Categories:**
@@ -279,10 +279,10 @@ Test the synthetic inputs:
 
 ```bash
 # Dry run with the generated inputs
-pipelex-agent run <bundle.plx> --dry-run --input-file pipelex-wip/inputs/test_input.json
+pipelex-agent run <bundle.plx> --dry-run --inputs pipelex-wip/inputs/test_input.json
 
 # Full run (uses actual AI/extraction models)
-pipelex-agent run <bundle.plx> --input-file pipelex-wip/inputs/test_input.json
+pipelex-agent run <bundle.plx> --inputs pipelex-wip/inputs/test_input.json
 ```
 
 ---
@@ -371,7 +371,7 @@ Create `pipelex-wip/inputs/city_image.json`:
 
 Run:
 ```bash
-pipelex run pipelex/builder/synthetic_inputs/synthesize_image.plx --inputs pipelex-wip/inputs/city_image.json
+pipelex-agent run pipelex/builder/synthetic_inputs/synthesize_image.plx --inputs pipelex-wip/inputs/city_image.json
 ```
 
 **Step 4**: Assemble input file
@@ -396,11 +396,12 @@ pipelex run pipelex/builder/synthetic_inputs/synthesize_image.plx --inputs pipel
 
 **Step 5**: Test
 ```bash
-pipelex-agent run image_analyzer.plx --input-file pipelex-wip/inputs/city_analysis_input.json
+pipelex-agent run image_analyzer.plx --inputs pipelex-wip/inputs/city_analysis_input.json
 ```
 
 ---
 
 ## Reference
 
-See [Pipelex Language Reference](../shared/pipelex-reference.md) for concept definitions and syntax.
+- [Pipelex Agent Guide](../shared/pipelex-agent-guide.md) for CLI philosophy and error type reference
+- [Pipelex Language Reference](../shared/pipelex-reference.md) for concept definitions and syntax

--- a/pipelex/cli/agent_cli/_agent_cli.py
+++ b/pipelex/cli/agent_cli/_agent_cli.py
@@ -10,6 +10,7 @@ from typing_extensions import override
 from pipelex.cli.agent_cli.commands.assemble_cmd import assemble_cmd
 from pipelex.cli.agent_cli.commands.build_cmd import build_cmd
 from pipelex.cli.agent_cli.commands.concept_cmd import concept_cmd
+from pipelex.cli.agent_cli.commands.graph_cmd import GraphFormat, graph_cmd
 from pipelex.cli.agent_cli.commands.inputs_cmd import inputs_cmd
 from pipelex.cli.agent_cli.commands.pipe_cmd import pipe_cmd
 from pipelex.cli.agent_cli.commands.run_cmd import run_cmd
@@ -24,7 +25,7 @@ class PipelexAgentCLI(TyperGroup):
     @override
     def list_commands(self, ctx: Context) -> list[str]:
         """List commands in proper order."""
-        return ["build", "run", "validate", "inputs", "concept", "pipe", "assemble", "doctor"]
+        return ["build", "run", "validate", "inputs", "concept", "pipe", "assemble", "graph", "doctor"]
 
     @override
     def get_command(self, ctx: Context, cmd_name: str) -> Command | None:
@@ -112,6 +113,10 @@ def run_command(
         bool,
         typer.Option("--mock-inputs", help="Generate mock data for missing required inputs (requires --dry-run)"),
     ] = False,
+    graph: Annotated[
+        bool,
+        typer.Option("--graph", help="Generate execution graph visualizations (saved alongside output)"),
+    ] = False,
     library_dir: Annotated[
         list[str] | None,
         typer.Option("--library-dir", "-L", help="Directory to search for pipe definitions (.plx files)"),
@@ -125,6 +130,7 @@ def run_command(
         inputs=inputs,
         dry_run=dry_run,
         mock_inputs=mock_inputs,
+        graph=graph,
         library_dir=library_dir,
     )
 
@@ -260,6 +266,25 @@ def assemble_command(
         concepts=concepts,
         pipes=pipes,
     )
+
+
+@app.command(name="graph", help="Render a graphspec.json to HTML visualizations")
+def graph_command(
+    graphspec_file: Annotated[
+        str,
+        typer.Argument(help="Path to a graphspec.json file"),
+    ],
+    out: Annotated[
+        str | None,
+        typer.Option("--out", "-o", help="Output directory (default: same directory as input file)"),
+    ] = None,
+    graph_format: Annotated[
+        GraphFormat,
+        typer.Option("--format", "-f", help="Graph format to generate: mermaidflow, reactflow, or both"),
+    ] = GraphFormat.BOTH,
+) -> None:
+    """Render a graphspec.json file to HTML visualizations."""
+    graph_cmd(graphspec_file=graphspec_file, out=out, graph_format=graph_format)
 
 
 @app.command(name="doctor", help="Check Pipelex configuration health and auto-fix issues")

--- a/pipelex/cli/agent_cli/commands/agent_output.py
+++ b/pipelex/cli/agent_cli/commands/agent_output.py
@@ -1,0 +1,45 @@
+"""Helpers for structured JSON output in agent CLI commands."""
+
+import json
+import sys
+from typing import Any, NoReturn
+
+import typer
+
+AGENT_ERROR_HINTS: dict[str, str] = {
+    "PipeOperatorModelChoiceError": "Run 'pipelex-agent doctor' to check available models and routing configuration",
+    "PipeOperatorModelAvailabilityError": "Run 'pipelex-agent doctor' to check available models and verify API keys",
+    "ValidateBundleError": "Check the 'validation_errors' array for specific issues to fix",
+}
+
+
+def agent_error(message: str, error_type: str, cause: BaseException | None = None, **extra: Any) -> NoReturn:
+    """Print a structured JSON error to stderr and exit with code 1.
+
+    Args:
+        message: Human-readable error message.
+        error_type: Error class name for programmatic matching.
+        cause: Optional exception to chain with ``raise ... from``.
+        **extra: Additional fields merged into the JSON object.
+                 Can override the auto-added ``hint`` field.
+    """
+    error_json: dict[str, Any] = {
+        "error": True,
+        "error_type": error_type,
+        "message": message,
+    }
+    hint = AGENT_ERROR_HINTS.get(error_type)
+    if hint:
+        error_json["hint"] = hint
+    error_json.update(extra)
+    print(json.dumps(error_json, indent=2), file=sys.stderr)
+    raise typer.Exit(1) from cause
+
+
+def agent_success(result: dict[str, Any]) -> None:
+    """Print a structured JSON success result to stdout.
+
+    Args:
+        result: Dictionary to serialize as JSON.
+    """
+    print(json.dumps(result, indent=2))

--- a/pipelex/cli/agent_cli/commands/assemble_cmd.py
+++ b/pipelex/cli/agent_cli/commands/assemble_cmd.py
@@ -4,13 +4,13 @@
 # pyright: reportArgumentType=false
 # mypy: disable-error-code="arg-type"
 
-import json
-import sys
 from pathlib import Path
-from typing import Annotated, Any
+from typing import Annotated
 
 import tomlkit
 import typer
+
+from pipelex.cli.agent_cli.commands.agent_output import agent_error, agent_success
 
 
 def _merge_toml_sections(
@@ -104,8 +104,6 @@ def assemble_cmd(
             --concepts '[concept.MyInput]' --pipes '[pipe.main]'
             --output bundle.plx
     """
-    error_json: dict[str, Any]
-
     try:
         # Create base document with domain header
         doc = tomlkit.document()
@@ -126,21 +124,9 @@ def assemble_cmd(
                     concept_content = _load_toml_content(concept_source)
                     _merge_toml_sections(doc, "concept", concept_content)
                 except FileNotFoundError:
-                    error_json = {
-                        "error": True,
-                        "error_type": "FileNotFoundError",
-                        "message": f"Concept file not found: {concept_source}",
-                    }
-                    print(json.dumps(error_json, indent=2), file=sys.stderr)
-                    raise typer.Exit(1) from None
+                    agent_error(f"Concept file not found: {concept_source}", "FileNotFoundError")
                 except Exception as exc:
-                    error_json = {
-                        "error": True,
-                        "error_type": "ConceptLoadError",
-                        "message": f"Failed to load concepts from '{concept_source}': {exc}",
-                    }
-                    print(json.dumps(error_json, indent=2), file=sys.stderr)
-                    raise typer.Exit(1) from exc
+                    agent_error(f"Failed to load concepts from '{concept_source}': {exc}", "ConceptLoadError", cause=exc)
 
         # Process pipe sources
         if pipes:
@@ -149,21 +135,9 @@ def assemble_cmd(
                     pipe_content = _load_toml_content(pipe_source)
                     _merge_toml_sections(doc, "pipe", pipe_content)
                 except FileNotFoundError:
-                    error_json = {
-                        "error": True,
-                        "error_type": "FileNotFoundError",
-                        "message": f"Pipe file not found: {pipe_source}",
-                    }
-                    print(json.dumps(error_json, indent=2), file=sys.stderr)
-                    raise typer.Exit(1) from None
+                    agent_error(f"Pipe file not found: {pipe_source}", "FileNotFoundError")
                 except Exception as exc:
-                    error_json = {
-                        "error": True,
-                        "error_type": "PipeLoadError",
-                        "message": f"Failed to load pipes from '{pipe_source}': {exc}",
-                    }
-                    print(json.dumps(error_json, indent=2), file=sys.stderr)
-                    raise typer.Exit(1) from exc
+                    agent_error(f"Failed to load pipes from '{pipe_source}': {exc}", "PipeLoadError", cause=exc)
 
         # Write output file
         output_path = Path(output)
@@ -176,22 +150,17 @@ def assemble_cmd(
         with open(output_path, "a", encoding="utf-8") as out_file:
             out_file.write("\n")
 
-        result = {
-            "success": True,
-            "bundle_path": str(output_path.resolve()),
-            "domain": domain,
-            "main_pipe": main_pipe,
-        }
-        print(json.dumps(result, indent=2))
+        agent_success(
+            {
+                "success": True,
+                "bundle_path": str(output_path.resolve()),
+                "domain": domain,
+                "main_pipe": main_pipe,
+            }
+        )
 
     except typer.Exit:
         raise
 
     except Exception as exc:
-        error_json = {
-            "error": True,
-            "error_type": type(exc).__name__,
-            "message": str(exc),
-        }
-        print(json.dumps(error_json, indent=2), file=sys.stderr)
-        raise typer.Exit(1) from exc
+        agent_error(str(exc), type(exc).__name__, cause=exc)

--- a/pipelex/cli/agent_cli/commands/build_cmd.py
+++ b/pipelex/cli/agent_cli/commands/build_cmd.py
@@ -1,12 +1,11 @@
 """Agent CLI build command - simplified pipe building with JSON output."""
 
 import asyncio
-import json
-import sys
 from typing import Annotated
 
 import typer
 
+from pipelex.cli.agent_cli.commands.agent_output import agent_error, agent_success
 from pipelex.cli.agent_cli.commands.build_core import BuildPipeError, build_pipe_core
 from pipelex.cli.cli_factory import make_pipelex_for_cli
 from pipelex.cli.error_handlers import ErrorContext
@@ -56,28 +55,16 @@ def build_cmd(
 
     try:
         result = asyncio.run(run_build())
-        # Output JSON to stdout on success
-        print(json.dumps(result.to_agent_json(), indent=2))
+        agent_success(result.to_agent_json())
 
     except BuildPipeError as exc:
-        # Output JSON to stderr on error
-        error_json = {
-            "error": True,
-            "message": exc.message,
-        }
+        extra: dict[str, str] = {}
         if exc.failure_memory_path:
-            error_json["failure_memory_path"] = str(exc.failure_memory_path)
-        print(json.dumps(error_json, indent=2), file=sys.stderr)
-        raise typer.Exit(1) from exc
+            extra["failure_memory_path"] = str(exc.failure_memory_path)
+        agent_error(exc.message, "BuildPipeError", cause=exc, **extra)
 
     except Exception as exc:
-        # Handle unexpected errors
-        error_json = {
-            "error": True,
-            "message": f"Build failed: {exc}",
-        }
-        print(json.dumps(error_json, indent=2), file=sys.stderr)
-        raise typer.Exit(1) from exc
+        agent_error(f"Build failed: {exc}", type(exc).__name__, cause=exc)
 
     finally:
         Pipelex.teardown_if_needed()

--- a/pipelex/cli/agent_cli/commands/build_core.py
+++ b/pipelex/cli/agent_cli/commands/build_core.py
@@ -30,6 +30,8 @@ class BuildPipeResult(BaseModel):
     inputs_file: Path | None = None
     main_pipe_code: str
     domain: str
+    pipe_inputs: dict[str, str] | None = None
+    pipe_output: str | None = None
 
     model_config = {"arbitrary_types_allowed": True}
 
@@ -47,6 +49,10 @@ class BuildPipeResult(BaseModel):
         }
         if self.inputs_file:
             result["inputs_file"] = str(self.inputs_file)
+        if self.pipe_inputs is not None:
+            result["pipe_inputs"] = self.pipe_inputs
+        if self.pipe_output is not None:
+            result["pipe_output"] = self.pipe_output
         return result
 
 
@@ -137,16 +143,22 @@ async def build_pipe_core(
     domain = pipelex_bundle_spec.domain or ""
 
     inputs_file_path: Path | None = None
+    pipe_inputs: dict[str, str] | None = None
+    pipe_output: str | None = None
 
-    # Generate inputs.json if requested and main_pipe_code exists
-    if generate_inputs and main_pipe_code:
+    # Load pipe metadata (inputs/output) and optionally generate inputs.json
+    if main_pipe_code:
         try:
             pipe = get_required_pipe(pipe_code=main_pipe_code)
-            inputs_json_str = pipe.inputs.render_inputs(indent=2)
-            inputs_file_path = Path(extras_output_dir) / DEFAULT_INPUTS_FILE_NAME
-            save_text_to_path(text=inputs_json_str, path=str(inputs_file_path))
+            pipe_inputs = {name: stuff_spec.to_bundle_representation() for name, stuff_spec in pipe.inputs.items}
+            pipe_output = pipe.output.to_bundle_representation()
+
+            if generate_inputs:
+                inputs_json_str = pipe.inputs.render_inputs(indent=2)
+                inputs_file_path = Path(extras_output_dir) / DEFAULT_INPUTS_FILE_NAME
+                save_text_to_path(text=inputs_json_str, path=str(inputs_file_path))
         except Exception as exc:
-            log.warning(f"Could not generate inputs.json: {exc}")
+            log.warning(f"Could not load pipe metadata: {exc}")
 
     return BuildPipeResult(
         output_dir=Path(extras_output_dir),
@@ -154,4 +166,6 @@ async def build_pipe_core(
         inputs_file=inputs_file_path,
         main_pipe_code=main_pipe_code,
         domain=domain,
+        pipe_inputs=pipe_inputs,
+        pipe_output=pipe_output,
     )

--- a/pipelex/cli/agent_cli/commands/concept_cmd.py
+++ b/pipelex/cli/agent_cli/commands/concept_cmd.py
@@ -3,7 +3,6 @@
 # pyright: reportUnknownMemberType=false
 
 import json
-import sys
 from typing import Annotated, Any
 
 import tomlkit
@@ -11,6 +10,7 @@ import typer
 from pydantic import ValidationError
 
 from pipelex.builder.concept.concept_spec import ConceptSpec, ConceptStructureSpec
+from pipelex.cli.agent_cli.commands.agent_output import agent_error, agent_success
 from pipelex.tools.typing.pydantic_utils import format_pydantic_validation_error
 
 
@@ -158,26 +158,12 @@ def concept_cmd(
         pipelex-agent concept --spec '{"the_concept_code": "Invoice", "description": "A commercial invoice", "refines": "Text"}'
         pipelex-agent concept --spec-file concept.json
     """
-    error_json: dict[str, Any]
-
     # Validate that exactly one of spec or spec_file is provided
     if spec is None and spec_file is None:
-        error_json = {
-            "error": True,
-            "error_type": "ArgumentError",
-            "message": "Either --spec or --spec-file must be provided",
-        }
-        print(json.dumps(error_json, indent=2), file=sys.stderr)
-        raise typer.Exit(1)
+        agent_error("Either --spec or --spec-file must be provided", "ArgumentError")
 
     if spec is not None and spec_file is not None:
-        error_json = {
-            "error": True,
-            "error_type": "ArgumentError",
-            "message": "Cannot use both --spec and --spec-file",
-        }
-        print(json.dumps(error_json, indent=2), file=sys.stderr)
-        raise typer.Exit(1)
+        agent_error("Cannot use both --spec and --spec-file", "ArgumentError")
 
     # Load spec data
     spec_data: dict[str, Any]
@@ -188,48 +174,25 @@ def concept_cmd(
         else:
             spec_data = json.loads(spec)  # type: ignore[arg-type]
     except FileNotFoundError:
-        error_json = {
-            "error": True,
-            "error_type": "FileNotFoundError",
-            "message": f"Spec file not found: {spec_file}",
-        }
-        print(json.dumps(error_json, indent=2), file=sys.stderr)
-        raise typer.Exit(1) from None
+        agent_error(f"Spec file not found: {spec_file}", "FileNotFoundError")
     except json.JSONDecodeError as exc:
-        error_json = {
-            "error": True,
-            "error_type": "JSONDecodeError",
-            "message": f"Invalid JSON: {exc.msg}",
-        }
-        print(json.dumps(error_json, indent=2), file=sys.stderr)
-        raise typer.Exit(1) from exc
+        agent_error(f"Invalid JSON: {exc.msg}", "JSONDecodeError", cause=exc)
 
     # Validate and convert spec
     try:
         concept_spec = _parse_concept_spec_from_json(spec_data)
         toml_content = _concept_spec_to_toml(concept_spec)
 
-        result = {
-            "success": True,
-            "concept_code": concept_spec.the_concept_code,
-            "toml": toml_content,
-        }
-        print(json.dumps(result, indent=2))
+        agent_success(
+            {
+                "success": True,
+                "concept_code": concept_spec.the_concept_code,
+                "toml": toml_content,
+            }
+        )
 
     except ValidationError as exc:
-        error_json = {
-            "error": True,
-            "error_type": "ValidationError",
-            "message": format_pydantic_validation_error(exc),
-        }
-        print(json.dumps(error_json, indent=2), file=sys.stderr)
-        raise typer.Exit(1) from exc
+        agent_error(format_pydantic_validation_error(exc), "ValidationError", cause=exc)
 
     except Exception as exc:
-        error_json = {
-            "error": True,
-            "error_type": type(exc).__name__,
-            "message": str(exc),
-        }
-        print(json.dumps(error_json, indent=2), file=sys.stderr)
-        raise typer.Exit(1) from exc
+        agent_error(str(exc), type(exc).__name__, cause=exc)

--- a/pipelex/cli/agent_cli/commands/graph_cmd.py
+++ b/pipelex/cli/agent_cli/commands/graph_cmd.py
@@ -10,10 +10,11 @@ from pipelex.cli.agent_cli.commands.agent_output import agent_error, agent_succe
 from pipelex.cli.cli_factory import make_pipelex_for_cli
 from pipelex.cli.error_handlers import ErrorContext
 from pipelex.config import get_config
-from pipelex.graph.graph_factory import generate_graph_outputs
+from pipelex.graph.graph_factory import generate_graph_outputs, save_graph_outputs_to_dir
 from pipelex.graph.graphspec import GraphSpec
 from pipelex.pipelex import Pipelex
 from pipelex.tools.misc.file_utils import load_text_from_path
+from pipelex.tools.misc.string_utils import snake_to_title_case
 from pipelex.types import StrEnum
 
 
@@ -74,14 +75,14 @@ def graph_cmd(
     else:
         output_dir = input_path.parent
 
-    output_dir.mkdir(parents=True, exist_ok=True)
-
     # Initialize Pipelex (needed for config access)
     make_pipelex_for_cli(context=ErrorContext.VALIDATION)
 
     try:
-        # Build graph config with data inclusion and format selection
         base_graph_config = get_config().pipelex.pipeline_execution_config.graph_config
+
+        # Enable all content formats (JSON, text, HTML) so the interactive HTML
+        # viewers can display data panels alongside the graph visualization
         new_data_inclusion = base_graph_config.data_inclusion.model_copy(
             update={
                 "stuff_json_content": True,
@@ -103,6 +104,9 @@ def graph_cmd(
                 include_mermaidflow = True
                 include_reactflow = True
 
+        # Only generate the final HTML files requested — skip intermediate formats
+        # (graphspec JSON, Mermaid .mmd source, ReactFlow viewspec JSON) that are
+        # only useful during pipeline execution, not for standalone rendering
         new_graphs_inclusion = base_graph_config.graphs_inclusion.model_copy(
             update={
                 "graphspec_json": False,
@@ -120,37 +124,22 @@ def graph_cmd(
             }
         )
 
-        # Derive a pipe code from the graphspec file name for the HTML title
-        pipe_code = input_path.stem.replace("graphspec", "").strip("_.- ")
-        if not pipe_code:
-            pipe_code = "pipeline"
-
         graph_outputs = asyncio.run(
             generate_graph_outputs(
                 graph_spec=graph_spec,
                 graph_config=graph_config,
-                pipe_code=pipe_code,
+                title=snake_to_title_case(input_path.stem),
             )
         )
 
         # Save generated files
-        files: dict[str, str] = {}
-
-        if graph_outputs.mermaidflow_html is not None:
-            mermaidflow_path = output_dir / "mermaidflow.html"
-            mermaidflow_path.write_text(graph_outputs.mermaidflow_html, encoding="utf-8")
-            files["mermaidflow_html"] = str(mermaidflow_path)
-
-        if graph_outputs.reactflow_html is not None:
-            reactflow_path = output_dir / "reactflow.html"
-            reactflow_path.write_text(graph_outputs.reactflow_html, encoding="utf-8")
-            files["reactflow_html"] = str(reactflow_path)
+        saved_files = save_graph_outputs_to_dir(graph_outputs=graph_outputs, output_dir=output_dir)
 
         agent_success(
             {
                 "success": True,
                 "output_dir": str(output_dir),
-                "files": files,
+                "files": {key: str(path) for key, path in saved_files.items()},
                 "node_count": len(graph_spec.nodes),
             }
         )

--- a/pipelex/cli/agent_cli/commands/graph_cmd.py
+++ b/pipelex/cli/agent_cli/commands/graph_cmd.py
@@ -1,0 +1,162 @@
+"""Agent CLI graph command - render graphspec.json to HTML visualizations with JSON output."""
+
+import asyncio
+from pathlib import Path
+from typing import Annotated
+
+import typer
+
+from pipelex.cli.agent_cli.commands.agent_output import agent_error, agent_success
+from pipelex.cli.cli_factory import make_pipelex_for_cli
+from pipelex.cli.error_handlers import ErrorContext
+from pipelex.config import get_config
+from pipelex.graph.graph_factory import generate_graph_outputs
+from pipelex.graph.graphspec import GraphSpec
+from pipelex.pipelex import Pipelex
+from pipelex.tools.misc.file_utils import load_text_from_path
+from pipelex.types import StrEnum
+
+
+class GraphFormat(StrEnum):
+    """Selectable graph output formats."""
+
+    MERMAIDFLOW = "mermaidflow"
+    REACTFLOW = "reactflow"
+    BOTH = "both"
+
+
+def graph_cmd(
+    graphspec_file: Annotated[
+        str,
+        typer.Argument(help="Path to a graphspec.json file"),
+    ],
+    out: Annotated[
+        str | None,
+        typer.Option("--out", "-o", help="Output directory (default: same directory as input file)"),
+    ] = None,
+    graph_format: Annotated[
+        GraphFormat,
+        typer.Option("--format", "-f", help="Graph format to generate: mermaidflow, reactflow, or both"),
+    ] = GraphFormat.BOTH,
+) -> None:
+    """Render a graphspec.json file to HTML visualizations.
+
+    Outputs JSON to stdout on success, JSON to stderr on error with exit code 1.
+
+    Examples:
+        pipelex-agent graph graphspec.json
+        pipelex-agent graph graphspec.json --format mermaidflow
+        pipelex-agent graph graphspec.json -o ./output/ --format reactflow
+    """
+    input_path = Path(graphspec_file)
+
+    if not input_path.exists():
+        agent_error(f"File not found: {graphspec_file}", "FileNotFoundError")
+
+    if input_path.suffix != ".json":
+        agent_error(f"Expected .json file, got: {input_path.name}", "ArgumentError")
+
+    # Load and parse the GraphSpec
+    try:
+        json_str = load_text_from_path(str(input_path))
+    except Exception as exc:
+        agent_error(f"Failed to read file: {exc}", type(exc).__name__, cause=exc)
+
+    try:
+        graph_spec = GraphSpec.model_validate_json(json_str)
+    except Exception as exc:
+        agent_error(f"Invalid graphspec JSON: {exc}", "GraphSpecParseError", cause=exc)
+
+    # Determine output directory
+    output_dir: Path
+    if out:
+        output_dir = Path(out)
+    else:
+        output_dir = input_path.parent
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Initialize Pipelex (needed for config access)
+    make_pipelex_for_cli(context=ErrorContext.VALIDATION)
+
+    try:
+        # Build graph config with data inclusion and format selection
+        base_graph_config = get_config().pipelex.pipeline_execution_config.graph_config
+        new_data_inclusion = base_graph_config.data_inclusion.model_copy(
+            update={
+                "stuff_json_content": True,
+                "stuff_text_content": True,
+                "stuff_html_content": True,
+            }
+        )
+
+        include_mermaidflow: bool
+        include_reactflow: bool
+        match graph_format:
+            case GraphFormat.MERMAIDFLOW:
+                include_mermaidflow = True
+                include_reactflow = False
+            case GraphFormat.REACTFLOW:
+                include_mermaidflow = False
+                include_reactflow = True
+            case GraphFormat.BOTH:
+                include_mermaidflow = True
+                include_reactflow = True
+
+        new_graphs_inclusion = base_graph_config.graphs_inclusion.model_copy(
+            update={
+                "graphspec_json": False,
+                "mermaidflow_mmd": False,
+                "mermaidflow_html": include_mermaidflow,
+                "reactflow_viewspec": False,
+                "reactflow_html": include_reactflow,
+            }
+        )
+
+        graph_config = base_graph_config.model_copy(
+            update={
+                "data_inclusion": new_data_inclusion,
+                "graphs_inclusion": new_graphs_inclusion,
+            }
+        )
+
+        # Derive a pipe code from the graphspec file name for the HTML title
+        pipe_code = input_path.stem.replace("graphspec", "").strip("_.- ")
+        if not pipe_code:
+            pipe_code = "pipeline"
+
+        graph_outputs = asyncio.run(
+            generate_graph_outputs(
+                graph_spec=graph_spec,
+                graph_config=graph_config,
+                pipe_code=pipe_code,
+            )
+        )
+
+        # Save generated files
+        files: dict[str, str] = {}
+
+        if graph_outputs.mermaidflow_html is not None:
+            mermaidflow_path = output_dir / "mermaidflow.html"
+            mermaidflow_path.write_text(graph_outputs.mermaidflow_html, encoding="utf-8")
+            files["mermaidflow_html"] = str(mermaidflow_path)
+
+        if graph_outputs.reactflow_html is not None:
+            reactflow_path = output_dir / "reactflow.html"
+            reactflow_path.write_text(graph_outputs.reactflow_html, encoding="utf-8")
+            files["reactflow_html"] = str(reactflow_path)
+
+        agent_success(
+            {
+                "success": True,
+                "output_dir": str(output_dir),
+                "files": files,
+                "node_count": len(graph_spec.nodes),
+            }
+        )
+
+    except Exception as exc:
+        agent_error(f"Failed to render graph: {exc}", type(exc).__name__, cause=exc)
+
+    finally:
+        Pipelex.teardown_if_needed()

--- a/pipelex/cli/agent_cli/commands/inputs_cmd.py
+++ b/pipelex/cli/agent_cli/commands/inputs_cmd.py
@@ -2,12 +2,12 @@
 
 import asyncio
 import json
-import sys
 from pathlib import Path
 from typing import Annotated, Any
 
 import typer
 
+from pipelex.cli.agent_cli.commands.agent_output import agent_error, agent_success
 from pipelex.cli.cli_factory import make_pipelex_for_cli
 from pipelex.cli.error_handlers import ErrorContext
 from pipelex.core.interpreter.helpers import is_pipelex_file
@@ -103,13 +103,7 @@ def inputs_cmd(
     """
     # Validate that at least one target is provided
     if target is None and pipe is None:
-        error_json: dict[str, Any] = {
-            "error": True,
-            "error_type": "ArgumentError",
-            "message": "No pipe code or bundle file specified",
-        }
-        print(json.dumps(error_json, indent=2), file=sys.stderr)
-        raise typer.Exit(1)
+        agent_error("No pipe code or bundle file specified", "ArgumentError")
 
     # Determine pipe_code and bundle_path from arguments
     pipe_code: str | None = None
@@ -118,105 +112,69 @@ def inputs_cmd(
     if target:
         target_path = Path(target)
         if target_path.is_dir():
-            error_json = {
-                "error": True,
-                "error_type": "ArgumentError",
-                "message": f"'{target}' is a directory. The inputs command requires a .plx file or a pipe code.",
-            }
-            print(json.dumps(error_json, indent=2), file=sys.stderr)
-            raise typer.Exit(1)
+            agent_error(
+                f"'{target}' is a directory. The inputs command requires a .plx file or a pipe code.",
+                "ArgumentError",
+            )
 
         if is_pipelex_file(target_path):
             bundle_path = target_path
         else:
             pipe_code = target
             if pipe:
-                error_json = {
-                    "error": True,
-                    "error_type": "ArgumentError",
-                    "message": "Cannot use --pipe if already passing a pipe code as positional argument",
-                }
-                print(json.dumps(error_json, indent=2), file=sys.stderr)
-                raise typer.Exit(1)
+                agent_error("Cannot use --pipe if already passing a pipe code as positional argument", "ArgumentError")
 
     if pipe:
         pipe_code = pipe
 
     if not pipe_code and not bundle_path:
-        error_json = {
-            "error": True,
-            "error_type": "ArgumentError",
-            "message": "No pipe code or bundle file specified",
-        }
-        print(json.dumps(error_json, indent=2), file=sys.stderr)
-        raise typer.Exit(1)
+        agent_error("No pipe code or bundle file specified", "ArgumentError")
 
     library_dirs = [Path(lib_dir) for lib_dir in library_dir] if library_dir else None
     make_pipelex_for_cli(context=ErrorContext.VALIDATION_BEFORE_BUILD_INPUTS, library_dirs=library_dirs)
 
     try:
         result = asyncio.run(_inputs_core(pipe_code=pipe_code, bundle_path=bundle_path, library_dirs=library_dirs))
-        print(json.dumps(result, indent=2))
+        agent_success(result)
 
     except FileNotFoundError as exc:
-        error_json = {
-            "error": True,
-            "error_type": "FileNotFoundError",
-            "message": f"Bundle file not found: {bundle_path}",
-        }
-        print(json.dumps(error_json, indent=2), file=sys.stderr)
-        raise typer.Exit(1) from exc
+        agent_error(f"Bundle file not found: {bundle_path}", "FileNotFoundError", cause=exc)
 
     except ValidateBundleError as exc:
-        error_json = {
-            "error": True,
-            "error_type": "ValidateBundleError",
-            "message": exc.message,
-        }
-        print(json.dumps(error_json, indent=2), file=sys.stderr)
-        raise typer.Exit(1) from exc
+        agent_error(exc.message, "ValidateBundleError", cause=exc)
 
     except NoInputsRequiredError as exc:
         # Not really an error - just a pipe with no inputs
-        result_json: dict[str, Any] = {
-            "success": True,
-            "pipe_code": pipe_code,
-            "inputs": {},
-            "message": str(exc),
-        }
-        print(json.dumps(result_json, indent=2))
+        agent_success(
+            {
+                "success": True,
+                "pipe_code": pipe_code,
+                "inputs": {},
+                "message": str(exc),
+            }
+        )
 
     except PipeOperatorModelChoiceError as exc:
-        error_json = {
-            "error": True,
-            "error_type": "PipeOperatorModelChoiceError",
-            "message": exc.message,
-            "pipe_code": exc.pipe_code,
-            "model_type": exc.model_type,
-            "model_choice": exc.model_choice,
-        }
-        print(json.dumps(error_json, indent=2), file=sys.stderr)
-        raise typer.Exit(1) from exc
+        agent_error(
+            exc.message,
+            "PipeOperatorModelChoiceError",
+            cause=exc,
+            pipe_code=exc.pipe_code,
+            model_type=exc.model_type,
+            model_choice=exc.model_choice,
+        )
 
     except PipeOperatorModelAvailabilityError as exc:
-        error_json = {
-            "error": True,
-            "error_type": "PipeOperatorModelAvailabilityError",
-            "message": str(exc),
-            "pipe_code": exc.pipe_code,
-            "model_handle": exc.model_handle,
-        }
-        print(json.dumps(error_json, indent=2), file=sys.stderr)
-        raise typer.Exit(1) from exc
+        agent_error(
+            str(exc),
+            "PipeOperatorModelAvailabilityError",
+            cause=exc,
+            pipe_code=exc.pipe_code,
+            model_handle=exc.model_handle,
+        )
 
     except Exception as exc:
-        error_json = {
-            "error": True,
-            "error_type": type(exc).__name__,
-            "message": str(exc),
-        }
-        print(json.dumps(error_json, indent=2), file=sys.stderr)
-        raise typer.Exit(1) from exc
+        agent_error(str(exc), type(exc).__name__, cause=exc)
 
     finally:
         Pipelex.teardown_if_needed()

--- a/pipelex/cli/agent_cli/commands/pipe_cmd.py
+++ b/pipelex/cli/agent_cli/commands/pipe_cmd.py
@@ -7,7 +7,6 @@
 # mypy: disable-error-code="arg-type,no-any-return,attr-defined"
 
 import json
-import sys
 from typing import Annotated, Any
 
 import tomlkit
@@ -25,6 +24,7 @@ from pipelex.builder.pipe.pipe_parallel_spec import PipeParallelSpec
 from pipelex.builder.pipe.pipe_sequence_spec import PipeSequenceSpec
 from pipelex.builder.pipe.pipe_spec import PipeSpec
 from pipelex.builder.pipe.pipe_spec_map import pipe_type_to_spec_class
+from pipelex.cli.agent_cli.commands.agent_output import agent_error, agent_success
 from pipelex.core.pipes.pipe_blueprint import PipeType
 from pipelex.tools.typing.pydantic_utils import format_pydantic_validation_error
 
@@ -259,26 +259,12 @@ def pipe_cmd(
         pipelex-agent pipe --type PipeLLM --spec '{"pipe_code": "summarize", ...}'
         pipelex-agent pipe --type PipeSequence --spec-file pipe.json
     """
-    error_json: dict[str, Any]
-
     # Validate that exactly one of spec or spec_file is provided
     if spec is None and spec_file is None:
-        error_json = {
-            "error": True,
-            "error_type": "ArgumentError",
-            "message": "Either --spec or --spec-file must be provided",
-        }
-        print(json.dumps(error_json, indent=2), file=sys.stderr)
-        raise typer.Exit(1)
+        agent_error("Either --spec or --spec-file must be provided", "ArgumentError")
 
     if spec is not None and spec_file is not None:
-        error_json = {
-            "error": True,
-            "error_type": "ArgumentError",
-            "message": "Cannot use both --spec and --spec-file",
-        }
-        print(json.dumps(error_json, indent=2), file=sys.stderr)
-        raise typer.Exit(1)
+        agent_error("Cannot use both --spec and --spec-file", "ArgumentError")
 
     # Load spec data
     spec_data: dict[str, Any]
@@ -289,58 +275,29 @@ def pipe_cmd(
         else:
             spec_data = json.loads(spec)  # type: ignore[arg-type]
     except FileNotFoundError:
-        error_json = {
-            "error": True,
-            "error_type": "FileNotFoundError",
-            "message": f"Spec file not found: {spec_file}",
-        }
-        print(json.dumps(error_json, indent=2), file=sys.stderr)
-        raise typer.Exit(1) from None
+        agent_error(f"Spec file not found: {spec_file}", "FileNotFoundError")
     except json.JSONDecodeError as exc:
-        error_json = {
-            "error": True,
-            "error_type": "JSONDecodeError",
-            "message": f"Invalid JSON: {exc.msg}",
-        }
-        print(json.dumps(error_json, indent=2), file=sys.stderr)
-        raise typer.Exit(1) from exc
+        agent_error(f"Invalid JSON: {exc.msg}", "JSONDecodeError", cause=exc)
 
     # Validate and convert spec
     try:
         pipe_spec = _parse_pipe_spec_from_json(pipe_type, spec_data)
         toml_content = _pipe_spec_to_toml(pipe_spec)
 
-        result = {
-            "success": True,
-            "pipe_code": pipe_spec.pipe_code,
-            "pipe_type": pipe_type,
-            "toml": toml_content,
-        }
-        print(json.dumps(result, indent=2))
+        agent_success(
+            {
+                "success": True,
+                "pipe_code": pipe_spec.pipe_code,
+                "pipe_type": pipe_type,
+                "toml": toml_content,
+            }
+        )
 
     except ValueError as exc:
-        error_json = {
-            "error": True,
-            "error_type": "ValueError",
-            "message": str(exc),
-        }
-        print(json.dumps(error_json, indent=2), file=sys.stderr)
-        raise typer.Exit(1) from exc
+        agent_error(str(exc), "ValueError", cause=exc)
 
     except ValidationError as exc:
-        error_json = {
-            "error": True,
-            "error_type": "ValidationError",
-            "message": format_pydantic_validation_error(exc),
-        }
-        print(json.dumps(error_json, indent=2), file=sys.stderr)
-        raise typer.Exit(1) from exc
+        agent_error(format_pydantic_validation_error(exc), "ValidationError", cause=exc)
 
     except Exception as exc:
-        error_json = {
-            "error": True,
-            "error_type": type(exc).__name__,
-            "message": str(exc),
-        }
-        print(json.dumps(error_json, indent=2), file=sys.stderr)
-        raise typer.Exit(1) from exc
+        agent_error(str(exc), type(exc).__name__, cause=exc)

--- a/pipelex/cli/agent_cli/commands/run_cmd.py
+++ b/pipelex/cli/agent_cli/commands/run_cmd.py
@@ -2,12 +2,12 @@
 
 import asyncio
 import json
-import sys
 from pathlib import Path
 from typing import Annotated, Any
 
 import typer
 
+from pipelex.cli.agent_cli.commands.agent_output import agent_error, agent_success
 from pipelex.cli.cli_factory import make_pipelex_for_cli
 from pipelex.cli.error_handlers import ErrorContext
 from pipelex.config import get_config
@@ -126,23 +126,11 @@ def run_cmd(
     # Validate that at least one target is provided
     provided_options = sum([target is not None, pipe is not None, bundle is not None])
     if provided_options == 0:
-        error_json: dict[str, Any] = {
-            "error": True,
-            "error_type": "ArgumentError",
-            "message": "No pipe code or bundle file specified",
-        }
-        print(json.dumps(error_json, indent=2), file=sys.stderr)
-        raise typer.Exit(1)
+        agent_error("No pipe code or bundle file specified", "ArgumentError")
 
     # Validate --mock-inputs requires --dry-run
     if mock_inputs and not dry_run:
-        error_json = {
-            "error": True,
-            "error_type": "ArgumentError",
-            "message": "--mock-inputs requires --dry-run",
-        }
-        print(json.dumps(error_json, indent=2), file=sys.stderr)
-        raise typer.Exit(1)
+        agent_error("--mock-inputs requires --dry-run", "ArgumentError")
 
     # Determine pipe_code and bundle_path from arguments
     pipe_code: str | None = None
@@ -152,23 +140,11 @@ def run_cmd(
         if is_pipelex_file(Path(target)):
             bundle_path = target
             if bundle:
-                error_json = {
-                    "error": True,
-                    "error_type": "ArgumentError",
-                    "message": "Cannot use --bundle if already passing a bundle file as positional argument",
-                }
-                print(json.dumps(error_json, indent=2), file=sys.stderr)
-                raise typer.Exit(1)
+                agent_error("Cannot use --bundle if already passing a bundle file as positional argument", "ArgumentError")
         else:
             pipe_code = target
             if pipe:
-                error_json = {
-                    "error": True,
-                    "error_type": "ArgumentError",
-                    "message": "Cannot use --pipe if already passing a pipe code as positional argument",
-                }
-                print(json.dumps(error_json, indent=2), file=sys.stderr)
-                raise typer.Exit(1)
+                agent_error("Cannot use --pipe if already passing a pipe code as positional argument", "ArgumentError")
 
     if bundle:
         bundle_path = bundle
@@ -177,13 +153,7 @@ def run_cmd(
         pipe_code = pipe
 
     if not pipe_code and not bundle_path:
-        error_json = {
-            "error": True,
-            "error_type": "ArgumentError",
-            "message": "No pipe code or bundle file specified",
-        }
-        print(json.dumps(error_json, indent=2), file=sys.stderr)
-        raise typer.Exit(1)
+        agent_error("No pipe code or bundle file specified", "ArgumentError")
 
     # Load plx content from bundle if provided
     plx_content: str | None = None
@@ -194,30 +164,15 @@ def run_cmd(
                 bundle_blueprint = PipelexInterpreter.make_pipelex_bundle_blueprint(plx_content=plx_content)
                 main_pipe_code = bundle_blueprint.main_pipe
                 if not main_pipe_code:
-                    error_json = {
-                        "error": True,
-                        "error_type": "BundleError",
-                        "message": f"Bundle '{bundle_path}' does not declare a main_pipe. Specify a pipe code with --pipe.",
-                    }
-                    print(json.dumps(error_json, indent=2), file=sys.stderr)
-                    raise typer.Exit(1)
+                    agent_error(
+                        f"Bundle '{bundle_path}' does not declare a main_pipe. Specify a pipe code with --pipe.",
+                        "BundleError",
+                    )
                 pipe_code = main_pipe_code
         except FileNotFoundError as exc:
-            error_json = {
-                "error": True,
-                "error_type": "FileNotFoundError",
-                "message": f"Bundle file not found: {bundle_path}",
-            }
-            print(json.dumps(error_json, indent=2), file=sys.stderr)
-            raise typer.Exit(1) from exc
+            agent_error(f"Bundle file not found: {bundle_path}", "FileNotFoundError", cause=exc)
         except (PipelexInterpreterError, PLXDecodeError) as exc:
-            error_json = {
-                "error": True,
-                "error_type": type(exc).__name__,
-                "message": f"Failed to parse bundle '{bundle_path}': {exc}",
-            }
-            print(json.dumps(error_json, indent=2), file=sys.stderr)
-            raise typer.Exit(1) from exc
+            agent_error(f"Failed to parse bundle '{bundle_path}': {exc}", type(exc).__name__, cause=exc)
 
     # Load inputs if provided
     pipeline_inputs: dict[str, Any] | None = None
@@ -226,32 +181,14 @@ def run_cmd(
             try:
                 pipeline_inputs = json.loads(inputs)
             except json.JSONDecodeError as exc:
-                error_json = {
-                    "error": True,
-                    "error_type": "JSONDecodeError",
-                    "message": f"Failed to parse inline JSON inputs: {exc}",
-                }
-                print(json.dumps(error_json, indent=2), file=sys.stderr)
-                raise typer.Exit(1) from exc
+                agent_error(f"Failed to parse inline JSON inputs: {exc}", "JSONDecodeError", cause=exc)
         else:
             try:
                 pipeline_inputs = load_json_dict_from_path(inputs)
             except FileNotFoundError as exc:
-                error_json = {
-                    "error": True,
-                    "error_type": "FileNotFoundError",
-                    "message": f"Input file not found: {inputs}",
-                }
-                print(json.dumps(error_json, indent=2), file=sys.stderr)
-                raise typer.Exit(1) from exc
+                agent_error(f"Input file not found: {inputs}", "FileNotFoundError", cause=exc)
             except JsonTypeError as exc:
-                error_json = {
-                    "error": True,
-                    "error_type": "JsonTypeError",
-                    "message": f"Input file must be a valid JSON dictionary: {inputs}",
-                }
-                print(json.dumps(error_json, indent=2), file=sys.stderr)
-                raise typer.Exit(1) from exc
+                agent_error(f"Input file must be a valid JSON dictionary: {inputs}", "JsonTypeError", cause=exc)
 
     make_pipelex_for_cli(context=ErrorContext.VALIDATION_BEFORE_PIPE_RUN)
 
@@ -267,50 +204,32 @@ def run_cmd(
                 library_dirs=library_dir,
             )
         )
-        print(json.dumps(result, indent=2))
+        agent_success(result)
 
     except PipelineExecutionError as exc:
-        error_json = {
-            "error": True,
-            "error_type": "PipelineExecutionError",
-            "message": exc.message,
-            "pipe_code": exc.pipe_code,
-            "pipe_stack": exc.pipe_stack,
-        }
-        print(json.dumps(error_json, indent=2), file=sys.stderr)
-        raise typer.Exit(1) from exc
+        agent_error(exc.message, "PipelineExecutionError", cause=exc, pipe_code=exc.pipe_code, pipe_stack=exc.pipe_stack)
 
     except PipeOperatorModelChoiceError as exc:
-        error_json = {
-            "error": True,
-            "error_type": "PipeOperatorModelChoiceError",
-            "message": exc.message,
-            "pipe_code": exc.pipe_code,
-            "model_type": exc.model_type,
-            "model_choice": exc.model_choice,
-        }
-        print(json.dumps(error_json, indent=2), file=sys.stderr)
-        raise typer.Exit(1) from exc
+        agent_error(
+            exc.message,
+            "PipeOperatorModelChoiceError",
+            cause=exc,
+            pipe_code=exc.pipe_code,
+            model_type=exc.model_type,
+            model_choice=exc.model_choice,
+        )
 
     except PipeOperatorModelAvailabilityError as exc:
-        error_json = {
-            "error": True,
-            "error_type": "PipeOperatorModelAvailabilityError",
-            "message": str(exc),
-            "pipe_code": exc.pipe_code,
-            "model_handle": exc.model_handle,
-        }
-        print(json.dumps(error_json, indent=2), file=sys.stderr)
-        raise typer.Exit(1) from exc
+        agent_error(
+            str(exc),
+            "PipeOperatorModelAvailabilityError",
+            cause=exc,
+            pipe_code=exc.pipe_code,
+            model_handle=exc.model_handle,
+        )
 
     except Exception as exc:
-        error_json = {
-            "error": True,
-            "error_type": type(exc).__name__,
-            "message": str(exc),
-        }
-        print(json.dumps(error_json, indent=2), file=sys.stderr)
-        raise typer.Exit(1) from exc
+        agent_error(str(exc), type(exc).__name__, cause=exc)
 
     finally:
         Pipelex.teardown_if_needed()

--- a/pipelex/cli/agent_cli/commands/run_cmd.py
+++ b/pipelex/cli/agent_cli/commands/run_cmd.py
@@ -15,6 +15,7 @@ from pipelex.core.interpreter.exceptions import PipelexInterpreterError, PLXDeco
 from pipelex.core.interpreter.helpers import is_pipelex_file
 from pipelex.core.interpreter.interpreter import PipelexInterpreter
 from pipelex.core.pipes.exceptions import PipeOperatorModelChoiceError
+from pipelex.graph.graph_factory import generate_graph_outputs
 from pipelex.pipe_operators.exceptions import PipeOperatorModelAvailabilityError
 from pipelex.pipe_run.pipe_run_mode import PipeRunMode
 from pipelex.pipelex import Pipelex
@@ -31,6 +32,7 @@ async def _run_pipeline_core(
     dry_run: bool = False,
     mock_inputs: bool = False,
     library_dirs: list[str] | None = None,
+    graph: bool = False,
 ) -> dict[str, Any]:
     """Core logic for running a pipeline and returning JSON-serializable output.
 
@@ -42,6 +44,7 @@ async def _run_pipeline_core(
         dry_run: Whether to run in dry mode (no actual inference).
         mock_inputs: Whether to generate mock data for missing inputs.
         library_dirs: List of library directories to search for pipe definitions.
+        graph: Whether to generate execution graph visualizations.
 
     Returns:
         Dictionary with execution results suitable for JSON serialization.
@@ -52,7 +55,7 @@ async def _run_pipeline_core(
     pipe_run_mode = PipeRunMode.DRY if dry_run else None
 
     execution_config = get_config().pipelex.pipeline_execution_config.with_graph_config_overrides(
-        generate_graph=False,
+        generate_graph=graph,
         mock_inputs=mock_inputs or None,
     )
 
@@ -75,13 +78,71 @@ async def _run_pipeline_core(
             "html": await main_stuff.content.rendered_html_async(),
         }
 
-    return {
+    result: dict[str, Any] = {
         "success": True,
         "pipe_code": pipe_code,
         "dry_run": dry_run,
         "main_stuff": main_stuff_json,
         "working_memory": pipe_output.working_memory.smart_dump(),
     }
+
+    # Generate and save graph visualizations if requested
+    if graph and pipe_output.graph_spec:
+        graph_config = execution_config.graph_config
+        # Enable HTML outputs and data inclusion for the render
+        render_graph_config = graph_config.model_copy(
+            update={
+                "data_inclusion": graph_config.data_inclusion.model_copy(
+                    update={
+                        "stuff_json_content": True,
+                        "stuff_text_content": True,
+                        "stuff_html_content": True,
+                    }
+                ),
+                "graphs_inclusion": graph_config.graphs_inclusion.model_copy(
+                    update={
+                        "graphspec_json": True,
+                        "mermaidflow_html": True,
+                        "reactflow_html": True,
+                    }
+                ),
+            }
+        )
+
+        graph_outputs = await generate_graph_outputs(
+            graph_spec=pipe_output.graph_spec,
+            graph_config=render_graph_config,
+            pipe_code=pipe_code,
+        )
+
+        # Determine output directory from bundle path or current directory
+        output_dir: Path
+        if bundle_uri:
+            output_dir = Path(bundle_uri).parent / "pipelex-wip"
+        else:
+            output_dir = Path("pipelex-wip")
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        graph_files: dict[str, str] = {}
+
+        if graph_outputs.graphspec_json is not None:
+            graphspec_path = output_dir / "graphspec.json"
+            graphspec_path.write_text(graph_outputs.graphspec_json, encoding="utf-8")
+            graph_files["graphspec_json"] = str(graphspec_path)
+
+        if graph_outputs.mermaidflow_html is not None:
+            mermaidflow_path = output_dir / "mermaidflow.html"
+            mermaidflow_path.write_text(graph_outputs.mermaidflow_html, encoding="utf-8")
+            graph_files["mermaidflow_html"] = str(mermaidflow_path)
+
+        if graph_outputs.reactflow_html is not None:
+            reactflow_path = output_dir / "reactflow.html"
+            reactflow_path.write_text(graph_outputs.reactflow_html, encoding="utf-8")
+            graph_files["reactflow_html"] = str(reactflow_path)
+
+        result["graph_files"] = graph_files
+
+    return result
 
 
 def run_cmd(
@@ -109,6 +170,10 @@ def run_cmd(
         bool,
         typer.Option("--mock-inputs", help="Generate mock data for missing required inputs (requires --dry-run)"),
     ] = False,
+    graph: Annotated[
+        bool,
+        typer.Option("--graph", help="Generate execution graph visualizations (saved alongside output)"),
+    ] = False,
     library_dir: Annotated[
         list[str] | None,
         typer.Option("--library-dir", "-L", help="Directory to search for pipe definitions (.plx files)"),
@@ -122,6 +187,7 @@ def run_cmd(
         pipelex-agent run my_pipe --inputs data.json
         pipelex-agent run my_bundle.plx --pipe my_pipe
         pipelex-agent run my_pipe --dry-run --mock-inputs
+        pipelex-agent run my_bundle.plx --graph
     """
     # Validate that at least one target is provided
     provided_options = sum([target is not None, pipe is not None, bundle is not None])
@@ -202,6 +268,7 @@ def run_cmd(
                 dry_run=dry_run,
                 mock_inputs=mock_inputs,
                 library_dirs=library_dir,
+                graph=graph,
             )
         )
         agent_success(result)

--- a/pipelex/cli/agent_cli/commands/run_cmd.py
+++ b/pipelex/cli/agent_cli/commands/run_cmd.py
@@ -15,7 +15,7 @@ from pipelex.core.interpreter.exceptions import PipelexInterpreterError, PLXDeco
 from pipelex.core.interpreter.helpers import is_pipelex_file
 from pipelex.core.interpreter.interpreter import PipelexInterpreter
 from pipelex.core.pipes.exceptions import PipeOperatorModelChoiceError
-from pipelex.graph.graph_factory import generate_graph_outputs
+from pipelex.graph.graph_factory import generate_graph_outputs, save_graph_outputs_to_dir
 from pipelex.pipe_operators.exceptions import PipeOperatorModelAvailabilityError
 from pipelex.pipe_run.pipe_run_mode import PipeRunMode
 from pipelex.pipelex import Pipelex
@@ -121,26 +121,9 @@ async def _run_pipeline_core(
             output_dir = Path(bundle_uri).parent / "pipelex-wip"
         else:
             output_dir = Path("pipelex-wip")
-        output_dir.mkdir(parents=True, exist_ok=True)
 
-        graph_files: dict[str, str] = {}
-
-        if graph_outputs.graphspec_json is not None:
-            graphspec_path = output_dir / "graphspec.json"
-            graphspec_path.write_text(graph_outputs.graphspec_json, encoding="utf-8")
-            graph_files["graphspec_json"] = str(graphspec_path)
-
-        if graph_outputs.mermaidflow_html is not None:
-            mermaidflow_path = output_dir / "mermaidflow.html"
-            mermaidflow_path.write_text(graph_outputs.mermaidflow_html, encoding="utf-8")
-            graph_files["mermaidflow_html"] = str(mermaidflow_path)
-
-        if graph_outputs.reactflow_html is not None:
-            reactflow_path = output_dir / "reactflow.html"
-            reactflow_path.write_text(graph_outputs.reactflow_html, encoding="utf-8")
-            graph_files["reactflow_html"] = str(reactflow_path)
-
-        result["graph_files"] = graph_files
+        saved_files = save_graph_outputs_to_dir(graph_outputs=graph_outputs, output_dir=output_dir)
+        result["graph_files"] = {key: str(path) for key, path in saved_files.items()}
 
     return result
 

--- a/pipelex/cli/agent_cli/commands/validate_cmd.py
+++ b/pipelex/cli/agent_cli/commands/validate_cmd.py
@@ -1,13 +1,12 @@
 """Agent CLI validate command - simplified pipeline validation with JSON output."""
 
 import asyncio
-import json
-import sys
 from pathlib import Path
 from typing import Annotated, Any
 
 import typer
 
+from pipelex.cli.agent_cli.commands.agent_output import agent_error, agent_success
 from pipelex.cli.cli_factory import make_pipelex_for_cli
 from pipelex.cli.error_handlers import ErrorContext
 from pipelex.core.interpreter.helpers import is_pipelex_file
@@ -196,51 +195,35 @@ def validate_cmd(
     # Handle --all flag
     if validate_all:
         if target or pipe or bundle:
-            error_json: dict[str, Any] = {
-                "error": True,
-                "error_type": "ArgumentError",
-                "message": "--all cannot be used with a target, --pipe, or --bundle",
-            }
-            print(json.dumps(error_json, indent=2), file=sys.stderr)
-            raise typer.Exit(1)
+            agent_error("--all cannot be used with a target, --pipe, or --bundle", "ArgumentError")
 
         make_pipelex_for_cli(context=ErrorContext.VALIDATION, library_dirs=library_dirs)
 
         try:
             result = asyncio.run(_validate_all_core(library_dirs=library_dirs))
-            print(json.dumps(result, indent=2))
+            agent_success(result)
 
         except PipeOperatorModelAvailabilityError as exc:
-            error_json = {
-                "error": True,
-                "error_type": "PipeOperatorModelAvailabilityError",
-                "message": str(exc),
-                "pipe_code": exc.pipe_code,
-                "model_handle": exc.model_handle,
-            }
-            print(json.dumps(error_json, indent=2), file=sys.stderr)
-            raise typer.Exit(1) from exc
+            agent_error(
+                str(exc),
+                "PipeOperatorModelAvailabilityError",
+                cause=exc,
+                pipe_code=exc.pipe_code,
+                model_handle=exc.model_handle,
+            )
 
         except PipeOperatorModelChoiceError as exc:
-            error_json = {
-                "error": True,
-                "error_type": "PipeOperatorModelChoiceError",
-                "message": exc.message,
-                "pipe_code": exc.pipe_code,
-                "model_type": exc.model_type,
-                "model_choice": exc.model_choice,
-            }
-            print(json.dumps(error_json, indent=2), file=sys.stderr)
-            raise typer.Exit(1) from exc
+            agent_error(
+                exc.message,
+                "PipeOperatorModelChoiceError",
+                cause=exc,
+                pipe_code=exc.pipe_code,
+                model_type=exc.model_type,
+                model_choice=exc.model_choice,
+            )
 
         except Exception as exc:
-            error_json = {
-                "error": True,
-                "error_type": type(exc).__name__,
-                "message": str(exc),
-            }
-            print(json.dumps(error_json, indent=2), file=sys.stderr)
-            raise typer.Exit(1) from exc
+            agent_error(str(exc), type(exc).__name__, cause=exc)
 
         finally:
             Pipelex.teardown_if_needed()
@@ -249,13 +232,7 @@ def validate_cmd(
     # Validate mutual exclusivity
     provided_options = sum([target is not None, pipe is not None, bundle is not None])
     if provided_options == 0:
-        error_json = {
-            "error": True,
-            "error_type": "ArgumentError",
-            "message": "No pipe code or bundle file specified. Use --all to validate all pipes.",
-        }
-        print(json.dumps(error_json, indent=2), file=sys.stderr)
-        raise typer.Exit(1)
+        agent_error("No pipe code or bundle file specified. Use --all to validate all pipes.", "ArgumentError")
 
     # Determine pipe_code and bundle_path from arguments
     pipe_code: str | None = None
@@ -266,23 +243,11 @@ def validate_cmd(
         if is_pipelex_file(target_path):
             bundle_path = target_path
             if bundle:
-                error_json = {
-                    "error": True,
-                    "error_type": "ArgumentError",
-                    "message": "Cannot use --bundle if already passing a bundle file as positional argument",
-                }
-                print(json.dumps(error_json, indent=2), file=sys.stderr)
-                raise typer.Exit(1)
+                agent_error("Cannot use --bundle if already passing a bundle file as positional argument", "ArgumentError")
         else:
             pipe_code = target
             if pipe:
-                error_json = {
-                    "error": True,
-                    "error_type": "ArgumentError",
-                    "message": "Cannot use --pipe if already passing a pipe code as positional argument",
-                }
-                print(json.dumps(error_json, indent=2), file=sys.stderr)
-                raise typer.Exit(1)
+                agent_error("Cannot use --pipe if already passing a pipe code as positional argument", "ArgumentError")
 
     if bundle:
         bundle_path = Path(bundle)
@@ -291,13 +256,7 @@ def validate_cmd(
         pipe_code = pipe
 
     if not pipe_code and not bundle_path:
-        error_json = {
-            "error": True,
-            "error_type": "ArgumentError",
-            "message": "No pipe code or bundle file specified",
-        }
-        print(json.dumps(error_json, indent=2), file=sys.stderr)
-        raise typer.Exit(1)
+        agent_error("No pipe code or bundle file specified", "ArgumentError")
 
     make_pipelex_for_cli(context=ErrorContext.VALIDATION)
 
@@ -312,16 +271,10 @@ def validate_cmd(
             # Validate a standalone pipe
             result = asyncio.run(_validate_pipe_core(pipe_code=pipe_code, library_dirs=library_dirs))  # type: ignore[arg-type]
 
-        print(json.dumps(result, indent=2))
+        agent_success(result)
 
     except FileNotFoundError as exc:
-        error_json = {
-            "error": True,
-            "error_type": "FileNotFoundError",
-            "message": f"Bundle file not found: {bundle_path}",
-        }
-        print(json.dumps(error_json, indent=2), file=sys.stderr)
-        raise typer.Exit(1) from exc
+        agent_error(f"Bundle file not found: {bundle_path}", "FileNotFoundError", cause=exc)
 
     except ValidateBundleError as exc:
         validation_errors: list[dict[str, Any]] = []
@@ -342,49 +295,33 @@ def validate_cmd(
                 }
             )
 
-        error_json = {
-            "error": True,
-            "error_type": "ValidateBundleError",
-            "message": exc.message,
-            "validation_errors": validation_errors,
-        }
+        extra: dict[str, Any] = {"validation_errors": validation_errors}
         if exc.dry_run_error_message:
-            error_json["dry_run_error"] = exc.dry_run_error_message
+            extra["dry_run_error"] = exc.dry_run_error_message
 
-        print(json.dumps(error_json, indent=2), file=sys.stderr)
-        raise typer.Exit(1) from exc
+        agent_error(exc.message, "ValidateBundleError", cause=exc, **extra)
 
     except PipeOperatorModelChoiceError as exc:
-        error_json = {
-            "error": True,
-            "error_type": "PipeOperatorModelChoiceError",
-            "message": exc.message,
-            "pipe_code": exc.pipe_code,
-            "model_type": exc.model_type,
-            "model_choice": exc.model_choice,
-        }
-        print(json.dumps(error_json, indent=2), file=sys.stderr)
-        raise typer.Exit(1) from exc
+        agent_error(
+            exc.message,
+            "PipeOperatorModelChoiceError",
+            cause=exc,
+            pipe_code=exc.pipe_code,
+            model_type=exc.model_type,
+            model_choice=exc.model_choice,
+        )
 
     except PipeOperatorModelAvailabilityError as exc:
-        error_json = {
-            "error": True,
-            "error_type": "PipeOperatorModelAvailabilityError",
-            "message": str(exc),
-            "pipe_code": exc.pipe_code,
-            "model_handle": exc.model_handle,
-        }
-        print(json.dumps(error_json, indent=2), file=sys.stderr)
-        raise typer.Exit(1) from exc
+        agent_error(
+            str(exc),
+            "PipeOperatorModelAvailabilityError",
+            cause=exc,
+            pipe_code=exc.pipe_code,
+            model_handle=exc.model_handle,
+        )
 
     except Exception as exc:
-        error_json = {
-            "error": True,
-            "error_type": type(exc).__name__,
-            "message": str(exc),
-        }
-        print(json.dumps(error_json, indent=2), file=sys.stderr)
-        raise typer.Exit(1) from exc
+        agent_error(str(exc), type(exc).__name__, cause=exc)
 
     finally:
         Pipelex.teardown_if_needed()

--- a/pipelex/cli/commands/build/pipe_cmd.py
+++ b/pipelex/cli/commands/build/pipe_cmd.py
@@ -22,9 +22,7 @@ from pipelex.cli.error_handlers import (
 from pipelex.config import get_config
 from pipelex.core.pipes.exceptions import PipeOperatorModelChoiceError
 from pipelex.core.pipes.variable_multiplicity import parse_concept_with_multiplicity
-from pipelex.graph.graph_config import GraphConfig
-from pipelex.graph.graph_factory import generate_graph_outputs
-from pipelex.graph.graphspec import GraphSpec
+from pipelex.graph.graph_factory import generate_graph_outputs, save_graph_outputs_to_dir
 from pipelex.hub import get_console, get_report_delegate, get_required_pipe, get_telemetry_manager
 from pipelex.language.plx_factory import PlxFactory
 from pipelex.pipe_operators.exceptions import PipeOperatorModelAvailabilityError
@@ -44,64 +42,6 @@ from pipelex.tools.misc.pretty import PrettyPrinter
 
 COMMAND = "build"
 SUB_COMMAND_PIPE = "pipe"
-
-
-async def _save_graph_outputs_to_dir(
-    graph_spec: GraphSpec,
-    graph_config: GraphConfig,
-    pipe_code: str,
-    output_dir: Path,
-) -> list[str]:
-    """Save graph outputs to a directory.
-
-    Args:
-        graph_spec: The graph specification to render.
-        graph_config: Configuration for graph generation.
-        pipe_code: The pipe code for use in titles.
-        output_dir: Directory where graph files will be saved.
-
-    Returns:
-        List of saved graph format names (e.g., "mermaidflow", "reactflow").
-    """
-    output_dir.mkdir(parents=True, exist_ok=True)
-
-    graph_outputs = await generate_graph_outputs(
-        graph_spec=graph_spec,
-        graph_config=graph_config,
-        pipe_code=pipe_code,
-    )
-
-    saved_formats: list[str] = []
-    if graph_outputs.graphspec_json is not None:
-        (output_dir / "graphspec.json").write_text(graph_outputs.graphspec_json, encoding="utf-8")
-        log.verbose(f"GraphSpec JSON saved to: {output_dir / 'graphspec.json'}")
-        saved_formats.append("graphspec")
-
-    if graph_outputs.mermaidflow_mmd is not None:
-        (output_dir / "mermaidflow.mmd").write_text(graph_outputs.mermaidflow_mmd, encoding="utf-8")
-        log.verbose(f"Mermaidflow Mermaid saved to: {output_dir / 'mermaidflow.mmd'}")
-        if "mermaidflow" not in saved_formats:
-            saved_formats.append("mermaidflow")
-
-    if graph_outputs.mermaidflow_html is not None:
-        (output_dir / "mermaidflow.html").write_text(graph_outputs.mermaidflow_html, encoding="utf-8")
-        log.verbose(f"Mermaidflow HTML saved to: {output_dir / 'mermaidflow.html'}")
-        if "mermaidflow" not in saved_formats:
-            saved_formats.append("mermaidflow")
-
-    if graph_outputs.reactflow_viewspec is not None:
-        (output_dir / "viewspec.json").write_text(graph_outputs.reactflow_viewspec, encoding="utf-8")
-        log.verbose(f"ReactFlow ViewSpec saved to: {output_dir / 'viewspec.json'}")
-        if "reactflow" not in saved_formats:
-            saved_formats.append("reactflow")
-
-    if graph_outputs.reactflow_html is not None:
-        (output_dir / "reactflow.html").write_text(graph_outputs.reactflow_html, encoding="utf-8")
-        log.verbose(f"ReactFlow HTML saved to: {output_dir / 'reactflow.html'}")
-        if "reactflow" not in saved_formats:
-            saved_formats.append("reactflow")
-
-    return saved_formats
 
 
 """
@@ -328,14 +268,15 @@ def build_pipe_cmd(
                     # Save builder pipeline graph in graphs/ subfolder
                     graphs_dir = Path(extras_output_dir) / "graphs"
                     builder_graph_dir = graphs_dir / "builder_graph"
-                    builder_graph_formats = await _save_graph_outputs_to_dir(
+                    builder_graph_outputs = await generate_graph_outputs(
                         graph_spec=builder_graph_spec,
                         graph_config=execution_config.graph_config,
                         pipe_code=builder_pipe,
-                        output_dir=builder_graph_dir,
                     )
-                    if builder_graph_formats:
-                        saved_graph_sections.append(("builder", builder_graph_formats))
+                    builder_saved = save_graph_outputs_to_dir(graph_outputs=builder_graph_outputs, output_dir=builder_graph_dir)
+                    if builder_saved:
+                        builder_formats = list(dict.fromkeys(key.split("_")[0] for key in builder_saved))
+                        saved_graph_sections.append(("builder", builder_formats))
 
                     # Run built pipeline in dry-run mode to generate its graph
                     try:
@@ -352,14 +293,15 @@ def build_pipe_cmd(
                         if built_pipe_output.graph_spec:
                             pipeline_graph_dir = graphs_dir / "pipeline_graph"
                             log.verbose(f"Saving pipeline graph for pipe {main_pipe_code} to {pipeline_graph_dir}")
-                            pipeline_graph_formats = await _save_graph_outputs_to_dir(
+                            pipeline_graph_outputs = await generate_graph_outputs(
                                 graph_spec=built_pipe_output.graph_spec,
                                 graph_config=execution_config.graph_config,
                                 pipe_code=main_pipe_code,
-                                output_dir=pipeline_graph_dir,
                             )
-                            if pipeline_graph_formats:
-                                saved_graph_sections.append(("pipeline", pipeline_graph_formats))
+                            pipeline_saved = save_graph_outputs_to_dir(graph_outputs=pipeline_graph_outputs, output_dir=pipeline_graph_dir)
+                            if pipeline_saved:
+                                pipeline_formats = list(dict.fromkeys(key.split("_")[0] for key in pipeline_saved))
+                                saved_graph_sections.append(("pipeline", pipeline_formats))
                     except Exception as graph_exc:
                         typer.secho(f"⚠️  Warning: Could not generate built pipeline graph: {graph_exc}", fg=typer.colors.YELLOW)
 

--- a/pipelex/cli/commands/graph_cmd.py
+++ b/pipelex/cli/commands/graph_cmd.py
@@ -19,14 +19,8 @@ from pipelex import log
 from pipelex.cli.cli_factory import make_pipelex_for_cli
 from pipelex.cli.error_handlers import ErrorContext
 from pipelex.config import get_config
-from pipelex.graph.graph_analysis import GraphAnalysis
+from pipelex.graph.graph_factory import generate_graph_outputs, save_graph_outputs_to_dir
 from pipelex.graph.graphspec import GraphSpec
-from pipelex.graph.mermaidflow.mermaid_html import render_mermaid_html_async, render_mermaid_html_with_data_async
-from pipelex.graph.mermaidflow.mermaidflow_factory import MermaidflowFactory
-from pipelex.graph.mermaidflow.stuff_collector import collect_stuff_data_html, collect_stuff_data_text
-from pipelex.graph.reactflow.reactflow_html import generate_reactflow_html_async
-from pipelex.graph.reactflow.viewspec import LayoutSpec
-from pipelex.graph.reactflow.viewspec_transformer import graphspec_to_viewspec
 from pipelex.hub import get_console, get_telemetry_manager
 from pipelex.pipelex import Pipelex
 from pipelex.system.runtime import IntegrationMode
@@ -65,23 +59,19 @@ def _do_graph_render(
     else:
         output_dir = input_file.parent
 
-    output_dir.mkdir(parents=True, exist_ok=True)
-
     # Determine what to generate:
     # - Default (no flags): both mermaidflow.html + reactflow.html
     # - --mermaidflow: mermaidflow.html only
     # - --reactflow: reactflow.html only
-    generate_mermaidflow = mermaidflow or (not mermaidflow and not reactflow)
-    generate_reactflow = reactflow or (not mermaidflow and not reactflow)
+    include_mermaidflow = mermaidflow or (not mermaidflow and not reactflow)
+    include_reactflow = reactflow or (not mermaidflow and not reactflow)
 
-    generated_files: list[Path] = []
-
-    async def render_views() -> None:
-        """Inner async function to render views with async HTML generation."""
-        nonlocal generated_files
-
-        # Get graph config with data inclusion enabled for interactive views
+    async def render_and_save() -> dict[str, Path]:
+        """Generate graph outputs and save to directory."""
         base_graph_config = get_config().pipelex.pipeline_execution_config.graph_config
+
+        # Enable all content formats (JSON, text, HTML) so the interactive HTML
+        # viewers can display data panels alongside the graph visualization
         new_data_inclusion = base_graph_config.data_inclusion.model_copy(
             update={
                 "stuff_json_content": True,
@@ -89,86 +79,54 @@ def _do_graph_render(
                 "stuff_html_content": True,
             }
         )
-        graph_config = base_graph_config.model_copy(update={"data_inclusion": new_data_inclusion})
 
-        # Get the mermaid theme from config
-        mermaid_theme = graph_config.mermaid_config.style.theme
+        # Only generate the final HTML files requested by the user — skip intermediate
+        # formats (graphspec JSON, Mermaid .mmd source, ReactFlow viewspec JSON) that
+        # are only useful during pipeline execution, not for standalone rendering
+        new_graphs_inclusion = base_graph_config.graphs_inclusion.model_copy(
+            update={
+                "graphspec_json": False,
+                "mermaidflow_mmd": False,
+                "mermaidflow_html": include_mermaidflow,
+                "reactflow_viewspec": False,
+                "reactflow_html": include_reactflow,
+            }
+        )
+        graph_config = base_graph_config.model_copy(
+            update={
+                "data_inclusion": new_data_inclusion,
+                "graphs_inclusion": new_graphs_inclusion,
+            }
+        )
 
         flow_direction = direction or FlowchartDirection.TOP_DOWN
 
-        # Generate mermaidflow view (default + --mermaidflow)
-        if generate_mermaidflow:
-            the_mermaidflow = MermaidflowFactory.make_from_graphspec(
-                graph_spec,
-                graph_config,
-                direction=flow_direction,
-                include_subgraphs=subgraphs,
-            )
-            if the_mermaidflow.stuff_data:
-                mermaidflow_html = await render_mermaid_html_with_data_async(
-                    the_mermaidflow.mermaid_code,
-                    stuff_data=the_mermaidflow.stuff_data,
-                    stuff_data_text=the_mermaidflow.stuff_data_text,
-                    stuff_data_html=the_mermaidflow.stuff_data_html,
-                    stuff_metadata=the_mermaidflow.stuff_metadata,
-                    stuff_content_type=the_mermaidflow.stuff_content_type,
-                    title=f"Pipeline: {snake_to_title_case(input_file.stem)}",
-                    theme=mermaid_theme,
-                )
-            else:
-                mermaidflow_html = await render_mermaid_html_async(
-                    the_mermaidflow.mermaid_code,
-                    title=f"Pipeline: {snake_to_title_case(input_file.stem)}",
-                    theme=mermaid_theme,
-                )
-            mermaidflow_html_path = output_dir / "mermaidflow.html"
-            mermaidflow_html_path.write_text(mermaidflow_html, encoding="utf-8")
-            generated_files.append(mermaidflow_html_path)
-            typer.secho("✅ mermaidflow.html", fg=typer.colors.GREEN, err=True)
+        graph_outputs = await generate_graph_outputs(
+            graph_spec=graph_spec,
+            graph_config=graph_config,
+            title=snake_to_title_case(input_file.stem),
+            direction=flow_direction,
+            include_subgraphs=subgraphs,
+        )
 
-        # Generate ReactFlow view (default + --reactflow)
-        if generate_reactflow:
-            # Create ViewSpec from GraphSpec
-            analysis = GraphAnalysis.from_graphspec(graph_spec)
-            rf_config = graph_config.reactflow_config
-            layout = LayoutSpec(
-                direction=rf_config.layout_direction,
-                nodesep=rf_config.nodesep,
-                ranksep=rf_config.ranksep,
-            )
-            viewspec = graphspec_to_viewspec(graph_spec, analysis, layout=layout)
+        return save_graph_outputs_to_dir(graph_outputs=graph_outputs, output_dir=output_dir)
 
-            # Collect stuff data in alternate formats
-            rf_stuff_data_text = collect_stuff_data_text(graph_spec) if graph_config.data_inclusion.stuff_text_content else None
-            rf_stuff_data_html = collect_stuff_data_html(graph_spec) if graph_config.data_inclusion.stuff_html_content else None
+    saved_files = asyncio.run(render_and_save())
 
-            # Generate ReactFlow HTML
-            reactflow_html = await generate_reactflow_html_async(
-                viewspec,
-                graph_config.reactflow_config,
-                graphspec=graph_spec,
-                stuff_data_text=rf_stuff_data_text,
-                stuff_data_html=rf_stuff_data_html,
-                title=f"Pipeline: {snake_to_title_case(input_file.stem)}",
-            )
-            reactflow_path = output_dir / "reactflow.html"
-            reactflow_path.write_text(reactflow_html, encoding="utf-8")
-            generated_files.append(reactflow_path)
-            typer.secho("✅ reactflow.html", fg=typer.colors.GREEN, err=True)
-
-    asyncio.run(render_views())
+    # Report saved files
+    for file_path in saved_files.values():
+        typer.secho(f"✅ {file_path.name}", fg=typer.colors.GREEN, err=True)
 
     typer.secho(f"\n📊 Saved to: {output_dir}", fg=typer.colors.CYAN, bold=True, err=True)
 
     # Open in browser if requested
-    if open_browser and generated_files:
-        if len(generated_files) == 1:
-            # Open the single generated file
-            file_to_open = generated_files[0]
+    if open_browser and saved_files:
+        saved_paths = list(saved_files.values())
+        if len(saved_paths) == 1:
+            file_to_open = saved_paths[0]
             webbrowser.open(f"file://{file_to_open.absolute()}")
             typer.secho(f"🌐 Opened {file_to_open.name} in browser", fg=typer.colors.BLUE, err=True)
         else:
-            # Open the output directory so user can see all files
             webbrowser.open(f"file://{output_dir.absolute()}")
             typer.secho("🌐 Opened output directory in browser", fg=typer.colors.BLUE, err=True)
 

--- a/pipelex/cli/commands/run_cmd.py
+++ b/pipelex/cli/commands/run_cmd.py
@@ -23,7 +23,7 @@ from pipelex.core.interpreter.helpers import is_pipelex_file
 from pipelex.core.interpreter.interpreter import PipelexInterpreter
 from pipelex.core.pipes.exceptions import PipeOperatorModelChoiceError
 from pipelex.core.stuffs.stuff_viewer import render_stuff_viewer
-from pipelex.graph.graph_factory import generate_graph_outputs
+from pipelex.graph.graph_factory import generate_graph_outputs, save_graph_outputs_to_dir
 from pipelex.hub import get_console, get_telemetry_manager
 from pipelex.pipe_operators.exceptions import PipeOperatorModelAvailabilityError
 from pipelex.pipe_run.pipe_run_mode import PipeRunMode
@@ -340,34 +340,12 @@ def run_cmd(
                 pipe_code=pipe_code,
             )
 
-            # Save outputs to files (only those that were generated)
-            if graph_outputs.graphspec_json is not None:
-                graphspec_path = output_path / "graphspec.json"
-                graphspec_path.write_text(graph_outputs.graphspec_json, encoding="utf-8")
-                log.verbose(f"GraphSpec JSON saved to: {graphspec_path}")
-
-            if graph_outputs.mermaidflow_mmd is not None:
-                mermaidflow_mmd_path = output_path / "mermaidflow.mmd"
-                mermaidflow_mmd_path.write_text(graph_outputs.mermaidflow_mmd, encoding="utf-8")
-                log.verbose(f"Mermaidflow MMD saved to: {mermaidflow_mmd_path}")
-
-            if graph_outputs.mermaidflow_html is not None:
-                mermaidflow_html_path = output_path / "mermaidflow.html"
-                mermaidflow_html_path.write_text(graph_outputs.mermaidflow_html, encoding="utf-8")
-                log.verbose(f"Mermaidflow HTML saved to: {mermaidflow_html_path}")
-                if "mermaidflow" not in saved_graphs:
+            # Save outputs to files
+            saved_graph_files = save_graph_outputs_to_dir(graph_outputs=graph_outputs, output_dir=output_path)
+            for output_type in saved_graph_files:
+                if "mermaidflow" in output_type and "mermaidflow" not in saved_graphs:
                     saved_graphs.append("mermaidflow")
-
-            if graph_outputs.reactflow_viewspec is not None:
-                viewspec_path = output_path / "viewspec.json"
-                viewspec_path.write_text(graph_outputs.reactflow_viewspec, encoding="utf-8")
-                log.verbose(f"ReactFlow ViewSpec saved to: {viewspec_path}")
-
-            if graph_outputs.reactflow_html is not None:
-                reactflow_html_path = output_path / "reactflow.html"
-                reactflow_html_path.write_text(graph_outputs.reactflow_html, encoding="utf-8")
-                log.verbose(f"ReactFlow HTML saved to: {reactflow_html_path}")
-                if "reactflow" not in saved_graphs:
+                elif "reactflow" in output_type and "reactflow" not in saved_graphs:
                     saved_graphs.append("reactflow")
 
         # Save main_stuff files if enabled

--- a/pipelex/graph/graph_factory.py
+++ b/pipelex/graph/graph_factory.py
@@ -22,6 +22,8 @@ from pipelex.tools.misc.chart_utils import FlowchartDirection
 from pipelex.tools.misc.string_utils import snake_to_title_case
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from pipelex.graph.graph_config import GraphConfig
     from pipelex.graph.graphspec import GraphSpec
 
@@ -49,9 +51,11 @@ class GraphOutputs(BaseModel):
 async def generate_graph_outputs(
     graph_spec: GraphSpec,
     graph_config: GraphConfig,
-    pipe_code: str,
     *,
+    pipe_code: str = "",
+    title: str | None = None,
     direction: FlowchartDirection = FlowchartDirection.TOP_DOWN,
+    include_subgraphs: bool = True,
 ) -> GraphOutputs:
     """Generate graph outputs from a GraphSpec based on configuration.
 
@@ -66,12 +70,15 @@ async def generate_graph_outputs(
     Args:
         graph_spec: The GraphSpec to render.
         graph_config: Configuration controlling which outputs to generate and data inclusion.
-        pipe_code: The pipe code for use in titles.
+        pipe_code: The pipe code, used to derive the HTML page title when title is not provided.
+        title: Explicit HTML page title. When provided, overrides the auto-derived title from pipe_code.
         direction: Flowchart direction for Mermaid diagrams.
+        include_subgraphs: Whether to render controller hierarchy as subgraphs in Mermaid output.
 
     Returns:
         GraphOutputs containing generated content as strings (None for disabled outputs).
     """
+    page_title = title or f"Pipeline: {snake_to_title_case(pipe_code)}"
     inclusion = graph_config.graphs_inclusion
 
     graphspec_json: str | None = None
@@ -90,7 +97,7 @@ async def generate_graph_outputs(
 
     # Generate mermaidflow view
     if inclusion.mermaidflow_mmd or inclusion.mermaidflow_html:
-        mermaidflow = MermaidflowFactory.make_from_graphspec(graph_spec, graph_config, direction=direction)
+        mermaidflow = MermaidflowFactory.make_from_graphspec(graph_spec, graph_config, direction=direction, include_subgraphs=include_subgraphs)
         if inclusion.mermaidflow_mmd:
             mermaidflow_mmd = mermaidflow.mermaid_code
         if inclusion.mermaidflow_html:
@@ -103,13 +110,11 @@ async def generate_graph_outputs(
                     stuff_data_html=mermaidflow.stuff_data_html,
                     stuff_metadata=mermaidflow.stuff_metadata,
                     stuff_content_type=mermaidflow.stuff_content_type,
-                    title=f"Pipeline: {snake_to_title_case(pipe_code)}",
+                    title=page_title,
                     theme=mermaid_theme,
                 )
             else:
-                mermaidflow_html = await render_mermaid_html_async(
-                    mermaidflow.mermaid_code, title=f"Pipeline: {snake_to_title_case(pipe_code)}", theme=mermaid_theme
-                )
+                mermaidflow_html = await render_mermaid_html_async(mermaidflow.mermaid_code, title=page_title, theme=mermaid_theme)
 
     # Generate ReactFlow outputs
     if inclusion.reactflow_viewspec or inclusion.reactflow_html:
@@ -143,7 +148,7 @@ async def generate_graph_outputs(
                 graphspec=graph_spec,
                 stuff_data_text=rf_stuff_data_text,
                 stuff_data_html=rf_stuff_data_html,
-                title=f"Pipeline: {snake_to_title_case(pipe_code)}",
+                title=page_title,
             )
 
     return GraphOutputs(
@@ -153,3 +158,57 @@ async def generate_graph_outputs(
         reactflow_viewspec=reactflow_viewspec,
         reactflow_html=reactflow_html,
     )
+
+
+def save_graph_outputs_to_dir(
+    graph_outputs: GraphOutputs,
+    output_dir: Path,
+) -> dict[str, Path]:
+    """Save graph outputs to a directory.
+
+    Only outputs that are not None will be saved. Each output is written to a
+    standard filename within the output directory.
+
+    Args:
+        graph_outputs: The generated graph outputs to save.
+        output_dir: Directory where graph files will be saved (created if needed).
+
+    Returns:
+        Dictionary mapping output type keys to the saved file paths.
+        Keys match GraphOutputs field names (e.g. "graphspec_json", "mermaidflow_html").
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    saved_files: dict[str, Path] = {}
+
+    if graph_outputs.graphspec_json is not None:
+        file_path = output_dir / "graphspec.json"
+        file_path.write_text(graph_outputs.graphspec_json, encoding="utf-8")
+        saved_files["graphspec_json"] = file_path
+        log.verbose(f"GraphSpec JSON saved to: {file_path}")
+
+    if graph_outputs.mermaidflow_mmd is not None:
+        file_path = output_dir / "mermaidflow.mmd"
+        file_path.write_text(graph_outputs.mermaidflow_mmd, encoding="utf-8")
+        saved_files["mermaidflow_mmd"] = file_path
+        log.verbose(f"Mermaidflow MMD saved to: {file_path}")
+
+    if graph_outputs.mermaidflow_html is not None:
+        file_path = output_dir / "mermaidflow.html"
+        file_path.write_text(graph_outputs.mermaidflow_html, encoding="utf-8")
+        saved_files["mermaidflow_html"] = file_path
+        log.verbose(f"Mermaidflow HTML saved to: {file_path}")
+
+    if graph_outputs.reactflow_viewspec is not None:
+        file_path = output_dir / "viewspec.json"
+        file_path.write_text(graph_outputs.reactflow_viewspec, encoding="utf-8")
+        saved_files["reactflow_viewspec"] = file_path
+        log.verbose(f"ReactFlow ViewSpec saved to: {file_path}")
+
+    if graph_outputs.reactflow_html is not None:
+        file_path = output_dir / "reactflow.html"
+        file_path.write_text(graph_outputs.reactflow_html, encoding="utf-8")
+        saved_files["reactflow_html"] = file_path
+        log.verbose(f"ReactFlow HTML saved to: {file_path}")
+
+    return saved_files

--- a/tests/integration/pipelex/builder/test_builder_plx_validation.py
+++ b/tests/integration/pipelex/builder/test_builder_plx_validation.py
@@ -25,10 +25,10 @@ class TestData:
     PIPE_DESIGN_PLX_PATH: ClassVar[Path] = BUILDER_DIR / "pipe" / "pipe_design.plx"
 
 
-@pytest.mark.asyncio(loop_scope="class")
 class TestBuilderPlxValidation:
     """Tests that builder domain PLX files are valid and type-consistent."""
 
+    @pytest.mark.asyncio(loop_scope="class")
     async def test_builder_plx_loads_and_validates(self):
         """Test that builder.plx can be loaded and validated successfully."""
         result = await validate_bundle(
@@ -41,6 +41,7 @@ class TestBuilderPlxValidation:
         assert result.blueprints[0].domain == "builder"
         assert len(result.pipes) > 0
 
+    @pytest.mark.asyncio(loop_scope="class")
     async def test_agentic_builder_plx_loads_and_validates(self):
         """Test that agentic_builder.plx can be loaded and validated successfully."""
         result = await validate_bundle(
@@ -53,6 +54,7 @@ class TestBuilderPlxValidation:
         assert result.blueprints[0].domain == "agentic_builder"
         assert len(result.pipes) > 0
 
+    @pytest.mark.asyncio(loop_scope="class")
     async def test_pipe_design_plx_loads_and_validates(self):
         """Test that pipe_design.plx can be loaded and validated successfully."""
         result = await validate_bundle(


### PR DESCRIPTION
## Summary

- **Centralize graph output saving**: Extract `save_graph_outputs_to_dir()` into `graph_factory.py` to eliminate duplicated file-writing logic across all CLI commands (graph, run, build). Simplify title derivation by replacing brittle `stem.replace("graphspec", "").strip(...)` with direct `snake_to_title_case(stem)`.
- **Add agent CLI graph command**: New `pipelex agent graph` command and `--graph` flag on `pipelex agent run` for rendering pipeline graphs from graphspec files in the agent CLI.
- **Extract agent CLI helpers**: Consolidate error/success output formatting into `agent_output.py` and simplify all agent CLI commands to use shared helpers, reducing boilerplate across assemble, build, concept, inputs, pipe, run, and validate commands.
- **Overhaul skills documentation**: Add comprehensive `run` skill, create shared `pipelex-agent-guide.md` reference, and update all existing skills with improved instructions.

## Test plan

- [x] `make agent-check` passes (linting, pyright, mypy)
- [x] `make agent-test` passes (all unit tests)
- [ ] Manual: `pipelex graph render <graphspec.json>` produces correct HTML titles
- [ ] Manual: `pipelex agent graph <graphspec.json>` renders graph outputs
- [ ] Manual: `pipelex agent run --graph <bundle>` includes graph in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multiple CLI entrypoints and output formats (agent JSON schema and graph file generation/saving), so regressions could impact automation that depends on these commands’ behavior and outputs.
> 
> **Overview**
> Adds **graph rendering support to the agent CLI**: a new `pipelex-agent graph` command for turning `graphspec.json` into HTML visualizations, and a new `--graph` flag on `pipelex-agent run` that saves graph artifacts and returns their paths in `graph_files`.
> 
> Centralizes graph file persistence by introducing `save_graph_outputs_to_dir()` in `graph_factory.py` and refactoring existing CLI commands (`pipelex graph`, human `run`, and builder graph saving) to use it; `generate_graph_outputs()` is also extended to support explicit titles and toggling Mermaid subgraphs.
> 
> Standardizes agent CLI JSON I/O by adding `agent_output.py` (`agent_success`/`agent_error` with auto hints) and migrating agent commands (`assemble`, `build`, `concept`, `pipe`, `inputs`, `run`, `validate`) to use it; `pipelex-agent build` now also returns main pipe input/output type metadata (`pipe_inputs`, `pipe_output`).
> 
> Updates Claude skills documentation to consistently use `pipelex-agent` (adds new `/run` skill + shared `pipelex-agent-guide.md`, refreshes `/check`, `/edit`, `/fix`, `/build`, `/synthesize-inputs`, and references).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c5e13a0c40eda234cc1653e9a40c98cf984ee34. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->