### PR TITLE
Fix Mermaid graph rendering for PipeBatch and PipeParallel edges

### DIFF
--- a/pipelex/graph/mermaidflow/mermaidflow_factory.py
+++ b/pipelex/graph/mermaidflow/mermaidflow_factory.py
@@ -13,6 +13,7 @@ from typing import Any
 from pipelex.graph.graph_analysis import GraphAnalysis
 from pipelex.graph.graph_config import GraphConfig
 from pipelex.graph.graphspec import (
+    EdgeSpec,
     GraphSpec,
     NodeKind,
     NodeSpec,
@@ -255,80 +256,8 @@ class MermaidflowFactory:
         if batch_item_edges or batch_aggregate_edges:
             lines.append("")
             lines.append("    %% Batch edges: list-item relationships")
-
-            for edge in batch_item_edges:
-                source_sid = stuff_id_mapping.get(edge.source_stuff_digest) if edge.source_stuff_digest else None
-                target_sid = stuff_id_mapping.get(edge.target_stuff_digest) if edge.target_stuff_digest else None
-                # Render missing stuff nodes on the fly
-                if not source_sid and edge.source_stuff_digest and edge.source_stuff_digest in all_stuff_info:
-                    name, concept = all_stuff_info[edge.source_stuff_digest]
-                    lines.append(
-                        cls._render_stuff_node(
-                            digest=edge.source_stuff_digest,
-                            name=name,
-                            concept=concept,
-                            stuff_id_mapping=stuff_id_mapping,
-                            show_stuff_codes=show_stuff_codes,
-                            indent="    ",
-                        )
-                    )
-                    source_sid = stuff_id_mapping.get(edge.source_stuff_digest)
-                if not target_sid and edge.target_stuff_digest and edge.target_stuff_digest in all_stuff_info:
-                    name, concept = all_stuff_info[edge.target_stuff_digest]
-                    lines.append(
-                        cls._render_stuff_node(
-                            digest=edge.target_stuff_digest,
-                            name=name,
-                            concept=concept,
-                            stuff_id_mapping=stuff_id_mapping,
-                            show_stuff_codes=show_stuff_codes,
-                            indent="    ",
-                        )
-                    )
-                    target_sid = stuff_id_mapping.get(edge.target_stuff_digest)
-                if source_sid and target_sid:
-                    label = edge.label or ""
-                    if label:
-                        lines.append(f'    {source_sid} -."{label}".-> {target_sid}')
-                    else:
-                        lines.append(f"    {source_sid} -.-> {target_sid}")
-
-            for edge in batch_aggregate_edges:
-                source_sid = stuff_id_mapping.get(edge.source_stuff_digest) if edge.source_stuff_digest else None
-                target_sid = stuff_id_mapping.get(edge.target_stuff_digest) if edge.target_stuff_digest else None
-                # Render missing stuff nodes on the fly
-                if not source_sid and edge.source_stuff_digest and edge.source_stuff_digest in all_stuff_info:
-                    name, concept = all_stuff_info[edge.source_stuff_digest]
-                    lines.append(
-                        cls._render_stuff_node(
-                            digest=edge.source_stuff_digest,
-                            name=name,
-                            concept=concept,
-                            stuff_id_mapping=stuff_id_mapping,
-                            show_stuff_codes=show_stuff_codes,
-                            indent="    ",
-                        )
-                    )
-                    source_sid = stuff_id_mapping.get(edge.source_stuff_digest)
-                if not target_sid and edge.target_stuff_digest and edge.target_stuff_digest in all_stuff_info:
-                    name, concept = all_stuff_info[edge.target_stuff_digest]
-                    lines.append(
-                        cls._render_stuff_node(
-                            digest=edge.target_stuff_digest,
-                            name=name,
-                            concept=concept,
-                            stuff_id_mapping=stuff_id_mapping,
-                            show_stuff_codes=show_stuff_codes,
-                            indent="    ",
-                        )
-                    )
-                    target_sid = stuff_id_mapping.get(edge.target_stuff_digest)
-                if source_sid and target_sid:
-                    label = edge.label or ""
-                    if label:
-                        lines.append(f'    {source_sid} -."{label}".-> {target_sid}')
-                    else:
-                        lines.append(f"    {source_sid} -.-> {target_sid}")
+            cls._render_dashed_edges(batch_item_edges, lines, stuff_id_mapping, all_stuff_info, show_stuff_codes)
+            cls._render_dashed_edges(batch_aggregate_edges, lines, stuff_id_mapping, all_stuff_info, show_stuff_codes)
 
         # Render parallel combine edges (branch outputs → combined output) with dashed styling
         # Same approach: use stuff digests to connect stuff-to-stuff.
@@ -336,42 +265,7 @@ class MermaidflowFactory:
         if parallel_combine_edges:
             lines.append("")
             lines.append("    %% Parallel combine edges: branch outputs → combined output")
-            for edge in parallel_combine_edges:
-                source_sid = stuff_id_mapping.get(edge.source_stuff_digest) if edge.source_stuff_digest else None
-                target_sid = stuff_id_mapping.get(edge.target_stuff_digest) if edge.target_stuff_digest else None
-                # Render missing stuff nodes on the fly
-                if not source_sid and edge.source_stuff_digest and edge.source_stuff_digest in all_stuff_info:
-                    name, concept = all_stuff_info[edge.source_stuff_digest]
-                    lines.append(
-                        cls._render_stuff_node(
-                            digest=edge.source_stuff_digest,
-                            name=name,
-                            concept=concept,
-                            stuff_id_mapping=stuff_id_mapping,
-                            show_stuff_codes=show_stuff_codes,
-                            indent="    ",
-                        )
-                    )
-                    source_sid = stuff_id_mapping.get(edge.source_stuff_digest)
-                if not target_sid and edge.target_stuff_digest and edge.target_stuff_digest in all_stuff_info:
-                    name, concept = all_stuff_info[edge.target_stuff_digest]
-                    lines.append(
-                        cls._render_stuff_node(
-                            digest=edge.target_stuff_digest,
-                            name=name,
-                            concept=concept,
-                            stuff_id_mapping=stuff_id_mapping,
-                            show_stuff_codes=show_stuff_codes,
-                            indent="    ",
-                        )
-                    )
-                    target_sid = stuff_id_mapping.get(edge.target_stuff_digest)
-                if source_sid and target_sid:
-                    label = edge.label or ""
-                    if label:
-                        lines.append(f'    {source_sid} -."{label}".-> {target_sid}')
-                    else:
-                        lines.append(f"    {source_sid} -.-> {target_sid}")
+            cls._render_dashed_edges(parallel_combine_edges, lines, stuff_id_mapping, all_stuff_info, show_stuff_codes)
 
         # Style definitions
         lines.append("")
@@ -512,6 +406,65 @@ class MermaidflowFactory:
             label = f"{label}<br/>{escape_mermaid_label(concept)}"
 
         return f'{indent}{stuff_mermaid_id}(["{label}"]):::stuff'
+
+    @classmethod
+    def _render_dashed_edges(
+        cls,
+        edges: list[EdgeSpec],
+        lines: list[str],
+        stuff_id_mapping: dict[str, str],
+        all_stuff_info: dict[str, tuple[str, str | None]],
+        show_stuff_codes: bool,
+    ) -> None:
+        """Render dashed edges between stuff nodes, resolving missing stuff nodes on the fly.
+
+        This handles BATCH_ITEM, BATCH_AGGREGATE, and PARALLEL_COMBINE edges which all share
+        the same rendering logic: look up source/target stuff IDs, render any missing stuff
+        nodes from all_stuff_info, and emit a dashed arrow with an optional label.
+
+        Args:
+            edges: The edges to render as dashed arrows.
+            lines: The mermaid output lines list (mutated).
+            stuff_id_mapping: Map to store/retrieve stuff mermaid IDs (mutated).
+            all_stuff_info: Supplementary stuff info from all nodes including controllers.
+            show_stuff_codes: Whether to show digest in stuff labels.
+        """
+        for edge in edges:
+            source_sid = stuff_id_mapping.get(edge.source_stuff_digest) if edge.source_stuff_digest else None
+            target_sid = stuff_id_mapping.get(edge.target_stuff_digest) if edge.target_stuff_digest else None
+            # Render missing stuff nodes on the fly
+            if not source_sid and edge.source_stuff_digest and edge.source_stuff_digest in all_stuff_info:
+                name, concept = all_stuff_info[edge.source_stuff_digest]
+                lines.append(
+                    cls._render_stuff_node(
+                        digest=edge.source_stuff_digest,
+                        name=name,
+                        concept=concept,
+                        stuff_id_mapping=stuff_id_mapping,
+                        show_stuff_codes=show_stuff_codes,
+                        indent="    ",
+                    )
+                )
+                source_sid = stuff_id_mapping.get(edge.source_stuff_digest)
+            if not target_sid and edge.target_stuff_digest and edge.target_stuff_digest in all_stuff_info:
+                name, concept = all_stuff_info[edge.target_stuff_digest]
+                lines.append(
+                    cls._render_stuff_node(
+                        digest=edge.target_stuff_digest,
+                        name=name,
+                        concept=concept,
+                        stuff_id_mapping=stuff_id_mapping,
+                        show_stuff_codes=show_stuff_codes,
+                        indent="    ",
+                    )
+                )
+                target_sid = stuff_id_mapping.get(edge.target_stuff_digest)
+            if source_sid and target_sid:
+                label = edge.label or ""
+                if label:
+                    lines.append(f'    {source_sid} -."{label}".-> {target_sid}')
+                else:
+                    lines.append(f"    {source_sid} -.-> {target_sid}")
 
     @classmethod
     def _render_subgraph_recursive(

--- a/pipelex/graph/mermaidflow/mermaidflow_factory.py
+++ b/pipelex/graph/mermaidflow/mermaidflow_factory.py
@@ -125,6 +125,25 @@ class MermaidflowFactory:
             # This allows batch item stuffs to be placed inside their consumer's subgraph
             rendered_orphan_stuffs: set[str] = set()
 
+            # Build mapping of controller node_id → {digest: (name, concept)} for parallel_combine
+            # target stuffs. These are outputs of parallel controllers and should be rendered
+            # inside the controller's subgraph rather than as orphans at top level.
+            # We collect the stuff info from controller node outputs directly, because these
+            # stuffs may not be in stuff_registry (which skips controller nodes).
+            controller_output_stuffs: dict[str, dict[str, tuple[str, str | None]]] = {}
+            controller_combine_digests: set[str] = set()
+            for edge in graph.edges:
+                if edge.kind.is_parallel_combine and edge.target_stuff_digest:
+                    controller_combine_digests.add(edge.target_stuff_digest)
+                    controller_output_stuffs.setdefault(edge.target, {})[edge.target_stuff_digest] = ("", None)
+            # Resolve names and concepts from the controller nodes' outputs
+            for controller_id, digest_map in controller_output_stuffs.items():
+                controller_node = analysis.nodes_by_id.get(controller_id)
+                if controller_node:
+                    for output_spec in controller_node.node_io.outputs:
+                        if output_spec.digest and output_spec.digest in digest_map:
+                            digest_map[output_spec.digest] = (output_spec.name, output_spec.concept)
+
             # Render pipe nodes and their produced stuff within controller subgraphs
             lines.append("")
             lines.append("    %% Pipe and stuff nodes within controller subgraphs")
@@ -141,6 +160,7 @@ class MermaidflowFactory:
                     subgraph_depths=subgraph_depths,
                     show_stuff_codes=show_stuff_codes,
                     rendered_orphan_stuffs=rendered_orphan_stuffs,
+                    controller_output_stuffs=controller_output_stuffs,
                 )
                 lines.extend(node_lines)
 
@@ -199,6 +219,15 @@ class MermaidflowFactory:
                 )
                 lines.append(stuff_line)
 
