### PR TITLE
Detect `pipelex validate all` and suggest `--all` flag

### DIFF
--- a/.pipelex/pipelex.toml
+++ b/.pipelex/pipelex.toml
@@ -68,6 +68,8 @@ pan_to_top = true    # Pan to show top of graph on load
 method = "in_memory"
 # Whether to fetch remote HTTP URLs and store them locally
 is_fetch_remote_content_enabled = true
+# Whether to upload local file paths to storage and replace with pipelex-storage:// URIs
+is_upload_local_content_enabled = true
 
 [pipelex.storage_config.local]
 # Local storage settings

--- a/pipelex/builder/builder_loop.py
+++ b/pipelex/builder/builder_loop.py
@@ -103,7 +103,10 @@ class BuilderLoop:
                 if attempt < max_attempts:
                     log.info(f"⚠️ Validation failed on attempt {attempt}/{max_attempts}, attempting fixes...")
                     pipelex_bundle_spec = self._fix_bundle_validation_error(
-                        bundle_error=exc, pipelex_bundle_spec=pipelex_bundle_spec, is_save_second_iteration_enabled=is_save_second_iteration_enabled
+                        bundle_error=exc,
+                        pipelex_bundle_spec=pipelex_bundle_spec,
+                        is_save_second_iteration_enabled=is_save_second_iteration_enabled,
+                        output_dir=output_dir,
                     )
                 else:
                     log.error(f"❌ Validation failed after {max_attempts} attempts, raising error")
@@ -506,6 +509,7 @@ class BuilderLoop:
         bundle_error: ValidateBundleError,
         pipelex_bundle_spec: PipelexBundleSpec,
         is_save_second_iteration_enabled: bool,
+        output_dir: str | None = None,
     ) -> PipelexBundleSpec:
         fixed_pipes: list[PipeSpecUnion] = []
         added_concepts: list[str] = []
@@ -691,7 +695,7 @@ class BuilderLoop:
             try:
                 plx_content = PlxFactory.make_plx_content(blueprint=pipelex_bundle_spec.to_blueprint())
                 second_iteration_path = get_incremental_file_path(
-                    base_path="results",
+                    base_path=output_dir or "results/pipe-builder",
                     base_name="generated_pipeline_2nd_iteration",
                     extension="plx",
                 )

--- a/pipelex/builder/pipe/sub_pipe_spec.py
+++ b/pipelex/builder/pipe/sub_pipe_spec.py
@@ -25,11 +25,13 @@ class SubPipeSpec(StructuredContent):
 
     pipe_code: str = Field(json_schema_extra={"mock_format": MockFormat.SNAKE_CASE})
     result: str = Field(json_schema_extra={"mock_format": MockFormat.SNAKE_CASE})
+    batch_over: str | None = Field(default=None, json_schema_extra={"mock_format": MockFormat.SNAKE_CASE})
+    batch_as: str | None = Field(default=None, json_schema_extra={"mock_format": MockFormat.SNAKE_CASE})
 
     def to_blueprint(self) -> SubPipeBlueprint:
         return SubPipeBlueprint(
             pipe=self.pipe_code,
             result=self.result,
-            batch_over=None,
-            batch_as=None,
+            batch_over=self.batch_over,
+            batch_as=self.batch_as,
         )

--- a/pipelex/cli/agent_cli/commands/build_core.py
+++ b/pipelex/cli/agent_cli/commands/build_core.py
@@ -103,6 +103,9 @@ async def build_pipe_core(
             inputs={"brief": prompt},
             execution_config=execution_config,
             output_dir=output_dir,
+            is_save_first_iteration_enabled=False,
+            is_save_second_iteration_enabled=False,
+            is_save_working_memory_enabled=False,
         )
     except PipeBuilderError as exc:
         msg = f"Builder loop: Failed to execute pipeline: {exc}."

--- a/pipelex/cli/agent_cli/commands/graph_cmd.py
+++ b/pipelex/cli/agent_cli/commands/graph_cmd.py
@@ -151,8 +151,8 @@ def graph_cmd(
             )
         )
 
