### PR TITLE
Fix PipeParallel graph

### DIFF
--- a/pipelex/graph/graph_tracer.py
+++ b/pipelex/graph/graph_tracer.py
@@ -108,6 +108,11 @@ class GraphTracer(GraphTracerProtocol):
         # The batch_controller_node_id is tracked to ensure BATCH_AGGREGATE edges target the correct node
         # (the PipeBatch), not a parent controller that may later register as producer of the same stuff
         self._batch_aggregate_map: dict[str, tuple[str | None, list[tuple[str, int]]]] = {}
+        # Maps combined_stuff_code -> (parallel_controller_node_id, [(branch_stuff_code, branch_producer_node_id)])
+        # Used to create PARALLEL_COMBINE edges from branch outputs to combined output
+        # The branch_producer_node_id is snapshotted at registration time, before register_controller_output
+        # overrides _stuff_producer_map to point branch stuff codes to the controller node
+        self._parallel_combine_map: dict[str, tuple[str, list[tuple[str, str]]]] = {}
 
     @property
     def is_active(self) -> bool:
@@ -137,6 +142,7 @@ class GraphTracer(GraphTracerProtocol):
         self._stuff_producer_map = {}
         self._batch_item_map = {}
         self._batch_aggregate_map = {}
+        self._parallel_combine_map = {}
 
         return GraphContext(
             graph_id=graph_id,
@@ -162,6 +168,7 @@ class GraphTracer(GraphTracerProtocol):
         self._generate_data_edges()
         self._generate_batch_item_edges()
         self._generate_batch_aggregate_edges()
+        self._generate_parallel_combine_edges()
 
         self._is_active = False
 
@@ -185,6 +192,7 @@ class GraphTracer(GraphTracerProtocol):
         self._stuff_producer_map = {}
         self._batch_item_map = {}
         self._batch_aggregate_map = {}
+        self._parallel_combine_map = {}
 
         return graph
 
@@ -292,6 +300,26 @@ class GraphTracer(GraphTracerProtocol):
                         target_stuff_digest=output_list_stuff_code,
                     )
 