+        # Build supplementary stuff info from all nodes (including controllers)
+        # This is needed for batch_aggregate target_stuff_digest which may not be in stuff_registry
+        # (GraphAnalysis.stuff_registry skips controller outputs)
+        all_stuff_info: dict[str, tuple[str, str | None]] = {}
+        for node in graph.nodes:
+            for output_spec in node.node_io.outputs:
+                if output_spec.digest and output_spec.digest not in all_stuff_info:
+                    all_stuff_info[output_spec.digest] = (output_spec.name, output_spec.concept)
+
         # Render edges: producer -> stuff
         lines.append("")
         lines.append("    %% Data flow edges: producer -> stuff -> consumer")
@@ -220,6 +249,8 @@ class MermaidflowFactory:
                     lines.append(f"    {cons_stuff_mermaid_id} --> {consumer_mermaid_id}")
 
         # Render batch edges (BATCH_ITEM and BATCH_AGGREGATE) with dashed styling
+        # These edges connect stuff-to-stuff (not node-to-node) because their source/target
+        # are controllers rendered as Mermaid subgraphs, not nodes.
         batch_item_edges = [edge for edge in graph.edges if edge.kind.is_batch_item]
         batch_aggregate_edges = [edge for edge in graph.edges if edge.kind.is_batch_aggregate]
 
