### PR TITLE
fix Pytest warnings due to bad mocking

### DIFF
--- a/tests/unit/pipelex/cli/test_agent_graph_cmd.py
+++ b/tests/unit/pipelex/cli/test_agent_graph_cmd.py
@@ -47,6 +47,10 @@ class TestGraphCmd:
 
         mock_graph_outputs = mocker.MagicMock()
 
+        # Patch async functions with non-async mocks so no coroutines are created (avoids "coroutine never awaited" warnings)
+        mocker.patch(f"{GRAPH_CMD_MODULE}.execute_pipeline", new=mocker.MagicMock())
+        mocker.patch(f"{GRAPH_CMD_MODULE}.generate_graph_outputs", new=mocker.MagicMock())
+
         # asyncio.run is called twice: first for execute_pipeline, then for generate_graph_outputs
         mocker.patch(f"{GRAPH_CMD_MODULE}.asyncio.run", side_effect=[mock_pipe_output, mock_graph_outputs])
 
@@ -90,6 +94,10 @@ class TestGraphCmd:
         mocker.patch(f"{GRAPH_CMD_MODULE}.make_pipelex_for_agent_cli")
         mocker.patch(f"{GRAPH_CMD_MODULE}.Pipelex.teardown_if_needed")
         mocker.patch(f"{GRAPH_CMD_MODULE}.get_config")
+
+        # Patch async functions with non-async mocks so no coroutines are created (avoids "coroutine never awaited" warnings)
+        mocker.patch(f"{GRAPH_CMD_MODULE}.execute_pipeline", new=mocker.MagicMock())
+        mocker.patch(f"{GRAPH_CMD_MODULE}.generate_graph_outputs", new=mocker.MagicMock())
 
         mock_pipe_output = mocker.MagicMock()
         mock_pipe_output.graph_spec = mocker.MagicMock()
@@ -182,6 +190,9 @@ class TestGraphCmd:
         mocker.patch(f"{GRAPH_CMD_MODULE}.make_pipelex_for_agent_cli")
         mocker.patch(f"{GRAPH_CMD_MODULE}.Pipelex.teardown_if_needed")
         mocker.patch(f"{GRAPH_CMD_MODULE}.get_config")
+
+        # Patch async function with non-async mock so no coroutine is created (avoids "coroutine never awaited" warning)
+        mocker.patch(f"{GRAPH_CMD_MODULE}.execute_pipeline", new=mocker.MagicMock())
 
         mock_pipe_output = mocker.MagicMock()
         mock_pipe_output.graph_spec = None


### PR DESCRIPTION
- fix/Pytest warnings due to bad mocking

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only mocking changes that don’t affect runtime behavior; risk is limited to potentially masking async-call expectations in these unit tests.
> 
> **Overview**
> Fixes `test_agent_graph_cmd.py` to mock `execute_pipeline`/`generate_graph_outputs` as *non-async* `MagicMock`s, preventing pytest "coroutine was never awaited" warnings while still asserting `asyncio.run` is invoked for the CLI graph flow.
> 
> No production code changes; behavior under test is unchanged, but test setup is now warning-free and more deterministic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d3d3c23de3e138e0746b911c614826eb49764acb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->