+    def _generate_parallel_combine_edges(self) -> None:
+        """Generate PARALLEL_COMBINE edges from branch output stuff nodes to the combined output stuff node.
+
+        For each registered parallel combine, create edges from each branch output
+        to the combined output, showing how individual branch results are merged.
+
+        Uses snapshotted branch producer node IDs captured during register_parallel_combine,
+        before register_controller_output overrides _stuff_producer_map.
+        """
+        for combined_stuff_code, (parallel_controller_node_id, branch_entries) in self._parallel_combine_map.items():
+            for branch_stuff_code, branch_producer_id in branch_entries:
+                if branch_producer_id != parallel_controller_node_id:
+                    self.add_edge(
+                        source_node_id=branch_producer_id,
+                        target_node_id=parallel_controller_node_id,
+                        edge_kind=EdgeKind.PARALLEL_COMBINE,
+                        source_stuff_digest=branch_stuff_code,
+                        target_stuff_digest=combined_stuff_code,
+                    )
+
     @override
     def register_batch_item_extraction(
         self,
@@ -345,6 +373,32 @@ class GraphTracer(GraphTracerProtocol):
         item_list.append((item_stuff_code, item_index))
         # Note: We keep the first batch_controller_node_id registered for this output list
         # (all items for the same output list should come from the same batch controller)
+
+    @override
+    def register_parallel_combine(
+        self,
+        combined_stuff_code: str,
+        branch_stuff_codes: list[str],
+        parallel_controller_node_id: str,
+    ) -> None:
+        """Register that branch outputs are combined into a single output in PipeParallel.
+
+        Args:
+            combined_stuff_code: The stuff_code of the combined output.
+            branch_stuff_codes: The stuff_codes of the individual branch outputs.
+            parallel_controller_node_id: The node_id of the PipeParallel controller.
+        """
+        if not self._is_active:
+            return
+        # Snapshot the current branch producers from _stuff_producer_map before
+        # register_controller_output overrides them to point to the controller node.
+        # This must be called BEFORE _register_branch_outputs_with_graph_tracer.
+        branch_entries: list[tuple[str, str]] = []
+        for branch_code in branch_stuff_codes:
+            producer_id = self._stuff_producer_map.get(branch_code)
+            if producer_id:
+                branch_entries.append((branch_code, producer_id))
+        self._parallel_combine_map[combined_stuff_code] = (parallel_controller_node_id, branch_entries)
 
     @override
     def on_pipe_start(

--- a/pipelex/graph/graph_tracer.py
+++ b/pipelex/graph/graph_tracer.py
@@ -47,7 +47,7 @@ class _MutableNodeData:
         self.metrics: dict[str, float] = {}
         self.error: ErrorSpec | None = None
         self.input_specs: list[IOSpec] = input_specs or []
-        self.output_spec: IOSpec | None = None
+        self.output_specs: list[IOSpec] = []
 
     def to_node_spec(self) -> NodeSpec:
         """Convert to immutable NodeSpec."""
@@ -59,9 +59,7 @@ class _MutableNodeData:
         )
 
         # Build NodeIOSpec from captured input/output specs
-        outputs: list[IOSpec] = []
-        if self.output_spec is not None:
-            outputs = [self.output_spec]
+        outputs = list(self.output_specs)
 
         node_io = NodeIOSpec(
             inputs=self.input_specs,
@@ -422,10 +420,45 @@ class GraphTracer(GraphTracerProtocol):
 
         # Store output spec and register in producer map for data flow tracking
         if output_spec is not None:
-            node_data.output_spec = output_spec
-            # Register this node as the producer of this stuff_code (digest)
-            if output_spec.digest:
-                self._stuff_producer_map[output_spec.digest] = node_id
+            # Skip pass-through outputs: if the output digest matches one of the node's
+            # input digests, the output is just the unchanged input flowing through
+            # (e.g., PipeParallel with add_each_output where main_stuff is the original input)
+            input_digests = {spec.digest for spec in node_data.input_specs if spec.digest is not None}
+            if output_spec.digest in input_digests:
+                # Pass-through: don't register as output or producer
+                pass
+            else:
+                node_data.output_specs.append(output_spec)
+                # Register this node as the producer of this stuff_code (digest)
+                if output_spec.digest:
+                    self._stuff_producer_map[output_spec.digest] = node_id
+
+    @override
+    def register_controller_output(
+        self,
+        node_id: str,
+        output_spec: IOSpec,
+    ) -> None:
+        """Register an additional output for a controller node.
+
+        This allows controllers like PipeParallel to explicitly register their
+        branch outputs, overriding sub-pipe registrations in _stuff_producer_map
+        so that DATA edges flow from the controller to downstream consumers.
+
+        Args:
+            node_id: The controller node ID.
+            output_spec: The IOSpec describing the output.
+        """
+        if not self._is_active:
+            return
+
+        node_data = self._nodes.get(node_id)
+        if node_data is None:
+            return
+
+        node_data.output_specs.append(output_spec)
+        if output_spec.digest:
+            self._stuff_producer_map[output_spec.digest] = node_id
 
     @override
     def on_pipe_end_error(

--- a/pipelex/graph/graph_tracer_manager.py
+++ b/pipelex/graph/graph_tracer_manager.py
@@ -298,6 +298,27 @@ class GraphTracerManager(metaclass=ABCSingletonMeta):
             label=label,
         )
 
+    def register_controller_output(
+        self,
+        graph_id: str,
+        node_id: str,
+        output_spec: IOSpec,
+    ) -> None:
+        """Register an additional output for a controller node.
+
+        Args:
+            graph_id: The graph identifier.
+            node_id: The controller node ID.
+            output_spec: The IOSpec describing the output.
+        """
+        tracer = self._get_tracer(graph_id)
+        if tracer is None:
+            return
+        tracer.register_controller_output(
+            node_id=node_id,
+            output_spec=output_spec,
+        )
+
     def register_batch_item_extraction(
         self,
         graph_id: str,

--- a/pipelex/graph/graph_tracer_manager.py
+++ b/pipelex/graph/graph_tracer_manager.py
@@ -374,3 +374,27 @@ class GraphTracerManager(metaclass=ABCSingletonMeta):
             item_index=item_index,
             batch_controller_node_id=batch_controller_node_id,
         )
+
+    def register_parallel_combine(
+        self,
+        graph_id: str,
+        combined_stuff_code: str,
+        branch_stuff_codes: list[str],
+        parallel_controller_node_id: str,
+    ) -> None:
+        """Register that branch outputs are combined into a single output in PipeParallel.
+
+        Args:
+            graph_id: The graph identifier.
+            combined_stuff_code: The stuff_code of the combined output.
+            branch_stuff_codes: The stuff_codes of the individual branch outputs.
+            parallel_controller_node_id: The node_id of the PipeParallel controller.
+        """
+        tracer = self._get_tracer(graph_id)
+        if tracer is None:
+            return
+        tracer.register_parallel_combine(
+            combined_stuff_code=combined_stuff_code,
+            branch_stuff_codes=branch_stuff_codes,
+            parallel_controller_node_id=parallel_controller_node_id,
+        )

--- a/pipelex/graph/graph_tracer_protocol.py
+++ b/pipelex/graph/graph_tracer_protocol.py
@@ -126,6 +126,22 @@ class GraphTracerProtocol(Protocol):
         """
         ...
 
+    def register_controller_output(
+        self,
+        node_id: str,
+        output_spec: IOSpec,
+    ) -> None:
+        """Register an additional output for a controller node.
+
+        This allows controllers like PipeParallel to explicitly register their
+        branch outputs so that DATA edges flow from the controller to downstream consumers.
+
+        Args:
+            node_id: The controller node ID.
+            output_spec: The IOSpec describing the output.
+        """
+        ...
+
     def register_batch_item_extraction(
         self,
         list_stuff_code: str,
@@ -232,6 +248,14 @@ class GraphTracerNoOp(GraphTracerProtocol):
         label: str | None = None,
         source_stuff_digest: str | None = None,
         target_stuff_digest: str | None = None,
+    ) -> None:
+        pass
+
+    @override
+    def register_controller_output(
+        self,
+        node_id: str,
+        output_spec: IOSpec,
     ) -> None:
         pass
 

--- a/pipelex/graph/graph_tracer_protocol.py
+++ b/pipelex/graph/graph_tracer_protocol.py
@@ -179,6 +179,24 @@ class GraphTracerProtocol(Protocol):
         """
         ...
 
+    def register_parallel_combine(
+        self,
+        combined_stuff_code: str,
+        branch_stuff_codes: list[str],
+        parallel_controller_node_id: str,
+    ) -> None:
+        """Register that branch outputs are combined into a single output in PipeParallel.
+
+        Creates PARALLEL_COMBINE edges from each branch output stuff node
+        to the combined output stuff node.
+
+        Args:
+            combined_stuff_code: The stuff_code of the combined output.
+            branch_stuff_codes: The stuff_codes of the individual branch outputs.
+            parallel_controller_node_id: The node_id of the PipeParallel controller.
+        """
+        ...
+
 
 class GraphTracerNoOp(GraphTracerProtocol):
     """No-operation implementation of GraphTracerProtocol.
@@ -276,5 +294,14 @@ class GraphTracerNoOp(GraphTracerProtocol):
         item_stuff_code: str,
         item_index: int,
         batch_controller_node_id: str | None = None,
+    ) -> None:
+        pass
+
+    @override
+    def register_parallel_combine(
+        self,
+        combined_stuff_code: str,
+        branch_stuff_codes: list[str],
+        parallel_controller_node_id: str,
     ) -> None:
         pass

--- a/pipelex/graph/graphspec.py
+++ b/pipelex/graph/graphspec.py
@@ -49,13 +49,21 @@ class EdgeKind(StrEnum):
     SELECTED_OUTCOME = "selected_outcome"
     BATCH_ITEM = "batch_item"  # list → item extraction during batch iteration
     BATCH_AGGREGATE = "batch_aggregate"  # items → output list aggregation
+    PARALLEL_COMBINE = "parallel_combine"  # branch outputs → combined output in PipeParallel
 
     @property
     def is_data(self) -> bool:
         match self:
             case EdgeKind.DATA:
                 return True
-            case EdgeKind.CONTROL | EdgeKind.CONTAINS | EdgeKind.SELECTED_OUTCOME | EdgeKind.BATCH_ITEM | EdgeKind.BATCH_AGGREGATE:
+            case (
+                EdgeKind.CONTROL
+                | EdgeKind.CONTAINS
+                | EdgeKind.SELECTED_OUTCOME
+                | EdgeKind.BATCH_ITEM
+                | EdgeKind.BATCH_AGGREGATE
+                | EdgeKind.PARALLEL_COMBINE
+            ):
                 return False
 
     @property
@@ -63,7 +71,14 @@ class EdgeKind(StrEnum):
         match self:
             case EdgeKind.CONTAINS:
                 return True
-            case EdgeKind.CONTROL | EdgeKind.DATA | EdgeKind.SELECTED_OUTCOME | EdgeKind.BATCH_ITEM | EdgeKind.BATCH_AGGREGATE:
+            case (
+                EdgeKind.CONTROL
+                | EdgeKind.DATA
+                | EdgeKind.SELECTED_OUTCOME
+                | EdgeKind.BATCH_ITEM
+                | EdgeKind.BATCH_AGGREGATE
+                | EdgeKind.PARALLEL_COMBINE
+            ):
                 return False
 
     @property
@@ -71,7 +86,7 @@ class EdgeKind(StrEnum):
         match self:
             case EdgeKind.SELECTED_OUTCOME:
                 return True
-            case EdgeKind.CONTROL | EdgeKind.DATA | EdgeKind.CONTAINS | EdgeKind.BATCH_ITEM | EdgeKind.BATCH_AGGREGATE:
+            case EdgeKind.CONTROL | EdgeKind.DATA | EdgeKind.CONTAINS | EdgeKind.BATCH_ITEM | EdgeKind.BATCH_AGGREGATE | EdgeKind.PARALLEL_COMBINE:
                 return False
 
     @property
@@ -79,7 +94,14 @@ class EdgeKind(StrEnum):
         match self:
             case EdgeKind.BATCH_ITEM:
                 return True
-            case EdgeKind.CONTROL | EdgeKind.DATA | EdgeKind.CONTAINS | EdgeKind.SELECTED_OUTCOME | EdgeKind.BATCH_AGGREGATE:
+            case (
+                EdgeKind.CONTROL
+                | EdgeKind.DATA
+                | EdgeKind.CONTAINS
+                | EdgeKind.SELECTED_OUTCOME
+                | EdgeKind.BATCH_AGGREGATE
+                | EdgeKind.PARALLEL_COMBINE
+            ):
                 return False
 
     @property
@@ -87,7 +109,15 @@ class EdgeKind(StrEnum):
         match self:
             case EdgeKind.BATCH_AGGREGATE:
                 return True
-            case EdgeKind.CONTROL | EdgeKind.DATA | EdgeKind.CONTAINS | EdgeKind.SELECTED_OUTCOME | EdgeKind.BATCH_ITEM:
+            case EdgeKind.CONTROL | EdgeKind.DATA | EdgeKind.CONTAINS | EdgeKind.SELECTED_OUTCOME | EdgeKind.BATCH_ITEM | EdgeKind.PARALLEL_COMBINE:
+                return False
+
+    @property
+    def is_parallel_combine(self) -> bool:
+        match self:
+            case EdgeKind.PARALLEL_COMBINE:
+                return True
+            case EdgeKind.CONTROL | EdgeKind.DATA | EdgeKind.CONTAINS | EdgeKind.SELECTED_OUTCOME | EdgeKind.BATCH_ITEM | EdgeKind.BATCH_AGGREGATE:
                 return False
 
 

--- a/pipelex/graph/mermaidflow/mermaidflow_factory.py
+++ b/pipelex/graph/mermaidflow/mermaidflow_factory.py
@@ -241,6 +241,18 @@ class MermaidflowFactory:
                     label = edge.label or ""
                     lines.append(f'    {source_mermaid_id} -."{label}".-> {target_mermaid_id}')
 
+        # Render parallel combine edges (branch outputs → combined output) with dashed styling
+        parallel_combine_edges = [edge for edge in graph.edges if edge.kind.is_parallel_combine]
+        if parallel_combine_edges:
+            lines.append("")
+            lines.append("    %% Parallel combine edges: branch outputs → combined output")
+            for edge in parallel_combine_edges:
+                source_mermaid_id = id_mapping.get(edge.source)
+                target_mermaid_id = id_mapping.get(edge.target)
+                if source_mermaid_id and target_mermaid_id:
+                    label = edge.label or ""
+                    lines.append(f'    {source_mermaid_id} -."{label}".-> {target_mermaid_id}')
+
         # Style definitions
         lines.append("")
         lines.append("    %% Style definitions")

--- a/pipelex/graph/reactflow/templates/_scripts.js.jinja2
+++ b/pipelex/graph/reactflow/templates/_scripts.js.jinja2
@@ -435,6 +435,33 @@ function buildDataflowGraph(graphspec, analysis) {
     //   batch_item: batch_controller → stuff_item, batch_aggregate: stuff_item → batch_controller
     // (showBatchController is declared earlier in the function)
 
+    // Create PARALLEL_COMBINE edges from GraphSpec
+    // These show branch outputs flowing into the combined output
+    for (const edge of graphspec.edges) {
+        if (edge.kind !== 'parallel_combine') continue;
+
+        if (!edge.source_stuff_digest || !edge.target_stuff_digest) continue;
+        const sourceId = `stuff_${edge.source_stuff_digest}`;
+        const targetId = `stuff_${edge.target_stuff_digest}`;
+
+        edges.push({
+            id: edge.id,
+            source: sourceId,
+            target: targetId,
+            type: {{ edge_type | tojson }},
+            animated: false,
+            style: {
+                stroke: 'var(--color-parallel-combine)',
+                strokeWidth: 2,
+                strokeDasharray: '5,5',
+            },
+            markerEnd: {
+                type: MarkerType?.ArrowClosed || 'arrowclosed',
+                color: 'var(--color-parallel-combine)',
+            },
+        });
+    }
+
     for (const edge of graphspec.edges) {
         if (edge.kind !== 'batch_item' && edge.kind !== 'batch_aggregate') {
             continue;

--- a/pipelex/graph/reactflow/templates/_styles.css.jinja2
+++ b/pipelex/graph/reactflow/templates/_styles.css.jinja2
@@ -27,6 +27,7 @@
     --color-edge: #3b82f6;
     --color-batch-item: #a855f7;
     --color-batch-aggregate: #22c55e;
+    --color-parallel-combine: #c084fc;
     --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
     --font-mono: 'JetBrains Mono', 'Monaco', 'Menlo', monospace;
     --radius-sm: 4px;
@@ -66,6 +67,7 @@
     --color-edge: #3b82f6;
     --color-batch-item: #9333ea;
     --color-batch-aggregate: #16a34a;
+    --color-parallel-combine: #a855f7;
     --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
     --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.1);
     --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.15);
@@ -100,6 +102,7 @@
         --color-edge: #3b82f6;
         --color-batch-item: #9333ea;
         --color-batch-aggregate: #16a34a;
+        --color-parallel-combine: #a855f7;
         --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
         --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.1);
         --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.15);
@@ -127,6 +130,7 @@
     --color-edge: #FFFACD;
     --color-batch-item: #bd93f9;
     --color-batch-aggregate: #50fa7b;
+    --color-parallel-combine: #d6a4ff;
 
     /* Status colors */
     --color-success: #50FA7B;             /* Bright Green */

--- a/pipelex/graph/reactflow/viewspec_transformer.py
+++ b/pipelex/graph/reactflow/viewspec_transformer.py
@@ -63,6 +63,8 @@ def _map_edge_kind_to_view_type(kind: EdgeKind) -> str:
             return "batch_item"
         case EdgeKind.BATCH_AGGREGATE:
             return "batch_aggregate"
+        case EdgeKind.PARALLEL_COMBINE:
+            return "parallel_combine"
 
 
 def _build_node_label(node_spec: Any) -> str:

--- a/pipelex/pipe_controllers/parallel/pipe_parallel.py
+++ b/pipelex/pipe_controllers/parallel/pipe_parallel.py
@@ -180,12 +180,6 @@ class PipeParallel(PipeController):
             output_stuff_contents[sub_pipe_output_name] = output_stuff.content
             log.verbose(f"PipeParallel '{self.code}': output_stuff_contents[{sub_pipe_output_name}]: {output_stuff_contents[sub_pipe_output_name]}")
 
-        # Register branch outputs with graph tracer so DATA edges flow from PipeParallel to downstream consumers
-        self._register_branch_outputs_with_graph_tracer(
-            job_metadata=job_metadata,
-            output_stuffs=output_stuffs,
-        )
-
         if self.combined_output:
             combined_output_stuff = StuffFactory.combine_stuffs(
                 concept=self.combined_output,
@@ -196,6 +190,21 @@ class PipeParallel(PipeController):
                 stuff=combined_output_stuff,
                 name=output_name,
             )
+
+            # Register parallel combine edges BEFORE register_branch_outputs, because
+            # register_parallel_combine snapshots the original branch producers from
+            # _stuff_producer_map before register_controller_output overrides them
+            self._register_parallel_combine_with_graph_tracer(
+                job_metadata=job_metadata,
+                combined_stuff=combined_output_stuff,
+                branch_stuffs=output_stuffs,
+            )
+
+        # Register branch outputs with graph tracer so DATA edges flow from PipeParallel to downstream consumers
+        self._register_branch_outputs_with_graph_tracer(
+            job_metadata=job_metadata,
+            output_stuffs=output_stuffs,
+        )
 
         return PipeOutput(
             working_memory=working_memory,
@@ -258,12 +267,6 @@ class PipeParallel(PipeController):
             output_stuffs[sub_pipe_output_name] = output_stuff
             output_stuff_contents[sub_pipe_output_name] = output_stuff.content
 
-        # Register branch outputs with graph tracer so DATA edges flow from PipeParallel to downstream consumers
-        self._register_branch_outputs_with_graph_tracer(
-            job_metadata=job_metadata,
-            output_stuffs=output_stuffs,
-        )
-
         # 4. Handle combined output if specified
         if self.combined_output:
             combined_output_stuff = StuffFactory.combine_stuffs(
@@ -275,6 +278,22 @@ class PipeParallel(PipeController):
                 stuff=combined_output_stuff,
                 name=output_name,
             )
+
+            # Register parallel combine edges BEFORE register_branch_outputs, because
+            # register_parallel_combine snapshots the original branch producers from
+            # _stuff_producer_map before register_controller_output overrides them
+            self._register_parallel_combine_with_graph_tracer(
+                job_metadata=job_metadata,
+                combined_stuff=combined_output_stuff,
+                branch_stuffs=output_stuffs,
+            )
+
+        # Register branch outputs with graph tracer so DATA edges flow from PipeParallel to downstream consumers
+        self._register_branch_outputs_with_graph_tracer(
+            job_metadata=job_metadata,
+            output_stuffs=output_stuffs,
+        )
+
         return PipeOutput(
             working_memory=working_memory,
             pipeline_run_id=job_metadata.pipeline_run_id,
@@ -316,6 +335,36 @@ class PipeParallel(PipeController):
                 node_id=graph_context.parent_node_id,
                 output_spec=output_spec,
             )
+
+    def _register_parallel_combine_with_graph_tracer(
+        self,
+        job_metadata: JobMetadata,
+        combined_stuff: "Stuff",
+        branch_stuffs: dict[str, "Stuff"],
+    ) -> None:
+        """Register parallel combine edges (branch outputs → combined output).
+
+        Creates PARALLEL_COMBINE edges showing how individual branch results
+        are merged into the combined output.
+
+        Args:
+            job_metadata: The job metadata containing graph context.
+            combined_stuff: The combined output Stuff.
+            branch_stuffs: Mapping of output_name to the branch output Stuff.
+        """
+        graph_context = job_metadata.graph_context
+        if graph_context is None:
+            return
+        tracer_manager = GraphTracerManager.get_instance()
+        if tracer_manager is None or graph_context.parent_node_id is None:
+            return
+        branch_stuff_codes = [stuff.stuff_code for stuff in branch_stuffs.values()]
+        tracer_manager.register_parallel_combine(
+            graph_id=graph_context.graph_id,
+            combined_stuff_code=combined_stuff.stuff_code,
+            branch_stuff_codes=branch_stuff_codes,
+            parallel_controller_node_id=graph_context.parent_node_id,
+        )
 
     @override
     async def _validate_before_run(

--- a/pipelex/pipe_controllers/parallel/pipe_parallel.py
+++ b/pipelex/pipe_controllers/parallel/pipe_parallel.py
@@ -13,6 +13,8 @@ from pipelex.core.pipes.inputs.input_stuff_specs import InputStuffSpecs
 from pipelex.core.pipes.inputs.input_stuff_specs_factory import InputStuffSpecsFactory
 from pipelex.core.pipes.pipe_output import PipeOutput
 from pipelex.core.stuffs.stuff_factory import StuffFactory
+from pipelex.graph.graph_tracer_manager import GraphTracerManager
+from pipelex.graph.graphspec import IOSpec
 from pipelex.hub import get_required_pipe
 from pipelex.libraries.pipe.exceptions import PipeNotFoundError
 from pipelex.pipe_controllers.pipe_controller import PipeController
@@ -178,6 +180,12 @@ class PipeParallel(PipeController):
             output_stuff_contents[sub_pipe_output_name] = output_stuff.content
             log.verbose(f"PipeParallel '{self.code}': output_stuff_contents[{sub_pipe_output_name}]: {output_stuff_contents[sub_pipe_output_name]}")
 
+        # Register branch outputs with graph tracer so DATA edges flow from PipeParallel to downstream consumers
+        self._register_branch_outputs_with_graph_tracer(
+            job_metadata=job_metadata,
+            output_stuffs=output_stuffs,
+        )
+
         if self.combined_output:
             combined_output_stuff = StuffFactory.combine_stuffs(
                 concept=self.combined_output,
@@ -250,6 +258,12 @@ class PipeParallel(PipeController):
             output_stuffs[sub_pipe_output_name] = output_stuff
             output_stuff_contents[sub_pipe_output_name] = output_stuff.content
 
+        # Register branch outputs with graph tracer so DATA edges flow from PipeParallel to downstream consumers
+        self._register_branch_outputs_with_graph_tracer(
+            job_metadata=job_metadata,
+            output_stuffs=output_stuffs,
+        )
+
         # 4. Handle combined output if specified
         if self.combined_output:
             combined_output_stuff = StuffFactory.combine_stuffs(
@@ -265,6 +279,43 @@ class PipeParallel(PipeController):
             working_memory=working_memory,
             pipeline_run_id=job_metadata.pipeline_run_id,
         )
+
+    def _register_branch_outputs_with_graph_tracer(
+        self,
+        job_metadata: JobMetadata,
+        output_stuffs: dict[str, "Stuff"],
+    ) -> None:
+        """Register branch outputs with the graph tracer.
+
+        This re-registers each branch output's stuff_code as produced by the PipeParallel
+        node, overriding the sub-pipe's registration so that DATA edges flow from
+        PipeParallel to downstream consumers.
+
+        Args:
+            job_metadata: The job metadata containing graph context.
+            output_stuffs: Mapping of output_name to the branch output Stuff.
+        """
+        graph_context = job_metadata.graph_context
+        if graph_context is None:
+            return
+        tracer_manager = GraphTracerManager.get_instance()
+        if tracer_manager is None or graph_context.parent_node_id is None:
+            return
+        for output_name_key, output_stuff in output_stuffs.items():
+            output_spec = IOSpec(
+                name=output_name_key,
+                concept=output_stuff.concept.code,
+                content_type=output_stuff.content.content_type,
+                digest=output_stuff.stuff_code,
+                data=output_stuff.content.smart_dump() if graph_context.data_inclusion.stuff_json_content else None,
+                data_text=output_stuff.content.rendered_pretty_text() if graph_context.data_inclusion.stuff_text_content else None,
+                data_html=output_stuff.content.rendered_pretty_html() if graph_context.data_inclusion.stuff_html_content else None,
+            )
+            tracer_manager.register_controller_output(
+                graph_id=graph_context.graph_id,
+                node_id=graph_context.parent_node_id,
+                output_spec=output_spec,
+            )
 
     @override
     async def _validate_before_run(

--- a/tests/e2e/pipelex/pipes/pipe_controller/pipe_parallel/parallel_graph_3branch.plx
+++ b/tests/e2e/pipelex/pipes/pipe_controller/pipe_parallel/parallel_graph_3branch.plx
@@ -1,0 +1,82 @@
+domain = "test_parallel_graph_3branch"
+description = "Test 3-branch PipeParallel with selective downstream consumption"
+main_pipe = "pg3_sequence"
+
+[concept.Pg3ToneResult]
+description = "Result of tone analysis"
+refines = "Text"
+
+[concept.Pg3LengthResult]
+description = "Result of length analysis"
+refines = "Text"
+
+[concept.Pg3StyleResult]
+description = "Result of style analysis"
+refines = "Text"
+
+[concept.Pg3CombinedResult]
+description = "Combined results from 3-branch parallel analysis"
+
+[pipe.pg3_sequence]
+type = "PipeSequence"
+description = "Run 3-branch parallel analysis then selectively consume 2 of 3 branch outputs"
+inputs = { input_text = "Text" }
+output = "Text"
+steps = [
+    { pipe = "pg3_parallel", result = "full_combo" },
+    { pipe = "pg3_refine_tone", result = "refined_tone" },
+    { pipe = "pg3_refine_length", result = "refined_length" },
+]
+
+[pipe.pg3_parallel]
+type = "PipeParallel"
+description = "Analyze tone, length, and style in parallel with combined output"
+inputs = { input_text = "Text" }
+output = "Pg3CombinedResult"
+add_each_output = true
+combined_output = "Pg3CombinedResult"
+branches = [
+    { pipe = "pg3_analyze_tone", result = "tone_result" },
+    { pipe = "pg3_analyze_length", result = "length_result" },
+    { pipe = "pg3_analyze_style", result = "style_result" },
+]
+
+[pipe.pg3_analyze_tone]
+type = "PipeLLM"
+description = "Analyze the tone of the text"
+inputs = { input_text = "Text" }
+output = "Pg3ToneResult"
+model = "$testing-text"
+prompt = "Describe the tone of: @input_text.text"
+
+[pipe.pg3_analyze_length]
+type = "PipeLLM"
+description = "Analyze the length of the text"
+inputs = { input_text = "Text" }
+output = "Pg3LengthResult"
+model = "$testing-text"
+prompt = "Describe the length characteristics of: @input_text.text"
+
+[pipe.pg3_analyze_style]
+type = "PipeLLM"
+description = "Analyze the writing style of the text"
+inputs = { input_text = "Text" }
+output = "Pg3StyleResult"
+model = "$testing-text"
+prompt = "Describe the writing style of: @input_text.text"
+
+[pipe.pg3_refine_tone]
+type = "PipeLLM"
+description = "Refine the tone analysis"
+inputs = { tone_result = "Pg3ToneResult" }
+output = "Text"
+model = "$testing-text"
+prompt = "Refine and elaborate on this tone analysis: @tone_result.text"
+
+[pipe.pg3_refine_length]
+type = "PipeLLM"
+description = "Refine the length analysis"
+inputs = { length_result = "Pg3LengthResult" }
+output = "Text"
+model = "$testing-text"
+prompt = "Refine and elaborate on this length analysis: @length_result.text"

--- a/tests/e2e/pipelex/pipes/pipe_controller/pipe_parallel/parallel_graph_add_each.plx
+++ b/tests/e2e/pipelex/pipes/pipe_controller/pipe_parallel/parallel_graph_add_each.plx
@@ -1,0 +1,59 @@
+domain = "test_parallel_graph_add_each"
+description = "Test PipeParallel with add_each_output for graph edge verification"
+main_pipe = "parallel_then_consume"
+
+[concept.ShortSummary]
+description = "A brief one-sentence summary"
+refines = "Text"
+
+[concept.DetailedSummary]
+description = "A detailed multi-sentence summary"
+refines = "Text"
+
+[pipe.parallel_then_consume]
+type = "PipeSequence"
+description = "Run parallel summaries then consume one downstream"
+inputs = { input_text = "Text" }
+output = "Text"
+steps = [
+    { pipe = "parallel_summarize", result = "..." },
+    { pipe = "combine_summaries" },
+]
+
+[pipe.parallel_summarize]
+type = "PipeParallel"
+description = "Generate short and detailed summaries in parallel"
+inputs = { input_text = "Text" }
+output = "Text"
+add_each_output = true
+branches = [
+    { pipe = "summarize_short", result = "short_summary" },
+    { pipe = "summarize_detailed", result = "detailed_summary" },
+]
+
+[pipe.summarize_short]
+type = "PipeLLM"
+description = "Generate a short one-sentence summary"
+inputs = { input_text = "Text" }
+output = "ShortSummary"
+model = "$testing-text"
+prompt = "Summarize in one sentence: @input_text.text"
+
+[pipe.summarize_detailed]
+type = "PipeLLM"
+description = "Generate a detailed summary"
+inputs = { input_text = "Text" }
+output = "DetailedSummary"
+model = "$testing-text"
+prompt = "Write a detailed summary of: @input_text.text"
+
+[pipe.combine_summaries]
+type = "PipeLLM"
+description = "Combine short and detailed summaries into a final result"
+inputs = { short_summary = "ShortSummary", detailed_summary = "DetailedSummary" }
+output = "Text"
+model = "$testing-text"
+prompt = """Combine these two summaries into a final result:
+
+Short: @short_summary.text
+Detailed: @detailed_summary.text"""

--- a/tests/e2e/pipelex/pipes/pipe_controller/pipe_parallel/parallel_graph_combined.plx
+++ b/tests/e2e/pipelex/pipes/pipe_controller/pipe_parallel/parallel_graph_combined.plx
@@ -1,6 +1,6 @@
 domain = "test_parallel_graph_combined"
-description = "Test PipeParallel with combined_output for graph edge verification"
-main_pipe = "pgc_parallel_analysis"
+description = "Test PipeParallel with combined_output wrapped in PipeSequence with follow-up consumer"
+main_pipe = "pgc_analysis_then_summarize"
 
 [concept.PgcToneResult]
 description = "Result of tone analysis"
@@ -12,6 +12,16 @@ refines = "Text"
 
 [concept.PgcCombinedResult]
 description = "Combined results from parallel analysis"
+
+[pipe.pgc_analysis_then_summarize]
+type = "PipeSequence"
+description = "Run parallel analysis then summarize the combined result"
+inputs = { input_text = "Text" }
+output = "Text"
+steps = [
+    { pipe = "pgc_parallel_analysis", result = "pgc_combined_result" },
+    { pipe = "pgc_summarize_combined" },
+]
 
 [pipe.pgc_parallel_analysis]
 type = "PipeParallel"
@@ -40,3 +50,11 @@ inputs = { input_text = "Text" }
 output = "PgcLengthResult"
 model = "$testing-text"
 prompt = "Describe the length characteristics of: @input_text.text"
+
+[pipe.pgc_summarize_combined]
+type = "PipeLLM"
+description = "Summarize the combined parallel analysis result"
+inputs = { pgc_combined_result = "PgcCombinedResult" }
+output = "Text"
+model = "$testing-text"
+prompt = "Summarize the following analysis: @pgc_combined_result"

--- a/tests/e2e/pipelex/pipes/pipe_controller/pipe_parallel/parallel_graph_combined.plx
+++ b/tests/e2e/pipelex/pipes/pipe_controller/pipe_parallel/parallel_graph_combined.plx
@@ -1,0 +1,42 @@
+domain = "test_parallel_graph_combined"
+description = "Test PipeParallel with combined_output for graph edge verification"
+main_pipe = "pgc_parallel_analysis"
+
+[concept.PgcToneResult]
+description = "Result of tone analysis"
+refines = "Text"
+
+[concept.PgcLengthResult]
+description = "Result of length analysis"
+refines = "Text"
+
+[concept.PgcCombinedResult]
+description = "Combined results from parallel analysis"
+
+[pipe.pgc_parallel_analysis]
+type = "PipeParallel"
+description = "Analyze tone and length in parallel with combined output"
+inputs = { input_text = "Text" }
+output = "PgcCombinedResult"
+add_each_output = true
+combined_output = "PgcCombinedResult"
+branches = [
+    { pipe = "pgc_analyze_tone", result = "tone_result" },
+    { pipe = "pgc_analyze_length", result = "length_result" },
+]
+
+[pipe.pgc_analyze_tone]
+type = "PipeLLM"
+description = "Analyze the tone of the text"
+inputs = { input_text = "Text" }
+output = "PgcToneResult"
+model = "$testing-text"
+prompt = "Describe the tone of: @input_text.text"
+
+[pipe.pgc_analyze_length]
+type = "PipeLLM"
+description = "Analyze the length of the text"
+inputs = { input_text = "Text" }
+output = "PgcLengthResult"
+model = "$testing-text"
+prompt = "Describe the length characteristics of: @input_text.text"

--- a/tests/e2e/pipelex/pipes/pipe_controller/pipe_parallel/parallel_graph_models.py
+++ b/tests/e2e/pipelex/pipes/pipe_controller/pipe_parallel/parallel_graph_models.py
@@ -9,3 +9,11 @@ class PgcCombinedResult(StructuredContent):
 
     tone_result: TextContent = Field(..., description="Result of tone analysis")
     length_result: TextContent = Field(..., description="Result of length analysis")
+
+
+class Pg3CombinedResult(StructuredContent):
+    """Combined results from 3-branch parallel analysis."""
+
+    tone_result: TextContent = Field(..., description="Result of tone analysis")
+    length_result: TextContent = Field(..., description="Result of length analysis")
+    style_result: TextContent = Field(..., description="Result of style analysis")

--- a/tests/e2e/pipelex/pipes/pipe_controller/pipe_parallel/parallel_graph_models.py
+++ b/tests/e2e/pipelex/pipes/pipe_controller/pipe_parallel/parallel_graph_models.py
@@ -1,0 +1,11 @@
+from pydantic import Field
+
+from pipelex.core.stuffs.structured_content import StructuredContent
+from pipelex.core.stuffs.text_content import TextContent
+
+
+class PgcCombinedResult(StructuredContent):
+    """Combined results from parallel analysis branches."""
+
+    tone_result: TextContent = Field(..., description="Result of tone analysis")
+    length_result: TextContent = Field(..., description="Result of length analysis")

--- a/tests/e2e/pipelex/pipes/pipe_controller/pipe_parallel/test_data.py
+++ b/tests/e2e/pipelex/pipes/pipe_controller/pipe_parallel/test_data.py
@@ -51,4 +51,5 @@ class ParallelCombinedGraphExpectations:
     # Expected number of edges by kind
     EXPECTED_EDGE_COUNTS: ClassVar[dict[str, int]] = {
         "contains": 2,  # parallel->tone, parallel->length
+        "parallel_combine": 2,  # tone_result->combined, length_result->combined
     }

--- a/tests/e2e/pipelex/pipes/pipe_controller/pipe_parallel/test_data.py
+++ b/tests/e2e/pipelex/pipes/pipe_controller/pipe_parallel/test_data.py
@@ -3,6 +3,15 @@
 from typing import ClassVar
 
 
+class ParallelCombinedGraphExpectationsBase:
+    """Base class for PipeParallel graph expectations with combined_output."""
+
+    PARALLEL_PIPE_CODE: ClassVar[str]
+    EXPECTED_PIPE_CODES: ClassVar[set[str]]
+    EXPECTED_NODE_COUNTS: ClassVar[dict[str, int]]
+    EXPECTED_EDGE_COUNTS: ClassVar[dict[str, int]]
+
+
 class ParallelAddEachGraphExpectations:
     """Expected structure for the parallel_graph_add_each graph."""
 
@@ -31,25 +40,67 @@ class ParallelAddEachGraphExpectations:
     }
 
 
-class ParallelCombinedGraphExpectations:
-    """Expected structure for the parallel_graph_combined graph."""
+class ParallelCombinedGraphExpectations(ParallelCombinedGraphExpectationsBase):
+    """Expected structure for the parallel_graph_combined graph (PipeSequence wrapping PipeParallel with combined_output)."""
+
+    PARALLEL_PIPE_CODE: ClassVar[str] = "pgc_parallel_analysis"
 
     # Expected node pipe_codes
     EXPECTED_PIPE_CODES: ClassVar[set[str]] = {
+        "pgc_analysis_then_summarize",  # PipeSequence (outer controller)
         "pgc_parallel_analysis",  # PipeParallel (parallel controller with combined_output)
         "pgc_analyze_tone",  # PipeLLM (branch 1)
         "pgc_analyze_length",  # PipeLLM (branch 2)
+        "pgc_summarize_combined",  # PipeLLM (downstream consumer of combined result)
     }
 
     # Expected number of nodes per pipe_code
     EXPECTED_NODE_COUNTS: ClassVar[dict[str, int]] = {
+        "pgc_analysis_then_summarize": 1,
         "pgc_parallel_analysis": 1,
         "pgc_analyze_tone": 1,
         "pgc_analyze_length": 1,
+        "pgc_summarize_combined": 1,
     }
 
     # Expected number of edges by kind
     EXPECTED_EDGE_COUNTS: ClassVar[dict[str, int]] = {
-        "contains": 2,  # parallel->tone, parallel->length
+        "contains": 4,  # sequence->parallel, sequence->summarize_combined, parallel->tone, parallel->length
         "parallel_combine": 2,  # tone_result->combined, length_result->combined
+        "data": 1,  # parallel->summarize_combined (combined result)
+    }
+
+
+class Parallel3BranchGraphExpectations(ParallelCombinedGraphExpectationsBase):
+    """Expected structure for the parallel_graph_3branch graph (3-branch PipeParallel with selective consumption)."""
+
+    PARALLEL_PIPE_CODE: ClassVar[str] = "pg3_parallel"
+
+    # Expected node pipe_codes
+    EXPECTED_PIPE_CODES: ClassVar[set[str]] = {
+        "pg3_sequence",  # PipeSequence (outer controller)
+        "pg3_parallel",  # PipeParallel (3-branch parallel with combined_output)
+        "pg3_analyze_tone",  # PipeLLM (branch 1)
+        "pg3_analyze_length",  # PipeLLM (branch 2)
+        "pg3_analyze_style",  # PipeLLM (branch 3 - unused downstream)
+        "pg3_refine_tone",  # PipeLLM (consumes tone_result)
+        "pg3_refine_length",  # PipeLLM (consumes length_result)
+    }
+
+    # Expected number of nodes per pipe_code
+    EXPECTED_NODE_COUNTS: ClassVar[dict[str, int]] = {
+        "pg3_sequence": 1,
+        "pg3_parallel": 1,
+        "pg3_analyze_tone": 1,
+        "pg3_analyze_length": 1,
+        "pg3_analyze_style": 1,
+        "pg3_refine_tone": 1,
+        "pg3_refine_length": 1,
+    }
+
+    # Expected number of edges by kind
+    EXPECTED_EDGE_COUNTS: ClassVar[dict[str, int]] = {
+        "contains": 6,  # sequence->parallel, sequence->refine_tone, sequence->refine_length, parallel->tone, parallel->length, parallel->style
+        "parallel_combine": 3,  # tone->combined, length->combined, style->combined
+        "data": 2,  # parallel->refine_tone (tone_result), parallel->refine_length (length_result)
     }

--- a/tests/e2e/pipelex/pipes/pipe_controller/pipe_parallel/test_data.py
+++ b/tests/e2e/pipelex/pipes/pipe_controller/pipe_parallel/test_data.py
@@ -1,0 +1,54 @@
+"""Test data for PipeParallel graph tests."""
+
+from typing import ClassVar
+
+
+class ParallelAddEachGraphExpectations:
+    """Expected structure for the parallel_graph_add_each graph."""
+
+    # Expected node pipe_codes
+    EXPECTED_PIPE_CODES: ClassVar[set[str]] = {
+        "parallel_then_consume",  # PipeSequence (outer controller)
+        "parallel_summarize",  # PipeParallel (parallel controller)
+        "summarize_short",  # PipeLLM (branch 1)
+        "summarize_detailed",  # PipeLLM (branch 2)
+        "combine_summaries",  # PipeLLM (downstream consumer)
+    }
+
+    # Expected number of nodes per pipe_code
+    EXPECTED_NODE_COUNTS: ClassVar[dict[str, int]] = {
+        "parallel_then_consume": 1,
+        "parallel_summarize": 1,
+        "summarize_short": 1,
+        "summarize_detailed": 1,
+        "combine_summaries": 1,
+    }
+
+    # Expected number of edges by kind
+    EXPECTED_EDGE_COUNTS: ClassVar[dict[str, int]] = {
+        "contains": 4,  # sequence->parallel, sequence->combine, parallel->short, parallel->detailed
+        "data": 2,  # parallel->combine (short_summary), parallel->combine (detailed_summary)
+    }
+
+
+class ParallelCombinedGraphExpectations:
+    """Expected structure for the parallel_graph_combined graph."""
+
+    # Expected node pipe_codes
+    EXPECTED_PIPE_CODES: ClassVar[set[str]] = {
+        "pgc_parallel_analysis",  # PipeParallel (parallel controller with combined_output)
+        "pgc_analyze_tone",  # PipeLLM (branch 1)
+        "pgc_analyze_length",  # PipeLLM (branch 2)
+    }
+
+    # Expected number of nodes per pipe_code
+    EXPECTED_NODE_COUNTS: ClassVar[dict[str, int]] = {
+        "pgc_parallel_analysis": 1,
+        "pgc_analyze_tone": 1,
+        "pgc_analyze_length": 1,
+    }
+
+    # Expected number of edges by kind
+    EXPECTED_EDGE_COUNTS: ClassVar[dict[str, int]] = {
+        "contains": 2,  # parallel->tone, parallel->length
+    }

--- a/tests/e2e/pipelex/pipes/pipe_controller/pipe_parallel/test_pipe_parallel_graph.py
+++ b/tests/e2e/pipelex/pipes/pipe_controller/pipe_parallel/test_pipe_parallel_graph.py
@@ -1,0 +1,271 @@
+"""E2E test for PipeParallel with graph tracing to verify DATA edges from controller to consumers."""
+
+from collections import Counter
+from pathlib import Path
+
+import pytest
+
+from pipelex import log, pretty_print
+from pipelex.config import get_config
+from pipelex.core.stuffs.text_content import TextContent
+from pipelex.graph.graph_factory import generate_graph_outputs
+from pipelex.graph.graphspec import GraphSpec, NodeSpec
+from pipelex.pipe_run.pipe_run_mode import PipeRunMode
+from pipelex.pipeline.execute import execute_pipeline
+from pipelex.tools.misc.file_utils import get_incremental_directory_path, save_text_to_path
+from tests.conftest import TEST_OUTPUTS_DIR
+from tests.e2e.pipelex.pipes.pipe_controller.pipe_parallel.test_data import (
+    ParallelAddEachGraphExpectations,
+    ParallelCombinedGraphExpectations,
+)
+
+
+def _get_next_output_folder(subfolder: str) -> Path:
+    """Get the next numbered output folder for parallel graph outputs."""
+    base_dir = str(Path(TEST_OUTPUTS_DIR) / f"pipe_parallel_graph_{subfolder}")
+    return Path(get_incremental_directory_path(base_dir, "run"))
+
+
+@pytest.mark.dry_runnable
+@pytest.mark.llm
+@pytest.mark.inference
+@pytest.mark.asyncio(loop_scope="class")
+class TestPipeParallelGraph:
+    """E2E tests for PipeParallel graph generation with correct DATA edges."""
+
+    async def test_parallel_add_each_output_graph(self, pipe_run_mode: PipeRunMode):
+        """Verify PipeParallel with add_each_output generates correct DATA edges.
+
+        This test runs a PipeSequence containing:
+        1. PipeParallel (add_each_output=true) that produces short_summary and detailed_summary
+        2. A downstream PipeLLM (combine_summaries) that consumes both branch outputs
+
+        Expected: DATA edges flow from PipeParallel to combine_summaries (not from sub-pipes).
+        """
+        # Build config with graph tracing and all graph outputs enabled
+        base_config = get_config().pipelex.pipeline_execution_config
+        exec_config = base_config.with_graph_config_overrides(
+            generate_graph=True,
+            force_include_full_data=False,
+        )
+        graph_config = exec_config.graph_config.model_copy(
+            update={
+                "graphs_inclusion": exec_config.graph_config.graphs_inclusion.model_copy(
+                    update={
+                        "graphspec_json": True,
+                        "mermaidflow_html": True,
+                        "reactflow_html": True,
+                    }
+                )
+            }
+        )
+        exec_config = exec_config.model_copy(update={"graph_config": graph_config})
+
+        # Run pipeline with input text
+        pipe_output = await execute_pipeline(
+            pipe_code="parallel_then_consume",
+            library_dirs=["tests/e2e/pipelex/pipes/pipe_controller/pipe_parallel"],
+            inputs={
+                "input_text": TextContent(text="The quick brown fox jumps over the lazy dog. This is a sample text for testing parallel processing.")
+            },
+            pipe_run_mode=pipe_run_mode,
+            execution_config=exec_config,
+        )
+
+        # Basic assertions
+        assert pipe_output is not None
+        assert pipe_output.working_memory is not None
+        assert pipe_output.main_stuff is not None
+
+        # Verify graph was generated
+        graph_spec = pipe_output.graph_spec
+        assert graph_spec is not None, "GraphSpec should be populated when generate_graph=True"
+        assert isinstance(graph_spec, GraphSpec)
+        assert len(graph_spec.nodes) > 0, "Graph should have nodes"
+        assert len(graph_spec.edges) > 0, "Graph should have edges"
+
+        log.info(f"Parallel add_each graph: {len(graph_spec.nodes)} nodes, {len(graph_spec.edges)} edges")
+
+        # Build node lookup
+        nodes_by_id: dict[str, NodeSpec] = {node.node_id: node for node in graph_spec.nodes}
+        nodes_by_pipe_code: dict[str, list[NodeSpec]] = {}
+        for node in graph_spec.nodes:
+            if node.pipe_code:
+                nodes_by_pipe_code.setdefault(node.pipe_code, []).append(node)
+
+        # 1. Verify all expected pipe_codes exist
+        actual_pipe_codes = set(nodes_by_pipe_code.keys())
+        assert actual_pipe_codes == ParallelAddEachGraphExpectations.EXPECTED_PIPE_CODES, (
+            f"Unexpected pipe codes. Expected: {ParallelAddEachGraphExpectations.EXPECTED_PIPE_CODES}, Got: {actual_pipe_codes}"
+        )
+
+        # 2. Verify node counts per pipe_code
+        for pipe_code, expected_count in ParallelAddEachGraphExpectations.EXPECTED_NODE_COUNTS.items():
+            actual_count = len(nodes_by_pipe_code.get(pipe_code, []))
+            assert actual_count == expected_count, f"Expected {expected_count} nodes for pipe_code '{pipe_code}', got {actual_count}"
+
+        # 3. Verify edge counts by kind
+        actual_edge_counts = Counter(str(edge.kind) for edge in graph_spec.edges)
+        for kind, expected_count in ParallelAddEachGraphExpectations.EXPECTED_EDGE_COUNTS.items():
+            actual_count = actual_edge_counts.get(kind, 0)
+            assert actual_count == expected_count, f"Expected {expected_count} edges of kind '{kind}', got {actual_count}"
+
+        # 4. Verify DATA edges source from PipeParallel, not from sub-pipes
+        parallel_node = nodes_by_pipe_code["parallel_summarize"][0]
+        combine_node = nodes_by_pipe_code["combine_summaries"][0]
+        data_edges = [edge for edge in graph_spec.edges if edge.kind.is_data]
+
+        for edge in data_edges:
+            # DATA edges targeting combine_summaries should come from PipeParallel
+            if edge.target == combine_node.node_id:
+                assert edge.source == parallel_node.node_id, (
+                    f"DATA edge to combine_summaries should come from PipeParallel '{parallel_node.node_id}', "
+                    f"but comes from '{edge.source}' (pipe_code: '{nodes_by_id[edge.source].pipe_code}')"
+                )
+
+        # 5. Verify PipeParallel node has output specs for both branch outputs
+        assert len(parallel_node.node_io.outputs) >= 2, (
+            f"PipeParallel should have at least 2 output specs (branch outputs), got {len(parallel_node.node_io.outputs)}"
+        )
+        output_names = {output.name for output in parallel_node.node_io.outputs}
+        assert "short_summary" in output_names, "PipeParallel should have 'short_summary' output"
+        assert "detailed_summary" in output_names, "PipeParallel should have 'detailed_summary' output"
+
+        # 6. Verify containment: sub-pipes are inside PipeParallel
+        contains_edges = [edge for edge in graph_spec.edges if edge.kind.is_contains]
+        parallel_children = {edge.target for edge in contains_edges if edge.source == parallel_node.node_id}
+        branch_pipe_codes = {"summarize_short", "summarize_detailed"}
+        branch_node_ids = {node.node_id for pipe_code in branch_pipe_codes for node in nodes_by_pipe_code.get(pipe_code, [])}
+        assert branch_node_ids.issubset(parallel_children), (
+            f"Branch nodes should be children of PipeParallel. Branch IDs: {branch_node_ids}, Parallel children: {parallel_children}"
+        )
+
+        # Generate and save graph outputs
+        graph_outputs = await generate_graph_outputs(
+            graph_spec=graph_spec,
+            graph_config=graph_config,
+            pipe_code="parallel_then_consume",
+        )
+
+        output_dir = _get_next_output_folder("add_each")
+        if graph_outputs.graphspec_json:
+            save_text_to_path(graph_outputs.graphspec_json, str(output_dir / "graph.json"))
+        if graph_outputs.mermaidflow_html:
+            save_text_to_path(graph_outputs.mermaidflow_html, str(output_dir / "mermaidflow.html"))
+        if graph_outputs.reactflow_html:
+            save_text_to_path(graph_outputs.reactflow_html, str(output_dir / "reactflow.html"))
+
+        pretty_print(
+            {
+                "graph_id": graph_spec.graph_id,
+                "nodes": len(graph_spec.nodes),
+                "edges": len(graph_spec.edges),
+                "edges_by_kind": dict(actual_edge_counts),
+                "output_dir": str(output_dir),
+            },
+            title="Parallel Add Each Graph Outputs",
+        )
+
+        log.info("Structural validation passed: DATA edges correctly source from PipeParallel")
+
+    async def test_parallel_combined_output_graph(self, pipe_run_mode: PipeRunMode):
+        """Verify PipeParallel with combined_output generates correct graph structure.
+
+        This test runs a PipeParallel with both add_each_output and combined_output.
+        Expected: PipeParallel node has branch outputs + combined output in its output specs.
+        """
+        # Build config with graph tracing
+        base_config = get_config().pipelex.pipeline_execution_config
+        exec_config = base_config.with_graph_config_overrides(
+            generate_graph=True,
+            force_include_full_data=False,
+        )
+        graph_config = exec_config.graph_config.model_copy(
+            update={
+                "graphs_inclusion": exec_config.graph_config.graphs_inclusion.model_copy(
+                    update={
+                        "graphspec_json": True,
+                        "reactflow_html": True,
+                    }
+                )
+            }
+        )
+        exec_config = exec_config.model_copy(update={"graph_config": graph_config})
+
+        # Run pipeline
+        pipe_output = await execute_pipeline(
+            pipe_code="pgc_parallel_analysis",
+            library_dirs=["tests/e2e/pipelex/pipes/pipe_controller/pipe_parallel"],
+            inputs={"input_text": TextContent(text="Hello world, this is a test document for parallel analysis.")},
+            pipe_run_mode=pipe_run_mode,
+            execution_config=exec_config,
+        )
+
+        assert pipe_output is not None
+        assert pipe_output.main_stuff is not None
+
+        # Verify graph
+        graph_spec = pipe_output.graph_spec
+        assert graph_spec is not None
+        assert isinstance(graph_spec, GraphSpec)
+
+        log.info(f"Parallel combined graph: {len(graph_spec.nodes)} nodes, {len(graph_spec.edges)} edges")
+
+        # Build node lookup
+        nodes_by_pipe_code: dict[str, list[NodeSpec]] = {}
+        for node in graph_spec.nodes:
+            if node.pipe_code:
+                nodes_by_pipe_code.setdefault(node.pipe_code, []).append(node)
+
+        # 1. Verify all expected pipe_codes exist
+        actual_pipe_codes = set(nodes_by_pipe_code.keys())
+        assert actual_pipe_codes == ParallelCombinedGraphExpectations.EXPECTED_PIPE_CODES, (
+            f"Unexpected pipe codes. Expected: {ParallelCombinedGraphExpectations.EXPECTED_PIPE_CODES}, Got: {actual_pipe_codes}"
+        )
+
+        # 2. Verify node counts per pipe_code
+        for pipe_code, expected_count in ParallelCombinedGraphExpectations.EXPECTED_NODE_COUNTS.items():
+            actual_count = len(nodes_by_pipe_code.get(pipe_code, []))
+            assert actual_count == expected_count, f"Expected {expected_count} nodes for pipe_code '{pipe_code}', got {actual_count}"
+
+        # 3. Verify edge counts by kind
+        actual_edge_counts = Counter(str(edge.kind) for edge in graph_spec.edges)
+        for kind, expected_count in ParallelCombinedGraphExpectations.EXPECTED_EDGE_COUNTS.items():
+            actual_count = actual_edge_counts.get(kind, 0)
+            assert actual_count == expected_count, f"Expected {expected_count} edges of kind '{kind}', got {actual_count}"
+
+        # 4. Verify PipeParallel node has outputs (branch outputs + combined output)
+        parallel_node = nodes_by_pipe_code["pgc_parallel_analysis"][0]
+        assert len(parallel_node.node_io.outputs) >= 2, (
+            f"PipeParallel with combined_output should have at least 2 output specs (branch outputs), got {len(parallel_node.node_io.outputs)}"
+        )
+        output_names = {output.name for output in parallel_node.node_io.outputs}
+        assert "tone_result" in output_names, "PipeParallel should have 'tone_result' output"
+        assert "length_result" in output_names, "PipeParallel should have 'length_result' output"
+
+        # Generate and save graph outputs
+        graph_outputs = await generate_graph_outputs(
+            graph_spec=graph_spec,
+            graph_config=graph_config,
+            pipe_code="pgc_parallel_analysis",
+        )
+
+        output_dir = _get_next_output_folder("combined")
+        if graph_outputs.graphspec_json:
+            save_text_to_path(graph_outputs.graphspec_json, str(output_dir / "graph.json"))
+        if graph_outputs.reactflow_html:
+            save_text_to_path(graph_outputs.reactflow_html, str(output_dir / "reactflow.html"))
+
+        pretty_print(
+            {
+                "graph_id": graph_spec.graph_id,
+                "nodes": len(graph_spec.nodes),
+                "edges": len(graph_spec.edges),
+                "edges_by_kind": dict(actual_edge_counts),
+                "parallel_outputs": [output.name for output in parallel_node.node_io.outputs],
+                "output_dir": str(output_dir),
+            },
+            title="Parallel Combined Graph Outputs",
+        )
+
+        log.info("Structural validation passed: PipeParallel combined_output graph is correct")

--- a/tests/e2e/pipelex/pipes/pipe_controller/pipe_parallel/test_pipe_parallel_graph.py
+++ b/tests/e2e/pipelex/pipes/pipe_controller/pipe_parallel/test_pipe_parallel_graph.py
@@ -15,8 +15,10 @@ from pipelex.pipeline.execute import execute_pipeline
 from pipelex.tools.misc.file_utils import get_incremental_directory_path, save_text_to_path
 from tests.conftest import TEST_OUTPUTS_DIR
 from tests.e2e.pipelex.pipes.pipe_controller.pipe_parallel.test_data import (
+    Parallel3BranchGraphExpectations,
     ParallelAddEachGraphExpectations,
     ParallelCombinedGraphExpectations,
+    ParallelCombinedGraphExpectationsBase,
 )
 
 
@@ -168,11 +170,24 @@ class TestPipeParallelGraph:
 
         log.info("Structural validation passed: DATA edges correctly source from PipeParallel")
 
-    async def test_parallel_combined_output_graph(self, pipe_run_mode: PipeRunMode):
+    @pytest.mark.parametrize(
+        ("pipe_code", "expectations_class"),
+        [
+            ("pgc_analysis_then_summarize", ParallelCombinedGraphExpectations),
+            ("pg3_sequence", Parallel3BranchGraphExpectations),
+        ],
+    )
+    async def test_parallel_combined_output_graph(
+        self,
+        pipe_run_mode: PipeRunMode,
+        pipe_code: str,
+        expectations_class: type[ParallelCombinedGraphExpectationsBase],
+    ):
         """Verify PipeParallel with combined_output generates correct graph structure.
 
-        This test runs a PipeParallel with both add_each_output and combined_output.
-        Expected: PipeParallel node has branch outputs + combined output in its output specs.
+        Parametrized with:
+        - pgc_analysis_then_summarize: 2-branch PipeParallel wrapped in PipeSequence with follow-up consumer
+        - pg3_sequence: 3-branch PipeParallel with selective downstream consumption (1 branch unused)
         """
         # Build config with graph tracing
         base_config = get_config().pipelex.pipeline_execution_config
@@ -194,7 +209,7 @@ class TestPipeParallelGraph:
 
         # Run pipeline
         pipe_output = await execute_pipeline(
-            pipe_code="pgc_parallel_analysis",
+            pipe_code=pipe_code,
             library_dirs=["tests/e2e/pipelex/pipes/pipe_controller/pipe_parallel"],
             inputs={"input_text": TextContent(text="Hello world, this is a test document for parallel analysis.")},
             pipe_run_mode=pipe_run_mode,
@@ -209,7 +224,7 @@ class TestPipeParallelGraph:
         assert graph_spec is not None
         assert isinstance(graph_spec, GraphSpec)
 
-        log.info(f"Parallel combined graph: {len(graph_spec.nodes)} nodes, {len(graph_spec.edges)} edges")
+        log.info(f"Parallel combined graph ({pipe_code}): {len(graph_spec.nodes)} nodes, {len(graph_spec.edges)} edges")
 
         # Build node lookup
         nodes_by_pipe_code: dict[str, list[NodeSpec]] = {}
@@ -219,33 +234,29 @@ class TestPipeParallelGraph:
 
         # 1. Verify all expected pipe_codes exist
         actual_pipe_codes = set(nodes_by_pipe_code.keys())
-        assert actual_pipe_codes == ParallelCombinedGraphExpectations.EXPECTED_PIPE_CODES, (
-            f"Unexpected pipe codes. Expected: {ParallelCombinedGraphExpectations.EXPECTED_PIPE_CODES}, Got: {actual_pipe_codes}"
+        assert actual_pipe_codes == expectations_class.EXPECTED_PIPE_CODES, (
+            f"Unexpected pipe codes. Expected: {expectations_class.EXPECTED_PIPE_CODES}, Got: {actual_pipe_codes}"
         )
 
         # 2. Verify node counts per pipe_code
-        for pipe_code, expected_count in ParallelCombinedGraphExpectations.EXPECTED_NODE_COUNTS.items():
-            actual_count = len(nodes_by_pipe_code.get(pipe_code, []))
-            assert actual_count == expected_count, f"Expected {expected_count} nodes for pipe_code '{pipe_code}', got {actual_count}"
+        for node_pipe_code, expected_count in expectations_class.EXPECTED_NODE_COUNTS.items():
+            actual_count = len(nodes_by_pipe_code.get(node_pipe_code, []))
+            assert actual_count == expected_count, f"Expected {expected_count} nodes for pipe_code '{node_pipe_code}', got {actual_count}"
 
         # 3. Verify edge counts by kind
         actual_edge_counts = Counter(str(edge.kind) for edge in graph_spec.edges)
-        for kind, expected_count in ParallelCombinedGraphExpectations.EXPECTED_EDGE_COUNTS.items():
+        for kind, expected_count in expectations_class.EXPECTED_EDGE_COUNTS.items():
             actual_count = actual_edge_counts.get(kind, 0)
             assert actual_count == expected_count, f"Expected {expected_count} edges of kind '{kind}', got {actual_count}"
 
-        # 4. Verify PipeParallel node has outputs (branch outputs + combined output)
-        parallel_node = nodes_by_pipe_code["pgc_parallel_analysis"][0]
-        assert len(parallel_node.node_io.outputs) >= 2, (
-            f"PipeParallel with combined_output should have at least 2 output specs (branch outputs), got {len(parallel_node.node_io.outputs)}"
-        )
-        output_names = {output.name for output in parallel_node.node_io.outputs}
-        assert "tone_result" in output_names, "PipeParallel should have 'tone_result' output"
-        assert "length_result" in output_names, "PipeParallel should have 'length_result' output"
-
-        # 5. Verify PARALLEL_COMBINE edges connect branch producers to the PipeParallel node
+        # 4. Verify PARALLEL_COMBINE edges connect branch producers to the PipeParallel node
+        parallel_pipe_code = expectations_class.PARALLEL_PIPE_CODE
+        parallel_node = nodes_by_pipe_code[parallel_pipe_code][0]
         parallel_combine_edges = [edge for edge in graph_spec.edges if edge.kind.is_parallel_combine]
-        assert len(parallel_combine_edges) == 2, f"Expected 2 PARALLEL_COMBINE edges (one per branch), got {len(parallel_combine_edges)}"
+        expected_combine_count = expectations_class.EXPECTED_EDGE_COUNTS.get("parallel_combine", 0)
+        assert len(parallel_combine_edges) == expected_combine_count, (
+            f"Expected {expected_combine_count} PARALLEL_COMBINE edges, got {len(parallel_combine_edges)}"
+        )
         for edge in parallel_combine_edges:
             assert edge.target == parallel_node.node_id, (
                 f"PARALLEL_COMBINE edge target should be PipeParallel '{parallel_node.node_id}', got '{edge.target}'"
@@ -257,10 +268,10 @@ class TestPipeParallelGraph:
         graph_outputs = await generate_graph_outputs(
             graph_spec=graph_spec,
             graph_config=graph_config,
-            pipe_code="pgc_parallel_analysis",
+            pipe_code=pipe_code,
         )
 
-        output_dir = _get_next_output_folder("combined")
+        output_dir = _get_next_output_folder(pipe_code)
         if graph_outputs.graphspec_json:
             save_text_to_path(graph_outputs.graphspec_json, str(output_dir / "graph.json"))
         if graph_outputs.reactflow_html:
@@ -275,7 +286,7 @@ class TestPipeParallelGraph:
                 "parallel_outputs": [output.name for output in parallel_node.node_io.outputs],
                 "output_dir": str(output_dir),
             },
-            title="Parallel Combined Graph Outputs",
+            title=f"Parallel Combined Graph Outputs ({pipe_code})",
         )
 
-        log.info("Structural validation passed: PipeParallel combined_output graph is correct")
+        log.info(f"Structural validation passed: {pipe_code} combined_output graph is correct")

--- a/tests/e2e/pipelex/pipes/pipe_controller/pipe_parallel/test_pipe_parallel_graph.py
+++ b/tests/e2e/pipelex/pipes/pipe_controller/pipe_parallel/test_pipe_parallel_graph.py
@@ -243,6 +243,16 @@ class TestPipeParallelGraph:
         assert "tone_result" in output_names, "PipeParallel should have 'tone_result' output"
         assert "length_result" in output_names, "PipeParallel should have 'length_result' output"
 
+        # 5. Verify PARALLEL_COMBINE edges connect branch producers to the PipeParallel node
+        parallel_combine_edges = [edge for edge in graph_spec.edges if edge.kind.is_parallel_combine]
+        assert len(parallel_combine_edges) == 2, f"Expected 2 PARALLEL_COMBINE edges (one per branch), got {len(parallel_combine_edges)}"
+        for edge in parallel_combine_edges:
+            assert edge.target == parallel_node.node_id, (
+                f"PARALLEL_COMBINE edge target should be PipeParallel '{parallel_node.node_id}', got '{edge.target}'"
+            )
+            assert edge.source_stuff_digest is not None, "PARALLEL_COMBINE edge should have source_stuff_digest"
+            assert edge.target_stuff_digest is not None, "PARALLEL_COMBINE edge should have target_stuff_digest"
+
         # Generate and save graph outputs
         graph_outputs = await generate_graph_outputs(
             graph_spec=graph_spec,

--- a/tests/unit/pipelex/graph/test_graph_tracer.py
+++ b/tests/unit/pipelex/graph/test_graph_tracer.py
@@ -872,3 +872,258 @@ class TestGraphTracer:
         edge = batch_aggregate_edges[0]
         assert edge.source_stuff_digest == "item_result_digest"
         assert edge.target_stuff_digest == "output_list_digest"
+
+    def test_register_controller_output(self) -> None:
+        """Test that register_controller_output adds to output_specs and _stuff_producer_map.
+
+        When a controller explicitly registers outputs, DATA edges should go from
+        the controller node to consumers of those outputs.
+        """
+        tracer = GraphTracer()
+        context = tracer.setup(graph_id="controller-output-test", data_inclusion=make_defaulted_data_inclusion_config())
+
+        started_at = datetime.now(timezone.utc)
+
+        # Controller node (e.g., PipeParallel)
+        controller_id, ctrl_ctx = tracer.on_pipe_start(
+            graph_context=context,
+            pipe_code="my_parallel",
+            pipe_type="PipeParallel",
+            node_kind=NodeKind.CONTROLLER,
+            started_at=started_at,
+            input_specs=[IOSpec(name="input_text", concept="Text", digest="input_digest")],
+        )
+
+        # Branch 1: produces output with digest "branch_output_1"
+        branch1_id, _ = tracer.on_pipe_start(
+            graph_context=ctrl_ctx,
+            pipe_code="branch_pipe_1",
+            pipe_type="PipeLLM",
+            node_kind=NodeKind.OPERATOR,
+            started_at=started_at + timedelta(milliseconds=10),
+            input_specs=[IOSpec(name="input_text", concept="Text", digest="input_digest")],
+        )
+        tracer.on_pipe_end_success(
+            node_id=branch1_id,
+            ended_at=started_at + timedelta(milliseconds=50),
+            output_spec=IOSpec(name="short_summary", concept="Text", digest="branch_output_1"),
+        )
+
+        # Branch 2: produces output with digest "branch_output_2"
+        branch2_id, _ = tracer.on_pipe_start(
+            graph_context=ctrl_ctx,
+            pipe_code="branch_pipe_2",
+            pipe_type="PipeLLM",
+            node_kind=NodeKind.OPERATOR,
+            started_at=started_at + timedelta(milliseconds=10),
+            input_specs=[IOSpec(name="input_text", concept="Text", digest="input_digest")],
+        )
+        tracer.on_pipe_end_success(
+            node_id=branch2_id,
+            ended_at=started_at + timedelta(milliseconds=50),
+            output_spec=IOSpec(name="long_summary", concept="Text", digest="branch_output_2"),
+        )
+
+        # Controller registers branch outputs (overriding sub-pipe registrations)
+        tracer.register_controller_output(
+            node_id=controller_id,
+            output_spec=IOSpec(name="short_summary", concept="Text", digest="branch_output_1"),
+        )
+        tracer.register_controller_output(
+            node_id=controller_id,
+            output_spec=IOSpec(name="long_summary", concept="Text", digest="branch_output_2"),
+        )
+
+        # Consumer pipe that uses branch_output_1
+        consumer_id, _ = tracer.on_pipe_start(
+            graph_context=context,
+            pipe_code="consumer_pipe",
+            pipe_type="PipeLLM",
+            node_kind=NodeKind.OPERATOR,
+            started_at=started_at + timedelta(milliseconds=60),
+            input_specs=[IOSpec(name="summary", concept="Text", digest="branch_output_1")],
+        )
+        tracer.on_pipe_end_success(
+            node_id=consumer_id,
+            ended_at=started_at + timedelta(milliseconds=100),
+        )
+
+        # End controller
+        tracer.on_pipe_end_success(
+            node_id=controller_id,
+            ended_at=started_at + timedelta(milliseconds=110),
+        )
+
+        graph_spec = tracer.teardown()
+
+        assert graph_spec is not None
+
+        # Verify controller node has 2 output specs
+        controller_node = next(node for node in graph_spec.nodes if node.node_id == controller_id)
+        assert len(controller_node.node_io.outputs) == 2
+        output_names = {output.name for output in controller_node.node_io.outputs}
+        assert output_names == {"short_summary", "long_summary"}
+
+        # Verify DATA edge goes from controller (not branch) to consumer
+        data_edges = [edge for edge in graph_spec.edges if edge.kind.is_data]
+        controller_to_consumer = [edge for edge in data_edges if edge.target == consumer_id]
+        assert len(controller_to_consumer) == 1
+        assert controller_to_consumer[0].source == controller_id
+
+    def test_passthrough_output_skipped(self) -> None:
+        """Test that on_pipe_end_success skips output registration when output matches an input.
+
+        When a controller's main_stuff is unchanged from one of its inputs (pass-through),
+        the output should not be registered to avoid corrupting data edges.
+        """
+        tracer = GraphTracer()
+        context = tracer.setup(graph_id="passthrough-test", data_inclusion=make_defaulted_data_inclusion_config())
+
+        started_at = datetime.now(timezone.utc)
+
+        # Producer pipe creates stuff with digest "original_stuff"
+        producer_id, _ = tracer.on_pipe_start(
+            graph_context=context,
+            pipe_code="producer",
+            pipe_type="PipeLLM",
+            node_kind=NodeKind.OPERATOR,
+            started_at=started_at,
+        )
+        tracer.on_pipe_end_success(
+            node_id=producer_id,
+            ended_at=started_at + timedelta(milliseconds=50),
+            output_spec=IOSpec(name="output", concept="Text", digest="original_stuff"),
+        )
+
+        # Controller consumes "original_stuff" and its main_stuff is the same
+        controller_id, _ctrl_ctx = tracer.on_pipe_start(
+            graph_context=context,
+            pipe_code="my_parallel",
+            pipe_type="PipeParallel",
+            node_kind=NodeKind.CONTROLLER,
+            started_at=started_at + timedelta(milliseconds=60),
+            input_specs=[IOSpec(name="input_text", concept="Text", digest="original_stuff")],
+        )
+
+        # Controller ends with the same digest as its input (pass-through)
+        tracer.on_pipe_end_success(
+            node_id=controller_id,
+            ended_at=started_at + timedelta(milliseconds=100),
+            output_spec=IOSpec(name="input_text", concept="Text", digest="original_stuff"),
+        )
+
+        # Consumer should still get the edge from the original producer, not the controller
+        consumer_id, _ = tracer.on_pipe_start(
+            graph_context=context,
+            pipe_code="consumer",
+            pipe_type="PipeLLM",
+            node_kind=NodeKind.OPERATOR,
+            started_at=started_at + timedelta(milliseconds=110),
+            input_specs=[IOSpec(name="input", concept="Text", digest="original_stuff")],
+        )
+        tracer.on_pipe_end_success(
+            node_id=consumer_id,
+            ended_at=started_at + timedelta(milliseconds=150),
+        )
+
+        graph_spec = tracer.teardown()
+
+        assert graph_spec is not None
+
+        # Controller should have NO outputs (pass-through was skipped)
+        controller_node = next(node for node in graph_spec.nodes if node.node_id == controller_id)
+        assert len(controller_node.node_io.outputs) == 0
+
+        # DATA edges should go from producer to both controller (as input) and consumer
+        # The controller does NOT steal the producer registration (pass-through skipped)
+        data_edges = [edge for edge in graph_spec.edges if edge.kind.is_data]
+        assert len(data_edges) == 2
+        assert all(edge.source == producer_id for edge in data_edges)
+        targets = {edge.target for edge in data_edges}
+        assert targets == {controller_id, consumer_id}
+
+    def test_multiple_output_specs(self) -> None:
+        """Test that a node can have multiple outputs via register_controller_output.
+
+        All registered outputs should produce correct DATA edges to their consumers.
+        """
+        tracer = GraphTracer()
+        context = tracer.setup(graph_id="multi-output-test", data_inclusion=make_defaulted_data_inclusion_config())
+
+        started_at = datetime.now(timezone.utc)
+
+        # Controller with multiple outputs
+        controller_id, _ = tracer.on_pipe_start(
+            graph_context=context,
+            pipe_code="multi_output_pipe",
+            pipe_type="PipeParallel",
+            node_kind=NodeKind.CONTROLLER,
+            started_at=started_at,
+        )
+
+        # Register three different outputs
+        tracer.register_controller_output(
+            node_id=controller_id,
+            output_spec=IOSpec(name="output_a", concept="Text", digest="digest_a"),
+        )
+        tracer.register_controller_output(
+            node_id=controller_id,
+            output_spec=IOSpec(name="output_b", concept="Text", digest="digest_b"),
+        )
+        tracer.register_controller_output(
+            node_id=controller_id,
+            output_spec=IOSpec(name="output_c", concept="Text", digest="digest_c"),
+        )
+
+        tracer.on_pipe_end_success(
+            node_id=controller_id,
+            ended_at=started_at + timedelta(milliseconds=100),
+        )
+
+        # Consumer A reads digest_a
+        consumer_a_id, _ = tracer.on_pipe_start(
+            graph_context=context,
+            pipe_code="consumer_a",
+            pipe_type="PipeLLM",
+            node_kind=NodeKind.OPERATOR,
+            started_at=started_at + timedelta(milliseconds=110),
+            input_specs=[IOSpec(name="input", concept="Text", digest="digest_a")],
+        )
+        tracer.on_pipe_end_success(node_id=consumer_a_id, ended_at=started_at + timedelta(milliseconds=120))
+
+        # Consumer B reads digest_b
+        consumer_b_id, _ = tracer.on_pipe_start(
+            graph_context=context,
+            pipe_code="consumer_b",
+            pipe_type="PipeLLM",
+            node_kind=NodeKind.OPERATOR,
+            started_at=started_at + timedelta(milliseconds=130),
+            input_specs=[IOSpec(name="input", concept="Text", digest="digest_b")],
+        )
+        tracer.on_pipe_end_success(node_id=consumer_b_id, ended_at=started_at + timedelta(milliseconds=140))
+
+        # Consumer C reads digest_c
+        consumer_c_id, _ = tracer.on_pipe_start(
+            graph_context=context,
+            pipe_code="consumer_c",
+            pipe_type="PipeLLM",
+            node_kind=NodeKind.OPERATOR,
+            started_at=started_at + timedelta(milliseconds=150),
+            input_specs=[IOSpec(name="input", concept="Text", digest="digest_c")],
+        )
+        tracer.on_pipe_end_success(node_id=consumer_c_id, ended_at=started_at + timedelta(milliseconds=160))
+
+        graph_spec = tracer.teardown()
+
+        assert graph_spec is not None
+
+        # Controller should have 3 output specs
+        controller_node = next(node for node in graph_spec.nodes if node.node_id == controller_id)
+        assert len(controller_node.node_io.outputs) == 3
+
+        # 3 DATA edges: controller -> consumer_a, controller -> consumer_b, controller -> consumer_c
+        data_edges = [edge for edge in graph_spec.edges if edge.kind.is_data]
+        assert len(data_edges) == 3
+        assert all(edge.source == controller_id for edge in data_edges)
+        targets = {edge.target for edge in data_edges}
+        assert targets == {consumer_a_id, consumer_b_id, consumer_c_id}


### PR DESCRIPTION
## Summary

- Add `register_controller_output` method to `GraphTracer` for tracking controller-level outputs
- Add `PARALLEL_COMBINE` edge kind to visualize how branch outputs feed into PipeParallel combined results
- Improve PipeParallel graph E2E tests: wrap combined_output test in a PipeSequence with a follow-up consumer, add a 3-branch PipeParallel variant with selective downstream consumption (2 consumed, 1 unused), and parametrize the test

## Test plan

- [x] `make agent-check` — all linters and type checkers pass
- [x] `make tp TEST=TestPipeParallelGraph` — all 3 test variants pass (add_each + 2 parametrized combined)
- [x] `make tp TEST=TestPipeBatchGraph` — regression check passes
- [x] `make agent-test` — full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches graph tracing and rendering logic that affects how data-flow edges are computed and displayed; mistakes could misattribute producers/consumers or alter existing graph output semantics, but changes are scoped and covered by new unit/E2E tests.
> 
> **Overview**
> Improves graph tracing for `PipeParallel` by allowing controllers to register multiple outputs via `register_controller_output`, ensuring downstream `DATA` edges source from the controller (and skipping pass-through outputs that would otherwise steal producer attribution).
> 
> Introduces a new `EdgeKind.PARALLEL_COMBINE` plus tracing (`register_parallel_combine`) and rendering support (Mermaid + ReactFlow styling) to visualize how parallel branch outputs merge into a combined output.
> 
> Adds comprehensive unit tests for controller output/waswo-through behavior and new E2E pipelines/tests covering `add_each_output`, combined output in a sequence, and a 3-branch selective-consumption scenario.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e4c62a00c44dde92aeb90c98fd79bdbc46569282. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->