@@ -228,30 +259,121 @@ class MermaidflowFactory:
             lines.append("    %% Batch edges: list-item relationships")
 
             for edge in batch_item_edges:
-                source_mermaid_id = id_mapping.get(edge.source)
-                target_mermaid_id = id_mapping.get(edge.target)
-                if source_mermaid_id and target_mermaid_id:
+                source_sid = stuff_id_mapping.get(edge.source_stuff_digest) if edge.source_stuff_digest else None
+                target_sid = stuff_id_mapping.get(edge.target_stuff_digest) if edge.target_stuff_digest else None
+                # Render missing stuff nodes on the fly
+                if not source_sid and edge.source_stuff_digest and edge.source_stuff_digest in all_stuff_info:
+                    name, concept = all_stuff_info[edge.source_stuff_digest]
+                    lines.append(
+                        cls._render_stuff_node(
+                            digest=edge.source_stuff_digest,
+                            name=name,
+                            concept=concept,
+                            stuff_id_mapping=stuff_id_mapping,
+                            show_stuff_codes=show_stuff_codes,
+                            indent="    ",
+                        )
+                    )
+                    source_sid = stuff_id_mapping.get(edge.source_stuff_digest)
+                if not target_sid and edge.target_stuff_digest and edge.target_stuff_digest in all_stuff_info:
+                    name, concept = all_stuff_info[edge.target_stuff_digest]
+                    lines.append(
+                        cls._render_stuff_node(
+                            digest=edge.target_stuff_digest,
+                            name=name,
+                            concept=concept,
+                            stuff_id_mapping=stuff_id_mapping,
+                            show_stuff_codes=show_stuff_codes,
+                            indent="    ",
+                        )
+                    )
+                    target_sid = stuff_id_mapping.get(edge.target_stuff_digest)
+                if source_sid and target_sid:
                     label = edge.label or ""
-                    lines.append(f'    {source_mermaid_id} -."{label}".-> {target_mermaid_id}')
+                    if label:
+                        lines.append(f'    {source_sid} -."{label}".-> {target_sid}')
+                    else:
+                        lines.append(f"    {source_sid} -.-> {target_sid}")
 
             for edge in batch_aggregate_edges:
-                source_mermaid_id = id_mapping.get(edge.source)
-                target_mermaid_id = id_mapping.get(edge.target)
-                if source_mermaid_id and target_mermaid_id:
+                source_sid = stuff_id_mapping.get(edge.source_stuff_digest) if edge.source_stuff_digest else None
+                target_sid = stuff_id_mapping.get(edge.target_stuff_digest) if edge.target_stuff_digest else None
+                # Render missing stuff nodes on the fly
+                if not source_sid and edge.source_stuff_digest and edge.source_stuff_digest in all_stuff_info:
+                    name, concept = all_stuff_info[edge.source_stuff_digest]
+                    lines.append(
+                        cls._render_stuff_node(
+                            digest=edge.source_stuff_digest,
+                            name=name,
+                            concept=concept,
+                            stuff_id_mapping=stuff_id_mapping,
+                            show_stuff_codes=show_stuff_codes,
+                            indent="    ",
+                        )
+                    )
+                    source_sid = stuff_id_mapping.get(edge.source_stuff_digest)
+                if not target_sid and edge.target_stuff_digest and edge.target_stuff_digest in all_stuff_info:
+                    name, concept = all_stuff_info[edge.target_stuff_digest]
+                    lines.append(
+                        cls._render_stuff_node(
+                            digest=edge.target_stuff_digest,
+                            name=name,
+                            concept=concept,
+                            stuff_id_mapping=stuff_id_mapping,
+                            show_stuff_codes=show_stuff_codes,
+                            indent="    ",
+                        )
+                    )
+                    target_sid = stuff_id_mapping.get(edge.target_stuff_digest)
+                if source_sid and target_sid:
                     label = edge.label or ""
-                    lines.append(f'    {source_mermaid_id} -."{label}".-> {target_mermaid_id}')
+                    if label:
+                        lines.append(f'    {source_sid} -."{label}".-> {target_sid}')
+                    else:
+                        lines.append(f"    {source_sid} -.-> {target_sid}")
 
         # Render parallel combine edges (branch outputs → combined output) with dashed styling
+        # Same approach: use stuff digests to connect stuff-to-stuff.
         parallel_combine_edges = [edge for edge in graph.edges if edge.kind.is_parallel_combine]
         if parallel_combine_edges:
             lines.append("")
             lines.append("    %% Parallel combine edges: branch outputs → combined output")
             for edge in parallel_combine_edges:
-                source_mermaid_id = id_mapping.get(edge.source)
-                target_mermaid_id = id_mapping.get(edge.target)
-                if source_mermaid_id and target_mermaid_id:
+                source_sid = stuff_id_mapping.get(edge.source_stuff_digest) if edge.source_stuff_digest else None
+                target_sid = stuff_id_mapping.get(edge.target_stuff_digest) if edge.target_stuff_digest else None
+                # Render missing stuff nodes on the fly
+                if not source_sid and edge.source_stuff_digest and edge.source_stuff_digest in all_stuff_info:
+                    name, concept = all_stuff_info[edge.source_stuff_digest]
+                    lines.append(
+                        cls._render_stuff_node(
+                            digest=edge.source_stuff_digest,
+                            name=name,
+                            concept=concept,
+                            stuff_id_mapping=stuff_id_mapping,
+                            show_stuff_codes=show_stuff_codes,
+                            indent="    ",
+                        )
+                    )
+                    source_sid = stuff_id_mapping.get(edge.source_stuff_digest)
+                if not target_sid and edge.target_stuff_digest and edge.target_stuff_digest in all_stuff_info:
+                    name, concept = all_stuff_info[edge.target_stuff_digest]
+                    lines.append(
+                        cls._render_stuff_node(
+                            digest=edge.target_stuff_digest,
+                            name=name,
+                            concept=concept,
+                            stuff_id_mapping=stuff_id_mapping,
+                            show_stuff_codes=show_stuff_codes,
+                            indent="    ",
+                        )
+                    )
+                    target_sid = stuff_id_mapping.get(edge.target_stuff_digest)
+                if source_sid and target_sid:
                     label = edge.label or ""
-                    lines.append(f'    {source_mermaid_id} -."{label}".-> {target_mermaid_id}')
+                    if label:
+                        lines.append(f'    {source_sid} -."{label}".-> {target_sid}')
+                    else:
+                        lines.append(f"    {source_sid} -.-> {target_sid}")
 
         # Style definitions
         lines.append("")
@@ -407,6 +529,7 @@ class MermaidflowFactory:
         subgraph_depths: dict[str, int],
         show_stuff_codes: bool,
         rendered_orphan_stuffs: set[str],
+        controller_output_stuffs: dict[str, dict[str, tuple[str, str | None]]],
         indent_level: int = 1,
         depth: int = 0,
     ) -> list[str]:
@@ -415,6 +538,8 @@ class MermaidflowFactory:
         This renders both pipe nodes and their produced stuff nodes inside subgraphs.
         Orphan stuffs (no producer) consumed by leaf nodes are also rendered inside
         the same subgraph as their consumer, enabling proper placement of batch item stuffs.
+        Controller output stuffs (e.g., parallel_combine targets) are rendered inside
+        their controller's subgraph.
 
         Args:
             node_id: The node to render.
@@ -428,6 +553,7 @@ class MermaidflowFactory:
             subgraph_depths: Map to track subgraph IDs and their depths (mutated).
             show_stuff_codes: Whether to show digest in stuff labels.
             rendered_orphan_stuffs: Set of orphan stuff digests already rendered (mutated).
+            controller_output_stuffs: Map of controller node_id to {digest: (name, concept)} for stuffs to render inside.
             indent_level: Current indentation level.
             depth: Current depth in the subgraph hierarchy (for coloring).
 
@@ -476,10 +602,25 @@ class MermaidflowFactory:
                     subgraph_depths=subgraph_depths,
                     show_stuff_codes=show_stuff_codes,
                     rendered_orphan_stuffs=rendered_orphan_stuffs,
+                    controller_output_stuffs=controller_output_stuffs,
                     indent_level=indent_level + 1,
                     depth=depth + 1,
                 )
                 lines.extend(child_lines)