-        # Save to <bundle_dir>/graph/
-        output_dir = input_path.parent / "graph"
+        # Save graph files alongside the bundle
+        output_dir = input_path.parent
         saved_files = save_graph_outputs_to_dir(graph_outputs=graph_outputs, output_dir=output_dir)
 
         agent_success(

--- a/pipelex/cli/agent_cli/commands/pipe_cmd.py
+++ b/pipelex/cli/agent_cli/commands/pipe_cmd.py
@@ -118,6 +118,10 @@ def _add_type_specific_fields(pipe_spec: PipeSpec, pipe_table: tomlkit.TOMLDocum
             step_inline = tomlkit.inline_table()
             step_inline.append("pipe", step.pipe_code)
             step_inline.append("result", step.result)
+            if step.batch_over is not None:
+                step_inline.append("batch_over", step.batch_over)
+            if step.batch_as is not None:
+                step_inline.append("batch_as", step.batch_as)
             steps_array.append(step_inline)
         pipe_table.add("steps", steps_array)
 

--- a/pipelex/cli/agent_cli/commands/validate_cmd.py
+++ b/pipelex/cli/agent_cli/commands/validate_cmd.py
@@ -251,6 +251,11 @@ def validate_cmd(
             if bundle:
                 agent_error("Cannot use --bundle if already passing a bundle file as positional argument", "ArgumentError")
         else:
+            if target == "all":
+                agent_error(
+                    "'all' is not a pipe code. Did you mean '--all'?",
+                    "ArgumentError",
+                )
             pipe_code = target
             if pipe:
                 agent_error("Cannot use --pipe if already passing a pipe code as positional argument", "ArgumentError")

--- a/pipelex/cli/agent_cli/commands/validate_cmd.py
+++ b/pipelex/cli/agent_cli/commands/validate_cmd.py
@@ -16,6 +16,7 @@ from pipelex.hub import (
     resolve_library_dirs,
     set_current_library,
 )
+from pipelex.libraries.pipe.exceptions import PipeNotFoundError
 from pipelex.pipe_operators.exceptions import PipeOperatorModelAvailabilityError
 from pipelex.pipe_run.dry_run import dry_run_pipe, dry_run_pipes
 from pipelex.pipelex import Pipelex
@@ -251,11 +252,6 @@ def validate_cmd(
             if bundle:
                 agent_error("Cannot use --bundle if already passing a bundle file as positional argument", "ArgumentError")
         else:
-            if target == "all":
-                agent_error(
-                    "'all' is not a pipe code. Did you mean '--all'?",
-                    "ArgumentError",
-                )
             pipe_code = target
             if pipe:
                 agent_error("Cannot use --pipe if already passing a pipe code as positional argument", "ArgumentError")
@@ -283,6 +279,12 @@ def validate_cmd(
             result = asyncio.run(_validate_pipe_core(pipe_code=pipe_code, library_dirs=library_dirs))  # type: ignore[arg-type]
 
         agent_success(result)
+
+    except PipeNotFoundError as exc:
+        error_message = str(exc)
+        if pipe_code == "all":
+            error_message += " Did you mean '--all'?"
+        agent_error(error_message, "PipeNotFoundError", cause=exc)
 
     except FileNotFoundError as exc:
         agent_error(f"Bundle file not found: {bundle_path}", "FileNotFoundError", cause=exc)

--- a/pipelex/cli/commands/validate_cmd.py
+++ b/pipelex/cli/commands/validate_cmd.py
@@ -154,6 +154,13 @@ def validate_cmd(
                 )
                 raise typer.Exit(1)
         else:
+            if target == "all":
+                typer.secho(
+                    "Failed to validate: 'all' is not a pipe code. Did you mean 'pipelex validate --all'?",
+                    fg=typer.colors.RED,
+                    err=True,
+                )
+                raise typer.Exit(1)
             pipe_code = target
             if pipe:
                 typer.secho(

--- a/pipelex/cli/commands/validate_cmd.py
+++ b/pipelex/cli/commands/validate_cmd.py
@@ -27,6 +27,7 @@ from pipelex.hub import (
     resolve_library_dirs,
     set_current_library,
 )
+from pipelex.libraries.pipe.exceptions import PipeNotFoundError
 from pipelex.pipe_operators.exceptions import PipeOperatorModelAvailabilityError
 from pipelex.pipe_run.dry_run import dry_run_pipe, dry_run_pipes
 from pipelex.pipelex import Pipelex
@@ -154,13 +155,6 @@ def validate_cmd(
                 )
                 raise typer.Exit(1)
         else:
-            if target == "all":
-                typer.secho(
-                    "Failed to validate: 'all' is not a pipe code. Did you mean 'pipelex validate --all'?",
-                    fg=typer.colors.RED,
-                    err=True,
-                )
-                raise typer.Exit(1)
             pipe_code = target
             if pipe:
                 typer.secho(
@@ -251,6 +245,16 @@ def validate_cmd(
                     library_dirs=library_dirs,
                 )
             )
+    except PipeNotFoundError as exc:
+        error_message = str(exc)
+        if pipe_code == "all":
+            error_message += "\nDid you mean 'pipelex validate --all'?"
+        typer.secho(
+            f"Failed to validate: {error_message}",
+            fg=typer.colors.RED,
+            err=True,
+        )
+        raise typer.Exit(1) from exc
     except PipeOperatorModelChoiceError as exc:
         handle_model_choice_error(exc, context=ErrorContext.VALIDATION)
     except PipeOperatorModelAvailabilityError as exc:

--- a/pipelex/core/stuffs/document_content.py
+++ b/pipelex/core/stuffs/document_content.py
@@ -44,7 +44,7 @@ class DocumentContent(StuffContent):
             template_source=template_source,
             template_category=TemplateCategory.HTML,
             templating_context={
-                "url": self.url,
+                "url": self.public_url or self.url,
                 "display_text": self.public_url or self.url,
             },
         )

--- a/pipelex/core/stuffs/templates/_stuff_utils.js.jinja2
+++ b/pipelex/core/stuffs/templates/_stuff_utils.js.jinja2
@@ -20,10 +20,10 @@ function makeLinksOpenInNewWindow(container) {
     });
 }
 
-// Validate that a URL is a safe HTTP/HTTPS URL (prevents javascript: and data: URL injection)
-function isValidHttpUrl(url) {
+// Validate that a URL is safe for display (prevents javascript: and data: URL injection)
+function isSafeDisplayUrl(url) {
     if (!url || typeof url !== 'string') return false;
-    return url.startsWith('https://') || url.startsWith('http://');
+    return url.startsWith('https://') || url.startsWith('http://') || url.startsWith('file://');
 }
 
 // Extract URL from stuff data (handles various data structures)
@@ -32,12 +32,12 @@ function extractUrl(jsonData) {
     if (!jsonData) return null;
     // Check if data itself is a URL string
     if (typeof jsonData === 'string') {
-        return isValidHttpUrl(jsonData) ? jsonData : null;
+        return isSafeDisplayUrl(jsonData) ? jsonData : null;
     }
-    // Prefer public_url (pre-signed S3 URL) over url (internal pipelex-storage:// URL)
+    // Prefer public_url (pre-signed S3 URL or file:// URI) over url (internal pipelex-storage:// URL)
     const candidates = [jsonData.public_url, jsonData.src, jsonData.href, jsonData.uri, jsonData.url];
     for (const candidate of candidates) {
-        if (isValidHttpUrl(candidate)) return candidate;
+        if (isSafeDisplayUrl(candidate)) return candidate;
     }
     return null;
 }

--- a/pipelex/core/stuffs/templates/stuff_viewer.html.jinja2
+++ b/pipelex/core/stuffs/templates/stuff_viewer.html.jinja2
@@ -169,7 +169,7 @@
             if (contentType === 'application/pdf') {
                 const url = extractUrl(stuffData);
                 if (url) {
-                    container.innerHTML = `<div class="stuff-content-pdf"><iframe src="${escapeHtml(url)}"></iframe></div>`;
+                    container.innerHTML = `<div class="stuff-content-pdf"><embed src="${escapeHtml(url)}" type="application/pdf"></div>`;
                 } else {
                     container.innerHTML = '<div class="stuff-content-text">PDF content (no URL available)</div>';
                 }

--- a/pipelex/graph/mermaidflow/templates/_interactive_scripts.js.jinja2
+++ b/pipelex/graph/mermaidflow/templates/_interactive_scripts.js.jinja2
@@ -201,7 +201,7 @@ function renderContent(stuffId, format) {
     const content = document.getElementById('modal-content');
     content.classList.remove('html-content', 'text-content', 'pdf-content', 'image-content');
 
-    // Handle PDF content type with iframe viewer
+    // Handle PDF content type with embedded viewer
     const contentType = stuffContentType?.[stuffId];
     const jsonData = stuffDataJson?.[stuffId];
 
@@ -210,10 +210,11 @@ function renderContent(stuffId, format) {
         if (pdfUrl) {
             content.classList.add('pdf-content');
             content.innerHTML = '';
-            const iframe = document.createElement('iframe');
-            iframe.src = pdfUrl;
-            iframe.style.cssText = 'width:100%; height:100%; border:none; min-height:500px;';
-            content.appendChild(iframe);
+            const embed = document.createElement('embed');
+            embed.src = pdfUrl;
+            embed.type = 'application/pdf';
+            embed.style.cssText = 'width:100%; height:100%; border:none; min-height:500px;';
+            content.appendChild(embed);
             updateOpenExternalButton(stuffId, contentType, jsonData);
             return;
         }

--- a/pipelex/graph/reactflow/templates/_scripts.js.jinja2
+++ b/pipelex/graph/reactflow/templates/_scripts.js.jinja2
@@ -1024,16 +1024,17 @@ function renderStuffContent(format) {
     const textData = window.currentStuffDataText || (stuffMermaidId && stuffDataText[stuffMermaidId]);
     const htmlData = window.currentStuffDataHtml || (stuffMermaidId && stuffDataHtml[stuffMermaidId]);
 
-    // Handle PDF content type with iframe viewer
+    // Handle PDF content type with embedded viewer
     if (format === 'html' && contentType === 'application/pdf') {
         const pdfUrl = extractUrl(jsonData);
         if (pdfUrl) {
             container.className = 'inspector-pdf-content';
             container.innerHTML = '';
-            const iframe = document.createElement('iframe');
-            iframe.src = pdfUrl;
-            iframe.style.cssText = 'width:100%; height:100%; border:none;';
-            container.appendChild(iframe);
+            const embed = document.createElement('embed');
+            embed.src = pdfUrl;
+            embed.type = 'application/pdf';
+            embed.style.cssText = 'width:100%; height:100%; border:none;';
+            container.appendChild(embed);
             updateOpenExternalButton();
             return;
         }
@@ -1346,16 +1347,17 @@ function renderStuffContentFullscreen(format) {
     const textData = window.currentStuffDataText || (stuffMermaidId && stuffDataText[stuffMermaidId]);
     const htmlData = window.currentStuffDataHtml || (stuffMermaidId && stuffDataHtml[stuffMermaidId]);
 
-    // Handle PDF content type with iframe viewer
+    // Handle PDF content type with embedded viewer
     if (format === 'html' && contentType === 'application/pdf') {
         const pdfUrl = extractUrl(jsonData);
         if (pdfUrl) {
             container.className = 'fullscreen-content inspector-pdf-content';
             container.innerHTML = '';
-            const iframe = document.createElement('iframe');
-            iframe.src = pdfUrl;
-            iframe.style.cssText = 'width:100%; height:100%; border:none;';
-            container.appendChild(iframe);
+            const embed = document.createElement('embed');
+            embed.src = pdfUrl;
+            embed.type = 'application/pdf';
+            embed.style.cssText = 'width:100%; height:100%; border:none;';
+            container.appendChild(embed);
             updateOpenExternalButton();
             return;
         }

--- a/pipelex/kit/configs/pipelex.toml
+++ b/pipelex/kit/configs/pipelex.toml
@@ -68,6 +68,8 @@ pan_to_top = true    # Pan to show top of graph on load
 method = "in_memory"
 # Whether to fetch remote HTTP URLs and store them locally
 is_fetch_remote_content_enabled = true
+# Whether to upload local file paths to storage and replace with pipelex-storage:// URIs
+is_upload_local_content_enabled = true
 
 [pipelex.storage_config.local]
 # Local storage settings

--- a/pipelex/pipelex.toml
+++ b/pipelex/pipelex.toml
@@ -4,6 +4,7 @@
 
 [pipelex.storage_config]
 is_fetch_remote_content_enabled = true
+is_upload_local_content_enabled = true
 method = "in_memory"                   # local, in_memory, s3, gcp
 
 [pipelex.storage_config.local]

--- a/pipelex/pipeline/input_normalizer.py
+++ b/pipelex/pipeline/input_normalizer.py
@@ -1,8 +1,8 @@
-"""Normalize pipeline inputs by converting data URLs to pipelex-storage:// URIs.
+"""Normalize pipeline inputs by converting data URLs and local file paths to pipelex-storage:// URIs.
 
 This module provides functions to scan WorkingMemory and convert any ImageContent
-or DocumentContent with data URLs (data:...;base64,...) to pipelex-storage:// URIs
-for more efficient pipeline processing.
+or DocumentContent with data URLs (data:...;base64,...) or local file paths to
+pipelex-storage:// URIs for more efficient pipeline processing.
 """
 
 import base64
@@ -10,15 +10,17 @@ from typing import Any, cast
 
 import shortuuid
 
+from pipelex.config import get_config
 from pipelex.core.memory.working_memory import WorkingMemory
 from pipelex.core.stuffs.document_content import DocumentContent
 from pipelex.core.stuffs.image_content import ImageContent
 from pipelex.core.stuffs.list_content import ListContent
 from pipelex.core.stuffs.structured_content import StructuredContent
 from pipelex.hub import get_storage_provider
+from pipelex.tools.misc.file_utils import load_binary_async
 from pipelex.tools.misc.filetype_utils import detect_file_type_from_bytes
 from pipelex.tools.storage.storage_provider_abstract import StorageProviderAbstract
-from pipelex.tools.uri.resolved_uri import ResolvedBase64DataUrl
+from pipelex.tools.uri.resolved_uri import ResolvedBase64DataUrl, ResolvedLocalPath
 from pipelex.tools.uri.uri_resolver import resolve_uri
 
 # Type alias for content types that can have their URLs normalized
@@ -192,20 +194,36 @@ async def _normalize_url_content(
     """
     resolved_uri = resolve_uri(content.url)
 
-    if not isinstance(resolved_uri, ResolvedBase64DataUrl):
-        # Not a data URL, we can keep the original content without any changes
+    if isinstance(resolved_uri, ResolvedBase64DataUrl):
+        # Decode base64 data and store
+        raw_bytes = base64.b64decode(resolved_uri.base64_data)
+        file_type = detect_file_type_from_bytes(raw_bytes)
+        key = f"normalized/{shortuuid.uuid()}.{file_type.extension}"
+        storage_uri = await storage.store(data=raw_bytes, key=key)
+
+        # Use model_copy to preserve all type-specific fields
+        return content.model_copy(
+            update={
+                "url": storage_uri,
+                "mime_type": resolved_uri.mime_type or content.mime_type,
+            }
+        )
+    elif isinstance(resolved_uri, ResolvedLocalPath):
+        if not get_config().pipelex.storage_config.is_upload_local_content_enabled:
+            return content
+
+        # Read local file, detect type, upload to storage
+        raw_bytes = await load_binary_async(resolved_uri.path)
+        file_type = detect_file_type_from_bytes(raw_bytes)
+        key = f"normalized/{shortuuid.uuid()}.{file_type.extension}"
+        storage_uri = await storage.store(data=raw_bytes, key=key)
+
+        return content.model_copy(
+            update={
+                "url": storage_uri,
+                "mime_type": file_type.mime,
+            }
+        )
+    else:
+        # Other URI types (HTTP URLs, pipelex-storage://) are kept unchanged
         return content
-
-    # Decode base64 data and store
-    raw_bytes = base64.b64decode(resolved_uri.base64_data)
-    file_type = detect_file_type_from_bytes(raw_bytes)
-    key = f"normalized/{shortuuid.uuid()}.{file_type.extension}"
-    storage_uri = await storage.store(data=raw_bytes, key=key)
-
-    # Use model_copy to preserve all type-specific fields
-    return content.model_copy(
-        update={
-            "url": storage_uri,
-            "mime_type": resolved_uri.mime_type or content.mime_type,
-        }
-    )

--- a/pipelex/pipeline/input_normalizer.py
+++ b/pipelex/pipeline/input_normalizer.py
@@ -198,14 +198,17 @@ async def _normalize_url_content(
         # Decode base64 data and store
         raw_bytes = base64.b64decode(resolved_uri.base64_data)
         file_type = detect_file_type_from_bytes(raw_bytes)
+        mime_type = resolved_uri.mime_type or content.mime_type
         key = f"normalized/{shortuuid.uuid()}.{file_type.extension}"
-        storage_uri = await storage.store(data=raw_bytes, key=key)
+        storage_uri = await storage.store(data=raw_bytes, key=key, content_type=mime_type)
+        public_url = await storage.public_url(uri=storage_uri)
 
         # Use model_copy to preserve all type-specific fields
         return content.model_copy(
             update={
                 "url": storage_uri,
-                "mime_type": resolved_uri.mime_type or content.mime_type,
+                "public_url": public_url,
+                "mime_type": mime_type,
             }
         )
     elif isinstance(resolved_uri, ResolvedLocalPath):
@@ -216,11 +219,13 @@ async def _normalize_url_content(
         raw_bytes = await load_binary_async(resolved_uri.path)
         file_type = detect_file_type_from_bytes(raw_bytes)
         key = f"normalized/{shortuuid.uuid()}.{file_type.extension}"
-        storage_uri = await storage.store(data=raw_bytes, key=key)
+        storage_uri = await storage.store(data=raw_bytes, key=key, content_type=file_type.mime)
+        public_url = await storage.public_url(uri=storage_uri)
 
         return content.model_copy(
             update={
                 "url": storage_uri,
+                "public_url": public_url,
                 "mime_type": file_type.mime,
             }
         )

--- a/pipelex/plugins/gateway/gateway_extract_worker.py
+++ b/pipelex/plugins/gateway/gateway_extract_worker.py
@@ -15,6 +15,7 @@ from pipelex.cogt.extract.extract_worker_abstract import ExtractWorkerAbstract
 from pipelex.cogt.inference.inference_constants import InferenceOutputType
 from pipelex.cogt.model_backends.model_spec import InferenceModelSpec
 from pipelex.config import get_config
+from pipelex.hub import get_storage_provider
 from pipelex.plugins.gateway.gateway_completions_factory import GatewayCompletionsFactory
 from pipelex.plugins.gateway.gateway_deck import GatewayDeck
 from pipelex.plugins.gateway.gateway_factory import GatewayFactory
@@ -84,8 +85,10 @@ class GatewayExtractWorker(ExtractWorkerAbstract):
         max_nb_images = extract_job.job_params.max_nb_images
         should_include_images = max_nb_images is None or max_nb_images > 0
 
+        storage = get_storage_provider()
+
         if image_uri := extract_job.extract_input.image_uri:
-            base64_url = await make_base64_url_from_any_uri(uri=image_uri)
+            base64_url = await make_base64_url_from_any_uri(uri=image_uri, storage_provider=storage)
             # Images (as input) don't have embedded images to extract
             extract_output = await self._extract_base64_url(
                 extract_job=extract_job,
@@ -98,7 +101,7 @@ class GatewayExtractWorker(ExtractWorkerAbstract):
             if extract_job.job_params.should_caption_images and not self.inference_model.is_caption_supported_for_extract:
                 msg = f"Captioning is not supported by '{self.inference_model.tag}'."
                 raise ExtractCapabilityError(msg)
-            base64_url = await make_base64_url_from_any_uri(uri=document_uri)
+            base64_url = await make_base64_url_from_any_uri(uri=document_uri, storage_provider=storage)
             extract_output = await self._extract_base64_url(
                 extract_job=extract_job,
                 base64_url=base64_url,

--- a/pipelex/tools/misc/base64_utils.py
+++ b/pipelex/tools/misc/base64_utils.py
@@ -30,6 +30,13 @@ async def make_base64_url_from_http_url(url: str) -> str:
     return make_base64_url(base64_data=base64_data, file_type=file_type)
 
 
+def make_base64_url_from_bytes(raw_bytes: bytes) -> str:
+    """Create a data: URL from raw bytes, detecting file type automatically."""
+    base64_data = base64.b64encode(raw_bytes).decode("ascii")
+    file_type = detect_file_type_from_bytes(raw_bytes=raw_bytes)
+    return make_base64_url(base64_data=base64_data, file_type=file_type)
+
+
 def make_base64_url(
     base64_data: str,
     file_type: FileType,

--- a/pipelex/tools/storage/storage_config.py
+++ b/pipelex/tools/storage/storage_config.py
@@ -101,6 +101,7 @@ class StorageGcpConfig(ConfigModel):
 
 class StorageConfig(ConfigModel):
     is_fetch_remote_content_enabled: bool
+    is_upload_local_content_enabled: bool
     method: StorageMethod = Field(strict=False)
     local: StorageLocalConfig | None = None
     in_memory: StorageInMemoryConfig | None = None

--- a/pipelex/tools/uri/uri_resolver.py
+++ b/pipelex/tools/uri/uri_resolver.py
@@ -2,10 +2,11 @@ import urllib.parse
 from pathlib import Path
 
 from pipelex.tools.misc.base64_utils import (
+    make_base64_url_from_bytes,
     make_base64_url_from_http_url,
     make_base64_url_from_path,
 )
-from pipelex.tools.storage.storage_provider_abstract import PIPELEX_STORAGE_SCHEME
+from pipelex.tools.storage.storage_provider_abstract import PIPELEX_STORAGE_SCHEME, StorageProviderAbstract
 from pipelex.tools.uri.resolved_uri import (
     ResolvedBase64DataUrl,
     ResolvedHttpUrl,
@@ -156,20 +157,25 @@ def _resolve_base64_data_url(uri: str) -> ResolvedBase64DataUrl:
     )
 
 
-async def make_base64_url_from_any_uri(uri: str) -> str:
+async def make_base64_url_from_any_uri(
+    uri: str,
+    storage_provider: StorageProviderAbstract | None = None,
+) -> str:
     """Convert a URI to a base64 data URL.
 
     Resolves the URI and fetches/converts content to base64 format.
     If the URI is already a data URL, returns it as-is.
 
     Args:
-        uri: A URI string (http://, local path, or data: URL)
+        uri: A URI string (http://, local path, data: URL, or pipelex-storage://)
+        storage_provider: Optional storage provider for resolving pipelex-storage:// URIs.
+            Required when the URI is a pipelex-storage:// URI.
 
     Returns:
         A base64 data URL string containing the base64-encoded data, whichever way we got it.
 
     Raises:
-        ValueError: If the URI type is not supported (e.g., pipelex-storage://)
+        ValueError: If the URI is a pipelex-storage:// URI and no storage provider is given.
     """
     base64_url: str
     resolved_uri = resolve_uri(uri)
@@ -182,6 +188,9 @@ async def make_base64_url_from_any_uri(uri: str) -> str:
         case ResolvedLocalPath():
             base64_url = await make_base64_url_from_path(path=resolved_uri.path)
         case ResolvedPipelexStorage():
-            msg = f"Unsupported URI type for base64 URL creation: {resolved_uri.kind} (requires storage provider)"
-            raise ValueError(msg)
+            if storage_provider is None:
+                msg = f"Cannot convert pipelex-storage:// URI to base64 without a storage provider: {uri}"
+                raise ValueError(msg)
+            raw_bytes = await storage_provider.load(uri=resolved_uri.storage_uri)
+            base64_url = make_base64_url_from_bytes(raw_bytes=raw_bytes)
     return base64_url

--- a/tests/integration/pipelex/tools/storage/conftest.py
+++ b/tests/integration/pipelex/tools/storage/conftest.py
@@ -234,6 +234,36 @@ def mock_fetch_remote_content_disabled(mocker: MockerFixture) -> None:
 
 
 @pytest.fixture
+def mock_upload_local_content_enabled(mocker: MockerFixture) -> None:
+    """Mock the config to enable uploading local content.
+
+    When `is_upload_local_content_enabled` is True, local file paths are read,
+    uploaded to storage, and replaced with pipelex-storage:// URIs.
+    """
+    original_config = get_config()
+    mocker.patch.object(
+        original_config.pipelex.storage_config,
+        "is_upload_local_content_enabled",
+        True,
+    )
+
+
+@pytest.fixture
+def mock_upload_local_content_disabled(mocker: MockerFixture) -> None:
+    """Mock the config to disable uploading local content.
+
+    When `is_upload_local_content_enabled` is False, local file paths are passed
+    through without being uploaded to storage.
+    """
+    original_config = get_config()
+    mocker.patch.object(
+        original_config.pipelex.storage_config,
+        "is_upload_local_content_enabled",
+        False,
+    )
+
+
+@pytest.fixture
 def storage_provider_patched(
     storage_provider: StorageProviderAbstract,
     mocker: MockerFixture,

--- a/tests/integration/pipelex/tools/storage/test_user_provided_image_storage.py
+++ b/tests/integration/pipelex/tools/storage/test_user_provided_image_storage.py
@@ -120,3 +120,66 @@ class TestUserProvidedImageStorage:
         normalized_stuff = normalized_memory.get_stuff("remote_image")
         assert isinstance(normalized_stuff.content, ImageContent)
         assert normalized_stuff.content.url == http_url
+
+    @pytest.mark.usefixtures("mock_upload_local_content_enabled")
+    async def test_user_image_local_file_to_storage_when_upload_enabled(self) -> None:
+        """Test that local file paths are uploaded to storage when upload is enabled.
+
+        When is_upload_local_content_enabled=True, local file paths should be read,
+        uploaded to storage, and replaced with pipelex-storage:// URIs.
+        """
+        local_path = ImageTestCases.IMAGE_FILE_PATH_LOGO_TINY
+        image_content = ImageContent(url=local_path)
+        stuff = StuffFactory.make_stuff(
+            concept=ConceptFactory.make_native_concept(native_concept_code=NativeConceptCode.IMAGE),
+            content=image_content,
+            name="local_image",
+        )
+        working_memory = WorkingMemoryFactory.make_from_single_stuff(stuff=stuff)
+
+        # Normalize - should upload the local file to storage
+        normalized_memory = await normalize_data_urls_to_storage(working_memory)
+
+        # Verify the URL was converted to pipelex-storage://
+        normalized_stuff = normalized_memory.get_stuff("local_image")
+        assert isinstance(normalized_stuff.content, ImageContent)
+        assert normalized_stuff.content.url.startswith(PIPELEX_STORAGE_SCHEME)
+        assert normalized_stuff.content.mime_type == "image/png"
+
+        # Verify roundtrip: storage -> PreparedImage
+        prompt_image = PromptImageFactory.make_prompt_image(uri=normalized_stuff.content.url)
+        assert isinstance(prompt_image, PromptImageUri)
+
+        prepared = await prepare_prompt_image(
+            prompt_image=prompt_image,
+            is_http_url_enabled=False,
+        )
+
+        assert isinstance(prepared, PreparedFileBase64)
+        # Verify the data can be decoded and is non-empty
+        decoded = base64.b64decode(prepared.base64_data)
+        assert len(decoded) > 0
+
+    @pytest.mark.usefixtures("mock_upload_local_content_disabled")
+    async def test_user_image_local_file_passthrough_when_upload_disabled(self) -> None:
+        """Test that local file paths are passed through when upload is disabled.
+
+        When is_upload_local_content_enabled=False, local file paths should not be
+        uploaded to storage. They should be passed through unchanged.
+        """
+        local_path = ImageTestCases.IMAGE_FILE_PATH_LOGO_TINY
+        image_content = ImageContent(url=local_path)
+        stuff = StuffFactory.make_stuff(
+            concept=ConceptFactory.make_native_concept(native_concept_code=NativeConceptCode.IMAGE),
+            content=image_content,
+            name="local_image",
+        )
+        working_memory = WorkingMemoryFactory.make_from_single_stuff(stuff=stuff)
+
+        # Normalize (should not change local paths when upload is disabled)
+        normalized_memory = await normalize_data_urls_to_storage(working_memory)
+
+        # Verify URL was NOT changed
+        normalized_stuff = normalized_memory.get_stuff("local_image")
+        assert isinstance(normalized_stuff.content, ImageContent)
+        assert normalized_stuff.content.url == local_path

--- a/tests/unit/pipelex/builder/pipe/pipe_controller/pipe_sequence/test_data.py
+++ b/tests/unit/pipelex/builder/pipe/pipe_controller/pipe_sequence/test_data.py
@@ -32,6 +32,30 @@ class PipeSequenceTestCases:
         ),
     )
 
+    SEQUENCE_WITH_BATCH_STEP = (
+        "sequence_with_batch_step",
+        PipeSequenceSpec(
+            pipe_code="batch_sequence",
+            description="A sequence with a batch step",
+            inputs={"items": "Text[]"},
+            output="Summary",
+            steps=[
+                SubPipeSpec(pipe_code="process_item", result="processed_items", batch_over="items", batch_as="item"),
+                SubPipeSpec(pipe_code="summarize", result="summary"),
+            ],
+        ),
+        PipeSequenceBlueprint(
+            description="A sequence with a batch step",
+            inputs={"items": "Text[]"},
+            output="Summary",
+            steps=[
+                SubPipeBlueprint(pipe="process_item", result="processed_items", batch_over="items", batch_as="item"),
+                SubPipeBlueprint(pipe="summarize", result="summary"),
+            ],
+        ),
+    )
+
     TEST_CASES: ClassVar[list[tuple[str, PipeSequenceSpec, PipeSequenceBlueprint]]] = [
         SIMPLE_SEQUENCE,
+        SEQUENCE_WITH_BATCH_STEP,
     ]

--- a/tests/unit/pipelex/builder/pipe/test_data_sub_pipe.py
+++ b/tests/unit/pipelex/builder/pipe/test_data_sub_pipe.py
@@ -11,6 +11,13 @@ class SubPipeTestCases:
         SubPipeBlueprint(pipe="process_data", result="processed_data"),
     )
 
+    SUB_PIPE_WITH_BATCH = (
+        "sub_pipe_with_batch",
+        SubPipeSpec(pipe_code="process_item", result="processed_items", batch_over="items", batch_as="item"),
+        SubPipeBlueprint(pipe="process_item", result="processed_items", batch_over="items", batch_as="item"),
+    )
+
     TEST_CASES: ClassVar[list[tuple[str, SubPipeSpec, SubPipeBlueprint]]] = [
         SIMPLE_SUB_PIPE,
+        SUB_PIPE_WITH_BATCH,
     ]

--- a/tests/unit/pipelex/core/stuffs/document_content/test_data.py
+++ b/tests/unit/pipelex/core/stuffs/document_content/test_data.py
@@ -30,6 +30,6 @@ class TestData:
     EXPECTED_RENDERED_MARKDOWN = f"[{URLs.pdf_example_1}]({URLs.pdf_example_1})"
     EXPECTED_RENDERED_MARKDOWN_WITH_DISPLAY_LINK = f"[Report.pdf]({URLs.pdf_example_1})"
     EXPECTED_RENDERED_HTML = f'<a href="{URLs.pdf_example_1}" class="msg-document">{URLs.pdf_example_1}</a>'
-    EXPECTED_RENDERED_HTML_WITH_DISPLAY_LINK = f'<a href="{URLs.pdf_example_1}" class="msg-document">Report.pdf</a>'
+    EXPECTED_RENDERED_HTML_WITH_PUBLIC_URL = '<a href="Report.pdf" class="msg-document">Report.pdf</a>'
     # rendered_for_prompt returns just the URL for documents
     EXPECTED_RENDERED_FOR_PROMPT = URLs.pdf_example_1

--- a/tests/unit/pipelex/core/stuffs/document_content/test_data.py
+++ b/tests/unit/pipelex/core/stuffs/document_content/test_data.py
@@ -28,6 +28,6 @@ class TestData:
     EXPECTED_RENDERED_MARKDOWN = "[https://example.com/document.pdf](https://example.com/document.pdf)"
     EXPECTED_RENDERED_MARKDOWN_WITH_DISPLAY_LINK = "[Report.pdf](https://example.com/document.pdf)"
     EXPECTED_RENDERED_HTML = '<a href="https://example.com/document.pdf" class="msg-document">https://example.com/document.pdf</a>'
-    EXPECTED_RENDERED_HTML_WITH_DISPLAY_LINK = '<a href="https://example.com/document.pdf" class="msg-document">Report.pdf</a>'
+    EXPECTED_RENDERED_HTML_WITH_DISPLAY_LINK = '<a href="Report.pdf" class="msg-document">Report.pdf</a>'
     # rendered_for_prompt returns just the URL for documents
     EXPECTED_RENDERED_FOR_PROMPT = "https://example.com/document.pdf"

--- a/tests/unit/pipelex/core/stuffs/document_content/test_document_content_renders.py
+++ b/tests/unit/pipelex/core/stuffs/document_content/test_document_content_renders.py
@@ -30,7 +30,7 @@ class TestDocumentContentRenders:
     def test_rendered_html_with_public_url(self):
         """Verify rendered_html uses public_url when available."""
         content = DocumentContent(url=TestData.SAMPLE_URL, public_url=TestData.SAMPLE_PUBLIC_URL)
-        assert content.rendered_html() == TestData.EXPECTED_RENDERED_HTML_WITH_DISPLAY_LINK
+        assert content.rendered_html() == TestData.EXPECTED_RENDERED_HTML_WITH_PUBLIC_URL
 
     def test_rendered_for_prompt(self):
         """Verify rendered_for_prompt returns markdown format."""

--- a/tests/unit/pipelex/tools/uri/test_make_base64_url_from_uri_async.py
+++ b/tests/unit/pipelex/tools/uri/test_make_base64_url_from_uri_async.py
@@ -60,11 +60,30 @@ class TestMakeBase64UrlFromUriAsync:
 
         assert result == original_data_url
 
-    async def test_pipelex_storage_raises_value_error(self) -> None:
-        """Test that pipelex-storage:// URIs raise ValueError."""
+    async def test_pipelex_storage_converts_to_base64_data_url(self, mocker: MockerFixture) -> None:
+        """Test that pipelex-storage:// URIs are loaded from storage and converted to base64 data URLs."""
+        # Load real PNG bytes from test file
+        with open(ImageTestCases.IMAGE_FILE_PATH_PNG_1, "rb") as file_handle:
+            png_bytes = file_handle.read()
+
+        # Mock the storage provider
+        mock_storage = mocker.AsyncMock()
+        mock_storage.load = mocker.AsyncMock(return_value=png_bytes)
+
+        storage_uri = f"{PIPELEX_STORAGE_SCHEME}images/photo.png"
+        result = await make_base64_url_from_any_uri(storage_uri, storage_provider=mock_storage)
+
+        assert result.startswith("data:image/png;base64,")
+        base64_part = result.split(",", 1)[1]
+        decoded = base64.b64decode(base64_part)
+        assert decoded == png_bytes
+        mock_storage.load.assert_called_once_with(uri=storage_uri)
+
+    async def test_pipelex_storage_raises_value_error_without_storage(self) -> None:
+        """Test that pipelex-storage:// URIs raise ValueError when no storage provider is given."""
         storage_uri = f"{PIPELEX_STORAGE_SCHEME}images/photo.png"
 
-        with pytest.raises(ValueError, match="Unsupported URI type"):
+        with pytest.raises(ValueError, match="Cannot convert pipelex-storage"):
             await make_base64_url_from_any_uri(storage_uri)
 
     async def test_http_url_converts_to_base64_data_url(self, mocker: MockerFixture) -> None:

--- a/tests/unit/pipelex/tools/uri/test_uri_resolver_error_handling.py
+++ b/tests/unit/pipelex/tools/uri/test_uri_resolver_error_handling.py
@@ -88,12 +88,17 @@ class TestUriResolverErrorHandling:
         with pytest.raises(httpx.ConnectError):
             await make_base64_url_from_any_uri("https://nonexistent-domain-12345.com/image.png")
 
-    async def test_pipelex_storage_raises_value_error_with_descriptive_message(self) -> None:
-        """Test that pipelex-storage:// URIs raise ValueError with helpful message."""
+    async def test_pipelex_storage_propagates_storage_errors(self, mocker: MockerFixture) -> None:
+        """Test that storage errors are propagated when loading pipelex-storage:// URIs."""
+        from pipelex.tools.storage.exceptions import StorageFileNotFoundError  # noqa: PLC0415
+
+        mock_storage = mocker.AsyncMock()
+        mock_storage.load = mocker.AsyncMock(side_effect=StorageFileNotFoundError("Key not found"))
+
         storage_uri = f"{PIPELEX_STORAGE_SCHEME}bucket/path/file.png"
 
-        with pytest.raises(ValueError, match="Unsupported URI type"):
-            await make_base64_url_from_any_uri(storage_uri)
+        with pytest.raises(StorageFileNotFoundError):
+            await make_base64_url_from_any_uri(storage_uri, storage_provider=mock_storage)
 
     async def test_local_file_not_found_raises_file_not_found_error(self) -> None:
         """Test that non-existent local files raise FileNotFoundError."""


### PR DESCRIPTION
- new feature: normalize Images and Documents on Storage for local files like we already did for online files 
- fix PDF display in Reactflow chart

## Summary

- Detect when users run `pipelex validate all` (old syntax) and show a helpful error pointing to the correct `--all` flag
- Applied to both the main CLI and agent CLI validate commands

## Test plan

- [ ] Run `pipelex validate all` and verify it shows the helpful error message
- [ ] Run `pipelex-agent validate all` and verify it shows the helpful error message
- [ ] Run `pipelex validate --all` and verify it still works correctly
- [ ] Run `pipelex validate <pipe_code>` and verify normal validation still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new input-normalization behavior that reads local files, uploads them to storage, and expands URI/base64 conversion to handle `pipelex-storage://`, which can affect data handling and storage backends. Also changes graph/PDF rendering and CLI error handling, which is lower risk but broad surface area.
> 
> **Overview**
> Enables optional normalization of *local file path* `ImageContent`/`DocumentContent` by uploading bytes to configured storage, replacing the URL with `pipelex-storage://` and populating `public_url` (new `storage_config.is_upload_local_content_enabled` flag, defaulted on in shipped configs).
> 
> Extends URI conversion to support `pipelex-storage://` via a provided storage provider (used by the gateway extract worker), and updates document/link rendering to prefer `public_url` plus allow safe `file://` display URLs.
> 
> Improves UX and output behavior in the CLIs: `validate` now catches `PipeNotFoundError` to suggest `--all` when users run `pipelex validate all` (also in agent CLI), agent build disables intermediate artifact saving, agent graph writes outputs next to the bundle, and sequence sub-pipes now support/serialize `batch_over`/`batch_as`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 308ad60108c108dcd42be17107ecc331c8c90e4a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->