### PR TITLE
Add SKIPPED status to dry run and distinguish from SUCCESS

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -euo pipefail
+
+# Only run in remote Claude Code sessions (web)
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+# Set CI to bypass the Pipelex Gateway terms acceptance check
+echo 'export CI=true' >> "$CLAUDE_ENV_FILE"
+
+# Install all dependencies (creates venv if needed, runs uv sync --all-extras)
+make install

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -9,9 +9,5 @@ fi
 # Set CI to bypass the Pipelex Gateway terms acceptance check
 echo 'export CI=true' >> "$CLAUDE_ENV_FILE"
 
-# Configure git identity for CLA compliance
-git config --global user.name "Louis Choquel"
-git config --global user.email "lchoquel@users.noreply.github.com"
-
 # Install all dependencies (creates venv if needed, runs uv sync --all-extras)
 make install

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -9,5 +9,9 @@ fi
 # Set CI to bypass the Pipelex Gateway terms acceptance check
 echo 'export CI=true' >> "$CLAUDE_ENV_FILE"
 
+# Configure git identity for CLA compliance
+git config --global user.name "Louis Choquel"
+git config --global user.email "lchoquel@users.noreply.github.com"
+
 # Install all dependencies (creates venv if needed, runs uv sync --all-extras)
 make install

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/pipelex/pipe_run/dry_run.py
+++ b/pipelex/pipe_run/dry_run.py
@@ -31,13 +31,22 @@ class DryRunError(PipelexError):
 class DryRunStatus(StrEnum):
     SUCCESS = "SUCCESS"
     FAILURE = "FAILURE"
+    SKIPPED = "SKIPPED"
 
     @property
     def is_failure(self) -> bool:
         match self:
             case DryRunStatus.FAILURE:
                 return True
+            case DryRunStatus.SUCCESS | DryRunStatus.SKIPPED:
+                return False
+
+    @property
+    def is_success(self) -> bool:
+        match self:
             case DryRunStatus.SUCCESS:
+                return True
+            case DryRunStatus.FAILURE | DryRunStatus.SKIPPED:
                 return False
 
 
@@ -61,7 +70,7 @@ async def dry_run_pipe(pipe: PipeAbstract, raise_on_failure: bool = False) -> Dr
         # Cross-package pipe dependencies may not be loaded; skip gracefully during dry-run
         error_message = f"Skipped dry run for pipe '{pipe.code}': unresolved dependency: {not_found_error}"
         log.verbose(error_message)
-        return DryRunOutput(pipe_code=pipe.code, status=DryRunStatus.SUCCESS, error_message=error_message)
+        return DryRunOutput(pipe_code=pipe.code, status=DryRunStatus.SKIPPED, error_message=error_message)
     except (PipeStackOverflowError, ValidationError, PipeComposeError) as exc:
         formatted_error = format_pydantic_validation_error(exc) if isinstance(exc, ValidationError) else str(exc)
         if pipe.code in get_config().pipelex.dry_run_config.allowed_to_fail_pipes:
@@ -105,18 +114,21 @@ async def dry_run_pipes(pipes: list[PipeAbstract], raise_on_failure: bool = True
 
     successful_pipes: list[str] = []
     failed_pipes: list[str] = []
+    skipped_pipes: list[str] = []
     for pipe_code, dry_run_output in results.items():
         match dry_run_output.status:
             case DryRunStatus.SUCCESS:
                 successful_pipes.append(pipe_code)
             case DryRunStatus.FAILURE:
                 failed_pipes.append(pipe_code)
+            case DryRunStatus.SKIPPED:
+                skipped_pipes.append(pipe_code)
 
     unexpected_failures = {pipe_code: results[pipe_code] for pipe_code in failed_pipes if pipe_code not in allowed_to_fail_pipes}
 
     log.verbose(
         f"Dry run completed: {len(successful_pipes)} successful, {len(failed_pipes)} failed, "
-        f"{len(allowed_to_fail_pipes)} allowed to fail, in {time.time() - start_time:.2f} seconds",
+        f"{len(skipped_pipes)} skipped, {len(allowed_to_fail_pipes)} allowed to fail, in {time.time() - start_time:.2f} seconds",
     )
     if unexpected_failures:
         unexpected_failures_details = "\n".join([f"'{pipe_code}': {results[pipe_code]}" for pipe_code in unexpected_failures])

--- a/tests/unit/pipelex/pipe_run/test_dry_run.py
+++ b/tests/unit/pipelex/pipe_run/test_dry_run.py
@@ -1,0 +1,67 @@
+import pytest
+from pytest_mock import MockerFixture
+
+from pipelex.libraries.pipe.exceptions import PipeNotFoundError
+from pipelex.pipe_run.dry_run import DryRunStatus, dry_run_pipe, dry_run_pipes
+
+
+class TestDryRun:
+    """Tests for dry_run_pipe and dry_run_pipes status reporting."""
+
+    @pytest.mark.asyncio
+    async def test_dry_run_pipe_with_unresolved_dependency_returns_skipped(self, mocker: MockerFixture) -> None:
+        """A pipe that raises PipeNotFoundError should be reported as SKIPPED, not SUCCESS."""
+        mock_pipe = mocker.MagicMock()
+        mock_pipe.code = "test_pipe"
+        mock_pipe.needed_inputs.side_effect = PipeNotFoundError("dep->some_domain.some_pipe not found")
+
+        result = await dry_run_pipe(mock_pipe)
+
+        assert result.status == DryRunStatus.SKIPPED
+        assert result.error_message is not None
+        assert "unresolved dependency" in result.error_message
+
+    @pytest.mark.asyncio
+    async def test_dry_run_pipe_with_unresolved_dependency_is_not_success(self, mocker: MockerFixture) -> None:
+        """Ensure skipped pipes are NOT counted as successful."""
+        mock_pipe = mocker.MagicMock()
+        mock_pipe.code = "test_pipe"
+        mock_pipe.needed_inputs.side_effect = PipeNotFoundError("dep->some_domain.some_pipe not found")
+
+        result = await dry_run_pipe(mock_pipe)
+
+        assert result.status != DryRunStatus.SUCCESS
+        assert not result.status.is_success
+
+    @pytest.mark.asyncio
+    async def test_dry_run_pipes_counts_skipped_separately(self, mocker: MockerFixture) -> None:
+        """Skipped pipes must not inflate the success count in dry_run_pipes."""
+        mock_successful_pipe = mocker.MagicMock()
+        mock_successful_pipe.code = "successful_pipe"
+        mock_successful_pipe.needed_inputs.return_value = mocker.MagicMock(named_stuff_specs=[])
+        mock_successful_pipe.validate_with_libraries.return_value = None
+        mock_successful_pipe.run_pipe = mocker.AsyncMock(return_value=None)
+
+        mock_skipped_pipe = mocker.MagicMock()
+        mock_skipped_pipe.code = "skipped_pipe"
+        mock_skipped_pipe.needed_inputs.side_effect = PipeNotFoundError("dep->domain.pipe not found")
+
+        results = await dry_run_pipes(
+            pipes=[mock_successful_pipe, mock_skipped_pipe],
+            raise_on_failure=False,
+        )
+
+        assert results["successful_pipe"].status == DryRunStatus.SUCCESS
+        assert results["skipped_pipe"].status == DryRunStatus.SKIPPED
+
+    @pytest.mark.asyncio
+    async def test_dry_run_pipe_skipped_is_not_failure(self, mocker: MockerFixture) -> None:
+        """A skipped pipe should not be treated as a failure either."""
+        mock_pipe = mocker.MagicMock()
+        mock_pipe.code = "test_pipe"
+        mock_pipe.needed_inputs.side_effect = PipeNotFoundError("missing dep")
+
+        result = await dry_run_pipe(mock_pipe)
+
+        assert result.status == DryRunStatus.SKIPPED
+        assert not result.status.is_failure


### PR DESCRIPTION
### 🔗 Related Issues

### 📝 Description

This PR introduces a new `SKIPPED` status to the dry run system to properly distinguish pipes that are skipped due to unresolved dependencies from pipes that successfully complete.

**Changes:**
- Added `DryRunStatus.SKIPPED` enum value to represent pipes skipped during dry run
- Added `is_success` property to `DryRunStatus` to explicitly check for successful completion
- Updated `is_failure` property to correctly handle the new SKIPPED status (not a failure)
- Changed `dry_run_pipe()` to return `SKIPPED` status instead of `SUCCESS` when a `PipeNotFoundError` occurs
- Updated `dry_run_pipes()` to track and report skipped pipes separately in logging
- Added comprehensive unit tests to verify SKIPPED status behavior

**Rationale:**
Previously, pipes with unresolved dependencies were incorrectly reported as `SUCCESS`, which could mask issues during dry runs. The new `SKIPPED` status provides clearer semantics: a skipped pipe is neither a success nor a failure—it's simply not evaluated due to missing dependencies. This allows better visibility into dry run results and prevents false positives in success counts.

### 🔄 Type of Change
- [x] 🐛 Bug fix
- [x] ✨ New feature
- [x] ✅ Test update

### 🧪 Tests

Added comprehensive unit tests in `tests/unit/pipelex/pipe_run/test_dry_run.py`:
- `test_dry_run_pipe_with_unresolved_dependency_returns_skipped`: Verifies pipes with unresolved dependencies return SKIPPED status
- `test_dry_run_pipe_with_unresolved_dependency_is_not_success`: Ensures SKIPPED is not counted as success
- `test_dry_run_pipes_counts_skipped_separately`: Validates that skipped pipes are tracked separately from successful ones
- `test_dry_run_pipe_skipped_is_not_failure`: Confirms SKIPPED is not treated as a failure

All tests pass and cover the new status behavior.

### 📋 Checklist

- [x] Linting / type-checking / unit tests pass locally with my changes
- [x] I've added tests that prove my fix is effective or that my feature works
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings

https://claude.ai/code/session_01RNB2PfXcEHxzpyeKjJr6VQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes status semantics for dry-run results (including logging/counting), which may affect validation workflows that implicitly assumed skipped pipes were successes. Hook scripts also run dependency installation automatically in remote Claude sessions, which can impact setup/runtime if misconfigured.
> 
> **Overview**
> Dry-run reporting now includes a new `DryRunStatus.SKIPPED` to represent pipes that can’t be evaluated due to `PipeNotFoundError`, instead of incorrectly marking them as `SUCCESS`.
> 
> `DryRunStatus` adds an explicit `is_success` property, updates `is_failure` semantics, and `dry_run_pipes()` now counts/logs skipped pipes separately; new unit tests cover the skipped/non-success/non-failure behavior.
> 
> Adds Claude Code session start hooks (`.claude/settings.json`, `.claude/hooks/session-start.sh`) to set `CI=true` and run `make install` automatically in remote sessions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4aba73da870d61e3290999be2e53cf733bd01aa3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->