+
+            # Render controller output stuffs (e.g., parallel_combine targets) inside the subgraph
+            for digest, (name, concept) in sorted(controller_output_stuffs.get(node_id, {}).items(), key=lambda item: item[1][0]):
+                if digest not in stuff_id_mapping:
+                    stuff_line = cls._render_stuff_node(
+                        digest=digest,
+                        name=name,
+                        concept=concept,
+                        stuff_id_mapping=stuff_id_mapping,
+                        show_stuff_codes=show_stuff_codes,
+                        indent=indent + "    ",
+                    )
+                    lines.append(stuff_line)
+                    rendered_orphan_stuffs.add(digest)
 
             lines.append(f"{indent}end")
         else:

--- a/pipelex/graph/mermaidflow/mermaidflow_factory.py
+++ b/pipelex/graph/mermaidflow/mermaidflow_factory.py
@@ -131,10 +131,8 @@ class MermaidflowFactory:
             # We collect the stuff info from controller node outputs directly, because these
             # stuffs may not be in stuff_registry (which skips controller nodes).
             controller_output_stuffs: dict[str, dict[str, tuple[str, str | None]]] = {}
-            controller_combine_digests: set[str] = set()
             for edge in graph.edges:
                 if edge.kind.is_parallel_combine and edge.target_stuff_digest:
-                    controller_combine_digests.add(edge.target_stuff_digest)
                     controller_output_stuffs.setdefault(edge.target, {})[edge.target_stuff_digest] = ("", None)
             # Resolve names and concepts from the controller nodes' outputs
             for controller_id, digest_map in controller_output_stuffs.items():

--- a/tests/e2e/pipelex/pipes/pipe_controller/pipe_parallel/test_pipe_parallel_graph.py
+++ b/tests/e2e/pipelex/pipes/pipe_controller/pipe_parallel/test_pipe_parallel_graph.py
@@ -274,6 +274,10 @@ class TestPipeParallelGraph:
         output_dir = _get_next_output_folder(pipe_code)
         if graph_outputs.graphspec_json:
             save_text_to_path(graph_outputs.graphspec_json, str(output_dir / "graph.json"))
+        if graph_outputs.mermaidflow_html:
+            save_text_to_path(graph_outputs.mermaidflow_html, str(output_dir / "mermaidflow.html"))
+        if graph_outputs.mermaidflow_mmd:
+            save_text_to_path(graph_outputs.mermaidflow_mmd, str(output_dir / "mermaidflow.mmd"))
         if graph_outputs.reactflow_html:
             save_text_to_path(graph_outputs.reactflow_html, str(output_dir / "reactflow.html"))
 

