### PR TITLE
Fix graph builder phantom nodes and three related package system bugs

### DIFF
--- a/pipelex/core/packages/dependency_resolver.py
+++ b/pipelex/core/packages/dependency_resolver.py
@@ -360,6 +360,45 @@ def _resolve_with_multiple_constraints(
     return _build_resolved_from_dir(alias, address, cached_path)
 
 
+def _remove_stale_subdep_constraints(
+    old_manifest: MthdsPackageManifest | None,
+    resolved_map: dict[str, ResolvedDependency],
+    constraints_by_address: dict[str, list[str]],
+) -> None:
+    """Remove constraints that were contributed by a dependency version being replaced.
+
+    When a diamond re-resolution picks a new version, the OLD version's sub-dependencies
+    may have added constraints to ``constraints_by_address``. Those constraints are stale
+    because the old version is no longer active. This function recursively removes them.
+
+    Args:
+        old_manifest: The manifest of the dependency version being replaced.
+        resolved_map: Address -> resolved dependency (entries may be removed).
+        constraints_by_address: Address -> list of version constraints (entries may be pruned).
+    """
+    if old_manifest is None or not old_manifest.dependencies:
+        return
+
+    for old_sub in old_manifest.dependencies:
+        if old_sub.path is not None:
+            continue
+        constraints_list = constraints_by_address.get(old_sub.address)
+        if constraints_list is None:
+            continue
+        # Remove the specific constraint string that the old sub-dep contributed
+        try:
+            constraints_list.remove(old_sub.version)
+        except ValueError:
+            continue
+        # If no constraints remain, the dep was only needed by the old version
+        if not constraints_list:
+            del constraints_by_address[old_sub.address]
+            old_resolved_sub = resolved_map.pop(old_sub.address, None)
+            if old_resolved_sub is not None:
+                # Recursively clean up the removed dep's own sub-dep contributions
+                _remove_stale_subdep_constraints(old_resolved_sub.manifest, resolved_map, constraints_by_address)
+
+
 def _resolve_transitive_tree(
     deps: list[PackageDependency],
     resolution_stack: set[str],
@@ -411,6 +450,10 @@ def _resolve_transitive_tree(
                 if version_satisfies(existing_ver, existing_constraint):
                     log.verbose(f"Transitive dep '{dep.address}' already resolved at {existing.manifest.version}, satisfies '{dep.version}'")
                     continue
+
+            # Diamond: remove stale constraints from the old version's sub-deps
+            # before re-resolving, so they don't cause false conflicts
+            _remove_stale_subdep_constraints(existing.manifest, resolved_map, constraints_by_address)
 
             # Diamond: re-resolve with all constraints
             override_url = (fetch_url_overrides or {}).get(dep.address)

--- a/pipelex/core/packages/dependency_resolver.py
+++ b/pipelex/core/packages/dependency_resolver.py
@@ -31,7 +31,7 @@ class ResolvedDependency(BaseModel):
     manifest: MthdsPackageManifest | None
     package_root: Path
     mthds_files: list[Path]
-    exported_pipe_codes: set[str]
+    exported_pipe_codes: set[str] | None
 
 
 def collect_mthds_files(directory: Path) -> list[Path]:
@@ -46,20 +46,26 @@ def collect_mthds_files(directory: Path) -> list[Path]:
     return sorted(directory.rglob("*.mthds"))
 
 
-def determine_exported_pipes(manifest: MthdsPackageManifest | None) -> set[str]:
+def determine_exported_pipes(manifest: MthdsPackageManifest | None) -> set[str] | None:
     """Determine which pipes are exported by a dependency.
 
-    If a manifest with exports exists, use the exports. Otherwise all pipes are public.
+    Returns None when all pipes should be public (no manifest, or manifest
+    without an ``[[exports]]`` section). Returns a set of pipe codes when
+    the manifest explicitly declares exports (the set may be empty if
+    export entries list no pipes, meaning only ``main_pipe`` is public).
 
     Args:
         manifest: The dependency's manifest (if any)
 
     Returns:
-        Set of exported pipe codes. Empty set means "all public" (no manifest).
+        None if all pipes are public, or the set of explicitly exported pipe codes.
     """
     if manifest is None:
-        # No manifest -> all pipes are public (empty set signals "all")
-        return set()
+        return None
+
+    # No exports section in manifest -> all pipes are public
+    if not manifest.exports:
+        return None
 
     exported: set[str] = set()
     for domain_export in manifest.exports:
@@ -129,7 +135,8 @@ def resolve_local_dependencies(
                 exported_pipe_codes=exported_pipe_codes,
             )
         )
-        log.verbose(f"Resolved dependency '{dep.alias}': {len(mthds_files)} .mthds files, {len(exported_pipe_codes)} exported pipes")
+        export_count = len(exported_pipe_codes) if exported_pipe_codes is not None else "all"
+        log.verbose(f"Resolved dependency '{dep.alias}': {len(mthds_files)} .mthds files, {export_count} exported pipes")
 
     return resolved
 
@@ -407,7 +414,7 @@ def _resolve_transitive_tree(
 
             # Diamond: re-resolve with all constraints
             override_url = (fetch_url_overrides or {}).get(dep.address)
-            resolved_map[dep.address] = _resolve_with_multiple_constraints(
+            re_resolved = _resolve_with_multiple_constraints(
                 address=dep.address,
                 alias=dep.alias,
                 constraints=constraints_by_address[dep.address],
@@ -415,6 +422,26 @@ def _resolve_transitive_tree(
                 cache_root=cache_root,
                 fetch_url_override=override_url,
             )
+            resolved_map[dep.address] = re_resolved
+
+            # Recurse into sub-dependencies of the re-resolved version,
+            # which may differ from the previously resolved version
+            if re_resolved.manifest is not None and re_resolved.manifest.dependencies:
+                remote_sub_deps = [sub for sub in re_resolved.manifest.dependencies if sub.path is None]
+                if remote_sub_deps:
+                    resolution_stack.add(dep.address)
+                    try:
+                        _resolve_transitive_tree(
+                            deps=remote_sub_deps,
+                            resolution_stack=resolution_stack,
+                            resolved_map=resolved_map,
+                            constraints_by_address=constraints_by_address,
+                            tags_cache=tags_cache,
+                            cache_root=cache_root,
+                            fetch_url_overrides=fetch_url_overrides,
+                        )
+                    finally:
+                        resolution_stack.discard(dep.address)
             continue
 
         # Normal resolve
@@ -487,10 +514,9 @@ def resolve_all_dependencies(
         if dep.path is not None:
             resolved_dep = _resolve_local_dependency(dep, package_root)
             local_resolved.append(resolved_dep)
+            local_export_count = len(resolved_dep.exported_pipe_codes) if resolved_dep.exported_pipe_codes is not None else "all"
             log.verbose(
-                f"Resolved local dependency '{resolved_dep.alias}': "
-                f"{len(resolved_dep.mthds_files)} .mthds files, "
-                f"{len(resolved_dep.exported_pipe_codes)} exported pipes"
+                f"Resolved local dependency '{resolved_dep.alias}': {len(resolved_dep.mthds_files)} .mthds files, {local_export_count} exported pipes"
             )
         else:
             remote_deps.append(dep)
@@ -513,10 +539,9 @@ def resolve_all_dependencies(
         )
 
     for resolved_dep in resolved_map.values():
+        remote_export_count = len(resolved_dep.exported_pipe_codes) if resolved_dep.exported_pipe_codes is not None else "all"
         log.verbose(
-            f"Resolved remote dependency '{resolved_dep.alias}': "
-            f"{len(resolved_dep.mthds_files)} .mthds files, "
-            f"{len(resolved_dep.exported_pipe_codes)} exported pipes"
+            f"Resolved remote dependency '{resolved_dep.alias}': {len(resolved_dep.mthds_files)} .mthds files, {remote_export_count} exported pipes"
         )
 
     return local_resolved + list(resolved_map.values())

--- a/pipelex/core/packages/graph/graph_builder.py
+++ b/pipelex/core/packages/graph/graph_builder.py
@@ -75,7 +75,7 @@ def _build_concept_nodes(
 
         if address not in package_concept_lookup:
             package_concept_lookup[address] = {}
-        package_concept_lookup[address][concept_entry.concept_code] = concept_id
+        package_concept_lookup[address][concept_entry.concept_ref] = concept_id
 
 
 def _build_native_concept_nodes(graph: KnowHowGraph) -> None:
@@ -158,12 +158,12 @@ def _resolve_refines_string(
 
     # Local reference: look up in same package
     local_lookup = package_concept_lookup.get(package_address, {})
-    # Try as a bare concept code first
+    # Try as a concept_ref (domain-qualified) key
     if refines in local_lookup:
         return local_lookup[refines]
-    # Try as a full concept_ref
+    # Fall back to bare concept code match
     for concept_id in local_lookup.values():
-        if concept_id.concept_ref == refines:
+        if concept_id.concept_code == refines:
             return concept_id
     return None
 
@@ -204,16 +204,15 @@ def _resolve_concept_code(
     if QualifiedRef.has_cross_package_prefix(concept_spec):
         return _resolve_cross_package_concept(concept_spec, package_address, index, package_concept_lookup)
 
-    # Look up in same package by bare concept code
+    # Look up in same package — try as concept_ref (domain-qualified) key first
     local_lookup = package_concept_lookup.get(package_address, {})
     if concept_spec in local_lookup:
         return local_lookup[concept_spec]
 
-    # Domain-qualified ref: domain.ConceptCode
-    if "." in concept_spec:
-        for concept_id in local_lookup.values():
-            if concept_id.concept_ref == concept_spec:
-                return concept_id
+    # Fall back to bare concept code match
+    for concept_id in local_lookup.values():
+        if concept_id.concept_code == concept_spec:
+            return concept_id
 
     # Unresolved: log warning and return None to exclude from the graph
     log.warning(f"Could not resolve concept '{concept_spec}' in package {package_address}, domain {domain_code}")
@@ -250,18 +249,18 @@ def _resolve_cross_package_concept(
 
     target_lookup = package_concept_lookup.get(resolved_address, {})
 
-    # Try by bare concept code (last segment of remainder)
+    # Try by full concept_ref (remainder is domain.ConceptCode)
+    if remainder in target_lookup:
+        return target_lookup[remainder]
+
+    # Fall back to bare concept code (last segment of remainder)
     try:
         ref = QualifiedRef.parse(remainder)
     except QualifiedRefError:
         log.warning(f"Malformed cross-package concept spec '{concept_spec}': remainder '{remainder}' is not a valid reference")
         return None
-    if ref.local_code in target_lookup:
-        return target_lookup[ref.local_code]
-
-    # Try by full concept_ref
     for concept_id in target_lookup.values():
-        if concept_id.concept_ref == remainder:
+        if concept_id.concept_code == ref.local_code:
             return concept_id
 
     log.warning(f"Could not resolve cross-package concept '{concept_spec}' in target package {resolved_address}")

--- a/pipelex/core/packages/graph/graph_builder.py
+++ b/pipelex/core/packages/graph/graph_builder.py
@@ -173,7 +173,7 @@ def _resolve_concept_code(
     package_address: str,
     domain_code: str,
     package_concept_lookup: dict[str, dict[str, ConceptId]],
-) -> ConceptId:
+) -> ConceptId | None:
     """Resolve a concept spec string (from pipe input/output) to a ConceptId.
 
     Args:
@@ -183,7 +183,7 @@ def _resolve_concept_code(
         package_concept_lookup: The package->code->ConceptId lookup table
 
     Returns:
-        A resolved ConceptId
+        A resolved ConceptId, or None if the concept could not be resolved
     """
     # Check if it's a native concept
     if NativeConceptCode.is_native_concept_ref_or_code(concept_spec):
@@ -198,12 +198,9 @@ def _resolve_concept_code(
     if concept_spec in local_lookup:
         return local_lookup[concept_spec]
 
-    # Unresolved: create a ConceptId with domain-qualified ref and log warning
+    # Unresolved: log warning and return None to exclude from the graph
     log.warning(f"Could not resolve concept '{concept_spec}' in package {package_address}, domain {domain_code}")
-    return ConceptId(
-        package_address=package_address,
-        concept_ref=f"{domain_code}.{concept_spec}",
-    )
+    return None
 
 
 def _build_pipe_nodes(
@@ -211,7 +208,11 @@ def _build_pipe_nodes(
     graph: KnowHowGraph,
     package_concept_lookup: dict[str, dict[str, ConceptId]],
 ) -> None:
-    """Create PipeNodes with resolved concept identities."""
+    """Create PipeNodes with resolved concept identities.
+
+    Pipes with unresolvable output or input concepts are excluded from the
+    graph rather than creating dangling references.
+    """
     for address, pipe_sig in index.all_pipes():
         output_concept_id = _resolve_concept_code(
             concept_spec=pipe_sig.output_spec,
@@ -219,15 +220,27 @@ def _build_pipe_nodes(
             domain_code=pipe_sig.domain_code,
             package_concept_lookup=package_concept_lookup,
         )
+        if output_concept_id is None:
+            log.warning(f"Excluding pipe '{pipe_sig.pipe_code}' from graph: unresolvable output concept '{pipe_sig.output_spec}'")
+            continue
 
         input_concept_ids: dict[str, ConceptId] = {}
+        has_unresolvable_input = False
         for param_name, input_spec in pipe_sig.input_specs.items():
-            input_concept_ids[param_name] = _resolve_concept_code(
+            resolved_input = _resolve_concept_code(
                 concept_spec=input_spec,
                 package_address=address,
                 domain_code=pipe_sig.domain_code,
                 package_concept_lookup=package_concept_lookup,
             )
+            if resolved_input is None:
+                log.warning(f"Excluding pipe '{pipe_sig.pipe_code}' from graph: unresolvable input concept '{input_spec}' for param '{param_name}'")
+                has_unresolvable_input = True
+                break
+            input_concept_ids[param_name] = resolved_input
+
+        if has_unresolvable_input:
+            continue
 
         pipe_node = PipeNode(
             package_address=address,

--- a/pipelex/core/packages/graph/graph_builder.py
+++ b/pipelex/core/packages/graph/graph_builder.py
@@ -173,14 +173,21 @@ def _resolve_concept_code(
     package_address: str,
     domain_code: str,
     package_concept_lookup: dict[str, dict[str, ConceptId]],
+    index: PackageIndex,
 ) -> ConceptId | None:
     """Resolve a concept spec string (from pipe input/output) to a ConceptId.
 
+    Handles native concepts, bare concept codes, domain-qualified refs
+    (e.g. ``domain.ConceptCode``), and cross-package refs
+    (e.g. ``alias->domain.ConceptCode``).
+
     Args:
-        concept_spec: The concept spec string (e.g. "Text", "PkgTestContractClause")
+        concept_spec: The concept spec string (e.g. "Text", "PkgTestContractClause",
+            "domain.ConceptCode", "alias->domain.ConceptCode")
         package_address: The package address containing the pipe
         domain_code: The domain code of the pipe
         package_concept_lookup: The package->code->ConceptId lookup table
+        index: The package index (needed for cross-package alias resolution)
 
     Returns:
         A resolved ConceptId, or None if the concept could not be resolved
@@ -193,13 +200,67 @@ def _resolve_concept_code(
             concept_ref=native_ref,
         )
 
+    # Cross-package ref: alias->domain.ConceptCode
+    if QualifiedRef.has_cross_package_prefix(concept_spec):
+        return _resolve_cross_package_concept(concept_spec, package_address, index, package_concept_lookup)
+
     # Look up in same package by bare concept code
     local_lookup = package_concept_lookup.get(package_address, {})
     if concept_spec in local_lookup:
         return local_lookup[concept_spec]
 
+    # Domain-qualified ref: domain.ConceptCode
+    if "." in concept_spec:
+        for concept_id in local_lookup.values():
+            if concept_id.concept_ref == concept_spec:
+                return concept_id
+
     # Unresolved: log warning and return None to exclude from the graph
     log.warning(f"Could not resolve concept '{concept_spec}' in package {package_address}, domain {domain_code}")
+    return None
+
+
+def _resolve_cross_package_concept(
+    concept_spec: str,
+    package_address: str,
+    index: PackageIndex,
+    package_concept_lookup: dict[str, dict[str, ConceptId]],
+) -> ConceptId | None:
+    """Resolve a cross-package concept spec (alias->domain.ConceptCode) to a ConceptId.
+
+    Args:
+        concept_spec: The cross-package concept spec (e.g. "scoring_dep->pkg_test_scoring.Score")
+        package_address: The address of the package containing the reference
+        index: The package index for alias resolution
+        package_concept_lookup: The package->code->ConceptId lookup table
+
+    Returns:
+        A resolved ConceptId, or None if the alias or concept could not be resolved
+    """
+    alias, remainder = QualifiedRef.split_cross_package_ref(concept_spec)
+    entry = index.get_entry(package_address)
+    if entry is None:
+        log.warning(f"Package '{package_address}' not found in index for cross-package ref '{concept_spec}'")
+        return None
+
+    resolved_address = entry.dependency_aliases.get(alias)
+    if resolved_address is None:
+        log.warning(f"Unknown dependency alias '{alias}' in concept spec '{concept_spec}' for package {package_address}")
+        return None
+
+    target_lookup = package_concept_lookup.get(resolved_address, {})
+
+    # Try by bare concept code (last segment of remainder)
+    ref = QualifiedRef.parse(remainder)
+    if ref.local_code in target_lookup:
+        return target_lookup[ref.local_code]
+
+    # Try by full concept_ref
+    for concept_id in target_lookup.values():
+        if concept_id.concept_ref == remainder:
+            return concept_id
+
+    log.warning(f"Could not resolve cross-package concept '{concept_spec}' in target package {resolved_address}")
     return None
 
 
@@ -219,6 +280,7 @@ def _build_pipe_nodes(
             package_address=address,
             domain_code=pipe_sig.domain_code,
             package_concept_lookup=package_concept_lookup,
+            index=index,
         )
         if output_concept_id is None:
             log.warning(f"Excluding pipe '{pipe_sig.pipe_code}' from graph: unresolvable output concept '{pipe_sig.output_spec}'")
@@ -232,6 +294,7 @@ def _build_pipe_nodes(
                 package_address=address,
                 domain_code=pipe_sig.domain_code,
                 package_concept_lookup=package_concept_lookup,
+                index=index,
             )
             if resolved_input is None:
                 log.warning(f"Excluding pipe '{pipe_sig.pipe_code}' from graph: unresolvable input concept '{input_spec}' for param '{param_name}'")

--- a/pipelex/core/packages/graph/graph_builder.py
+++ b/pipelex/core/packages/graph/graph_builder.py
@@ -16,7 +16,7 @@ from pipelex.core.packages.graph.models import (
     PipeNode,
 )
 from pipelex.core.packages.index.models import PackageIndex
-from pipelex.core.qualified_ref import QualifiedRef
+from pipelex.core.qualified_ref import QualifiedRef, QualifiedRefError
 
 
 def build_know_how_graph(index: PackageIndex) -> KnowHowGraph:
@@ -251,7 +251,11 @@ def _resolve_cross_package_concept(
     target_lookup = package_concept_lookup.get(resolved_address, {})
 
     # Try by bare concept code (last segment of remainder)
-    ref = QualifiedRef.parse(remainder)
+    try:
+        ref = QualifiedRef.parse(remainder)
+    except QualifiedRefError:
+        log.warning(f"Malformed cross-package concept spec '{concept_spec}': remainder '{remainder}' is not a valid reference")
+        return None
     if ref.local_code in target_lookup:
         return target_lookup[ref.local_code]
 

--- a/pipelex/core/packages/index/index_builder.py
+++ b/pipelex/core/packages/index/index_builder.py
@@ -223,17 +223,17 @@ def _build_concept_entry(
 
 def _is_pipe_exported(
     pipe_code: str,
-    exported_pipe_codes: set[str],
+    exported_pipe_codes: set[str] | None,
     main_pipe: str | None,
 ) -> bool:
     """Determine if a pipe is exported.
 
     A pipe is exported if:
-    - exported_pipe_codes is empty (no manifest or no exports = all public)
+    - exported_pipe_codes is None (no manifest = all public)
     - pipe_code is in the exported set
     - pipe_code is the main_pipe (auto-exported)
     """
-    if not exported_pipe_codes:
+    if exported_pipe_codes is None:
         return True
     return pipe_code in exported_pipe_codes or pipe_code == main_pipe
 

--- a/pipelex/libraries/library_manager.py
+++ b/pipelex/libraries/library_manager.py
@@ -718,9 +718,17 @@ class LibraryManager(LibraryManagerAbstract):
             if blueprint.main_pipe:
                 main_pipes.add(blueprint.main_pipe)
 
-        # Determine if we filter by exports or load all
-        has_exports = len(resolved_dep.exported_pipe_codes) > 0
-        all_exported = resolved_dep.exported_pipe_codes | main_pipes
+        # Determine if we filter by exports or load all.
+        # exported_pipe_codes is None when no manifest exists (all pipes public),
+        # or a set (possibly empty) when a manifest defines exports.
+        if resolved_dep.exported_pipe_codes is None:
+            # No manifest: all pipes are public, no filtering
+            has_exports = False
+            all_exported: set[str] = set()
+        else:
+            # Manifest exists: filter to exported pipes + main_pipes
+            has_exports = True
+            all_exported = resolved_dep.exported_pipe_codes | main_pipes
 
         # Temporarily register dep concepts in main library for pipe construction
         # (PipeFactory resolves concepts through the hub's current library)
@@ -730,28 +738,30 @@ class LibraryManager(LibraryManagerAbstract):
                 library.concept_library.add_new_concept(concept=concept)
                 temp_concept_refs.append(concept.concept_ref)
 
-        # Load exported pipes into child library
-        concept_codes = [concept.code for concept in dep_concepts]
-        for blueprint in dep_blueprints:
-            if blueprint.pipe is None:
-                continue
-            for pipe_code, pipe_blueprint in blueprint.pipe.items():
-                # If manifest has exports, only load exported pipes
-                if has_exports and pipe_code not in all_exported:
+        # Load exported pipes into child library, ensuring temp concepts are
+        # always cleaned up even if an unexpected exception occurs
+        try:
+            concept_codes = [concept.code for concept in dep_concepts]
+            for blueprint in dep_blueprints:
+                if blueprint.pipe is None:
                     continue
-                try:
-                    pipe = PipeFactory[PipeAbstract].make_from_blueprint(
-                        domain_code=blueprint.domain,
-                        pipe_code=pipe_code,
-                        blueprint=pipe_blueprint,
-                        concept_codes_from_the_same_domain=concept_codes,
-                    )
-                    child_library.pipe_library.add_new_pipe(pipe=pipe)
-                except (PipeLibraryError, ValidationError) as exc:
-                    log.warning(f"Could not load dependency '{alias}' pipe '{pipe_code}': {exc}")
-
-        # Remove temporary native-key entries from main library
-        library.concept_library.remove_concepts_by_concept_refs(concept_refs=temp_concept_refs)
+                for pipe_code, pipe_blueprint in blueprint.pipe.items():
+                    # If manifest has exports, only load exported pipes
+                    if has_exports and pipe_code not in all_exported:
+                        continue
+                    try:
+                        pipe = PipeFactory[PipeAbstract].make_from_blueprint(
+                            domain_code=blueprint.domain,
+                            pipe_code=pipe_code,
+                            blueprint=pipe_blueprint,
+                            concept_codes_from_the_same_domain=concept_codes,
+                        )
+                        child_library.pipe_library.add_new_pipe(pipe=pipe)
+                    except (PipeLibraryError, ValidationError) as exc:
+                        log.warning(f"Could not load dependency '{alias}' pipe '{pipe_code}': {exc}")
+        finally:
+            # Remove temporary concept entries from main library
+            library.concept_library.remove_concepts_by_concept_refs(concept_refs=temp_concept_refs)
 
         # Register child library for isolation
         library.dependency_libraries[alias] = child_library

--- a/tests/integration/pipelex/core/packages/test_cross_package_integration.py
+++ b/tests/integration/pipelex/core/packages/test_cross_package_integration.py
@@ -45,6 +45,7 @@ class TestCrossPackageIntegration:
         assert dep.manifest is not None
         assert dep.manifest.address == "github.com/mthds/scoring-lib"
         assert len(dep.mthds_files) >= 1
+        assert dep.exported_pipe_codes is not None
         assert "pkg_test_compute_score" in dep.exported_pipe_codes
 
     def test_scoring_dep_manifest_parsed_correctly(self):

--- a/tests/unit/pipelex/core/packages/graph/test_data.py
+++ b/tests/unit/pipelex/core/packages/graph/test_data.py
@@ -28,6 +28,8 @@ ANALYTICS_LIB_ADDRESS = "github.com/pkg_test/analytics-lib"
 PHANTOM_PKG_ADDRESS = "github.com/pkg_test/phantom-pkg"
 QUALIFIED_REF_ADDRESS = "github.com/pkg_test/qualified-ref-pkg"
 MALFORMED_REF_ADDRESS = "github.com/pkg_test/malformed-ref-pkg"
+MULTI_DOMAIN_PKG_ADDRESS = "github.com/pkg_test/multi-domain-pkg"
+MULTI_DOMAIN_CONSUMER_ADDRESS = "github.com/pkg_test/multi-domain-consumer"
 
 
 def make_test_package_index() -> PackageIndex:
@@ -386,5 +388,112 @@ def make_test_package_index_with_malformed_cross_package_ref() -> PackageIndex:
         dependency_aliases={"scoring_dep": SCORING_LIB_ADDRESS},
     )
     index.add_entry(malformed_pkg)
+
+    return index
+
+
+def make_test_package_index_with_multi_domain_same_concept_code() -> PackageIndex:
+    """Build a PackageIndex where one package has the same concept code in two domains.
+
+    This tests that cross-package resolution picks the correct domain when
+    ``alias->domain.ConceptCode`` is used and the target package has that
+    concept code in multiple domains.
+
+    Creates:
+    - multi-domain-pkg with:
+      - Domain pkg_test_scoring: PkgTestMetric (concept_ref: pkg_test_scoring.PkgTestMetric)
+      - Domain pkg_test_analytics: PkgTestMetric (concept_ref: pkg_test_analytics.PkgTestMetric)
+      - Two pipes producing each variant
+    - multi-domain-consumer that:
+      - Depends on multi-domain-pkg (alias: multi_domain)
+      - Has a pipe consuming multi_domain->pkg_test_scoring.PkgTestMetric
+      - Has a pipe consuming multi_domain->pkg_test_analytics.PkgTestMetric
+    """
+    index = PackageIndex()
+
+    multi_domain_pkg = PackageIndexEntry(
+        address=MULTI_DOMAIN_PKG_ADDRESS,
+        version="1.0.0",
+        description="Package with same concept code in two domains",
+        domains=[
+            DomainEntry(domain_code="pkg_test_scoring"),
+            DomainEntry(domain_code="pkg_test_analytics"),
+        ],
+        concepts=[
+            ConceptEntry(
+                concept_code="PkgTestMetric",
+                domain_code="pkg_test_scoring",
+                concept_ref="pkg_test_scoring.PkgTestMetric",
+                description="A scoring metric",
+                structure_fields=["score_value"],
+            ),
+            ConceptEntry(
+                concept_code="PkgTestMetric",
+                domain_code="pkg_test_analytics",
+                concept_ref="pkg_test_analytics.PkgTestMetric",
+                description="An analytics metric",
+                structure_fields=["analytics_value"],
+            ),
+        ],
+        pipes=[
+            PipeSignature(
+                pipe_code="pkg_test_compute_scoring_metric",
+                pipe_type="PipeLLM",
+                domain_code="pkg_test_scoring",
+                description="Compute scoring metric from text",
+                input_specs={"text": "Text"},
+                output_spec="PkgTestMetric",
+                is_exported=True,
+            ),
+            PipeSignature(
+                pipe_code="pkg_test_compute_analytics_metric",
+                pipe_type="PipeLLM",
+                domain_code="pkg_test_analytics",
+                description="Compute analytics metric from text",
+                input_specs={"text": "Text"},
+                output_spec="PkgTestMetric",
+                is_exported=True,
+            ),
+        ],
+    )
+    index.add_entry(multi_domain_pkg)
+
+    multi_domain_consumer = PackageIndexEntry(
+        address=MULTI_DOMAIN_CONSUMER_ADDRESS,
+        version="1.0.0",
+        description="Consumer that references specific domains of multi-domain-pkg",
+        domains=[DomainEntry(domain_code="pkg_test_consumer")],
+        concepts=[
+            ConceptEntry(
+                concept_code="PkgTestConsumerResult",
+                domain_code="pkg_test_consumer",
+                concept_ref="pkg_test_consumer.PkgTestConsumerResult",
+                description="A consumer result",
+            ),
+        ],
+        pipes=[
+            PipeSignature(
+                pipe_code="pkg_test_use_scoring_metric",
+                pipe_type="PipeLLM",
+                domain_code="pkg_test_consumer",
+                description="Use scoring metric from dependency",
+                input_specs={"metric": "multi_domain->pkg_test_scoring.PkgTestMetric"},
+                output_spec="Text",
+                is_exported=True,
+            ),
+            PipeSignature(
+                pipe_code="pkg_test_use_analytics_metric",
+                pipe_type="PipeLLM",
+                domain_code="pkg_test_consumer",
+                description="Use analytics metric from dependency",
+                input_specs={"metric": "multi_domain->pkg_test_analytics.PkgTestMetric"},
+                output_spec="Text",
+                is_exported=True,
+            ),
+        ],
+        dependencies=[MULTI_DOMAIN_PKG_ADDRESS],
+        dependency_aliases={"multi_domain": MULTI_DOMAIN_PKG_ADDRESS},
+    )
+    index.add_entry(multi_domain_consumer)
 
     return index

--- a/tests/unit/pipelex/core/packages/graph/test_data.py
+++ b/tests/unit/pipelex/core/packages/graph/test_data.py
@@ -25,6 +25,7 @@ SCORING_LIB_ADDRESS = "github.com/pkg_test/scoring-lib"
 REFINING_APP_ADDRESS = "github.com/pkg_test/refining-app"
 LEGAL_TOOLS_ADDRESS = "github.com/pkg_test/legal-tools"
 ANALYTICS_LIB_ADDRESS = "github.com/pkg_test/analytics-lib"
+PHANTOM_PKG_ADDRESS = "github.com/pkg_test/phantom-pkg"
 
 
 def make_test_package_index() -> PackageIndex:
@@ -155,5 +156,64 @@ def make_test_package_index() -> PackageIndex:
         ],
     )
     index.add_entry(analytics_lib)
+
+    return index
+
+
+def make_test_package_index_with_unresolvable_concepts() -> PackageIndex:
+    """Build a PackageIndex containing pipes with unresolvable concept references.
+
+    Creates a package with:
+    - One valid concept (PkgTestValidConcept)
+    - One pipe with a valid output concept (pkg_test_valid_pipe)
+    - One pipe whose output references a nonexistent concept (pkg_test_bad_output_pipe)
+    - One pipe whose input references a nonexistent concept (pkg_test_bad_input_pipe)
+    """
+    index = PackageIndex()
+
+    phantom_pkg = PackageIndexEntry(
+        address=PHANTOM_PKG_ADDRESS,
+        version="1.0.0",
+        description="Package with unresolvable concept references",
+        domains=[DomainEntry(domain_code="pkg_test_phantom")],
+        concepts=[
+            ConceptEntry(
+                concept_code="PkgTestValidConcept",
+                domain_code="pkg_test_phantom",
+                concept_ref="pkg_test_phantom.PkgTestValidConcept",
+                description="A valid concept",
+            ),
+        ],
+        pipes=[
+            PipeSignature(
+                pipe_code="pkg_test_valid_pipe",
+                pipe_type="PipeLLM",
+                domain_code="pkg_test_phantom",
+                description="Valid pipe with resolvable concepts",
+                input_specs={"text": "Text"},
+                output_spec="PkgTestValidConcept",
+                is_exported=True,
+            ),
+            PipeSignature(
+                pipe_code="pkg_test_bad_output_pipe",
+                pipe_type="PipeLLM",
+                domain_code="pkg_test_phantom",
+                description="Pipe with unresolvable output concept",
+                input_specs={"text": "Text"},
+                output_spec="NonExistentOutputConcept",
+                is_exported=True,
+            ),
+            PipeSignature(
+                pipe_code="pkg_test_bad_input_pipe",
+                pipe_type="PipeLLM",
+                domain_code="pkg_test_phantom",
+                description="Pipe with unresolvable input concept",
+                input_specs={"data": "NonExistentInputConcept"},
+                output_spec="PkgTestValidConcept",
+                is_exported=True,
+            ),
+        ],
+    )
+    index.add_entry(phantom_pkg)
 
     return index

--- a/tests/unit/pipelex/core/packages/graph/test_data.py
+++ b/tests/unit/pipelex/core/packages/graph/test_data.py
@@ -26,6 +26,7 @@ REFINING_APP_ADDRESS = "github.com/pkg_test/refining-app"
 LEGAL_TOOLS_ADDRESS = "github.com/pkg_test/legal-tools"
 ANALYTICS_LIB_ADDRESS = "github.com/pkg_test/analytics-lib"
 PHANTOM_PKG_ADDRESS = "github.com/pkg_test/phantom-pkg"
+QUALIFIED_REF_ADDRESS = "github.com/pkg_test/qualified-ref-pkg"
 
 
 def make_test_package_index() -> PackageIndex:
@@ -215,5 +216,100 @@ def make_test_package_index_with_unresolvable_concepts() -> PackageIndex:
         ],
     )
     index.add_entry(phantom_pkg)
+
+    return index
+
+
+def make_test_package_index_with_qualified_concept_specs() -> PackageIndex:
+    """Build a PackageIndex with pipes that use domain-qualified and cross-package concept specs.
+
+    Creates:
+    - scoring-lib with PkgTestWeightedScore in domain pkg_test_scoring_dep
+    - qualified-ref-pkg that:
+      - Has its own concept PkgTestLocalResult in domain pkg_test_qualified
+      - Depends on scoring-lib (alias: scoring_dep)
+      - Has a pipe using a domain-qualified output spec (pkg_test_qualified.PkgTestLocalResult)
+      - Has a pipe using a cross-package input spec (scoring_dep->pkg_test_scoring_dep.PkgTestWeightedScore)
+    """
+    index = PackageIndex()
+
+    # scoring-lib (dependency)
+    scoring_lib = PackageIndexEntry(
+        address=SCORING_LIB_ADDRESS,
+        version="1.0.0",
+        description="Scoring library",
+        domains=[DomainEntry(domain_code="pkg_test_scoring_dep")],
+        concepts=[
+            ConceptEntry(
+                concept_code="PkgTestWeightedScore",
+                domain_code="pkg_test_scoring_dep",
+                concept_ref="pkg_test_scoring_dep.PkgTestWeightedScore",
+                description="A weighted score",
+            ),
+        ],
+        pipes=[
+            PipeSignature(
+                pipe_code="pkg_test_compute_score",
+                pipe_type="PipeLLM",
+                domain_code="pkg_test_scoring_dep",
+                description="Compute score from text",
+                input_specs={"text": "Text"},
+                output_spec="PkgTestWeightedScore",
+                is_exported=True,
+            ),
+        ],
+    )
+    index.add_entry(scoring_lib)
+
+    # qualified-ref-pkg (consumer with qualified concept specs)
+    qualified_ref_pkg = PackageIndexEntry(
+        address=QUALIFIED_REF_ADDRESS,
+        version="1.0.0",
+        description="Package using qualified concept references in pipes",
+        domains=[DomainEntry(domain_code="pkg_test_qualified")],
+        concepts=[
+            ConceptEntry(
+                concept_code="PkgTestLocalResult",
+                domain_code="pkg_test_qualified",
+                concept_ref="pkg_test_qualified.PkgTestLocalResult",
+                description="A local result concept",
+            ),
+        ],
+        pipes=[
+            # Pipe with domain-qualified output spec
+            PipeSignature(
+                pipe_code="pkg_test_produce_result",
+                pipe_type="PipeLLM",
+                domain_code="pkg_test_qualified",
+                description="Produce a local result from text",
+                input_specs={"text": "Text"},
+                output_spec="pkg_test_qualified.PkgTestLocalResult",
+                is_exported=True,
+            ),
+            # Pipe with cross-package input spec
+            PipeSignature(
+                pipe_code="pkg_test_consume_score",
+                pipe_type="PipeLLM",
+                domain_code="pkg_test_qualified",
+                description="Consume a cross-package weighted score",
+                input_specs={"score": "scoring_dep->pkg_test_scoring_dep.PkgTestWeightedScore"},
+                output_spec="Text",
+                is_exported=True,
+            ),
+            # Pipe with cross-package output spec
+            PipeSignature(
+                pipe_code="pkg_test_forward_score",
+                pipe_type="PipeLLM",
+                domain_code="pkg_test_qualified",
+                description="Forward a cross-package score",
+                input_specs={"text": "Text"},
+                output_spec="scoring_dep->pkg_test_scoring_dep.PkgTestWeightedScore",
+                is_exported=True,
+            ),
+        ],
+        dependencies=[SCORING_LIB_ADDRESS],
+        dependency_aliases={"scoring_dep": SCORING_LIB_ADDRESS},
+    )
+    index.add_entry(qualified_ref_pkg)
 
     return index

--- a/tests/unit/pipelex/core/packages/graph/test_data.py
+++ b/tests/unit/pipelex/core/packages/graph/test_data.py
@@ -27,6 +27,7 @@ LEGAL_TOOLS_ADDRESS = "github.com/pkg_test/legal-tools"
 ANALYTICS_LIB_ADDRESS = "github.com/pkg_test/analytics-lib"
 PHANTOM_PKG_ADDRESS = "github.com/pkg_test/phantom-pkg"
 QUALIFIED_REF_ADDRESS = "github.com/pkg_test/qualified-ref-pkg"
+MALFORMED_REF_ADDRESS = "github.com/pkg_test/malformed-ref-pkg"
 
 
 def make_test_package_index() -> PackageIndex:
@@ -311,5 +312,79 @@ def make_test_package_index_with_qualified_concept_specs() -> PackageIndex:
         dependency_aliases={"scoring_dep": SCORING_LIB_ADDRESS},
     )
     index.add_entry(qualified_ref_pkg)
+
+    return index
+
+
+def make_test_package_index_with_malformed_cross_package_ref() -> PackageIndex:
+    """Build a PackageIndex with a pipe whose cross-package remainder is malformed.
+
+    Creates a package with:
+    - One valid concept (PkgTestValidConcept)
+    - One valid pipe (pkg_test_valid_pipe) that uses bare concept codes
+    - One pipe (pkg_test_malformed_ref_pipe) whose output spec is a cross-package ref
+      with a malformed remainder (e.g. "scoring_dep->..BadRef") that would cause
+      QualifiedRefError if not caught
+    - scoring-lib as a dependency so the alias resolves
+    """
+    index = PackageIndex()
+
+    # scoring-lib (dependency)
+    scoring_lib = PackageIndexEntry(
+        address=SCORING_LIB_ADDRESS,
+        version="1.0.0",
+        description="Scoring library",
+        domains=[DomainEntry(domain_code="pkg_test_scoring_dep")],
+        concepts=[
+            ConceptEntry(
+                concept_code="PkgTestWeightedScore",
+                domain_code="pkg_test_scoring_dep",
+                concept_ref="pkg_test_scoring_dep.PkgTestWeightedScore",
+                description="A weighted score",
+            ),
+        ],
+        pipes=[],
+    )
+    index.add_entry(scoring_lib)
+
+    malformed_pkg = PackageIndexEntry(
+        address=MALFORMED_REF_ADDRESS,
+        version="1.0.0",
+        description="Package with malformed cross-package refs",
+        domains=[DomainEntry(domain_code="pkg_test_malformed")],
+        concepts=[
+            ConceptEntry(
+                concept_code="PkgTestValidConcept",
+                domain_code="pkg_test_malformed",
+                concept_ref="pkg_test_malformed.PkgTestValidConcept",
+                description="A valid concept",
+            ),
+        ],
+        pipes=[
+            # Valid pipe — should survive even if sibling has malformed ref
+            PipeSignature(
+                pipe_code="pkg_test_valid_pipe",
+                pipe_type="PipeLLM",
+                domain_code="pkg_test_malformed",
+                description="Valid pipe with resolvable concepts",
+                input_specs={"text": "Text"},
+                output_spec="PkgTestValidConcept",
+                is_exported=True,
+            ),
+            # Malformed cross-package ref: remainder starts with ".."
+            PipeSignature(
+                pipe_code="pkg_test_malformed_ref_pipe",
+                pipe_type="PipeLLM",
+                domain_code="pkg_test_malformed",
+                description="Pipe with malformed cross-package remainder",
+                input_specs={"text": "Text"},
+                output_spec="scoring_dep->..BadRef",
+                is_exported=True,
+            ),
+        ],
+        dependencies=[SCORING_LIB_ADDRESS],
+        dependency_aliases={"scoring_dep": SCORING_LIB_ADDRESS},
+    )
+    index.add_entry(malformed_pkg)
 
     return index

--- a/tests/unit/pipelex/core/packages/graph/test_graph_builder.py
+++ b/tests/unit/pipelex/core/packages/graph/test_graph_builder.py
@@ -8,11 +8,13 @@ from pipelex.core.packages.index.models import PackageIndex
 from tests.unit.pipelex.core.packages.graph.test_data import (
     ANALYTICS_LIB_ADDRESS,
     LEGAL_TOOLS_ADDRESS,
+    MALFORMED_REF_ADDRESS,
     PHANTOM_PKG_ADDRESS,
     QUALIFIED_REF_ADDRESS,
     REFINING_APP_ADDRESS,
     SCORING_LIB_ADDRESS,
     make_test_package_index,
+    make_test_package_index_with_malformed_cross_package_ref,
     make_test_package_index_with_qualified_concept_specs,
     make_test_package_index_with_unresolvable_concepts,
 )
@@ -275,3 +277,23 @@ class TestGraphBuilder:
             f"{QUALIFIED_REF_ADDRESS}::pkg_test_forward_score",
         }
         assert set(graph.pipe_nodes.keys()) == expected_pipes
+
+    def test_malformed_cross_package_ref_excluded_without_crash(self) -> None:
+        """Malformed cross-package remainder is excluded gracefully, not raising."""
+        index = make_test_package_index_with_malformed_cross_package_ref()
+        # This must not raise QualifiedRefError
+        graph = build_know_how_graph(index)
+
+        # The malformed pipe should be excluded
+        bad_key = f"{MALFORMED_REF_ADDRESS}::pkg_test_malformed_ref_pipe"
+        assert graph.get_pipe_node(bad_key) is None
+
+    def test_valid_pipe_survives_malformed_sibling(self) -> None:
+        """Valid pipe in same package is still included when sibling has malformed ref."""
+        index = make_test_package_index_with_malformed_cross_package_ref()
+        graph = build_know_how_graph(index)
+
+        valid_key = f"{MALFORMED_REF_ADDRESS}::pkg_test_valid_pipe"
+        pipe_node = graph.get_pipe_node(valid_key)
+        assert pipe_node is not None
+        assert pipe_node.output_concept_id.package_address == MALFORMED_REF_ADDRESS

--- a/tests/unit/pipelex/core/packages/graph/test_graph_builder.py
+++ b/tests/unit/pipelex/core/packages/graph/test_graph_builder.py
@@ -9,9 +9,11 @@ from tests.unit.pipelex.core.packages.graph.test_data import (
     ANALYTICS_LIB_ADDRESS,
     LEGAL_TOOLS_ADDRESS,
     PHANTOM_PKG_ADDRESS,
+    QUALIFIED_REF_ADDRESS,
     REFINING_APP_ADDRESS,
     SCORING_LIB_ADDRESS,
     make_test_package_index,
+    make_test_package_index_with_qualified_concept_specs,
     make_test_package_index_with_unresolvable_concepts,
 )
 
@@ -225,3 +227,51 @@ class TestGraphBuilder:
         assert len(non_native_keys) == 1
         expected_key = f"{PHANTOM_PKG_ADDRESS}::pkg_test_phantom.PkgTestValidConcept"
         assert non_native_keys[0] == expected_key
+
+    def test_domain_qualified_output_spec_resolved(self) -> None:
+        """Pipe with domain-qualified output spec (domain.ConceptCode) is included in graph."""
+        index = make_test_package_index_with_qualified_concept_specs()
+        graph = build_know_how_graph(index)
+
+        pipe_key = f"{QUALIFIED_REF_ADDRESS}::pkg_test_produce_result"
+        pipe_node = graph.get_pipe_node(pipe_key)
+        assert pipe_node is not None, f"Pipe '{pipe_key}' should be in graph but was excluded"
+        assert pipe_node.output_concept_id.package_address == QUALIFIED_REF_ADDRESS
+        assert pipe_node.output_concept_id.concept_ref == "pkg_test_qualified.PkgTestLocalResult"
+
+    def test_cross_package_input_spec_resolved(self) -> None:
+        """Pipe with cross-package input spec (alias->domain.Code) is included in graph."""
+        index = make_test_package_index_with_qualified_concept_specs()
+        graph = build_know_how_graph(index)
+
+        pipe_key = f"{QUALIFIED_REF_ADDRESS}::pkg_test_consume_score"
+        pipe_node = graph.get_pipe_node(pipe_key)
+        assert pipe_node is not None, f"Pipe '{pipe_key}' should be in graph but was excluded"
+        # The input should resolve to the scoring-lib's concept
+        score_input = pipe_node.input_concept_ids["score"]
+        assert score_input.package_address == SCORING_LIB_ADDRESS
+        assert score_input.concept_ref == "pkg_test_scoring_dep.PkgTestWeightedScore"
+
+    def test_cross_package_output_spec_resolved(self) -> None:
+        """Pipe with cross-package output spec (alias->domain.Code) is included in graph."""
+        index = make_test_package_index_with_qualified_concept_specs()
+        graph = build_know_how_graph(index)
+
+        pipe_key = f"{QUALIFIED_REF_ADDRESS}::pkg_test_forward_score"
+        pipe_node = graph.get_pipe_node(pipe_key)
+        assert pipe_node is not None, f"Pipe '{pipe_key}' should be in graph but was excluded"
+        assert pipe_node.output_concept_id.package_address == SCORING_LIB_ADDRESS
+        assert pipe_node.output_concept_id.concept_ref == "pkg_test_scoring_dep.PkgTestWeightedScore"
+
+    def test_all_qualified_ref_pipes_included(self) -> None:
+        """All pipes using qualified/cross-package concept specs are included in graph."""
+        index = make_test_package_index_with_qualified_concept_specs()
+        graph = build_know_how_graph(index)
+
+        expected_pipes = {
+            f"{SCORING_LIB_ADDRESS}::pkg_test_compute_score",
+            f"{QUALIFIED_REF_ADDRESS}::pkg_test_produce_result",
+            f"{QUALIFIED_REF_ADDRESS}::pkg_test_consume_score",
+            f"{QUALIFIED_REF_ADDRESS}::pkg_test_forward_score",
+        }
+        assert set(graph.pipe_nodes.keys()) == expected_pipes

--- a/tests/unit/pipelex/core/packages/graph/test_graph_builder.py
+++ b/tests/unit/pipelex/core/packages/graph/test_graph_builder.py
@@ -8,9 +8,11 @@ from pipelex.core.packages.index.models import PackageIndex
 from tests.unit.pipelex.core.packages.graph.test_data import (
     ANALYTICS_LIB_ADDRESS,
     LEGAL_TOOLS_ADDRESS,
+    PHANTOM_PKG_ADDRESS,
     REFINING_APP_ADDRESS,
     SCORING_LIB_ADDRESS,
     make_test_package_index,
+    make_test_package_index_with_unresolvable_concepts,
 )
 
 
@@ -185,3 +187,41 @@ class TestGraphBuilder:
         assert len(graph.concept_nodes) > 0
         native_keys = [key for key in graph.concept_nodes if key.startswith(NATIVE_PACKAGE_ADDRESS)]
         assert len(native_keys) == len(graph.concept_nodes)
+
+    def test_pipe_with_unresolvable_output_excluded(self) -> None:
+        """Pipe referencing a nonexistent output concept is excluded from the graph."""
+        index = make_test_package_index_with_unresolvable_concepts()
+        graph = build_know_how_graph(index)
+
+        bad_output_key = f"{PHANTOM_PKG_ADDRESS}::pkg_test_bad_output_pipe"
+        assert graph.get_pipe_node(bad_output_key) is None
+
+    def test_pipe_with_unresolvable_input_excluded(self) -> None:
+        """Pipe referencing a nonexistent input concept is excluded from the graph."""
+        index = make_test_package_index_with_unresolvable_concepts()
+        graph = build_know_how_graph(index)
+
+        bad_input_key = f"{PHANTOM_PKG_ADDRESS}::pkg_test_bad_input_pipe"
+        assert graph.get_pipe_node(bad_input_key) is None
+
+    def test_valid_pipe_not_affected_by_unresolvable_siblings(self) -> None:
+        """Valid pipes in the same package are still included when siblings have unresolvable concepts."""
+        index = make_test_package_index_with_unresolvable_concepts()
+        graph = build_know_how_graph(index)
+
+        valid_key = f"{PHANTOM_PKG_ADDRESS}::pkg_test_valid_pipe"
+        pipe_node = graph.get_pipe_node(valid_key)
+        assert pipe_node is not None
+        assert pipe_node.output_concept_id.package_address == PHANTOM_PKG_ADDRESS
+        assert pipe_node.output_concept_id.concept_ref == "pkg_test_phantom.PkgTestValidConcept"
+
+    def test_no_phantom_concept_nodes_created(self) -> None:
+        """Unresolvable concept specs do not create phantom entries in concept_nodes."""
+        index = make_test_package_index_with_unresolvable_concepts()
+        graph = build_know_how_graph(index)
+
+        # Only the valid concept and native concepts should exist
+        non_native_keys = [key for key in graph.concept_nodes if not key.startswith(NATIVE_PACKAGE_ADDRESS)]
+        assert len(non_native_keys) == 1
+        expected_key = f"{PHANTOM_PKG_ADDRESS}::pkg_test_phantom.PkgTestValidConcept"
+        assert non_native_keys[0] == expected_key

--- a/tests/unit/pipelex/core/packages/graph/test_graph_builder.py
+++ b/tests/unit/pipelex/core/packages/graph/test_graph_builder.py
@@ -9,12 +9,15 @@ from tests.unit.pipelex.core.packages.graph.test_data import (
     ANALYTICS_LIB_ADDRESS,
     LEGAL_TOOLS_ADDRESS,
     MALFORMED_REF_ADDRESS,
+    MULTI_DOMAIN_CONSUMER_ADDRESS,
+    MULTI_DOMAIN_PKG_ADDRESS,
     PHANTOM_PKG_ADDRESS,
     QUALIFIED_REF_ADDRESS,
     REFINING_APP_ADDRESS,
     SCORING_LIB_ADDRESS,
     make_test_package_index,
     make_test_package_index_with_malformed_cross_package_ref,
+    make_test_package_index_with_multi_domain_same_concept_code,
     make_test_package_index_with_qualified_concept_specs,
     make_test_package_index_with_unresolvable_concepts,
 )
@@ -297,3 +300,47 @@ class TestGraphBuilder:
         pipe_node = graph.get_pipe_node(valid_key)
         assert pipe_node is not None
         assert pipe_node.output_concept_id.package_address == MALFORMED_REF_ADDRESS
+
+    def test_cross_package_ref_resolves_correct_domain_when_same_code_in_multiple_domains(self) -> None:
+        """Cross-package ref alias->domain.Code resolves to the specified domain, not another domain with same code."""
+        index = make_test_package_index_with_multi_domain_same_concept_code()
+        graph = build_know_how_graph(index)
+
+        # Both concept nodes should exist in the multi-domain package
+        scoring_concept = ConceptId(
+            package_address=MULTI_DOMAIN_PKG_ADDRESS,
+            concept_ref="pkg_test_scoring.PkgTestMetric",
+        )
+        analytics_concept = ConceptId(
+            package_address=MULTI_DOMAIN_PKG_ADDRESS,
+            concept_ref="pkg_test_analytics.PkgTestMetric",
+        )
+        assert graph.get_concept_node(scoring_concept) is not None
+        assert graph.get_concept_node(analytics_concept) is not None
+
+        # The consumer pipe referencing multi_domain->pkg_test_scoring.PkgTestMetric
+        # must resolve to the scoring domain, NOT analytics
+        scoring_pipe_key = f"{MULTI_DOMAIN_CONSUMER_ADDRESS}::pkg_test_use_scoring_metric"
+        scoring_pipe = graph.get_pipe_node(scoring_pipe_key)
+        assert scoring_pipe is not None, f"Pipe '{scoring_pipe_key}' should be in graph"
+        scoring_input = scoring_pipe.input_concept_ids["metric"]
+        assert scoring_input.package_address == MULTI_DOMAIN_PKG_ADDRESS
+        assert scoring_input.concept_ref == "pkg_test_scoring.PkgTestMetric"
+
+        # The consumer pipe referencing multi_domain->pkg_test_analytics.PkgTestMetric
+        # must resolve to the analytics domain, NOT scoring
+        analytics_pipe_key = f"{MULTI_DOMAIN_CONSUMER_ADDRESS}::pkg_test_use_analytics_metric"
+        analytics_pipe = graph.get_pipe_node(analytics_pipe_key)
+        assert analytics_pipe is not None, f"Pipe '{analytics_pipe_key}' should be in graph"
+        analytics_input = analytics_pipe.input_concept_ids["metric"]
+        assert analytics_input.package_address == MULTI_DOMAIN_PKG_ADDRESS
+        assert analytics_input.concept_ref == "pkg_test_analytics.PkgTestMetric"
+
+    def test_multi_domain_same_code_both_concept_nodes_preserved(self) -> None:
+        """Same concept code in two domains within one package creates distinct nodes."""
+        index = make_test_package_index_with_multi_domain_same_concept_code()
+        graph = build_know_how_graph(index)
+
+        # Count non-native concept nodes from the multi-domain package
+        multi_domain_keys = [key for key in graph.concept_nodes if key.startswith(MULTI_DOMAIN_PKG_ADDRESS)]
+        assert len(multi_domain_keys) == 2, f"Expected 2 concept nodes for multi-domain-pkg, got {len(multi_domain_keys)}: {multi_domain_keys}"

--- a/tests/unit/pipelex/core/packages/test_dependency_resolver.py
+++ b/tests/unit/pipelex/core/packages/test_dependency_resolver.py
@@ -36,6 +36,7 @@ class TestDependencyResolver:
         assert dep.package_root == (PACKAGES_DIR / "scoring_dep").resolve()
         assert len(dep.mthds_files) >= 1
         # The scoring_dep has exports, so exported_pipe_codes should be populated
+        assert dep.exported_pipe_codes is not None
         assert "pkg_test_compute_score" in dep.exported_pipe_codes
 
     def test_dependency_without_path_is_skipped(self):
@@ -78,7 +79,7 @@ class TestDependencyResolver:
             resolve_local_dependencies(manifest=manifest, package_root=package_root)
 
     def test_dependency_without_manifest_has_no_exports(self):
-        """A dependency directory without METHODS.toml -> empty exported_pipe_codes (all public)."""
+        """A dependency directory without METHODS.toml -> None exported_pipe_codes (all public)."""
         manifest = MthdsPackageManifest(
             address="github.com/mthds/consumer-app",
             version="1.0.0",
@@ -99,8 +100,8 @@ class TestDependencyResolver:
         dep = resolved[0]
         assert dep.alias == "standalone"
         assert dep.manifest is None
-        # No manifest = empty exports = all public
-        assert dep.exported_pipe_codes == set()
+        # No manifest = None exports = all public
+        assert dep.exported_pipe_codes is None
 
     def test_resolved_dependency_is_frozen(self, tmp_path: Path):
         """ResolvedDependency should be immutable (frozen model)."""
@@ -110,6 +111,6 @@ class TestDependencyResolver:
             manifest=None,
             package_root=tmp_path / "test",
             mthds_files=[],
-            exported_pipe_codes=set(),
+            exported_pipe_codes=None,
         )
         assert dep.alias == "test"

--- a/tests/unit/pipelex/core/packages/test_lock_file.py
+++ b/tests/unit/pipelex/core/packages/test_lock_file.py
@@ -277,7 +277,7 @@ class TestLockFile:
                 manifest=None,
                 package_root=tmp_path / "local",
                 mthds_files=[],
-                exported_pipe_codes=set(),
+                exported_pipe_codes=None,
             ),
             ResolvedDependency(
                 alias="remote_dep",
@@ -285,7 +285,7 @@ class TestLockFile:
                 manifest=remote_manifest,
                 package_root=remote_dir,
                 mthds_files=[],
-                exported_pipe_codes=set(),
+                exported_pipe_codes=None,
             ),
         ]
 
@@ -323,7 +323,7 @@ class TestLockFile:
                 manifest=None,
                 package_root=local_dir,
                 mthds_files=[],
-                exported_pipe_codes=set(),
+                exported_pipe_codes=None,
             ),
         ]
 

--- a/tests/unit/pipelex/core/packages/test_transitive_resolver.py
+++ b/tests/unit/pipelex/core/packages/test_transitive_resolver.py
@@ -41,7 +41,7 @@ def _make_resolved(
         manifest=manifest,
         package_root=pkg_dir,
         mthds_files=[],
-        exported_pipe_codes=set(),
+        exported_pipe_codes=None,
     )
 
 
@@ -298,6 +298,109 @@ sub_dep = { address = "github.com/org/sub_dep", version = "^1.0.0" }
         result = resolve_all_dependencies(manifest_a, tmp_path)
         assert len(result) == 1
         assert result[0].alias == "local_pkg"
+
+    def test_diamond_re_resolve_recurses_into_new_sub_deps(self, mocker: MockerFixture, tmp_path: Path) -> None:
+        """When diamond re-resolution picks a new version, its sub-deps are resolved."""
+        # D v1.2.0 has sub-dep E (which D v1.0.0 did not have)
+        manifest_e = _make_manifest("github.com/org/pkg_e", "1.0.0")
+        manifest_d_v1 = _make_manifest("github.com/org/pkg_d", "1.0.0")
+        manifest_d_v1_2 = _make_manifest(
+            "github.com/org/pkg_d",
+            "1.2.0",
+            dependencies=[
+                PackageDependency(address="github.com/org/pkg_e", version="^1.0.0", alias="pkg_e"),
+            ],
+        )
+        manifest_b = _make_manifest(
+            "github.com/org/pkg_b",
+            "1.0.0",
+            dependencies=[
+                PackageDependency(address="github.com/org/pkg_d", version="^1.0.0", alias="pkg_d"),
+            ],
+        )
+        manifest_c = _make_manifest(
+            "github.com/org/pkg_c",
+            "1.0.0",
+            dependencies=[
+                PackageDependency(address="github.com/org/pkg_d", version="^1.1.0", alias="pkg_d"),
+            ],
+        )
+
+        resolved_b = _make_resolved("pkg_b", "github.com/org/pkg_b", manifest_b, tmp_path)
+        resolved_c = _make_resolved("pkg_c", "github.com/org/pkg_c", manifest_c, tmp_path)
+        resolved_d_v1 = _make_resolved("pkg_d", "github.com/org/pkg_d", manifest_d_v1, tmp_path)
+        resolved_e = _make_resolved("pkg_e", "github.com/org/pkg_e", manifest_e, tmp_path)
+
+        def mock_resolve_remote(dep: PackageDependency, **_kwargs: object) -> ResolvedDependency:
+            if dep.address == "github.com/org/pkg_b":
+                return resolved_b
+            if dep.address == "github.com/org/pkg_c":
+                return resolved_c
+            if dep.address == "github.com/org/pkg_d":
+                return resolved_d_v1
+            if dep.address == "github.com/org/pkg_e":
+                return resolved_e
+            msg = f"Unexpected address: {dep.address}"
+            raise AssertionError(msg)
+
+        mocker.patch(
+            "pipelex.core.packages.dependency_resolver.resolve_remote_dependency",
+            side_effect=mock_resolve_remote,
+        )
+
+        # First encounter of D: v1.0.0 satisfies ^1.0.0 but NOT ^1.1.0
+        mocker.patch(
+            "pipelex.core.packages.dependency_resolver.version_satisfies",
+            return_value=False,
+        )
+        mocker.patch(
+            "pipelex.core.packages.dependency_resolver.parse_constraint",
+            return_value=mocker.MagicMock(),
+        )
+        mocker.patch(
+            "pipelex.core.packages.dependency_resolver.parse_version",
+            return_value=Version("1.0.0"),
+        )
+
+        # Diamond re-resolution picks D v1.2.0
+        mocker.patch(
+            "pipelex.core.packages.dependency_resolver.list_remote_version_tags",
+            return_value=[(Version("1.0.0"), "v1.0.0"), (Version("1.2.0"), "v1.2.0")],
+        )
+        mocker.patch(
+            "pipelex.core.packages.dependency_resolver.select_minimum_version_for_multiple_constraints",
+            return_value=Version("1.2.0"),
+        )
+        mocker.patch(
+            "pipelex.core.packages.dependency_resolver.is_cached",
+            return_value=True,
+        )
+        mocker.patch(
+            "pipelex.core.packages.dependency_resolver.get_cached_package_path",
+            return_value=tmp_path / "pkg_d",
+        )
+        mocker.patch(
+            "pipelex.core.packages.dependency_resolver._find_manifest_in_dir",
+            return_value=manifest_d_v1_2,
+        )
+        mocker.patch(
+            "pipelex.core.packages.dependency_resolver.collect_mthds_files",
+            return_value=[],
+        )
+
+        manifest_a = _make_manifest(
+            "github.com/org/pkg_a",
+            "1.0.0",
+            dependencies=[
+                PackageDependency(address="github.com/org/pkg_b", version="^1.0.0", alias="pkg_b"),
+                PackageDependency(address="github.com/org/pkg_c", version="^1.0.0", alias="pkg_c"),
+            ],
+        )
+
+        result = resolve_all_dependencies(manifest_a, tmp_path)
+        addresses = {dep.address for dep in result}
+        # E should be resolved as a sub-dep of the re-resolved D v1.2.0
+        assert "github.com/org/pkg_e" in addresses
 
     def test_dedup_same_address(self, mocker: MockerFixture, tmp_path: Path) -> None:
         """Multiple paths to same address: resolved only once."""

--- a/tests/unit/pipelex/core/packages/test_transitive_resolver.py
+++ b/tests/unit/pipelex/core/packages/test_transitive_resolver.py
@@ -402,6 +402,141 @@ sub_dep = { address = "github.com/org/sub_dep", version = "^1.0.0" }
         # E should be resolved as a sub-dep of the re-resolved D v1.2.0
         assert "github.com/org/pkg_e" in addresses
 
+    def test_stale_subdep_constraints_cleaned_on_diamond_reresolution(self, mocker: MockerFixture, tmp_path: Path) -> None:
+        """Stale constraints from an old version's sub-deps are removed during diamond re-resolution.
+
+        Scenario: A→B→D@^1.0, A→C→D@^1.1. D@1.0.0 depends on E@^1.0.
+        Diamond re-resolves D to 1.1.0. D@1.1.0 depends on E@^2.0.
+        The stale E@^1.0 constraint from D@1.0.0 must be removed so E resolves
+        cleanly with just ^2.0 instead of failing on the incompatible [^1.0, ^2.0].
+        """
+        # E v2.0.0 (the version D@1.1.0 needs)
+        manifest_e = _make_manifest("github.com/org/pkg_e", "2.0.0")
+
+        # D v1.0.0 (old) depends on E@^1.0
+        manifest_d_v1 = _make_manifest(
+            "github.com/org/pkg_d",
+            "1.0.0",
+            dependencies=[
+                PackageDependency(address="github.com/org/pkg_e", version="^1.0.0", alias="pkg_e"),
+            ],
+        )
+        # D v1.1.0 (new, after diamond re-resolution) depends on E@^2.0
+        manifest_d_v1_1 = _make_manifest(
+            "github.com/org/pkg_d",
+            "1.1.0",
+            dependencies=[
+                PackageDependency(address="github.com/org/pkg_e", version="^2.0.0", alias="pkg_e"),
+            ],
+        )
+
+        # B depends on D@^1.0
+        manifest_b = _make_manifest(
+            "github.com/org/pkg_b",
+            "1.0.0",
+            dependencies=[
+                PackageDependency(address="github.com/org/pkg_d", version="^1.0.0", alias="pkg_d"),
+            ],
+        )
+        # C depends on D@^1.1
+        manifest_c = _make_manifest(
+            "github.com/org/pkg_c",
+            "1.0.0",
+            dependencies=[
+                PackageDependency(address="github.com/org/pkg_d", version="^1.1.0", alias="pkg_d"),
+            ],
+        )
+
+        resolved_b = _make_resolved("pkg_b", "github.com/org/pkg_b", manifest_b, tmp_path)
+        resolved_c = _make_resolved("pkg_c", "github.com/org/pkg_c", manifest_c, tmp_path)
+        resolved_d_v1 = _make_resolved("pkg_d", "github.com/org/pkg_d", manifest_d_v1, tmp_path)
+        resolved_e = _make_resolved("pkg_e", "github.com/org/pkg_e", manifest_e, tmp_path)
+
+        # Track which addresses were resolved via resolve_remote_dependency
+        remote_resolve_calls: list[str] = []
+
+        def mock_resolve_remote(dep: PackageDependency, **_kwargs: object) -> ResolvedDependency:
+            remote_resolve_calls.append(dep.address)
+            if dep.address == "github.com/org/pkg_b":
+                return resolved_b
+            if dep.address == "github.com/org/pkg_c":
+                return resolved_c
+            if dep.address == "github.com/org/pkg_d":
+                return resolved_d_v1  # First resolution gets v1.0.0
+            if dep.address == "github.com/org/pkg_e":
+                return resolved_e
+            msg = f"Unexpected address: {dep.address}"
+            raise AssertionError(msg)
+
+        mocker.patch(
+            "pipelex.core.packages.dependency_resolver.resolve_remote_dependency",
+            side_effect=mock_resolve_remote,
+        )
+
+        # version_satisfies: D@1.0.0 does NOT satisfy ^1.1.0
+        def mock_version_satisfies(version: Version, _constraint: object) -> bool:
+            return bool(version != Version("1.0.0"))
+
+        mocker.patch(
+            "pipelex.core.packages.dependency_resolver.version_satisfies",
+            side_effect=mock_version_satisfies,
+        )
+        mocker.patch(
+            "pipelex.core.packages.dependency_resolver.parse_constraint",
+            return_value=mocker.MagicMock(),
+        )
+        mocker.patch(
+            "pipelex.core.packages.dependency_resolver.parse_version",
+            return_value=Version("1.0.0"),
+        )
+
+        # Diamond re-resolution for D picks v1.1.0
+        mocker.patch(
+            "pipelex.core.packages.dependency_resolver.list_remote_version_tags",
+            return_value=[(Version("1.0.0"), "v1.0.0"), (Version("1.1.0"), "v1.1.0")],
+        )
+        mocker.patch(
+            "pipelex.core.packages.dependency_resolver.select_minimum_version_for_multiple_constraints",
+            return_value=Version("1.1.0"),
+        )
+        mocker.patch(
+            "pipelex.core.packages.dependency_resolver.is_cached",
+            return_value=True,
+        )
+        mocker.patch(
+            "pipelex.core.packages.dependency_resolver.get_cached_package_path",
+            return_value=tmp_path / "pkg_d",
+        )
+        mocker.patch(
+            "pipelex.core.packages.dependency_resolver._find_manifest_in_dir",
+            return_value=manifest_d_v1_1,
+        )
+        mocker.patch(
+            "pipelex.core.packages.dependency_resolver.collect_mthds_files",
+            return_value=[],
+        )
+
+        manifest_a = _make_manifest(
+            "github.com/org/pkg_a",
+            "1.0.0",
+            dependencies=[
+                PackageDependency(address="github.com/org/pkg_b", version="^1.0.0", alias="pkg_b"),
+                PackageDependency(address="github.com/org/pkg_c", version="^1.0.0", alias="pkg_c"),
+            ],
+        )
+
+        # Without the fix, this would raise TransitiveDependencyError because
+        # E would have stale constraint ^1.0.0 from D@1.0.0 plus ^2.0.0 from D@1.1.0
+        result = resolve_all_dependencies(manifest_a, tmp_path)
+        addresses = {dep.address for dep in result}
+
+        # E should be resolved (D@1.1.0's sub-dep)
+        assert "github.com/org/pkg_e" in addresses
+        # All deps should be present
+        assert "github.com/org/pkg_b" in addresses
+        assert "github.com/org/pkg_c" in addresses
+        assert "github.com/org/pkg_d" in addresses
+
     def test_dedup_same_address(self, mocker: MockerFixture, tmp_path: Path) -> None:
         """Multiple paths to same address: resolved only once."""
         manifest_d = _make_manifest("github.com/org/pkg_d", "1.0.0")


### PR DESCRIPTION
### 🔗 Related Issues

### 📝 Description

This PR fixes a critical issue in transitive dependency resolution where diamond dependency re-resolution would fail to resolve new sub-dependencies introduced by the re-resolved version.

**Problem:** When a diamond dependency (a package required by multiple dependents with conflicting version constraints) is re-resolved to a newer version, that newer version may have different sub-dependencies than the originally resolved version. The resolver was not recursing into these new sub-dependencies, leaving them unresolved.

**Solution:** After re-resolving a diamond dependency, the resolver now checks if the re-resolved version has a manifest with new remote sub-dependencies and recursively resolves them. This ensures all transitive dependencies are properly discovered and resolved.

**Additional improvements:**
- Changed `exported_pipe_codes` from `set[str]` to `set[str] | None` to distinguish between "no manifest (all pipes public)" and "manifest with explicit exports". This provides clearer semantics:
  - `None`: No manifest exists, all pipes are public
  - `set()`: Manifest exists with exports section, only listed pipes are public
  - `set[str]`: Manifest exists with specific exported pipes
- Updated graph builder to exclude pipes with unresolvable concept references instead of creating phantom concept nodes
- Added proper cleanup of temporary concept entries using try/finally in library manager
- Updated logging to handle the new `None` value for exported_pipe_codes

### 🔄 Type of Change
- [x] 🐛 Bug fix
- [x] 🧹 Code refactor
- [x] ✅ Test update

### 🧪 Tests

- Added `test_diamond_re_resolve_recurses_into_new_sub_deps` to verify that when a diamond dependency is re-resolved to a version with new sub-dependencies, those sub-dependencies are properly resolved
- Added `test_pipe_with_unresolvable_output_excluded`, `test_pipe_with_unresolvable_input_excluded`, `test_valid_pipe_not_affected_by_unresolvable_siblings`, and `test_no_phantom_concept_nodes_created` to verify pipes with unresolvable concepts are excluded from the graph
- Updated existing tests to account for the `exported_pipe_codes` semantic change

### 📋 Checklist

- [x] Linting / type-checking / unit tests pass locally with my changes
- [x] I've added tests that prove my fix is effective or that my feature works
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings

https://claude.ai/code/session_01NCAqMvGmELZTjtPzBgywg6

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core dependency resolution and graph construction logic; incorrect handling could change which packages/pipes are loaded or cause resolution failures, though changes are well-covered by new unit/integration tests.
> 
> **Overview**
> Fixes transitive dependency *diamond re-resolution* so that when a dependency is re-picked at a new version, the resolver (a) **removes stale sub-dependency constraints** from the replaced version and (b) **recurses into the newly selected version’s sub-dependencies**, preventing false conflicts and missing deps.
> 
> Clarifies package export semantics by changing `ResolvedDependency.exported_pipe_codes` from `set[str]` to `set[str] | None` (`None` = no manifest / no exports section ⇒ all public; empty set now means “explicit exports but no pipes”), updating index export checks, dependency loading filters, and logging accordingly.
> 
> Hardens `build_know_how_graph` concept resolution: supports domain-qualified and cross-package concept specs (`alias->domain.ConceptCode`), and **excludes pipes** whose input/output concepts can’t be resolved (including malformed qualified refs) instead of creating phantom concept nodes; adds/updates tests covering these scenarios and the diamond fixes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9308a8cb1efd67aeeba264250a42854727d93204. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->