--- a/tests/unit/pipelex/graph/test_dashed_edge_rendering.py
+++ b/tests/unit/pipelex/graph/test_dashed_edge_rendering.py
@@ -1,0 +1,279 @@
+import re
+from datetime import datetime, timezone
+from typing import Any, ClassVar
+
+import pytest
+
+from pipelex.graph.graphspec import (
+    EdgeKind,
+    EdgeSpec,
+    GraphSpec,
+    IOSpec,
+    NodeIOSpec,
+    NodeKind,
+    NodeSpec,
+    NodeStatus,
+    PipelineRef,
+)
+from pipelex.graph.mermaidflow.mermaidflow_factory import MermaidflowFactory
+
+from .conftest import make_graph_config
+
+
+class TestDashedEdgeRendering:
+    """Tests for dashed-edge rendering logic across BATCH_ITEM, BATCH_AGGREGATE, and PARALLEL_COMBINE edge kinds."""
+
+    GRAPH_ID: ClassVar[str] = "dashed_edge_test:001"
+    CREATED_AT: ClassVar[datetime] = datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc)
+
+    def _make_graph(
+        self,
+        nodes: list[dict[str, Any]],
+        edges: list[dict[str, Any]] | None = None,
+    ) -> GraphSpec:
+        """Helper to create a GraphSpec with nodes and edges."""
+        node_specs: list[NodeSpec] = []
+        for node_dict in nodes:
+            node_specs.append(NodeSpec(**node_dict))
+
+        edge_specs: list[EdgeSpec] = []
+        if edges:
+            for edge_dict in edges:
+                edge_specs.append(EdgeSpec(**edge_dict))
+
+        return GraphSpec(
+            graph_id=self.GRAPH_ID,
+            created_at=self.CREATED_AT,
+            pipeline_ref=PipelineRef(),
+            nodes=node_specs,
+            edges=edge_specs,
+        )
+
+    def _extract_dashed_edges(self, mermaid_code: str) -> list[str]:
+        """Extract all dashed-edge lines from mermaid code.
+
+        Returns:
+            Lines containing dashed arrows (-.-> or -."label".->).
+        """
+        return [line.strip() for line in mermaid_code.split("\n") if ".->" in line]
+
+    def _build_controller_graph_with_dashed_edge(
+        self,
+        edge_kind: EdgeKind,
+        edge_label: str | None = None,
+    ) -> GraphSpec:
+        """Build a graph with a controller, two children, and a dashed edge between their stuffs.
+
+        The controller contains two child pipes. The dashed edge connects
+        source_stuff from child_a to target_stuff owned by the controller (for aggregate/combine)
+        or child_b (for batch_item).
+
+        Args:
+            edge_kind: The kind of dashed edge to create.
+            edge_label: Optional label for the dashed edge.
+
+        Returns:
+            A GraphSpec with the dashed-edge scenario.
+        """
+        controller = {
+            "node_id": "ctrl_1",
+            "kind": NodeKind.CONTROLLER,
+            "pipe_code": "batch_ctrl",
+            "status": NodeStatus.SUCCEEDED,
+            "node_io": NodeIOSpec(
+                inputs=[],
+                outputs=[IOSpec(name="ctrl_output", concept="OutputList", digest="ctrl_out_digest")],
+            ),
+        }
+        child_a = {
+            "node_id": "child_a",
+            "kind": NodeKind.OPERATOR,
+            "pipe_code": "pipe_a",
+            "status": NodeStatus.SUCCEEDED,
+            "node_io": NodeIOSpec(
+                inputs=[],
+                outputs=[IOSpec(name="source_stuff", concept="Text", digest="source_digest")],
+            ),
+        }
+        child_b = {
+            "node_id": "child_b",
+            "kind": NodeKind.OPERATOR,
+            "pipe_code": "pipe_b",
+            "status": NodeStatus.SUCCEEDED,
+            "node_io": NodeIOSpec(
+                inputs=[IOSpec(name="target_stuff", concept="Text", digest="target_digest")],
+                outputs=[],
+            ),
+        }
+        contains_a = {
+            "edge_id": "edge_contains_a",
+            "source": "ctrl_1",
+            "target": "child_a",
+            "kind": EdgeKind.CONTAINS,
+        }
+        contains_b = {
+            "edge_id": "edge_contains_b",
+            "source": "ctrl_1",
+            "target": "child_b",
+            "kind": EdgeKind.CONTAINS,
+        }
+
+        # For BATCH_AGGREGATE and PARALLEL_COMBINE, target is the controller's output stuff
+        # For BATCH_ITEM, target is child_b's input stuff
+        target_stuff_digest: str
+        match edge_kind:
+            case EdgeKind.BATCH_ITEM:
+                target_stuff_digest = "target_digest"
+            case EdgeKind.BATCH_AGGREGATE | EdgeKind.PARALLEL_COMBINE:
+                target_stuff_digest = "ctrl_out_digest"
+            case EdgeKind.CONTROL | EdgeKind.DATA | EdgeKind.CONTAINS | EdgeKind.SELECTED_OUTCOME:
+                msg = f"Unexpected edge kind for dashed edge test: {edge_kind}"
+                raise ValueError(msg)
+
+        dashed_edge: dict[str, Any] = {
+            "edge_id": "edge_dashed",
+            "source": "child_a",
+            "target": "ctrl_1",
+            "kind": edge_kind,
+            "source_stuff_digest": "source_digest",
+            "target_stuff_digest": target_stuff_digest,
+        }
+        if edge_label:
+            dashed_edge["label"] = edge_label
+
+        return self._make_graph(
+            nodes=[controller, child_a, child_b],
+            edges=[contains_a, contains_b, dashed_edge],
+        )
+
+    @pytest.mark.parametrize(
+        ("topic", "edge_kind"),
+        [
+            ("BATCH_ITEM", EdgeKind.BATCH_ITEM),
+            ("BATCH_AGGREGATE", EdgeKind.BATCH_AGGREGATE),
+            ("PARALLEL_COMBINE", EdgeKind.PARALLEL_COMBINE),
+        ],
+    )
+    def test_dashed_edge_rendered_for_each_kind(self, topic: str, edge_kind: EdgeKind) -> None:
+        """Verify that each dashed-edge kind produces at least one dashed arrow."""
+        graph = self._build_controller_graph_with_dashed_edge(edge_kind=edge_kind)
+        graph_config = make_graph_config()
+        result = MermaidflowFactory.make_from_graphspec(graph, graph_config)
+
+        dashed_lines = self._extract_dashed_edges(result.mermaid_code)
+        assert len(dashed_lines) >= 1, f"Expected at least one dashed edge for {topic}, got none"
+
+    @pytest.mark.parametrize(
+        ("topic", "edge_kind"),
+        [
+            ("BATCH_ITEM", EdgeKind.BATCH_ITEM),
+            ("BATCH_AGGREGATE", EdgeKind.BATCH_AGGREGATE),
+            ("PARALLEL_COMBINE", EdgeKind.PARALLEL_COMBINE),
+        ],
+    )
+    def test_dashed_edge_with_label(self, topic: str, edge_kind: EdgeKind) -> None:
+        """Verify that labeled dashed edges include the label in the mermaid syntax."""
+        graph = self._build_controller_graph_with_dashed_edge(edge_kind=edge_kind, edge_label="my_label")
+        graph_config = make_graph_config()
+        result = MermaidflowFactory.make_from_graphspec(graph, graph_config)
+
+        dashed_lines = self._extract_dashed_edges(result.mermaid_code)
+        labeled = [line for line in dashed_lines if "my_label" in line]
+        assert len(labeled) >= 1, f"Expected a labeled dashed edge for {topic}, got: {dashed_lines}"
+
+    @pytest.mark.parametrize(
+        ("topic", "edge_kind"),
+        [
+            ("BATCH_ITEM", EdgeKind.BATCH_ITEM),
+            ("BATCH_AGGREGATE", EdgeKind.BATCH_AGGREGATE),
+            ("PARALLEL_COMBINE", EdgeKind.PARALLEL_COMBINE),
+        ],
+    )
+    def test_dashed_edge_without_label(self, topic: str, edge_kind: EdgeKind) -> None:
+        """Verify that unlabeled dashed edges use plain dashed arrow syntax."""
+        graph = self._build_controller_graph_with_dashed_edge(edge_kind=edge_kind)
+        graph_config = make_graph_config()
+        result = MermaidflowFactory.make_from_graphspec(graph, graph_config)
+
+        dashed_lines = self._extract_dashed_edges(result.mermaid_code)
+        # Unlabeled edges use `-.->` without a label string
+        plain_dashed = [line for line in dashed_lines if ".->" in line and '-."' not in line]
+        assert len(plain_dashed) >= 1, f"Expected a plain dashed edge for {topic}, got: {dashed_lines}"
+
+    def test_all_edge_kinds_use_same_dashed_syntax(self) -> None:
+        """Verify that all three dashed-edge kinds produce structurally identical dashed arrow syntax.
+
+        This test catches divergence if one copy of the logic is modified but not the others.
+        """
+        results_by_kind: dict[str, list[str]] = {}
+        for edge_kind in (EdgeKind.BATCH_ITEM, EdgeKind.BATCH_AGGREGATE, EdgeKind.PARALLEL_COMBINE):
+            graph = self._build_controller_graph_with_dashed_edge(edge_kind=edge_kind, edge_label="test_label")
+            graph_config = make_graph_config()
+            result = MermaidflowFactory.make_from_graphspec(graph, graph_config)
+
+            dashed_lines = self._extract_dashed_edges(result.mermaid_code)
+            # Extract just the arrow operator from each line (e.g., `-."test_label".->` or `-.->`)
+            # by replacing stuff IDs (s_XXX) with a placeholder
+            normalized = [re.sub(r"s_[a-f0-9]+", "ID", line) for line in dashed_lines]
+            results_by_kind[edge_kind] = normalized
+
+        # All three should produce the same normalized patterns
+        kinds = list(results_by_kind.keys())
+        for index_kind in range(1, len(kinds)):
+            assert results_by_kind[kinds[0]] == results_by_kind[kinds[index_kind]], (
+                f"Dashed edge syntax differs between {kinds[0]} and {kinds[index_kind]}: "
+                f"{results_by_kind[kinds[0]]} vs {results_by_kind[kinds[index_kind]]}"
+            )
+
+    def test_missing_stuff_resolved_on_the_fly(self) -> None:
+        """Verify that stuff nodes not in the normal stuff_registry get rendered on-the-fly for dashed edges.
+
+        Creates a scenario where the target stuff only exists on the controller's output
+        (not registered through normal pipe IOSpec), so it must be resolved from all_stuff_info.
+        """
+        controller = {
+            "node_id": "ctrl_1",
+            "kind": NodeKind.CONTROLLER,
+            "pipe_code": "batch_ctrl",
+            "status": NodeStatus.SUCCEEDED,
+            "node_io": NodeIOSpec(
+                inputs=[],
+                outputs=[IOSpec(name="aggregated_output", concept="OutputList", digest="agg_digest")],
+            ),
+        }
+        child = {
+            "node_id": "child_1",
+            "kind": NodeKind.OPERATOR,
+            "pipe_code": "child_pipe",
+            "status": NodeStatus.SUCCEEDED,
+            "node_io": NodeIOSpec(
+                inputs=[],
+                outputs=[IOSpec(name="item_output", concept="Text", digest="item_digest")],
+            ),
+        }
+        contains = {
+            "edge_id": "edge_contains",
+            "source": "ctrl_1",
+            "target": "child_1",
+            "kind": EdgeKind.CONTAINS,
+        }
+        aggregate_edge = {
+            "edge_id": "edge_agg",
+            "source": "child_1",
+            "target": "ctrl_1",
+            "kind": EdgeKind.BATCH_AGGREGATE,
+            "source_stuff_digest": "item_digest",
+            "target_stuff_digest": "agg_digest",
+        }
+        graph = self._make_graph(
+            nodes=[controller, child],
+            edges=[contains, aggregate_edge],
+        )
+        graph_config = make_graph_config()
+        result = MermaidflowFactory.make_from_graphspec(graph, graph_config)
+
+        # The aggregated_output stuff should be rendered (resolved on the fly)
+        assert "aggregated_output" in result.mermaid_code
+        # And there should be a dashed edge connecting them
+        dashed_lines = self._extract_dashed_edges(result.mermaid_code)
+        assert len(dashed_lines) >= 1, "Expected a dashed edge for aggregate, got none"

--- a/tests/unit/pipelex/graph/test_mermaidflow.py
+++ b/tests/unit/pipelex/graph/test_mermaidflow.py
@@ -386,3 +386,89 @@ class TestMermaidflow:
         # Should have multiple subgraphs with different colors
         assert "subgraph" in result.mermaid_code
         assert "style sg_" in result.mermaid_code  # Subgraph styling
+
+    def test_parallel_combine_stuff_rendered_inside_controller_subgraph(self) -> None:
+        """Test that PARALLEL_COMBINE target stuffs are rendered inside the controller's subgraph."""
+        parallel_ctrl = {
+            "node_id": "parallel_ctrl",
+            "kind": NodeKind.CONTROLLER,
+            "pipe_code": "parallel_controller",
+            "status": NodeStatus.SUCCEEDED,
+            "node_io": NodeIOSpec(
+                inputs=[],
+                outputs=[IOSpec(name="combined_output", concept="MergedText", digest="combined_digest_001")],
+            ),
+        }
+        branch_a = {
+            "node_id": "branch_a",
+            "kind": NodeKind.OPERATOR,
+            "pipe_code": "branch_a_pipe",
+            "status": NodeStatus.SUCCEEDED,
+            "node_io": NodeIOSpec(
+                inputs=[],
+                outputs=[IOSpec(name="branch_a_out", concept="Text", digest="branch_a_digest")],
+            ),
+        }
+        branch_b = {
+            "node_id": "branch_b",
+            "kind": NodeKind.OPERATOR,
+            "pipe_code": "branch_b_pipe",
+            "status": NodeStatus.SUCCEEDED,
+            "node_io": NodeIOSpec(
+                inputs=[],
+                outputs=[IOSpec(name="branch_b_out", concept="Text", digest="branch_b_digest")],
+            ),
+        }
+        contains_a = {
+            "edge_id": "edge_contains_a",
+            "source": "parallel_ctrl",
+            "target": "branch_a",
+            "kind": EdgeKind.CONTAINS,
+        }
+        contains_b = {
+            "edge_id": "edge_contains_b",
+            "source": "parallel_ctrl",
+            "target": "branch_b",
+            "kind": EdgeKind.CONTAINS,
+        }
+        combine_a = {
+            "edge_id": "edge_combine_a",
+            "source": "branch_a",
+            "target": "parallel_ctrl",
+            "kind": EdgeKind.PARALLEL_COMBINE,
+            "source_stuff_digest": "branch_a_digest",
+            "target_stuff_digest": "combined_digest_001",
+        }
+        combine_b = {
+            "edge_id": "edge_combine_b",
+            "source": "branch_b",
+            "target": "parallel_ctrl",
+            "kind": EdgeKind.PARALLEL_COMBINE,
+            "source_stuff_digest": "branch_b_digest",
+            "target_stuff_digest": "combined_digest_001",
+        }
+        graph = self._make_graph(
+            nodes=[parallel_ctrl, branch_a, branch_b],
+            edges=[contains_a, contains_b, combine_a, combine_b],
+        )
+        graph_config = make_graph_config()
+        result = MermaidflowFactory.make_from_graphspec(graph, graph_config)
+
+        # The combined output stuff should appear inside the controller's subgraph
+        # (between subgraph ... and end)
+        lines = result.mermaid_code.split("\n")
+        subgraph_start_idx = None
+        subgraph_end_idx = None
+        for index_line, line in enumerate(lines):
+            if "subgraph" in line and "parallel_controller" in line:
+                subgraph_start_idx = index_line
+            if subgraph_start_idx is not None and subgraph_end_idx is None and line.strip() == "end":
+                subgraph_end_idx = index_line
+                break
+
+        assert subgraph_start_idx is not None, "Controller subgraph not found"
+        assert subgraph_end_idx is not None, "Controller subgraph end not found"
+
+        subgraph_content = "\n".join(lines[subgraph_start_idx : subgraph_end_idx + 1])
+        assert "combined_output" in subgraph_content, "Combined output stuff should be inside the controller subgraph"
+        assert ":::stuff" in subgraph_content, "Combined output stuff should have :::stuff class styling"


### PR DESCRIPTION
## Summary

- **Fix phantom nodes in Mermaid graphs**: Batch/parallel edges were referencing controller node IDs, but controllers are rendered as Mermaid subgraphs (not nodes), creating phantom auto-generated nodes. Fixed by using `source_stuff_digest`/`target_stuff_digest` to connect stuff-to-stuff instead.
- **Place parallel_combine target stuffs inside their controller subgraph**: Combined output stuff nodes (e.g., `pgc_combined_result`, `full_combo`) are now rendered inside the parallel controller's subgraph rather than as orphans at top level.
- **Fix empty-label dashed edge syntax**: Use plain `-.->` when edge labels are empty to avoid Mermaid syntax errors (`-."".->` is invalid).

## Test plan

- [x] `make agent-check` passes (pyright, mypy, ruff)
- [x] `make agent-test` passes
- [x] `make tp TEST=test_parallel_combined_output_graph` passes for both test cases (pgc_analysis_then_summarize and pg3_sequence)
- [ ] Visually verify `mermaidflow.html` for batch (`joke_batch.plx`) and parallel (`parallel_graph_combined.plx`, `parallel_graph_3branch.plx`) — no phantom nodes, dashed edges connect correct stuff nodes, combined outputs inside controller subgraphs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Mermaid graph rendering and related tests; main risk is visual/regression in graph outputs for controller edges rather than runtime pipeline behavior.
> 
> **Overview**
> Fixes Mermaid rendering for controller-related dashed edges by switching `BATCH_ITEM`, `BATCH_AGGREGATE`, and `PARALLEL_COMBINE` to connect **stuff-to-stuff** via `source_stuff_digest`/`target_stuff_digest` (avoiding phantom nodes caused by controllers being rendered as subgraphs). A new `_render_dashed_edges` helper also renders missing stuff nodes on-the-fly and emits valid unlabeled syntax (`-.->` vs `-."".->`).
> 
> Updates subgraph rendering to place `PARALLEL_COMBINE` target outputs inside the controller’s subgraph, and expands test coverage with new unit tests for dashed-edge behavior plus an assertion for combine-output placement; the parallel e2e test also now saves Mermaidflow outputs when generated.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 45bfa2ee3d743450ca4a4e7ad4ca9e1dadc81598. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->