### PR TITLE
mths-7 Add plxt tooling and MTHDS JSON Schema generator

### DIFF
--- a/.pipelex/toml_config.toml
+++ b/.pipelex/toml_config.toml
@@ -1,0 +1,123 @@
+# =============================================================================
+# Pipelex TOML Configuration for pipelex-demo
+# =============================================================================
+# Configures TOML/MTHDS formatting and linting behaviour for this project.
+# Powered by the Pipelex extension (plxt / taplo engine).
+#
+# Docs: https://taplo.tamasfe.dev/configuration/
+# =============================================================================
+
+# ---------------------------------------------------------------------------
+# File discovery
+# ---------------------------------------------------------------------------
+
+# Glob patterns for files to process.
+include = ["**/*.toml", "**/*.mthds", "**/*.plx"]
+
+exclude = [
+  ".venv/**",
+  ".mypy_cache/**",
+  ".ruff_cache/**",
+  ".pytest_cache/**",
+  "__pycache__/**",
+  "target/**",
+  "node_modules/**",
+  ".git/**",
+  "*.lock",
+] # Glob patterns for files to ignore.
+# These are evaluated relative to the config file location.
+
+# =============================================================================
+# Global formatting defaults
+# =============================================================================
+# These apply to every file matched by `include` unless overridden by a
+# [[rule]].formatting section below.  Every option is shown at its built-in
+# default so you can tune any of them in one place.
+
+[formatting]
+align_entries = false         # line up "=" signs across consecutive entries
+align_comments = true         # align end-of-line comments on consecutive lines
+align_single_comments = true  # also align lone comments (requires align_comments)
+array_trailing_comma = true
+array_auto_expand = true      # go multiline when array exceeds column_width
+array_auto_collapse = false   # don't re-collapse multiline arrays that fit
+inline_table_expand = true    # expand inline tables exceeding column_width
+compact_arrays = true         # [1, 2] not [ 1, 2 ]
+compact_inline_tables = false # keep spaces inside braces: { a = 1 }
+compact_entries = false       # keep spaces around "=": key = value
+column_width = 80
+indent_tables = false
+indent_entries = false
+indent_string = "  "
+trailing_newline = true
+reorder_keys = false
+reorder_arrays = false
+reorder_inline_tables = false
+allowed_blank_lines = 2
+crlf = false
+
+# =============================================================================
+# Per-file-type rules
+# =============================================================================
+# Each [[rule]] can narrow its scope with `include` / `exclude` globs and
+# provide its own [rule.formatting] overrides.  Options not listed here fall
+# back to the global [formatting] section above.
+
+
+# ---------------------------------------------------------------------------
+# Rule: TOML files
+# ---------------------------------------------------------------------------
+[[rule]]
+# Which files this rule applies to (relative globs).
+include = ["**/*.toml"]
+
+# Per-rule formatting overrides — all at defaults so you can tweak them
+# independently of .mthds files.
+[rule.formatting]
+# align_entries = false
+# align_comments = true
+# align_single_comments = true
+# array_trailing_comma = true
+# array_auto_expand = true
+# array_auto_collapse = true
+# inline_table_expand = true
+# compact_arrays = true
+# compact_inline_tables = false
+# compact_entries = false
+# column_width = 80
+# indent_tables = false
+# indent_entries = false
+# indent_string = "  "
+# trailing_newline = true
+# allowed_blank_lines = 2
+
+
+# ---------------------------------------------------------------------------
+# Rule: MTHDS files (Pipelex pipeline definitions)
+# ---------------------------------------------------------------------------
+[[rule]]
+# Which files this rule applies to (relative globs).
+include = ["**/*.mthds", "**/*.plx"]
+
+[rule.schema]
+path = "pipelex/language/mthds_schema.json"
+
+# Per-rule formatting overrides — all at defaults so you can tweak them
+# independently of .toml files.
+[rule.formatting]
+align_entries = true
+# align_comments = true
+# align_single_comments = true
+# array_trailing_comma = true
+# array_auto_expand = true
+# array_auto_collapse = true
+# inline_table_expand = true
+# compact_arrays = true
+# compact_inline_tables = false
+# compact_entries = false
+# column_width = 80
+# indent_tables = false
+# indent_entries = false
+# indent_string = "  "
+# trailing_newline = true
+# allowed_blank_lines = 2

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -22,10 +22,18 @@
     "python.testing.pytestEnabled": true,
     "djlint.showInstallError": false,
     "files.associations": {
-        "*.plx": "plx"
+        "*.plx": "mthds"
     },
     "editor.formatOnSave": true,
     "[html]": {
         "editor.formatOnSave": false
+    },
+    "[toml]": {
+        "editor.defaultFormatter": "Pipelex.pipelex",
+        "editor.formatOnSave": true
+    },
+    "[mthds]": {
+        "editor.defaultFormatter": "Pipelex.pipelex",
+        "editor.formatOnSave": true
     }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,13 +9,14 @@
    ```bash
    make agent-check
    # If the current system doesn't have the `make` command,
-   # lookup the "agent-check" target in the Makefile and run the commands one by one (targets fix-unused-imports format lint pyright mypy)
+   # lookup the "agent-check" target in the Makefile and run the commands one by one (targets fix-unused-imports format lint pyright mypy plxt-format plxt-lint)
    ```
 
    This runs multiple code quality tools:
    - Pyright: Static type checking
    - Ruff: Fix unused imports, lint, format  
    - Mypy: Static type checker
+   - plxt: Format and lint TOML, MTHDS, and PLX files
 
    Always fix any issues reported by these tools before proceeding.
 
@@ -81,6 +82,22 @@
    ```
 
    For standard installations, the virtual environment is named `.venv`. Always check this first. On Windows, the path is `.venv\Scripts\` instead of `.venv/bin/`.
+
+### Pipelex Dev CLI (`pipelex-dev`)
+
+   The `pipelex-dev` CLI provides internal development tools that are not distributed with the package. It is available in the virtual environment.
+
+   ```bash
+   .venv/bin/pipelex-dev --help
+   ```
+
+   Key commands:
+
+   - **`generate-mthds-schema`**: Regenerate the MTHDS JSON Schema (`pipelex/language/mthds_schema.json`). Run this after modifying `mthds_schema_generator.py`.
+
+     ```bash
+     .venv/bin/pipelex-dev generate-mthds-schema
+     ```
 
 ## Coding Standards & Best Practices for Python Code
 

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ VENV_PIPELEX := "$(VIRTUAL_ENV)/bin/pipelex"
 VENV_MKDOCS := "$(VIRTUAL_ENV)/bin/mkdocs"
 VENV_MIKE := "$(VIRTUAL_ENV)/bin/mike"
 VENV_PYLINT := "$(VIRTUAL_ENV)/bin/pylint"
+VENV_PLXT := RUST_LOG=warn "$(VIRTUAL_ENV)/bin/plxt"
 VENV_PIPELEX_DEV := "$(VIRTUAL_ENV)/bin/pipelex-dev"
 SKELETON_DIR := "$(HOME)/.pipelex-skeleton/"
 
@@ -58,6 +59,8 @@ make format                   - format with ruff format
 make lint                     - lint with ruff check
 make pyright                  - Check types with pyright
 make mypy                     - Check types with mypy
+make plxt-format              - Format TOML/MTHDS/PLX files with plxt
+make plxt-lint                - Lint TOML/MTHDS/PLX files with plxt
 
 make rules                    - Install agent rules for contributing to Pipelex
 make up-kit-configs           - Update kit configs from .pipelex/
@@ -67,6 +70,8 @@ make ccs                      - Shorthand -> check-config-sync
 make check-rules              - Verify installed agent rules match kit templates
 make check-urls               - Check all URLs in pipelex/urls.py for broken links (quiet)
 make cu                       - Check URLs with verbose output (shows details)
+make generate-mthds-schema    - Generate JSON Schema for .mthds files
+make gms                      - Shorthand -> generate-mthds-schema
 make update-gateway-models    - Update gateway models reference
 make ugm                      - Shorthand -> update-gateway-models
 make check-gateway-models     - Check gateway models reference is up-to-date
@@ -84,6 +89,8 @@ make merge-check-ruff-lint    - Run ruff merge check without updating files
 make merge-check-ruff-format  - Run ruff merge check without updating files
 make merge-check-mypy         - Run mypy merge check without updating files
 make merge-check-pyright	  - Run pyright merge check without updating files
+make merge-check-plxt-format  - Run plxt format check without modifying files
+make merge-check-plxt-lint    - Run plxt lint check
 
 make v                        - Shorthand -> validate
 make codex-tests              - Run tests for Codex (exit on first failure) (no inference, no codex_disabled)
@@ -148,7 +155,7 @@ export HELP
 
 .PHONY: \
 	all help env env-verbose check-uv check-uv-verbose lock install update build \
-	format lint pyright mypy pylint \
+	format lint pyright mypy pylint plxt-format plxt-lint \
     rules up-kit-configs ukc check-config-sync ccs check-rules check-urls cu insert-skeleton \
 	cleanderived cleanenv cleanall \
 	test test-xdist t test-quiet tq test-with-prints tp test-inference ti \
@@ -156,9 +163,10 @@ export HELP
 	run-all-tests run-manual-trigger-gha-tests run-gha_disabled-tests \
 	validate v check c cc agent-check agent-test \
 	test-durations td test-durations-serial tds test-time tt test-time-serial tts \
-	merge-check-ruff-lint merge-check-ruff-format merge-check-mypy merge-check-pyright \
+	merge-check-ruff-lint merge-check-ruff-format merge-check-mypy merge-check-pyright merge-check-plxt-format merge-check-plxt-lint \
 	li check-unused-imports fix-unused-imports check-TODOs check-uv \
 	docs docs-check docs-serve-versioned docs-list docs-deploy docs-deploy-stable docs-deploy-specific-version docs-delete \
+	generate-mthds-schema gms \
 	update-gateway-models ugm check-gateway-models cgm up \
 	test-count check-test-badge \
 	serve-graph serve-graph-bg stop-graph-server view-graph sg vg \
@@ -224,6 +232,12 @@ lock: env
 	@uv lock && \
 	echo uv lock without update;
 
+plxt: env ## Rebuild and reinstall plxt CLI from local vscode-pipelex source
+	$(call PRINT_TITLE,"Reinstalling plxt from source")
+	@. $(VIRTUAL_ENV)/bin/activate && \
+	uv sync --all-extras --reinstall-package plxt && \
+	echo "Reinstalled plxt in ${VIRTUAL_ENV}";
+
 update: env
 	$(call PRINT_TITLE,"Updating all dependencies")
 	@uv lock --upgrade && \
@@ -275,6 +289,15 @@ check-config-sync: env
 
 ccs: check-config-sync
 	@echo "> done: ccs = check-config-sync"
+
+generate-mthds-schema: env
+	$(call PRINT_TITLE,"Generating MTHDS JSON Schema")
+	$(VENV_PIPELEX_DEV) generate-mthds-schema
+
+gms: generate-mthds-schema
+	@echo "> done: gms = generate-mthds-schema"
+
+# TODO: Add check-mthds-schema target (like check-gateway-models) for CI freshness verification
 
 update-gateway-models: env
 	$(call PRINT_TITLE,"Updating gateway models reference")
@@ -687,6 +710,14 @@ pylint: env
 	$(call PRINT_TITLE,"Linting with pylint")
 	$(VENV_PYLINT) --rcfile pyproject.toml pipelex tests
 
+plxt-format: env
+	$(call PRINT_TITLE,"Formatting TOML/MTHDS with plxt")
+	$(VENV_PLXT) fmt
+
+plxt-lint: env
+	$(call PRINT_TITLE,"Linting TOML/MTHDS with plxt")
+	$(VENV_PLXT) lint
+
 
 ##########################################################################################
 ### MERGE CHECKS
@@ -711,6 +742,14 @@ merge-check-mypy: env
 merge-check-pylint: env
 	$(call PRINT_TITLE,"Linting with pylint")
 	$(VENV_PYLINT) --rcfile pyproject.toml .
+
+merge-check-plxt-format: env
+	$(call PRINT_TITLE,"Checking TOML/MTHDS formatting with plxt")
+	$(VENV_PLXT) fmt --check
+
+merge-check-plxt-lint: env
+	$(call PRINT_TITLE,"Linting TOML/MTHDS with plxt")
+	$(VENV_PLXT) lint
 
 ##########################################################################################
 ### MISCELLANEOUS
@@ -829,7 +868,7 @@ vg: view-graph
 ### SHORTHANDS
 ##########################################################################################
 
-c: format lint pyright mypy
+c: format lint pyright mypy plxt-format plxt-lint
 	@echo "> done: c = check"
 
 cc: cleanderived regenerate-test-models-quiet c
@@ -841,7 +880,7 @@ up: update-gateway-models up-kit-configs rules
 check: cc check-unused-imports check-config-sync check-rules check-urls check-gateway-models pylint
 	@echo "> done: check"
 
-agent-check: fix-unused-imports format lint pyright mypy
+agent-check: fix-unused-imports format lint pyright mypy plxt-format plxt-lint
 	@echo "> done: agent-check"
 
 v: validate

--- a/Makefile
+++ b/Makefile
@@ -710,13 +710,19 @@ pylint: env
 	$(call PRINT_TITLE,"Linting with pylint")
 	$(VENV_PYLINT) --rcfile pyproject.toml pipelex tests
 
-plxt-format: env
-	$(call PRINT_TITLE,"Formatting TOML/MTHDS with plxt")
-	$(VENV_PLXT) fmt
+# No-op: disabled to pass CI/CD before we reformat all the TOML and PLX files
+# plxt-format: env
+# 	$(call PRINT_TITLE,"Formatting TOML/MTHDS with plxt")
+# 	$(VENV_PLXT) fmt
+plxt-format:
+	@true
 
-plxt-lint: env
-	$(call PRINT_TITLE,"Linting TOML/MTHDS with plxt")
-	$(VENV_PLXT) lint
+# No-op: disabled to pass CI/CD before we reformat all the TOML and PLX files
+# plxt-lint: env
+# 	$(call PRINT_TITLE,"Linting TOML/MTHDS with plxt")
+# 	$(VENV_PLXT) lint
+plxt-lint:
+	@true
 
 
 ##########################################################################################

--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,10 @@ make update                   - Upgrade dependencies via uv
 make validate                 - Run the setup sequence to validate the config and libraries
 make build                    - Build the wheels
 
-make format                   - format with ruff format
-make lint                     - lint with ruff check
+make format                   - format with ruff and plxt
+make lint                     - lint with ruff and plxt
+make ruff-format              - format with ruff format
+make ruff-lint                - lint with ruff check
 make pyright                  - Check types with pyright
 make mypy                     - Check types with mypy
 make plxt-format              - Format TOML/MTHDS/PLX files with plxt
@@ -155,7 +157,7 @@ export HELP
 
 .PHONY: \
 	all help env env-verbose check-uv check-uv-verbose lock install update build \
-	format lint pyright mypy pylint plxt-format plxt-lint \
+	format lint ruff-format ruff-lint pyright mypy pylint plxt-format plxt-lint \
     rules up-kit-configs ukc check-config-sync ccs check-rules check-urls cu insert-skeleton \
 	cleanderived cleanenv cleanall \
 	test test-xdist t test-quiet tq test-with-prints tp test-inference ti \
@@ -687,16 +689,30 @@ cm: cov-missing
 	@echo "> done: cm = cov-missing"
 
 ##########################################################################################
-### LINTING
+### FORMATTING, LINTING, AND TYPECHECKING
 ##########################################################################################
 
-format: env
+ruff-format: env
 	$(call PRINT_TITLE,"Formatting with ruff")
 	$(VENV_RUFF) format . --config pyproject.toml
 
-lint: env
+ruff-lint: env
 	$(call PRINT_TITLE,"Linting with ruff")
 	$(VENV_RUFF) check . --fix --config pyproject.toml
+
+plxt-format: env
+	$(call PRINT_TITLE,"Formatting TOML/MTHDS with plxt")
+	$(VENV_PLXT) fmt
+
+plxt-lint: env
+	$(call PRINT_TITLE,"Linting TOML/MTHDS with plxt")
+	$(VENV_PLXT) lint
+
+format: ruff-format plxt-format
+	@echo "> done: format = ruff-format plxt-format"
+
+lint: ruff-lint plxt-lint
+	@echo "> done: lint = ruff-lint plxt-lint"
 
 pyright: env
 	$(call PRINT_TITLE,"Typechecking with pyright")
@@ -709,20 +725,6 @@ mypy: env
 pylint: env
 	$(call PRINT_TITLE,"Linting with pylint")
 	$(VENV_PYLINT) --rcfile pyproject.toml pipelex tests
-
-# No-op: disabled to pass CI/CD before we reformat all the TOML and PLX files
-# plxt-format: env
-# 	$(call PRINT_TITLE,"Formatting TOML/MTHDS with plxt")
-# 	$(VENV_PLXT) fmt
-plxt-format:
-	@true
-
-# No-op: disabled to pass CI/CD before we reformat all the TOML and PLX files
-# plxt-lint: env
-# 	$(call PRINT_TITLE,"Linting TOML/MTHDS with plxt")
-# 	$(VENV_PLXT) lint
-plxt-lint:
-	@true
 
 
 ##########################################################################################
@@ -874,7 +876,7 @@ vg: view-graph
 ### SHORTHANDS
 ##########################################################################################
 
-c: format lint pyright mypy plxt-format plxt-lint
+c: format lint pyright mypy
 	@echo "> done: c = check"
 
 cc: cleanderived regenerate-test-models-quiet c
@@ -886,7 +888,7 @@ up: update-gateway-models up-kit-configs rules
 check: cc check-unused-imports check-config-sync check-rules check-urls check-gateway-models pylint
 	@echo "> done: check"
 
-agent-check: fix-unused-imports format lint pyright mypy plxt-format plxt-lint
+agent-check: fix-unused-imports format lint pyright mypy
 	@echo "> done: agent-check"
 
 v: validate

--- a/docs/home/9-tools/plxt.md
+++ b/docs/home/9-tools/plxt.md
@@ -1,0 +1,124 @@
+# plxt (Formatter & Linter)
+
+## Overview
+
+`plxt` is a fast formatting and linting tool for TOML, MTHDS, and PLX files in Pipelex projects. It ensures consistent style across all configuration and pipeline definition files, powered by the [taplo](https://taplo.tamasfe.dev/) engine.
+
+## Installation
+
+`plxt` is included as a Pipelex development dependency. It is automatically installed into your virtual environment when you run:
+
+```bash
+make install
+```
+
+You can verify the installation with:
+
+```bash
+.venv/bin/plxt --help
+```
+
+## Configuration
+
+`plxt` reads its configuration from `.pipelex/toml_config.toml` at the root of your project. This file controls file discovery, formatting rules, and per-file-type overrides.
+
+### File Discovery
+
+The `include` and `exclude` top-level keys control which files `plxt` processes:
+
+```toml
+include = ["**/*.toml", "**/*.mthds", "**/*.plx"]
+
+exclude = [
+  ".venv/**",
+  ".mypy_cache/**",
+  ".ruff_cache/**",
+  ".pytest_cache/**",
+  "__pycache__/**",
+  "target/**",
+  "node_modules/**",
+  ".git/**",
+  "*.lock",
+]
+```
+
+### Supported File Types
+
+| Extension | Description |
+|-----------|-------------|
+| `.toml` | Standard TOML configuration files |
+| `.mthds` | Pipelex pipeline method definitions |
+| `.plx` | Pipelex pipeline execution files |
+
+### Key Formatting Options
+
+The `[formatting]` section in `toml_config.toml` controls the global formatting behavior. Each option can be overridden per file type using `[[rule]]` sections.
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `align_entries` | `true` | Align consecutive `key = value` entries so `=` signs line up |
+| `align_comments` | `true` | Align end-of-line comments on consecutive lines |
+| `array_trailing_comma` | `true` | Add a trailing comma after the last element in multiline arrays |
+| `array_auto_expand` | `true` | Expand arrays to multiple lines when exceeding `column_width` |
+| `column_width` | `80` | Target maximum line width used for auto-expand/collapse |
+| `compact_arrays` | `true` | Omit spaces inside single-line array brackets |
+| `trailing_newline` | `true` | Ensure files end with a newline character |
+| `reorder_keys` | `false` | Sort top-level keys alphabetically |
+
+For the full list of options, see the comments in `.pipelex/toml_config.toml` or the [taplo configuration reference](https://taplo.tamasfe.dev/configuration/).
+
+### Per-File-Type Rules
+
+You can define `[[rule]]` sections to apply different formatting settings to different file types. For example, the default configuration includes separate rules for `.toml` files and for `.mthds`/`.plx` files:
+
+```toml
+[[rule]]
+include = ["**/*.toml"]
+[rule.formatting]
+# TOML-specific overrides here
+
+[[rule]]
+include = ["**/*.mthds", "**/*.plx"]
+[rule.formatting]
+align_entries = true
+array_auto_collapse = true
+# ... more MTHDS/PLX-specific overrides
+```
+
+## Usage
+
+### Command Line
+
+Format all discovered files in place:
+
+```bash
+.venv/bin/plxt fmt
+```
+
+Check formatting without modifying files (useful for CI):
+
+```bash
+.venv/bin/plxt fmt --check
+```
+
+Lint all discovered files:
+
+```bash
+.venv/bin/plxt lint
+```
+
+### Make Targets
+
+The following Make targets are available for convenience:
+
+| Target | Description |
+|--------|-------------|
+| `make plxt-format` | Format all TOML/MTHDS/PLX files |
+| `make plxt-lint` | Lint all TOML/MTHDS/PLX files |
+| `make merge-check-plxt-format` | Check formatting without modifying files |
+| `make merge-check-plxt-lint` | Run lint check |
+
+`plxt` is also included in the composite check targets:
+
+- `make c` (check) runs `plxt-format` and `plxt-lint` alongside ruff, pyright, and mypy
+- `make agent-check` includes `plxt-format` and `plxt-lint` in the full quality pipeline

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -187,6 +187,7 @@ nav:
           - Inputs: home/9-tools/cli/build/inputs.md
           - Output: home/9-tools/cli/build/output.md
       - Pipe Builder: home/9-tools/pipe-builder.md
+      - plxt (Formatter & Linter): home/9-tools/plxt.md
       - Logging: home/9-tools/logging.md
     - Advanced Customizations:
       - Overview: home/10-advanced-customizations/index.md

--- a/pipelex/cli/dev_cli/_dev_cli.py
+++ b/pipelex/cli/dev_cli/_dev_cli.py
@@ -1,6 +1,7 @@
 """Main entry point for the internal development CLI."""
 
 import sys
+from pathlib import Path
 from typing import Annotated
 
 import typer
@@ -13,6 +14,7 @@ from pipelex.cli.dev_cli.commands.check_config_sync_cmd import LeadingConfig, ch
 from pipelex.cli.dev_cli.commands.check_gateway_models_cmd import check_gateway_models_cmd
 from pipelex.cli.dev_cli.commands.check_rules_sync_cmd import check_rules_sync_cmd
 from pipelex.cli.dev_cli.commands.check_urls_cmd import DEFAULT_TIMEOUT, check_urls_cmd
+from pipelex.cli.dev_cli.commands.generate_mthds_schema_cmd import generate_mthds_schema_cmd
 from pipelex.cli.dev_cli.commands.kit_cmd import kit_app
 from pipelex.cli.dev_cli.commands.preprocess_test_models_cmd import preprocess_test_models_cmd
 from pipelex.cli.dev_cli.commands.sync_main_config_cmd import SyncTarget, sync_main_config_cmd
@@ -32,6 +34,7 @@ class PipelexDevCLI(TyperGroup):
             "check-gateway-models",
             "check-rules",
             "check-urls",
+            "generate-mthds-schema",
             "kit",
             "preprocess-test-models",
             "sync-main-config",
@@ -128,6 +131,24 @@ def check_urls_command(
     """Check all URLs in pipelex/urls.py for broken links."""
     try:
         check_urls_cmd(quiet=quiet, timeout=timeout)
+    except Exception:
+        console = get_console()
+        console.print()
+        console.print("[bold red]Unexpected error occurred[/bold red]")
+        console.print()
+        console.print(Traceback())
+        sys.exit(1)
+
+
+@app.command(name="generate-mthds-schema", help="Generate JSON Schema for .mthds files (for Taplo validation)")
+def generate_mthds_schema_command(
+    output: Annotated[str | None, typer.Option("--output", "-o", help="Custom output path for the schema file")] = None,
+    quiet: Annotated[bool, typer.Option("--quiet", "-q", help="Output only a single validation line")] = False,
+) -> None:
+    """Generate a Taplo-compatible JSON Schema from MTHDS blueprint classes."""
+    try:
+        output_path = Path(output) if output else None
+        generate_mthds_schema_cmd(output=output_path, quiet=quiet)
     except Exception:
         console = get_console()
         console.print()

--- a/pipelex/cli/dev_cli/commands/generate_mthds_schema_cmd.py
+++ b/pipelex/cli/dev_cli/commands/generate_mthds_schema_cmd.py
@@ -1,0 +1,65 @@
+"""Command to generate JSON Schema for .mthds files."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from rich.panel import Panel
+
+from pipelex.hub import get_console
+from pipelex.language.mthds_schema_generator import generate_mthds_schema
+
+# Path to the generated schema file, alongside mthds_factory.py and mthds_config.py
+MTHDS_SCHEMA_PATH = Path("pipelex/language/mthds_schema.json")
+
+
+def generate_mthds_schema_cmd(output: Path | None = None, quiet: bool = False) -> None:
+    """Generate a Taplo-compatible JSON Schema for .mthds files.
+
+    Generates the schema from PipelexBundleBlueprint and writes it as JSON.
+    The schema enables IDE validation and autocompletion in the vscode-pipelex extension.
+
+    Args:
+        output: Custom output path. Defaults to pipelex/language/mthds_schema.json.
+        quiet: If True, output only a single validation line.
+    """
+    console = get_console()
+    output_path = output or MTHDS_SCHEMA_PATH
+
+    if not quiet:
+        console.print()
+        console.print("[bold]Generating MTHDS JSON Schema...[/bold]")
+        console.print()
+
+    try:
+        schema = generate_mthds_schema()
+    except Exception:
+        if quiet:
+            console.print("[red]\u2717 MTHDS schema generation: FAILED[/red]")
+        else:
+            console.print("[bold red]\u2717 Failed to generate MTHDS schema[/bold red]")
+        sys.exit(1)
+
+    # Ensure parent directory exists
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Write the schema file
+    schema_json = json.dumps(schema, indent=2, ensure_ascii=False) + "\n"
+    output_path.write_text(schema_json, encoding="utf-8")
+
+    # Count definitions for reporting
+    definition_count = len(schema.get("definitions", {}))
+
+    if quiet:
+        console.print(f"[green]\u2713 MTHDS schema generation: PASSED[/green] ({definition_count} definitions)")
+    else:
+        success_panel = Panel(
+            f"[green]\u2713[/green] Schema generated successfully!\n\n[dim]Output: {output_path}[/dim]\n[dim]Definitions: {definition_count}[/dim]",
+            title="[bold green]MTHDS Schema Generation: PASSED[/bold green]",
+            border_style="green",
+            padding=(1, 2),
+        )
+        console.print(success_panel)
+        console.print()

--- a/pipelex/kit/agent_rules/codex_commands.md
+++ b/pipelex/kit/agent_rules/codex_commands.md
@@ -7,13 +7,14 @@
    ```bash
    make agent-check
    # If the current system doesn't have the `make` command,
-   # lookup the "agent-check" target in the Makefile and run the commands one by one (targets fix-unused-imports format lint pyright mypy)
+   # lookup the "agent-check" target in the Makefile and run the commands one by one (targets fix-unused-imports format lint pyright mypy plxt-format plxt-lint)
    ```
 
    This runs multiple code quality tools:
    - Pyright: Static type checking
    - Ruff: Fix unused imports, lint, format  
    - Mypy: Static type checker
+   - plxt: Format and lint TOML, MTHDS, and PLX files
 
    Always fix any issues reported by these tools before proceeding.
 
@@ -49,6 +50,22 @@
    ```
 
    For standard installations, the virtual environment is named `.venv`. Always check this first. On Windows, the path is `.venv\Scripts\` instead of `.venv/bin/`.
+
+## Pipelex Dev CLI (`pipelex-dev`)
+
+   The `pipelex-dev` CLI provides internal development tools that are not distributed with the package. It is available in the virtual environment.
+
+   ```bash
+   .venv/bin/pipelex-dev --help
+   ```
+
+   Key commands:
+
+   - **`generate-mthds-schema`**: Regenerate the MTHDS JSON Schema (`pipelex/language/mthds_schema.json`). Run this after modifying `mthds_schema_generator.py`.
+
+     ```bash
+     .venv/bin/pipelex-dev generate-mthds-schema
+     ```
 
 ## Pipelex CLI Commands
 

--- a/pipelex/kit/agent_rules/commands.md
+++ b/pipelex/kit/agent_rules/commands.md
@@ -7,13 +7,14 @@
    ```bash
    make agent-check
    # If the current system doesn't have the `make` command,
-   # lookup the "agent-check" target in the Makefile and run the commands one by one (targets fix-unused-imports format lint pyright mypy)
+   # lookup the "agent-check" target in the Makefile and run the commands one by one (targets fix-unused-imports format lint pyright mypy plxt-format plxt-lint)
    ```
 
    This runs multiple code quality tools:
    - Pyright: Static type checking
    - Ruff: Fix unused imports, lint, format  
    - Mypy: Static type checker
+   - plxt: Format and lint TOML, MTHDS, and PLX files
 
    Always fix any issues reported by these tools before proceeding.
 
@@ -79,3 +80,19 @@
    ```
 
    For standard installations, the virtual environment is named `.venv`. Always check this first. On Windows, the path is `.venv\Scripts\` instead of `.venv/bin/`.
+
+## Pipelex Dev CLI (`pipelex-dev`)
+
+   The `pipelex-dev` CLI provides internal development tools that are not distributed with the package. It is available in the virtual environment.
+
+   ```bash
+   .venv/bin/pipelex-dev --help
+   ```
+
+   Key commands:
+
+   - **`generate-mthds-schema`**: Regenerate the MTHDS JSON Schema (`pipelex/language/mthds_schema.json`). Run this after modifying `mthds_schema_generator.py`.
+
+     ```bash
+     .venv/bin/pipelex-dev generate-mthds-schema
+     ```

--- a/pipelex/kit/configs/toml_config.toml
+++ b/pipelex/kit/configs/toml_config.toml
@@ -1,0 +1,123 @@
+# =============================================================================
+# Pipelex TOML Configuration for pipelex-demo
+# =============================================================================
+# Configures TOML/MTHDS formatting and linting behaviour for this project.
+# Powered by the Pipelex extension (plxt / taplo engine).
+#
+# Docs: https://taplo.tamasfe.dev/configuration/
+# =============================================================================
+
+# ---------------------------------------------------------------------------
+# File discovery
+# ---------------------------------------------------------------------------
+
+# Glob patterns for files to process.
+include = ["**/*.toml", "**/*.mthds", "**/*.plx"]
+
+exclude = [
+  ".venv/**",
+  ".mypy_cache/**",
+  ".ruff_cache/**",
+  ".pytest_cache/**",
+  "__pycache__/**",
+  "target/**",
+  "node_modules/**",
+  ".git/**",
+  "*.lock",
+] # Glob patterns for files to ignore.
+# These are evaluated relative to the config file location.
+
+# =============================================================================
+# Global formatting defaults
+# =============================================================================
+# These apply to every file matched by `include` unless overridden by a
+# [[rule]].formatting section below.  Every option is shown at its built-in
+# default so you can tune any of them in one place.
+
+[formatting]
+align_entries = false         # line up "=" signs across consecutive entries
+align_comments = true         # align end-of-line comments on consecutive lines
+align_single_comments = true  # also align lone comments (requires align_comments)
+array_trailing_comma = true
+array_auto_expand = true      # go multiline when array exceeds column_width
+array_auto_collapse = false   # don't re-collapse multiline arrays that fit
+inline_table_expand = true    # expand inline tables exceeding column_width
+compact_arrays = true         # [1, 2] not [ 1, 2 ]
+compact_inline_tables = false # keep spaces inside braces: { a = 1 }
+compact_entries = false       # keep spaces around "=": key = value
+column_width = 80
+indent_tables = false
+indent_entries = false
+indent_string = "  "
+trailing_newline = true
+reorder_keys = false
+reorder_arrays = false
+reorder_inline_tables = false
+allowed_blank_lines = 2
+crlf = false
+
+# =============================================================================
+# Per-file-type rules
+# =============================================================================
+# Each [[rule]] can narrow its scope with `include` / `exclude` globs and
+# provide its own [rule.formatting] overrides.  Options not listed here fall
+# back to the global [formatting] section above.
+
+
+# ---------------------------------------------------------------------------
+# Rule: TOML files
+# ---------------------------------------------------------------------------
+[[rule]]
+# Which files this rule applies to (relative globs).
+include = ["**/*.toml"]
+
+# Per-rule formatting overrides — all at defaults so you can tweak them
+# independently of .mthds files.
+[rule.formatting]
+# align_entries = false
+# align_comments = true
+# align_single_comments = true
+# array_trailing_comma = true
+# array_auto_expand = true
+# array_auto_collapse = true
+# inline_table_expand = true
+# compact_arrays = true
+# compact_inline_tables = false
+# compact_entries = false
+# column_width = 80
+# indent_tables = false
+# indent_entries = false
+# indent_string = "  "
+# trailing_newline = true
+# allowed_blank_lines = 2
+
+
+# ---------------------------------------------------------------------------
+# Rule: MTHDS files (Pipelex pipeline definitions)
+# ---------------------------------------------------------------------------
+[[rule]]
+# Which files this rule applies to (relative globs).
+include = ["**/*.mthds", "**/*.plx"]
+
+[rule.schema]
+path = "pipelex/language/mthds_schema.json"
+
+# Per-rule formatting overrides — all at defaults so you can tweak them
+# independently of .toml files.
+[rule.formatting]
+align_entries = true
+# align_comments = true
+# align_single_comments = true
+# array_trailing_comma = true
+# array_auto_expand = true
+# array_auto_collapse = true
+# inline_table_expand = true
+# compact_arrays = true
+# compact_inline_tables = false
+# compact_entries = false
+# column_width = 80
+# indent_tables = false
+# indent_entries = false
+# indent_string = "  "
+# trailing_newline = true
+# allowed_blank_lines = 2

--- a/pipelex/language/mthds_schema.json
+++ b/pipelex/language/mthds_schema.json
@@ -319,7 +319,7 @@
       "description": "Construct section defining how to compose a StructuredContent from working memory fields.",
       "type": "object",
       "additionalProperties": {
-        "oneOf": [
+        "anyOf": [
           {
             "type": "string",
             "description": "Fixed string value"
@@ -382,7 +382,7 @@
     },
     "ConstructFieldBlueprint": {
       "title": "ConstructFieldBlueprint",
-      "oneOf": [
+      "anyOf": [
         {
           "type": "string",
           "description": "Fixed string value"
@@ -534,9 +534,9 @@
         "nb_steps": {
           "anyOf": [
             {
-              "minimum": 0,
               "exclusiveMinimum": true,
-              "type": "integer"
+              "type": "integer",
+              "minimum": 0
             },
             {
               "type": "null"
@@ -548,9 +548,9 @@
         "guidance_scale": {
           "anyOf": [
             {
-              "minimum": 0,
               "exclusiveMinimum": true,
-              "type": "number"
+              "type": "number",
+              "minimum": 0
             },
             {
               "type": "null"
@@ -658,9 +658,9 @@
         "reasoning_budget": {
           "anyOf": [
             {
-              "minimum": 0,
               "exclusiveMinimum": true,
-              "type": "integer"
+              "type": "integer",
+              "minimum": 0
             },
             {
               "type": "null"

--- a/pipelex/language/mthds_schema.json
+++ b/pipelex/language/mthds_schema.json
@@ -1,0 +1,1707 @@
+{
+  "additionalProperties": false,
+  "properties": {
+    "domain": {
+      "title": "Domain",
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Description"
+    },
+    "system_prompt": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "System Prompt"
+    },
+    "main_pipe": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Main Pipe"
+    },
+    "concept": {
+      "anyOf": [
+        {
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/ConceptBlueprint"
+              },
+              {
+                "type": "string"
+              }
+            ]
+          },
+          "type": "object"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "title": "Concept"
+    },
+    "pipe": {
+      "anyOf": [
+        {
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/PipeFuncBlueprint"
+              },
+              {
+                "$ref": "#/definitions/PipeImgGenBlueprint"
+              },
+              {
+                "$ref": "#/definitions/PipeComposeBlueprint"
+              },
+              {
+                "$ref": "#/definitions/PipeLLMBlueprint"
+              },
+              {
+                "$ref": "#/definitions/PipeExtractBlueprint"
+              },
+              {
+                "$ref": "#/definitions/PipeBatchBlueprint"
+              },
+              {
+                "$ref": "#/definitions/PipeConditionBlueprint"
+              },
+              {
+                "$ref": "#/definitions/PipeParallelBlueprint"
+              },
+              {
+                "$ref": "#/definitions/PipeSequenceBlueprint"
+              }
+            ]
+          },
+          "type": "object"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "title": "Pipe"
+    }
+  },
+  "required": [
+    "domain"
+  ],
+  "title": "MTHDS File Schema",
+  "type": "object",
+  "definitions": {
+    "AspectRatio": {
+      "enum": [
+        "square",
+        "landscape_4_3",
+        "landscape_3_2",
+        "landscape_16_9",
+        "landscape_21_9",
+        "portrait_3_4",
+        "portrait_2_3",
+        "portrait_9_16",
+        "portrait_9_21"
+      ],
+      "title": "AspectRatio",
+      "type": "string"
+    },
+    "Background": {
+      "enum": [
+        "transparent",
+        "opaque",
+        "auto"
+      ],
+      "title": "Background",
+      "type": "string"
+    },
+    "ConceptBlueprint": {
+      "additionalProperties": false,
+      "properties": {
+        "description": {
+          "title": "Description",
+          "type": "string"
+        },
+        "structure": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "$ref": "#/definitions/ConceptStructureBlueprint"
+                  }
+                ]
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Structure"
+        },
+        "refines": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Refines"
+        }
+      },
+      "required": [
+        "description"
+      ],
+      "title": "ConceptBlueprint",
+      "type": "object"
+    },
+    "ConceptStructureBlueprint": {
+      "properties": {
+        "description": {
+          "title": "Description",
+          "type": "string"
+        },
+        "type": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ConceptStructureBlueprintFieldType"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "key_type": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Key Type"
+        },
+        "value_type": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Value Type"
+        },
+        "item_type": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Item Type"
+        },
+        "concept_ref": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Concept Ref"
+        },
+        "item_concept_ref": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Item Concept Ref"
+        },
+        "choices": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Choices"
+        },
+        "default_value": {
+          "anyOf": [
+            {},
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Default Value"
+        },
+        "required": {
+          "default": false,
+          "title": "Required",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "description"
+      ],
+      "title": "ConceptStructureBlueprint",
+      "type": "object"
+    },
+    "ConceptStructureBlueprintFieldType": {
+      "enum": [
+        "text",
+        "list",
+        "dict",
+        "integer",
+        "boolean",
+        "number",
+        "date",
+        "concept"
+      ],
+      "title": "ConceptStructureBlueprintFieldType",
+      "type": "string"
+    },
+    "ConstructBlueprint": {
+      "title": "ConstructBlueprint",
+      "description": "Construct section defining how to compose a StructuredContent from working memory fields.",
+      "type": "object",
+      "additionalProperties": {
+        "oneOf": [
+          {
+            "type": "string",
+            "description": "Fixed string value"
+          },
+          {
+            "type": "number",
+            "description": "Fixed numeric value"
+          },
+          {
+            "type": "boolean",
+            "description": "Fixed boolean value"
+          },
+          {
+            "type": "array",
+            "description": "Fixed array value"
+          },
+          {
+            "type": "object",
+            "description": "Variable reference from working memory",
+            "properties": {
+              "from": {
+                "type": "string",
+                "description": "Path to variable in working memory"
+              },
+              "list_to_dict_keyed_by": {
+                "type": "string",
+                "description": "Convert list to dict keyed by this attribute"
+              }
+            },
+            "required": [
+              "from"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "description": "Jinja2 template string",
+            "properties": {
+              "template": {
+                "type": "string",
+                "description": "Jinja2 template string (with $ preprocessing)"
+              }
+            },
+            "required": [
+              "template"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "description": "Nested construct",
+            "additionalProperties": {
+              "$ref": "#/definitions/ConstructFieldBlueprint"
+            },
+            "minProperties": 1
+          }
+        ]
+      },
+      "minProperties": 1
+    },
+    "ConstructFieldBlueprint": {
+      "title": "ConstructFieldBlueprint",
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "Fixed string value"
+        },
+        {
+          "type": "number",
+          "description": "Fixed numeric value"
+        },
+        {
+          "type": "boolean",
+          "description": "Fixed boolean value"
+        },
+        {
+          "type": "array",
+          "description": "Fixed array value"
+        },
+        {
+          "type": "object",
+          "description": "Variable reference from working memory",
+          "properties": {
+            "from": {
+              "type": "string",
+              "description": "Path to variable in working memory"
+            },
+            "list_to_dict_keyed_by": {
+              "type": "string",
+              "description": "Convert list to dict keyed by this attribute"
+            }
+          },
+          "required": [
+            "from"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "description": "Jinja2 template string",
+          "properties": {
+            "template": {
+              "type": "string",
+              "description": "Jinja2 template string (with $ preprocessing)"
+            }
+          },
+          "required": [
+            "template"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "description": "Nested construct",
+          "additionalProperties": {
+            "$ref": "#/definitions/ConstructFieldBlueprint"
+          },
+          "minProperties": 1
+        }
+      ]
+    },
+    "ConstructFieldMethod": {
+      "description": "Method used to compose a field value.",
+      "enum": [
+        "fixed",
+        "from_var",
+        "template",
+        "nested"
+      ],
+      "title": "ConstructFieldMethod",
+      "type": "string"
+    },
+    "ExtractSetting": {
+      "additionalProperties": false,
+      "properties": {
+        "model": {
+          "title": "Model",
+          "type": "string"
+        },
+        "max_nb_images": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Max Nb Images"
+        },
+        "image_min_size": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Image Min Size"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Description"
+        }
+      },
+      "required": [
+        "model"
+      ],
+      "title": "ExtractSetting",
+      "type": "object"
+    },
+    "ImageFormat": {
+      "enum": [
+        "png",
+        "jpeg",
+        "webp"
+      ],
+      "title": "ImageFormat",
+      "type": "string"
+    },
+    "ImgGenSetting": {
+      "additionalProperties": false,
+      "properties": {
+        "model": {
+          "title": "Model",
+          "type": "string"
+        },
+        "quality": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Quality"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "nb_steps": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "exclusiveMinimum": true,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Nb Steps"
+        },
+        "guidance_scale": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "exclusiveMinimum": true,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Guidance Scale"
+        },
+        "is_moderated": {
+          "default": false,
+          "title": "Is Moderated",
+          "type": "boolean"
+        },
+        "safety_tolerance": {
+          "anyOf": [
+            {
+              "maximum": 6,
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Safety Tolerance"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Description"
+        }
+      },
+      "required": [
+        "model"
+      ],
+      "title": "ImgGenSetting",
+      "type": "object"
+    },
+    "LLMSetting": {
+      "additionalProperties": false,
+      "properties": {
+        "model": {
+          "title": "Model",
+          "type": "string"
+        },
+        "temperature": {
+          "maximum": 1,
+          "minimum": 0,
+          "title": "Temperature",
+          "type": "number"
+        },
+        "max_tokens": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Max Tokens"
+        },
+        "image_detail": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PromptImageDetail"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "prompting_target": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PromptingTarget"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "reasoning_effort": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ReasoningEffort"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "reasoning_budget": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "exclusiveMinimum": true,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Reasoning Budget"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Description"
+        }
+      },
+      "required": [
+        "model",
+        "temperature"
+      ],
+      "title": "LLMSetting",
+      "type": "object"
+    },
+    "ModelReference": {
+      "description": "A parsed model reference with explicit kind and name.\n\nArgs:\n    kind: The type of reference (preset, alias, waterfall, or handle)\n    name: The actual name of the model/preset/alias/waterfall (without prefix)\n    raw: The original input string (for error messages)",
+      "properties": {
+        "kind": {
+          "$ref": "#/definitions/ModelReferenceKind"
+        },
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "raw": {
+          "title": "Raw",
+          "type": "string"
+        }
+      },
+      "required": [
+        "kind",
+        "name",
+        "raw"
+      ],
+      "title": "ModelReference",
+      "type": "object"
+    },
+    "ModelReferenceKind": {
+      "description": "The kind of model reference.",
+      "enum": [
+        "preset",
+        "alias",
+        "waterfall",
+        "handle"
+      ],
+      "title": "ModelReferenceKind",
+      "type": "string"
+    },
+    "PipeBatchBlueprint": {
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "default": "PipeBatch",
+          "title": "Type",
+          "type": "string",
+          "enum": [
+            "PipeBatch"
+          ]
+        },
+        "description": {
+          "title": "Description",
+          "type": "string"
+        },
+        "inputs": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Inputs"
+        },
+        "output": {
+          "title": "Output",
+          "type": "string"
+        },
+        "branch_pipe_code": {
+          "title": "Branch Pipe Code",
+          "type": "string"
+        },
+        "input_list_name": {
+          "title": "Input List Name",
+          "type": "string"
+        },
+        "input_item_name": {
+          "title": "Input Item Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "description",
+        "output",
+        "branch_pipe_code",
+        "input_list_name",
+        "input_item_name"
+      ],
+      "title": "PipeBatchBlueprint",
+      "type": "object"
+    },
+    "PipeComposeBlueprint": {
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "default": "PipeCompose",
+          "title": "Type",
+          "type": "string",
+          "enum": [
+            "PipeCompose"
+          ]
+        },
+        "description": {
+          "title": "Description",
+          "type": "string"
+        },
+        "inputs": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Inputs"
+        },
+        "output": {
+          "title": "Output",
+          "type": "string"
+        },
+        "template": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/TemplateBlueprint"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Template"
+        },
+        "construct": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ConstructBlueprint"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "required": [
+        "description",
+        "output"
+      ],
+      "title": "PipeComposeBlueprint",
+      "type": "object"
+    },
+    "PipeConditionBlueprint": {
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "default": "PipeCondition",
+          "title": "Type",
+          "type": "string",
+          "enum": [
+            "PipeCondition"
+          ]
+        },
+        "description": {
+          "title": "Description",
+          "type": "string"
+        },
+        "inputs": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Inputs"
+        },
+        "output": {
+          "title": "Output",
+          "type": "string"
+        },
+        "expression_template": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Expression Template"
+        },
+        "expression": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Expression"
+        },
+        "outcomes": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "title": "Outcomes",
+          "type": "object"
+        },
+        "default_outcome": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/SpecialOutcome"
+            }
+          ],
+          "title": "Default Outcome"
+        },
+        "add_alias_from_expression_to": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Add Alias From Expression To"
+        }
+      },
+      "required": [
+        "description",
+        "output",
+        "default_outcome"
+      ],
+      "title": "PipeConditionBlueprint",
+      "type": "object"
+    },
+    "PipeExtractBlueprint": {
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "default": "PipeExtract",
+          "title": "Type",
+          "type": "string",
+          "enum": [
+            "PipeExtract"
+          ]
+        },
+        "description": {
+          "title": "Description",
+          "type": "string"
+        },
+        "inputs": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Inputs"
+        },
+        "output": {
+          "title": "Output",
+          "type": "string"
+        },
+        "model": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ExtractSetting"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/ModelReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Model"
+        },
+        "max_page_images": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Max Page Images"
+        },
+        "page_image_captions": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Page Image Captions"
+        },
+        "page_views": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Page Views"
+        },
+        "page_views_dpi": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Page Views Dpi"
+        }
+      },
+      "required": [
+        "description",
+        "output"
+      ],
+      "title": "PipeExtractBlueprint",
+      "type": "object"
+    },
+    "PipeFuncBlueprint": {
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "default": "PipeFunc",
+          "title": "Type",
+          "type": "string",
+          "enum": [
+            "PipeFunc"
+          ]
+        },
+        "description": {
+          "title": "Description",
+          "type": "string"
+        },
+        "inputs": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Inputs"
+        },
+        "output": {
+          "title": "Output",
+          "type": "string"
+        },
+        "function_name": {
+          "description": "The name of the function to call.",
+          "title": "Function Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "description",
+        "output",
+        "function_name"
+      ],
+      "title": "PipeFuncBlueprint",
+      "type": "object"
+    },
+    "PipeImgGenBlueprint": {
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "default": "PipeImgGen",
+          "title": "Type",
+          "type": "string",
+          "enum": [
+            "PipeImgGen"
+          ]
+        },
+        "description": {
+          "title": "Description",
+          "type": "string"
+        },
+        "inputs": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Inputs"
+        },
+        "output": {
+          "title": "Output",
+          "type": "string"
+        },
+        "prompt": {
+          "title": "Prompt",
+          "type": "string"
+        },
+        "negative_prompt": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Negative Prompt"
+        },
+        "model": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ImgGenSetting"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/ModelReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Model"
+        },
+        "aspect_ratio": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AspectRatio"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "is_raw": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Is Raw"
+        },
+        "seed": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string",
+              "enum": [
+                "auto"
+              ]
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Seed"
+        },
+        "background": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Background"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "output_format": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ImageFormat"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "required": [
+        "description",
+        "output",
+        "prompt"
+      ],
+      "title": "PipeImgGenBlueprint",
+      "type": "object"
+    },
+    "PipeLLMBlueprint": {
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "default": "PipeLLM",
+          "title": "Type",
+          "type": "string",
+          "enum": [
+            "PipeLLM"
+          ]
+        },
+        "description": {
+          "title": "Description",
+          "type": "string"
+        },
+        "inputs": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Inputs"
+        },
+        "output": {
+          "title": "Output",
+          "type": "string"
+        },
+        "model": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LLMSetting"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/ModelReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Model"
+        },
+        "model_to_structure": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LLMSetting"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/ModelReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Model To Structure"
+        },
+        "system_prompt": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "System Prompt"
+        },
+        "prompt": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Prompt"
+        },
+        "structuring_method": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StructuringMethod"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "required": [
+        "description",
+        "output"
+      ],
+      "title": "PipeLLMBlueprint",
+      "type": "object"
+    },
+    "PipeParallelBlueprint": {
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "default": "PipeParallel",
+          "title": "Type",
+          "type": "string",
+          "enum": [
+            "PipeParallel"
+          ]
+        },
+        "description": {
+          "title": "Description",
+          "type": "string"
+        },
+        "inputs": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Inputs"
+        },
+        "output": {
+          "title": "Output",
+          "type": "string"
+        },
+        "branches": {
+          "items": {
+            "$ref": "#/definitions/SubPipeBlueprint"
+          },
+          "title": "Branches",
+          "type": "array"
+        },
+        "add_each_output": {
+          "default": false,
+          "title": "Add Each Output",
+          "type": "boolean"
+        },
+        "combined_output": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Combined Output"
+        }
+      },
+      "required": [
+        "description",
+        "output",
+        "branches"
+      ],
+      "title": "PipeParallelBlueprint",
+      "type": "object"
+    },
+    "PipeSequenceBlueprint": {
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "default": "PipeSequence",
+          "title": "Type",
+          "type": "string",
+          "enum": [
+            "PipeSequence"
+          ]
+        },
+        "description": {
+          "title": "Description",
+          "type": "string"
+        },
+        "inputs": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Inputs"
+        },
+        "output": {
+          "title": "Output",
+          "type": "string"
+        },
+        "steps": {
+          "items": {
+            "$ref": "#/definitions/SubPipeBlueprint"
+          },
+          "title": "Steps",
+          "type": "array"
+        }
+      },
+      "required": [
+        "description",
+        "output",
+        "steps"
+      ],
+      "title": "PipeSequenceBlueprint",
+      "type": "object"
+    },
+    "PromptImageDetail": {
+      "enum": [
+        "high",
+        "low",
+        "auto"
+      ],
+      "title": "PromptImageDetail",
+      "type": "string"
+    },
+    "PromptingTarget": {
+      "enum": [
+        "openai",
+        "anthropic",
+        "mistral",
+        "gemini",
+        "fal"
+      ],
+      "title": "PromptingTarget",
+      "type": "string"
+    },
+    "Quality": {
+      "enum": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "title": "Quality",
+      "type": "string"
+    },
+    "ReasoningEffort": {
+      "enum": [
+        "none",
+        "minimal",
+        "low",
+        "medium",
+        "high",
+        "max"
+      ],
+      "title": "ReasoningEffort",
+      "type": "string"
+    },
+    "SpecialOutcome": {
+      "enum": [
+        "fail",
+        "continue"
+      ],
+      "title": "SpecialOutcome",
+      "type": "string"
+    },
+    "StructuringMethod": {
+      "enum": [
+        "direct",
+        "preliminary_text"
+      ],
+      "title": "StructuringMethod",
+      "type": "string"
+    },
+    "SubPipeBlueprint": {
+      "additionalProperties": false,
+      "properties": {
+        "pipe": {
+          "title": "Pipe",
+          "type": "string"
+        },
+        "result": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Result"
+        },
+        "nb_output": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Nb Output"
+        },
+        "multiple_output": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Multiple Output"
+        },
+        "batch_over": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Batch Over"
+        },
+        "batch_as": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Batch As"
+        }
+      },
+      "required": [
+        "pipe"
+      ],
+      "title": "SubPipeBlueprint",
+      "type": "object"
+    },
+    "TagStyle": {
+      "enum": [
+        "no_tag",
+        "ticks",
+        "xml",
+        "square_brackets"
+      ],
+      "title": "TagStyle",
+      "type": "string"
+    },
+    "TemplateBlueprint": {
+      "properties": {
+        "template": {
+          "description": "Raw template source",
+          "title": "Template",
+          "type": "string"
+        },
+        "templating_style": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TemplatingStyle"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Style of prompting to use (typically for different LLMs)"
+        },
+        "category": {
+          "$ref": "#/definitions/TemplateCategory",
+          "description": "Category of the template (could also be HTML, MARKDOWN, MERMAID, etc.), influences template rendering rules"
+        },
+        "extra_context": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Additional context variables for template rendering",
+          "title": "Extra Context"
+        }
+      },
+      "required": [
+        "template",
+        "category"
+      ],
+      "title": "TemplateBlueprint",
+      "type": "object"
+    },
+    "TemplateCategory": {
+      "enum": [
+        "basic",
+        "expression",
+        "html",
+        "markdown",
+        "mermaid",
+        "llm_prompt",
+        "img_gen_prompt"
+      ],
+      "title": "TemplateCategory",
+      "type": "string"
+    },
+    "TemplatingStyle": {
+      "properties": {
+        "tag_style": {
+          "$ref": "#/definitions/TagStyle"
+        },
+        "text_format": {
+          "$ref": "#/definitions/TextFormat",
+          "default": "plain"
+        }
+      },
+      "required": [
+        "tag_style"
+      ],
+      "title": "TemplatingStyle",
+      "type": "object"
+    },
+    "TextFormat": {
+      "enum": [
+        "plain",
+        "markdown",
+        "html",
+        "json"
+      ],
+      "title": "TextFormat",
+      "type": "string"
+    }
+  },
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$comment": "Generated from PipelexBundleBlueprint v0.18.0b3. Do not edit manually.",
+  "x-taplo": {
+    "initKeys": [
+      "domain"
+    ]
+  }
+}

--- a/pipelex/language/mthds_schema_generator.py
+++ b/pipelex/language/mthds_schema_generator.py
@@ -14,7 +14,6 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
 from pipelex.core.bundles.pipelex_bundle_blueprint import PipelexBundleBlueprint
-from pipelex.core.pipes.pipe_blueprint import PipeType
 from pipelex.tools.misc.package_utils import get_package_version
 
 # Fields that are injected at load time, never written by users in .mthds files
@@ -274,12 +273,3 @@ def _walk_schema(node: dict[str, Any] | list[Any] | Any, visitor: Callable[[dict
         typed_list = cast("list[Any]", node)
         for child_item in typed_list:
             _walk_schema(child_item, visitor)
-
-
-def get_all_pipe_type_values() -> list[str]:
-    """Return all PipeType enum values for schema validation.
-
-    Returns:
-        List of all pipe type string values (e.g., ['PipeFunc', 'PipeLLM', ...])
-    """
-    return PipeType.value_list()

--- a/pipelex/language/mthds_schema_generator.py
+++ b/pipelex/language/mthds_schema_generator.py
@@ -198,7 +198,7 @@ def _build_construct_field_schema() -> dict[str, Any]:
     - Object with other keys: nested construct (recursive)
     """
     return {
-        "oneOf": [
+        "anyOf": [
             {"type": "string", "description": "Fixed string value"},
             {"type": "number", "description": "Fixed numeric value"},
             {"type": "boolean", "description": "Fixed boolean value"},

--- a/pipelex/language/mthds_schema_generator.py
+++ b/pipelex/language/mthds_schema_generator.py
@@ -1,0 +1,285 @@
+"""Generator for JSON Schema from MTHDS blueprint classes.
+
+Produces a Taplo-compatible JSON Schema (Draft 4) from PipelexBundleBlueprint's
+Pydantic v2 model schema. The generated schema enables IDE validation and
+autocompletion for .mthds files in the vscode-pipelex extension.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import TYPE_CHECKING, Any, cast
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+from pipelex.core.bundles.pipelex_bundle_blueprint import PipelexBundleBlueprint
+from pipelex.core.pipes.pipe_blueprint import PipeType
+from pipelex.tools.misc.package_utils import get_package_version
+
+# Fields that are injected at load time, never written by users in .mthds files
+_INTERNAL_FIELDS = {"source"}
+
+# Fields that are technical union discriminators, not user-facing
+_PIPE_INTERNAL_FIELDS = {"pipe_category"}
+
+# Pipe definition names (as they appear in Pydantic schema $defs)
+_PIPE_DEFINITION_NAMES = {
+    "PipeFuncBlueprint",
+    "PipeImgGenBlueprint",
+    "PipeComposeBlueprint",
+    "PipeLLMBlueprint",
+    "PipeExtractBlueprint",
+    "PipeBatchBlueprint",
+    "PipeConditionBlueprint",
+    "PipeParallelBlueprint",
+    "PipeSequenceBlueprint",
+}
+
+
+def generate_mthds_schema() -> dict[str, Any]:
+    """Generate a Taplo-compatible JSON Schema for .mthds files.
+
+    Uses PipelexBundleBlueprint.model_json_schema() as the base, then applies
+    post-processing steps to make it compatible with Taplo (JSON Schema Draft 4)
+    and match the user-facing MTHDS file format.
+
+    Returns:
+        A JSON Schema dict ready to be serialized to JSON.
+    """
+    schema = PipelexBundleBlueprint.model_json_schema(
+        by_alias=True,
+        mode="validation",
+    )
+
+    schema = _remove_internal_fields(schema)
+    schema = _convert_to_draft4(schema)
+    schema = _patch_construct_schema(schema)
+
+    return _add_taplo_metadata(schema)
+
+
+def _remove_internal_fields(schema: dict[str, Any]) -> dict[str, Any]:
+    """Remove fields that users never write in .mthds files.
+
+    - `source` is removed from all definitions (injected at load time)
+    - `pipe_category` is removed from pipe definitions (union discriminator)
+    """
+    schema = copy.deepcopy(schema)
+    defs_key = "$defs" if "$defs" in schema else "definitions"
+    definitions = schema.get(defs_key, {})
+
+    # Remove 'source' from root properties
+    root_props = schema.get("properties", {})
+    for field_name in _INTERNAL_FIELDS:
+        root_props.pop(field_name, None)
+    _remove_from_required(schema, _INTERNAL_FIELDS)
+
+    # Remove internal fields from all definitions
+    for def_name, def_schema in definitions.items():
+        props = def_schema.get("properties", {})
+        for field_name in _INTERNAL_FIELDS:
+            props.pop(field_name, None)
+        _remove_from_required(def_schema, _INTERNAL_FIELDS)
+
+        # Remove pipe_category only from pipe blueprint definitions
+        if def_name in _PIPE_DEFINITION_NAMES:
+            for field_name in _PIPE_INTERNAL_FIELDS:
+                props.pop(field_name, None)
+            _remove_from_required(def_schema, _PIPE_INTERNAL_FIELDS)
+
+    return schema
+
+
+def _remove_from_required(schema_obj: dict[str, Any], field_names: set[str]) -> None:
+    """Remove field names from a schema object's 'required' list."""
+    required = schema_obj.get("required")
+    if required is not None:
+        schema_obj["required"] = [req for req in required if req not in field_names]
+        if not schema_obj["required"]:
+            del schema_obj["required"]
+
+
+def _convert_to_draft4(schema: dict[str, Any]) -> dict[str, Any]:
+    """Convert JSON Schema from Pydantic's Draft 2020-12 to Draft 4 for Taplo.
+
+    - Renames `$defs` to `definitions`
+    - Converts `const` to single-value `enum`
+    - Removes `discriminator` (not in Draft 4)
+    - Fixes `$ref` paths from `#/$defs/` to `#/definitions/`
+    - Converts `exclusiveMinimum`/`exclusiveMaximum` from number (Draft 6+) to boolean (Draft 4)
+    """
+    schema = copy.deepcopy(schema)
+
+    # Rename $defs to definitions
+    if "$defs" in schema:
+        schema["definitions"] = schema.pop("$defs")
+
+    # Walk the schema tree to apply conversions
+    _walk_schema(schema, _draft4_visitor)
+
+    return schema
+
+
+def _draft4_visitor(node: dict[str, Any]) -> None:
+    """Visitor that converts Draft 2020-12 constructs to Draft 4."""
+    # Convert const to single-value enum
+    if "const" in node:
+        node["enum"] = [node.pop("const")]
+
+    # Remove discriminator (not in Draft 4)
+    node.pop("discriminator", None)
+
+    # Fix $ref paths
+    if "$ref" in node:
+        ref_value = node["$ref"]
+        if isinstance(ref_value, str) and "#/$defs/" in ref_value:
+            node["$ref"] = ref_value.replace("#/$defs/", "#/definitions/")
+
+    # Convert exclusiveMinimum/exclusiveMaximum from Draft 6+ (number) to Draft 4 (boolean)
+    # Draft 6+: "exclusiveMinimum": 0  →  Draft 4: "minimum": 0, "exclusiveMinimum": true
+    if "exclusiveMinimum" in node and not isinstance(node["exclusiveMinimum"], bool):
+        node["minimum"] = node["exclusiveMinimum"]
+        node["exclusiveMinimum"] = True
+    if "exclusiveMaximum" in node and not isinstance(node["exclusiveMaximum"], bool):
+        node["maximum"] = node["exclusiveMaximum"]
+        node["exclusiveMaximum"] = True
+
+
+def _patch_construct_schema(schema: dict[str, Any]) -> dict[str, Any]:
+    """Patch ConstructBlueprint definition to match user-facing MTHDS format.
+
+    In .mthds files, construct fields are written directly at root level:
+        [pipe.my_pipe.construct]
+        field_a = "value"
+        field_b = { from = "var_name" }
+
+    But the Pydantic model wraps them in a `fields` dict. This patch replaces
+    the ConstructBlueprint definition with one that uses `additionalProperties`
+    to accept arbitrary field names with field-value schemas.
+
+    Also replaces ConstructFieldBlueprint with a user-facing schema that accepts
+    the raw MTHDS formats: raw values, {from: str}, {template: str}, or nested constructs.
+    """
+    schema = copy.deepcopy(schema)
+    definitions = schema.get("definitions", {})
+
+    # Build the user-facing field value schema (what goes in each construct field)
+    construct_field_schema = _build_construct_field_schema()
+
+    # Replace ConstructBlueprint with MTHDS-format schema
+    if "ConstructBlueprint" in definitions:
+        definitions["ConstructBlueprint"] = {
+            "title": "ConstructBlueprint",
+            "description": "Construct section defining how to compose a StructuredContent from working memory fields.",
+            "type": "object",
+            "additionalProperties": construct_field_schema,
+            "minProperties": 1,
+        }
+
+    # Replace ConstructFieldBlueprint with user-facing schema
+    if "ConstructFieldBlueprint" in definitions:
+        definitions["ConstructFieldBlueprint"] = {
+            "title": "ConstructFieldBlueprint",
+            **construct_field_schema,
+        }
+
+    return schema
+
+
+def _build_construct_field_schema() -> dict[str, Any]:
+    """Build a JSON Schema for a construct field value as written in MTHDS files.
+
+    Matches the parsing logic in ConstructFieldBlueprint.make_from_raw():
+    - Raw values (string, number, boolean, array): fixed value
+    - {from: str}: variable reference from working memory
+    - {from: str, list_to_dict_keyed_by: str}: variable ref with dict conversion
+    - {template: str}: Jinja2 template
+    - Object with other keys: nested construct (recursive)
+    """
+    return {
+        "oneOf": [
+            {"type": "string", "description": "Fixed string value"},
+            {"type": "number", "description": "Fixed numeric value"},
+            {"type": "boolean", "description": "Fixed boolean value"},
+            {"type": "array", "description": "Fixed array value"},
+            {
+                "type": "object",
+                "description": "Variable reference from working memory",
+                "properties": {
+                    "from": {"type": "string", "description": "Path to variable in working memory"},
+                    "list_to_dict_keyed_by": {
+                        "type": "string",
+                        "description": "Convert list to dict keyed by this attribute",
+                    },
+                },
+                "required": ["from"],
+                "additionalProperties": False,
+            },
+            {
+                "type": "object",
+                "description": "Jinja2 template string",
+                "properties": {
+                    "template": {"type": "string", "description": "Jinja2 template string (with $ preprocessing)"},
+                },
+                "required": ["template"],
+                "additionalProperties": False,
+            },
+            {
+                "type": "object",
+                "description": "Nested construct",
+                "additionalProperties": {"$ref": "#/definitions/ConstructFieldBlueprint"},
+                "minProperties": 1,
+            },
+        ],
+    }
+
+
+def _add_taplo_metadata(schema: dict[str, Any]) -> dict[str, Any]:
+    """Add Taplo-specific metadata and JSON Schema Draft 4 header.
+
+    - Sets $schema to Draft 4
+    - Adds title and version comment
+    - Adds x-taplo.initKeys on the root schema for better IDE experience
+    """
+    schema = copy.deepcopy(schema)
+
+    version = get_package_version()
+
+    schema["$schema"] = "http://json-schema.org/draft-04/schema#"
+    schema["title"] = "MTHDS File Schema"
+    schema["$comment"] = f"Generated from PipelexBundleBlueprint v{version}. Do not edit manually."
+
+    # x-taplo.initKeys suggests which keys to auto-insert when creating a new .mthds file
+    schema["x-taplo"] = {
+        "initKeys": ["domain"],
+    }
+
+    return schema
+
+
+def _walk_schema(node: dict[str, Any] | list[Any] | Any, visitor: Callable[[dict[str, Any]], None]) -> None:
+    """Recursively walk a JSON Schema tree, calling visitor on each dict node.
+
+    Args:
+        node: Current node in the schema tree
+        visitor: Callable that receives each dict node for in-place modification
+    """
+    if isinstance(node, dict):
+        typed_node = cast("dict[str, Any]", node)
+        visitor(typed_node)
+        for child_value in typed_node.values():
+            _walk_schema(child_value, visitor)
+    elif isinstance(node, list):
+        typed_list = cast("list[Any]", node)
+        for child_item in typed_list:
+            _walk_schema(child_item, visitor)
+
+
+def get_all_pipe_type_values() -> list[str]:
+    """Return all PipeType enum values for schema validation.
+
+    Returns:
+        List of all pipe type string values (e.g., ['PipeFunc', 'PipeLLM', ...])
+    """
+    return PipeType.value_list()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ dependencies = [
   "opentelemetry-semantic-conventions",
   "opentelemetry-sdk",
   "pillow>=11.2.1",
-  "plxt",
   "polyfactory>=2.21.0",
   "portkey-ai>=2.1.0",
   "posthog>=6.7.0",
@@ -80,6 +79,7 @@ dev = [
   "boto3-stubs>=1.35.24",
   "moto[s3]>=5.0.0",
   "mypy==1.19.1",
+  "pipelex-tools>=0.1.1",
   "pyright==1.1.408",
   "pylint==4.0.4",
   "pytest>=9.0.2",
@@ -95,9 +95,6 @@ dev = [
   "types-networkx>=3.3.0.20241020",
   "types-PyYAML>=6.0.12.20250326",
 ]
-
-[tool.uv.sources]
-plxt = { path = "../vscode-pipelex", editable = false }
 
 [project.scripts]
 pipelex = "pipelex.cli._cli:app"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,46 +8,47 @@ license = "MIT"
 readme = "README.md"
 requires-python = ">=3.10,<3.15"
 classifiers = [
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
-    "Programming Language :: Python :: 3.14",
-    "Operating System :: OS Independent",
-    "License :: OSI Approved :: MIT License",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
+  "Operating System :: OS Independent",
+  "License :: OSI Approved :: MIT License",
 ]
 
 dependencies = [
-    "aiofiles>=23.2.1",
-    "backports.strenum>=1.3.0 ; python_version < '3.11'",
-    "filetype>=1.2.0",
-    "httpx>=0.23.0,<1.0.0",
-    "instructor>=1.8.3,!=1.11.*,!=1.12.*",                # 1.11.x caused typing errors with mypy
-    "jinja2>=3.1.4",
-    "json2html>=1.3.0",
-    "kajson==0.3.1",
-    "markdown>=3.6",
-    "networkx>=3.4.2",
-    "openai>=1.108.1",
-    "opentelemetry-api",
-    "opentelemetry-exporter-otlp-proto-http",
-    "opentelemetry-semantic-conventions",
-    "opentelemetry-sdk",
-    "pillow>=11.2.1",
-    "polyfactory>=2.21.0",
-    "portkey-ai>=2.1.0",
-    "posthog>=6.7.0",
-    "pypdfium2>=4.30.0,!=4.30.1,<5.0.0",
-    "pydantic>=2.10.6,<3.0.0",
-    "python-dotenv>=1.0.1",
-    "PyYAML>=6.0.2",
-    "rich>=13.8.1",
-    "shortuuid>=1.0.13",
-    "tomli>=2.3.0",
-    "tomlkit>=0.13.2",
-    "typer>=0.16.0",
-    "typing-extensions>=4.13.2",
+  "aiofiles>=23.2.1",
+  "backports.strenum>=1.3.0 ; python_version < '3.11'",
+  "filetype>=1.2.0",
+  "httpx>=0.23.0,<1.0.0",
+  "instructor>=1.8.3,!=1.11.*,!=1.12.*",                # 1.11.x caused typing errors with mypy
+  "jinja2>=3.1.4",
+  "json2html>=1.3.0",
+  "kajson==0.3.1",
+  "markdown>=3.6",
+  "networkx>=3.4.2",
+  "openai>=1.108.1",
+  "opentelemetry-api",
+  "opentelemetry-exporter-otlp-proto-http",
+  "opentelemetry-semantic-conventions",
+  "opentelemetry-sdk",
+  "pillow>=11.2.1",
+  "plxt",
+  "polyfactory>=2.21.0",
+  "portkey-ai>=2.1.0",
+  "posthog>=6.7.0",
+  "pypdfium2>=4.30.0,!=4.30.1,<5.0.0",
+  "pydantic>=2.10.6,<3.0.0",
+  "python-dotenv>=1.0.1",
+  "PyYAML>=6.0.2",
+  "rich>=13.8.1",
+  "shortuuid>=1.0.13",
+  "tomli>=2.3.0",
+  "tomlkit>=0.13.2",
+  "typer>=0.16.0",
+  "typing-extensions>=4.13.2",
 ]
 
 [project.urls]
@@ -68,32 +69,35 @@ huggingface = ["huggingface_hub>=0.23,<1.0.0"]
 mistralai = ["mistralai>=1.12.0"]
 s3 = ["boto3>=1.34.131", "aioboto3>=13.4.0"]
 docs = [
-    "mkdocs>=1.6.1",
-    "mkdocs-glightbox>=0.4.0",
-    "mkdocs-material>=9.6.14",
-    "mkdocs-meta-manager>=1.1.0",
-    "mike>=2.1.3",
+  "mkdocs>=1.6.1",
+  "mkdocs-glightbox>=0.4.0",
+  "mkdocs-material>=9.6.14",
+  "mkdocs-meta-manager>=1.1.0",
+  "mike>=2.1.3",
 ]
 
 dev = [
-    "boto3-stubs>=1.35.24",
-    "moto[s3]>=5.0.0",
-    "mypy==1.19.1",
-    "pyright==1.1.408",
-    "pylint==4.0.4",
-    "pytest>=9.0.2",
-    "pytest-asyncio>=0.24.0",
-    "pytest-cov>=6.1.1",
-    "pytest-mock>=3.14.0",
-    "pytest-sugar>=1.0.0",
-    "pytest-xdist>= 3.6.1",
-    "ruff==0.14.13",
-    "types-aioboto3[bedrock,bedrock-runtime]>=13.4.0",
-    "types-aiofiles>=24.1.0.20240626",
-    "types-markdown>=3.6.0.20240316",
-    "types-networkx>=3.3.0.20241020",
-    "types-PyYAML>=6.0.12.20250326",
+  "boto3-stubs>=1.35.24",
+  "moto[s3]>=5.0.0",
+  "mypy==1.19.1",
+  "pyright==1.1.408",
+  "pylint==4.0.4",
+  "pytest>=9.0.2",
+  "pytest-asyncio>=0.24.0",
+  "pytest-cov>=6.1.1",
+  "pytest-mock>=3.14.0",
+  "pytest-sugar>=1.0.0",
+  "pytest-xdist>= 3.6.1",
+  "ruff==0.14.13",
+  "types-aioboto3[bedrock,bedrock-runtime]>=13.4.0",
+  "types-aiofiles>=24.1.0.20240626",
+  "types-markdown>=3.6.0.20240316",
+  "types-networkx>=3.3.0.20241020",
+  "types-PyYAML>=6.0.12.20250326",
 ]
+
+[tool.uv.sources]
+plxt = { path = "../vscode-pipelex", editable = false }
 
 [project.scripts]
 pipelex = "pipelex.cli._cli:app"
@@ -117,11 +121,11 @@ warn_unused_configs = true
 [[tool.mypy.overrides]]
 ignore_missing_imports = true
 module = [
-    "backports.strenum",
-    "filetype",
-    "json2html",
-    "pypdfium2",
-    "pypdfium2.raw",
+  "backports.strenum",
+  "filetype",
+  "json2html",
+  "pypdfium2",
+  "pypdfium2.raw",
 ]
 
 [tool.pyright]
@@ -222,30 +226,30 @@ typeCheckingMode = "strict"
 [tool.pytest]
 minversion = "9.0"
 addopts = [
-    "--import-mode=importlib",
-    "-ra",                                                         # Show all test outcomes (including skips)
-    "-m",
-    "not (inference or llm or img_gen or extract or pipelex_api)",
+  "--import-mode=importlib",
+  "-ra",                                                         # Show all test outcomes (including skips)
+  "-m",
+  "not (inference or llm or img_gen or extract or pipelex_api)",
 ]
 asyncio_default_fixture_loop_scope = "session"
 xfail_strict = true
 filterwarnings = [
-    "ignore:Support for class-based `config` is deprecated:DeprecationWarning",
-    "ignore:websockets.*is deprecated:DeprecationWarning",
-    "ignore:typing\\.io is deprecated:DeprecationWarning",
-    "ignore:typing\\.re is deprecated:DeprecationWarning",
-    "ignore:.*has been moved to cryptography.*",
-    "ignore:Use.*Types instead",
+  "ignore:Support for class-based `config` is deprecated:DeprecationWarning",
+  "ignore:websockets.*is deprecated:DeprecationWarning",
+  "ignore:typing\\.io is deprecated:DeprecationWarning",
+  "ignore:typing\\.re is deprecated:DeprecationWarning",
+  "ignore:.*has been moved to cryptography.*",
+  "ignore:Use.*Types instead",
 ]
 markers = [
-    "inference: slow and costly due to inference calls",
-    "llm: slow and costly due to llm inference calls",
-    "img_gen: slow and costly due to image generation inference calls",
-    "extract: slow and costly due to doc extraction inference calls",
-    "gha_disabled: tests that should not run in GitHub Actions",
-    "codex_disabled: tests that should not run in Codex",
-    "dry_runnable: tests that can be run in dry-run mode",
-    "pipelex_api: tests that require access to the Pipelex API",
+  "inference: slow and costly due to inference calls",
+  "llm: slow and costly due to llm inference calls",
+  "img_gen: slow and costly due to image generation inference calls",
+  "extract: slow and costly due to doc extraction inference calls",
+  "gha_disabled: tests that should not run in GitHub Actions",
+  "codex_disabled: tests that should not run in Codex",
+  "dry_runnable: tests that can be run in dry-run mode",
+  "pipelex_api: tests that require access to the Pipelex API",
 ]
 
 [tool.coverage.run]
@@ -254,24 +258,24 @@ omit = ["tests/*", "**/__init__.py"]
 
 [tool.coverage.report]
 exclude_lines = [
-    "pragma: no cover",
-    "def __repr__",
-    "raise NotImplementedError",
-    "if __name__ == .__main__.:",
-    "pass",
-    "raise ImportError",
+  "pragma: no cover",
+  "def __repr__",
+  "raise NotImplementedError",
+  "if __name__ == .__main__.:",
+  "pass",
+  "raise ImportError",
 ]
 
 [tool.ruff]
 exclude = [
-    ".cursor",
-    ".git",
-    ".github",
-    ".mypy_cache",
-    ".ruff_cache",
-    ".venv",
-    ".vscode",
-    "trigger_pipeline",
+  ".cursor",
+  ".git",
+  ".github",
+  ".mypy_cache",
+  ".ruff_cache",
+  ".venv",
+  ".vscode",
+  "trigger_pipeline",
 ]
 line-length = 150
 target-version = "py311"
@@ -282,122 +286,122 @@ target-version = "py311"
 preview = true
 select = ["ALL"]
 ignore = [
-    "ANN201",   # Missing return type annotation for public function `my_func`
-    "ANN202",   # Missing return type annotation for private function `my_func`
-    "ANN204",   # Missing return type annotation for special method `my_func`
-    "ANN206",   #  Missing return type annotation for classmethod `my_func`
-    "ANN401",   # Dynamically typed expressions (typing.Any) are disallowed in `...`
-    "ASYNC230", # Async functions should not open files with blocking methods like `open`
-    "ASYNC240", # Async functions should not use pathlib.Path methods, use trio.Path or anyio.path
+  "ANN201",   # Missing return type annotation for public function `my_func`
+  "ANN202",   # Missing return type annotation for private function `my_func`
+  "ANN204",   # Missing return type annotation for special method `my_func`
+  "ANN206",   #  Missing return type annotation for classmethod `my_func`
+  "ANN401",   # Dynamically typed expressions (typing.Any) are disallowed in `...`
+  "ASYNC230", # Async functions should not open files with blocking methods like `open`
+  "ASYNC240", # Async functions should not use pathlib.Path methods, use trio.Path or anyio.path
 
-    "B903", # Class could be dataclass or namedtuple
+  "B903", # Class could be dataclass or namedtuple
 
-    "C901",   # Is to complex
-    "COM812", # Checks for the absence of trailing commas.
+  "C901",   # Is to complex
+  "COM812", # Checks for the absence of trailing commas.
 
-    "CPY001", # Missing copyright notice at top of file
+  "CPY001", # Missing copyright notice at top of file
 
-    "D100", # Missing docstring in public module
-    "D101", # Missing docstring in public class
-    "D102", # Missing docstring in public method
-    "D103", # Missing docstring in public function
-    "D104", # Missing docstring in public package
-    "D105", # Missing docstring in magic method
-    "D107", # Missing docstring in __init__
-    "D205", # 1 blank line required between summary line and description
-    "D400", # First line should end with a period
-    "D401", # First line of docstring should be in imperative mood: "My docstring...."
-    "D404", # First word of the docstring should not be "This"
-    "D415", # First line should end with a period, question mark, or exclamation point
+  "D100", # Missing docstring in public module
+  "D101", # Missing docstring in public class
+  "D102", # Missing docstring in public method
+  "D103", # Missing docstring in public function
+  "D104", # Missing docstring in public package
+  "D105", # Missing docstring in magic method
+  "D107", # Missing docstring in __init__
+  "D205", # 1 blank line required between summary line and description
+  "D400", # First line should end with a period
+  "D401", # First line of docstring should be in imperative mood: "My docstring...."
+  "D404", # First word of the docstring should not be "This"
+  "D415", # First line should end with a period, question mark, or exclamation point
 
-    "DOC201", # `return` is not documented in docstring
-    "DOC202", # Docstring should not have a returns section because the function doesn't return anything
-    "DOC402", # `yield` is not documented in docstring
-    "DOC502", # Raised exception is not explicitly raised: `FileNotFoundError`
-    "DOC501", # Raised exception `ModuleFileError` missing from docstring
+  "DOC201", # `return` is not documented in docstring
+  "DOC202", # Docstring should not have a returns section because the function doesn't return anything
+  "DOC402", # `yield` is not documented in docstring
+  "DOC502", # Raised exception is not explicitly raised: `FileNotFoundError`
+  "DOC501", # Raised exception `ModuleFileError` missing from docstring
 
-    "DTZ001", # `datetime.datetime()` called without a `tzinfo` argument
-    "DTZ005", # `datetime.datetime.now()` called without a `tz` argument
+  "DTZ001", # `datetime.datetime()` called without a `tzinfo` argument
+  "DTZ005", # `datetime.datetime.now()` called without a `tz` argument
 
-    "ERA001", # Found commented-out code
+  "ERA001", # Found commented-out code
 
-    "FBT001", # Boolean-typed positional argument in function definition
-    "FBT002", # Boolean default positional argument in function definition
-    "FBT003", #Boolean positional value in function call
+  "FBT001", # Boolean-typed positional argument in function definition
+  "FBT002", # Boolean default positional argument in function definition
+  "FBT003", #Boolean positional value in function call
 
-    "FIX002", # Line contains TODO, consider resolving the issue
+  "FIX002", # Line contains TODO, consider resolving the issue
 
-    "FURB101", # `open` and `read` should be replaced by `Path(file_path.path).read_text(encoding="utf-8")`
-    "FURB113", # Checks for consecutive calls to append.
-    "FURB152", # Checks for literals that are similar to constants in math module.
+  "FURB101", # `open` and `read` should be replaced by `Path(file_path.path).read_text(encoding="utf-8")`
+  "FURB113", # Checks for consecutive calls to append.
+  "FURB152", # Checks for literals that are similar to constants in math module.
 
-    "LOG004", # `.exception()` call outside exception handlers
+  "LOG004", # `.exception()` call outside exception handlers
 
-    "PLC0105", # `TypeVar` name "SomethingType" does not reflect its covariance; consider renaming it to "SomethingType_co"
-    "PLC1901", # Checks for comparisons to empty strings.
+  "PLC0105", # `TypeVar` name "SomethingType" does not reflect its covariance; consider renaming it to "SomethingType_co"
+  "PLC1901", # Checks for comparisons to empty strings.
 
-    "PLR0904", # Too many public methods ( > 20)
-    "PLR0911", # Too many return statements (/6)
-    "PLR0912", # Too many branches (/12)
-    "PLR0913", # Too many arguments in function definition (/5)
-    "PLR0914", # Too many local variables ( /15)
-    "PLR0915", # Too many statements (/50)
-    "PLR0917", # Too many positional arguments ( /5)
-    "PLR2004", # Magic value used in comparison, consider replacing `2` with a constant variable
-    "PLR6301", # Too many return statements in `for` loop
-    "PLR1702", # Too many nested blocks ( > 5)
+  "PLR0904", # Too many public methods ( > 20)
+  "PLR0911", # Too many return statements (/6)
+  "PLR0912", # Too many branches (/12)
+  "PLR0913", # Too many arguments in function definition (/5)
+  "PLR0914", # Too many local variables ( /15)
+  "PLR0915", # Too many statements (/50)
+  "PLR0917", # Too many positional arguments ( /5)
+  "PLR2004", # Magic value used in comparison, consider replacing `2` with a constant variable
+  "PLR6301", # Too many return statements in `for` loop
+  "PLR1702", # Too many nested blocks ( > 5)
 
-    "PT013", # Incorrect import of `pytest`; use `import pytest` instead
+  "PT013", # Incorrect import of `pytest`; use `import pytest` instead
 
-    "PTH100", # `os.path.abspath()` should be replaced by `Path.resolve()`
-    "PTH103", # `os.makedirs()` should be replaced by `Path.mkdir(parents=True)`
-    "PTH107", # `os.remove()` should be replaced by `Path.unlink()`
-    "PTH109", # `os.getcwd()` should be replaced by `Path.cwd()`
-    "PTH118", # `os.path.join()` should be replaced by `Path` with `/` operator
-    "PTH120", # `os.path.dirname()` should be replaced by `Path.parent`
-    "PTH110", # `os.path.exists()` should be replaced by `Path.exists()`
-    "PTH112", # `os.path.isdir()` should be replaced by `Path.is_dir()`
-    "PTH119", # `os.path.basename()` should be replaced by `Path.name`
-    "PTH123", # `open()` should be replaced by `Path.open()`
-    "PTH208", # Use `pathlib.Path.iterdir()` instead.
+  "PTH100", # `os.path.abspath()` should be replaced by `Path.resolve()`
+  "PTH103", # `os.makedirs()` should be replaced by `Path.mkdir(parents=True)`
+  "PTH107", # `os.remove()` should be replaced by `Path.unlink()`
+  "PTH109", # `os.getcwd()` should be replaced by `Path.cwd()`
+  "PTH118", # `os.path.join()` should be replaced by `Path` with `/` operator
+  "PTH120", # `os.path.dirname()` should be replaced by `Path.parent`
+  "PTH110", # `os.path.exists()` should be replaced by `Path.exists()`
+  "PTH112", # `os.path.isdir()` should be replaced by `Path.is_dir()`
+  "PTH119", # `os.path.basename()` should be replaced by `Path.name`
+  "PTH123", # `open()` should be replaced by `Path.open()`
+  "PTH208", # Use `pathlib.Path.iterdir()` instead.
 
-    "PYI051", # `Literal["auto"]` is redundant in a union with `str`
+  "PYI051", # `Literal["auto"]` is redundant in a union with `str`
 
-    "RET505", # superfluous-else-return
+  "RET505", # superfluous-else-return
 
-    "RUF001", # String contains ambiguous `′` (PRIME). Did you mean ``` (GRAVE ACCENT)?
-    "RUF003", # Comment contains ambiguous `’` (RIGHT SINGLE QUOTATION MARK). Did you mean ``` (GRAVE ACCENT)?
-    "RUF022", # Checks for __all__ definitions that are not ordered according to an "isort-style" sort.
+  "RUF001", # String contains ambiguous `′` (PRIME). Did you mean ``` (GRAVE ACCENT)?
+  "RUF003", # Comment contains ambiguous `’` (RIGHT SINGLE QUOTATION MARK). Did you mean ``` (GRAVE ACCENT)?
+  "RUF022", # Checks for __all__ definitions that are not ordered according to an "isort-style" sort.
 
-    "SIM105", # Use `contextlib.suppress(ValueError)` instead of `try`-`except`-`pass`
-    "SIM108", # Use ternary operator `description = func.__doc__.strip().split("\n")[0] if func.__doc__ else func.__name__` instead of `if`-`else`-block
+  "SIM105", # Use `contextlib.suppress(ValueError)` instead of `try`-`except`-`pass`
+  "SIM108", # Use ternary operator `description = func.__doc__.strip().split("\n")[0] if func.__doc__ else func.__name__` instead of `if`-`else`-block
 
-    "S101", # Use of `assert` detected
-    "S102", # Use of `exec` detected
-    "S106", # Possible hardcoded password assigned to argument: "secret"
-    "S105", # Possible hardcoded password assigned to: "child_secret"
+  "S101", # Use of `assert` detected
+  "S102", # Use of `exec` detected
+  "S106", # Possible hardcoded password assigned to argument: "secret"
+  "S105", # Possible hardcoded password assigned to: "child_secret"
 
-    "S311", # Cryptographically weak pseudo-random number generator
+  "S311", # Cryptographically weak pseudo-random number generator
 
-    "TD002", # Missing author in TODO; try: `# TODO(<author_name>): ...` or `# TODO @<author_name>: ...`
-    "TD003", # Missing issue link for this TODO
+  "TD002", # Missing author in TODO; try: `# TODO(<author_name>): ...` or `# TODO @<author_name>: ...`
+  "TD003", # Missing issue link for this TODO
 
-    "T201", # `print` found
+  "T201", # `print` found
 
-    # TODO: stop ignoring these rules
-    "BLE001",  # Do not catch blind exception: `Exception`
-    "B027",    # Checks for empty methods in abstract base classes without an abstract decorator.
-    "UP007",   # Use `X | Y` for type annotations
-    "UP036",   # Version block is outdated for minimum Python version
-    "SIM102",  # Use a single `if` statement instead of nested `if` statements
-    "S701",    # Using jinja2 templates with `autoescape=False` is dangerous and can lead to XSS. Ensure `autoescape=True` or use the `select_autoescape` function.
-    "TRY301",  # Abstract `raise` to an inner function
-    "PERF401", # Use a list comprehension to create a transformed list
-    "PLW2901", # `for` loop variable `line` overwritten by assignment target
-    "TRY300",  # Consider moving this statement to an `else` block
-    "UP035",   # `typing.List` is deprecated, use `list` instead
-    "RET503",  # Missing explicit `return` at the end of function able to return non-`None` value
-    "UP017",   # Use `datetime.UTC` alias - but UTC only available in Python 3.11+
+  # TODO: stop ignoring these rules
+  "BLE001",  # Do not catch blind exception: `Exception`
+  "B027",    # Checks for empty methods in abstract base classes without an abstract decorator.
+  "UP007",   # Use `X | Y` for type annotations
+  "UP036",   # Version block is outdated for minimum Python version
+  "SIM102",  # Use a single `if` statement instead of nested `if` statements
+  "S701",    # Using jinja2 templates with `autoescape=False` is dangerous and can lead to XSS. Ensure `autoescape=True` or use the `select_autoescape` function.
+  "TRY301",  # Abstract `raise` to an inner function
+  "PERF401", # Use a list comprehension to create a transformed list
+  "PLW2901", # `for` loop variable `line` overwritten by assignment target
+  "TRY300",  # Consider moving this statement to an `else` block
+  "UP035",   # `typing.List` is deprecated, use `list` instead
+  "RET503",  # Missing explicit `return` at the end of function able to return non-`None` value
+  "UP017",   # Use `datetime.UTC` alias - but UTC only available in Python 3.11+
 ]
 
 [tool.ruff.lint.pydocstyle]
@@ -405,7 +409,7 @@ convention = "google"
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**/*.py" = [
-    "INP001", # Allow test files to not have __init__.py in their directories (avoids namespace collisions)
+  "INP001", # Allow test files to not have __init__.py in their directories (avoids namespace collisions)
 ]
 
 [tool.uv]
@@ -430,8 +434,8 @@ reports = false
 [tool.pylint.messages_control]
 disable = ["all"]
 enable = [
-    "W0101", # Unreachable code: Used when there is some code behind a "return" or "raise" statement, which will never be accessed.
-    "C0103", # invalid-name (naming convention)
+  "W0101", # Unreachable code: Used when there is some code behind a "return" or "raise" statement, which will never be accessed.
+  "C0103", # invalid-name (naming convention)
 ]
 ignore = [".venv", "__pycache__", "build", "dist", ".git"]
 

--- a/tests/unit/pipelex/language/test_mthds_schema.py
+++ b/tests/unit/pipelex/language/test_mthds_schema.py
@@ -1,0 +1,206 @@
+"""Tests for MTHDS JSON Schema generation."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+
+from pipelex.core.pipes.pipe_blueprint import PipeType
+from pipelex.language.mthds_schema_generator import generate_mthds_schema
+
+
+class TestMthdsSchemaGeneration:
+    """Tests for generate_mthds_schema() and its post-processing pipeline."""
+
+    @pytest.fixture(scope="class")
+    def schema(self) -> dict[str, Any]:
+        """Generate the schema once for all tests in this class."""
+        return generate_mthds_schema()
+
+    def test_schema_is_valid_draft4(self, schema: dict[str, Any]) -> None:
+        """Verify the schema uses Draft 4 conventions, not Draft 2020-12."""
+        # Must have definitions, not $defs
+        assert "definitions" in schema, "Schema should use 'definitions' (Draft 4), not '$defs'"
+        assert "$defs" not in schema, "Schema should not contain '$defs' (Draft 2020-12)"
+
+        # Check no const anywhere in the schema (should be converted to enum)
+        _assert_key_absent_recursive(schema, "const", "const should be converted to single-value enum")
+
+        # Check no discriminator anywhere in the schema (not in Draft 4)
+        _assert_key_absent_recursive(schema, "discriminator", "discriminator is not part of Draft 4")
+
+        # Must have $schema pointing to Draft 4
+        assert schema.get("$schema") == "http://json-schema.org/draft-04/schema#"
+
+    def test_exclusive_minimum_is_draft4_boolean(self, schema: dict[str, Any]) -> None:
+        """Verify exclusiveMinimum/exclusiveMaximum use Draft 4 boolean syntax, not Draft 6+ number syntax.
+
+        Draft 4: "minimum": 0, "exclusiveMinimum": true
+        Draft 6+: "exclusiveMinimum": 0 (number, standalone)
+        """
+        exclusive_nodes: list[tuple[str, dict[str, Any]]] = []
+        _collect_exclusive_nodes(schema, "", exclusive_nodes)
+
+        assert len(exclusive_nodes) > 0, "Schema should contain at least one exclusiveMinimum or exclusiveMaximum"
+
+        for path, node in exclusive_nodes:
+            if "exclusiveMinimum" in node:
+                assert node["exclusiveMinimum"] is True, (
+                    f"exclusiveMinimum at {path} should be boolean true (Draft 4), got {node['exclusiveMinimum']!r}"
+                )
+                assert "minimum" in node, f"exclusiveMinimum at {path} requires a companion 'minimum' field in Draft 4"
+            if "exclusiveMaximum" in node:
+                assert node["exclusiveMaximum"] is True, (
+                    f"exclusiveMaximum at {path} should be boolean true (Draft 4), got {node['exclusiveMaximum']!r}"
+                )
+                assert "maximum" in node, f"exclusiveMaximum at {path} requires a companion 'maximum' field in Draft 4"
+
+    def test_source_field_excluded(self, schema: dict[str, Any]) -> None:
+        """Verify that 'source' field is not present in any definition."""
+        # Check root properties
+        root_props = schema.get("properties", {})
+        assert "source" not in root_props, "source should be excluded from root properties"
+
+        # Check all definitions
+        definitions = schema.get("definitions", {})
+        for def_name, def_schema in definitions.items():
+            props = def_schema.get("properties", {})
+            assert "source" not in props, f"source should be excluded from {def_name}"
+
+    def test_pipe_category_field_excluded(self, schema: dict[str, Any]) -> None:
+        """Verify that 'pipe_category' is not present in pipe definitions."""
+        definitions = schema.get("definitions", {})
+        pipe_def_names = [def_name for def_name in definitions if def_name.startswith("Pipe") and def_name.endswith("Blueprint")]
+
+        assert len(pipe_def_names) > 0, "Should have pipe blueprint definitions"
+
+        for def_name in pipe_def_names:
+            props = definitions[def_name].get("properties", {})
+            assert "pipe_category" not in props, f"pipe_category should be excluded from {def_name}"
+
+    def test_construct_alias_used(self, schema: dict[str, Any]) -> None:
+        """Verify PipeComposeBlueprint uses 'construct' alias, not 'construct_blueprint'."""
+        definitions = schema.get("definitions", {})
+        compose_def = definitions.get("PipeComposeBlueprint", {})
+        props = compose_def.get("properties", {})
+
+        assert "construct" in props, "PipeComposeBlueprint should have 'construct' (alias), not 'construct_blueprint'"
+        assert "construct_blueprint" not in props, "Internal name 'construct_blueprint' should not appear in schema"
+
+    def test_all_pipe_types_present(self, schema: dict[str, Any]) -> None:
+        """Verify all 9 pipe types are represented in the schema definitions."""
+        definitions = schema.get("definitions", {})
+
+        expected_blueprint_names = {
+            "PipeFuncBlueprint",
+            "PipeImgGenBlueprint",
+            "PipeComposeBlueprint",
+            "PipeLLMBlueprint",
+            "PipeExtractBlueprint",
+            "PipeBatchBlueprint",
+            "PipeConditionBlueprint",
+            "PipeParallelBlueprint",
+            "PipeSequenceBlueprint",
+        }
+
+        for blueprint_name in expected_blueprint_names:
+            assert blueprint_name in definitions, f"{blueprint_name} should be present in schema definitions"
+
+        # Also verify we have 9 pipe types matching the PipeType enum
+        assert len(PipeType.value_list()) == 9, "Should have exactly 9 pipe types"
+
+    def test_construct_schema_matches_mthds_format(self, schema: dict[str, Any]) -> None:
+        """Verify ConstructBlueprint uses additionalProperties, not 'fields' wrapper."""
+        definitions = schema.get("definitions", {})
+        construct_def = definitions.get("ConstructBlueprint", {})
+
+        # Should use additionalProperties (MTHDS format: fields at root)
+        assert "additionalProperties" in construct_def, "ConstructBlueprint should use additionalProperties for MTHDS-format fields"
+
+        # Should not have a 'fields' property (internal model structure)
+        props = construct_def.get("properties", {})
+        assert "fields" not in props, "ConstructBlueprint should not expose internal 'fields' wrapper"
+
+        # Should require at least one field
+        assert construct_def.get("minProperties") == 1, "ConstructBlueprint should require at least one field"
+
+    def test_taplo_metadata_present(self, schema: dict[str, Any]) -> None:
+        """Verify root schema has x-taplo.initKeys metadata."""
+        assert "x-taplo" in schema, "Schema should have x-taplo metadata"
+        taplo_meta = schema["x-taplo"]
+        assert "initKeys" in taplo_meta, "x-taplo should have initKeys"
+        assert "domain" in taplo_meta["initKeys"], "initKeys should include 'domain'"
+
+    def test_schema_has_title_and_comment(self, schema: dict[str, Any]) -> None:
+        """Verify the schema has proper title and version comment."""
+        assert schema.get("title") == "MTHDS File Schema"
+        assert "$comment" in schema
+        assert "PipelexBundleBlueprint" in schema["$comment"]
+
+    def test_ref_paths_use_definitions(self, schema: dict[str, Any]) -> None:
+        """Verify all $ref paths use #/definitions/ (Draft 4), not #/$defs/."""
+        refs: list[str] = []
+        _collect_refs_recursive(schema, refs)
+
+        for ref_value in refs:
+            assert "#/$defs/" not in ref_value, f"$ref should use #/definitions/, got: {ref_value}"
+
+    def test_construct_field_schema_has_all_methods(self, schema: dict[str, Any]) -> None:
+        """Verify the construct field schema covers all 4 composition methods."""
+        definitions = schema.get("definitions", {})
+        field_def = definitions.get("ConstructFieldBlueprint", {})
+
+        one_of = field_def.get("oneOf", [])
+        assert len(one_of) >= 4, "ConstructFieldBlueprint should have at least 4 oneOf variants"
+
+        # Check we have the key formats: raw values, {from: ...}, {template: ...}, nested
+        descriptions = [item.get("description", "") for item in one_of]
+        has_from = any("from" in desc.lower() or "variable" in desc.lower() for desc in descriptions)
+        has_template = any("template" in desc.lower() for desc in descriptions)
+        has_nested = any("nested" in desc.lower() for desc in descriptions)
+
+        assert has_from, "Should have a 'from' (variable reference) variant"
+        assert has_template, "Should have a 'template' variant"
+        assert has_nested, "Should have a 'nested construct' variant"
+
+
+def _assert_key_absent_recursive(node: Any, key: str, message: str) -> None:
+    """Assert that a key is not present anywhere in a nested dict/list structure."""
+    if isinstance(node, dict):
+        typed_node = cast("dict[str, Any]", node)
+        assert key not in typed_node, f"{message} (found in dict with keys: {list(typed_node.keys())[:5]})"
+        for child_value in typed_node.values():
+            _assert_key_absent_recursive(child_value, key, message)
+    elif isinstance(node, list):
+        typed_list = cast("list[Any]", node)
+        for child_item in typed_list:
+            _assert_key_absent_recursive(child_item, key, message)
+
+
+def _collect_refs_recursive(node: Any, refs: list[str]) -> None:
+    """Collect all $ref values from a nested dict/list structure."""
+    if isinstance(node, dict):
+        typed_node = cast("dict[str, Any]", node)
+        if "$ref" in typed_node and isinstance(typed_node["$ref"], str):
+            refs.append(typed_node["$ref"])
+        for child_value in typed_node.values():
+            _collect_refs_recursive(child_value, refs)
+    elif isinstance(node, list):
+        typed_list = cast("list[Any]", node)
+        for child_item in typed_list:
+            _collect_refs_recursive(child_item, refs)
+
+
+def _collect_exclusive_nodes(node: Any, path: str, results: list[tuple[str, dict[str, Any]]]) -> None:
+    """Collect all nodes that contain exclusiveMinimum or exclusiveMaximum."""
+    if isinstance(node, dict):
+        typed_node = cast("dict[str, Any]", node)
+        if "exclusiveMinimum" in typed_node or "exclusiveMaximum" in typed_node:
+            results.append((path, typed_node))
+        for key, child_value in typed_node.items():
+            _collect_exclusive_nodes(child_value, f"{path}.{key}", results)
+    elif isinstance(node, list):
+        typed_list = cast("list[Any]", node)
+        for index, child_item in enumerate(typed_list):
+            _collect_exclusive_nodes(child_item, f"{path}[{index}]", results)

--- a/tests/unit/pipelex/language/test_mthds_schema.py
+++ b/tests/unit/pipelex/language/test_mthds_schema.py
@@ -151,11 +151,11 @@ class TestMthdsSchemaGeneration:
         definitions = schema.get("definitions", {})
         field_def = definitions.get("ConstructFieldBlueprint", {})
 
-        one_of = field_def.get("oneOf", [])
-        assert len(one_of) >= 4, "ConstructFieldBlueprint should have at least 4 oneOf variants"
+        any_of = field_def.get("anyOf", [])
+        assert len(any_of) >= 4, "ConstructFieldBlueprint should have at least 4 anyOf variants"
 
         # Check we have the key formats: raw values, {from: ...}, {template: ...}, nested
-        descriptions = [item.get("description", "") for item in one_of]
+        descriptions = [item.get("description", "") for item in any_of]
         has_from = any("from" in desc.lower() or "variable" in desc.lower() for desc in descriptions)
         has_template = any("template" in desc.lower() for desc in descriptions)
         has_nested = any("nested" in desc.lower() for desc in descriptions)

--- a/uv.lock
+++ b/uv.lock
@@ -3259,7 +3259,6 @@ dependencies = [
     { name = "opentelemetry-sdk" },
     { name = "opentelemetry-semantic-conventions" },
     { name = "pillow" },
-    { name = "plxt" },
     { name = "polyfactory" },
     { name = "portkey-ai" },
     { name = "posthog" },
@@ -3287,6 +3286,7 @@ dev = [
     { name = "boto3-stubs" },
     { name = "moto", extra = ["s3"] },
     { name = "mypy" },
+    { name = "pipelex-tools" },
     { name = "pylint" },
     { name = "pyright" },
     { name = "pytest" },
@@ -3375,7 +3375,7 @@ requires-dist = [
     { name = "opentelemetry-sdk" },
     { name = "opentelemetry-semantic-conventions" },
     { name = "pillow", specifier = ">=11.2.1" },
-    { name = "plxt", directory = "../vscode-pipelex" },
+    { name = "pipelex-tools", marker = "extra == 'dev'", specifier = ">=0.1.1" },
     { name = "polyfactory", specifier = ">=2.21.0" },
     { name = "portkey-ai", specifier = ">=2.1.0" },
     { name = "posthog", specifier = ">=6.7.0" },
@@ -3407,6 +3407,20 @@ requires-dist = [
 provides-extras = ["anthropic", "bedrock", "docling", "fal", "gcp-storage", "google", "google-genai", "huggingface", "mistralai", "s3", "docs", "dev"]
 
 [[package]]
+name = "pipelex-tools"
+version = "0.1.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/4e/2a641f89e3e724346d1a90df63d6354254f04a6573e627e886174623bb1d/pipelex_tools-0.1.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3139abea91dc75db59d53296889e9af5a986291883535e1be2be1e69b1a41571", size = 5069080, upload-time = "2026-02-16T09:40:46.38Z" },
+    { url = "https://files.pythonhosted.org/packages/99/3d/c0ac42358d04712701d58011428156796c233ad20a53054eaa22afc8dcd9/pipelex_tools-0.1.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d8edd414f82d034447730c21b487ceda2f2effd7b91e07cc6464181ed2056c7a", size = 4813160, upload-time = "2026-02-16T09:40:48.792Z" },
+    { url = "https://files.pythonhosted.org/packages/39/87/5c768956c1d37235e4a2a5726d8c68d9837a5e05872f6b9f0c02ada9a549/pipelex_tools-0.1.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4a310467e8eaf5bfd69cade8a2dd6b8d2973ab6a4585898a82aba52f92d787ee", size = 4951287, upload-time = "2026-02-16T09:40:50.899Z" },
+    { url = "https://files.pythonhosted.org/packages/56/62/df5fefbb895b8f4dc7e32362a328a6eb79dc3476e496e3b1523e5b6c863c/pipelex_tools-0.1.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e20a8c53ce51ace23a2073592e6ff07e9c80606548745a569bae7feb1aa4116f", size = 5187577, upload-time = "2026-02-16T09:40:53.052Z" },
+    { url = "https://files.pythonhosted.org/packages/25/db/33bd9134c9d3c1752abc578b0bd2fcc3ce21c4fdba2f3d61e0b92e6ae898/pipelex_tools-0.1.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:66a4996705e683b7728de9c4be1f0e20fbb8b1a71ff509d9ad4306f8602d1033", size = 5209456, upload-time = "2026-02-16T09:40:55.067Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/aa/ba3812a280e4f3f6ff1dc33b89e634b78fea6eed35429fbac11fb7f9e71e/pipelex_tools-0.1.1-py3-none-win32.whl", hash = "sha256:6471c9df3941d4f572d93ef2b79fc9b3d832ab14535cecfc8429246b84b6052c", size = 4587506, upload-time = "2026-02-16T09:40:56.458Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/b7/66b955396f04e8e6582e817fc11c4a4e9151e9e44e63f106fb00cbfec4f7/pipelex_tools-0.1.1-py3-none-win_amd64.whl", hash = "sha256:84e0f7c4b298ef701c7f8403e370cd8364d4382353c2024c091c13f73954adaa", size = 5378844, upload-time = "2026-02-16T09:40:57.983Z" },
+]
+
+[[package]]
 name = "platformdirs"
 version = "4.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3423,10 +3437,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
-
-[[package]]
-name = "plxt"
-source = { directory = "../vscode-pipelex" }
 
 [[package]]
 name = "polyfactory"

--- a/uv.lock
+++ b/uv.lock
@@ -3259,6 +3259,7 @@ dependencies = [
     { name = "opentelemetry-sdk" },
     { name = "opentelemetry-semantic-conventions" },
     { name = "pillow" },
+    { name = "plxt" },
     { name = "polyfactory" },
     { name = "portkey-ai" },
     { name = "posthog" },
@@ -3374,6 +3375,7 @@ requires-dist = [
     { name = "opentelemetry-sdk" },
     { name = "opentelemetry-semantic-conventions" },
     { name = "pillow", specifier = ">=11.2.1" },
+    { name = "plxt", directory = "../vscode-pipelex" },
     { name = "polyfactory", specifier = ">=2.21.0" },
     { name = "portkey-ai", specifier = ">=2.1.0" },
     { name = "posthog", specifier = ">=6.7.0" },
@@ -3421,6 +3423,10 @@ sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
+
+[[package]]
+name = "plxt"
+source = { directory = "../vscode-pipelex" }
 
 [[package]]
 name = "polyfactory"


### PR DESCRIPTION
## Summary
- Add plxt (TOML/MTHDS/PLX linter and formatter) integration into the build pipeline with quiet output via `RUST_LOG=warn`
- Add MTHDS JSON Schema generator (`pipelex-dev generate-mthds-schema`) with comprehensive schema coverage and unit tests
- Add `pipelex-dev` CLI documentation to agent rules and CLAUDE.md
- Add plxt documentation page to MkDocs

## Test plan
- [ ] Verify `make plxt-lint` and `make plxt-format` run quietly (no INFO spam) and still report errors
- [ ] Verify `pipelex-dev generate-mthds-schema` regenerates the schema correctly
- [ ] Verify unit tests pass with `make agent-test`
- [ ] Verify CI/CD passes (plxt targets temporarily disabled in agent-check for reformatting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Build/dev workflow changes (new formatter/linter steps and schema generation) may cause CI/local diffs or new failures if tooling/config drifts; runtime product behavior is largely unaffected.
> 
> **Overview**
> Adds `plxt` as a first-class formatting/linting step for TOML/MTHDS/PLX via new `.pipelex/toml_config.toml` (also vendored into `pipelex/kit/configs`) and wires it into `make format`, `make lint`, and new merge-check targets, with quieter output via `RUST_LOG=warn`.
> 
> Introduces an MTHDS JSON Schema generation pipeline: a new `pipelex.language.mthds_schema_generator` that post-processes Pydantic output into Taplo-compatible Draft 4 schema, a `pipelex-dev generate-mthds-schema` command (plus `make generate-mthds-schema`) that writes `pipelex/language/mthds_schema.json`, and unit tests to lock down schema invariants.
> 
> Updates VS Code settings to format `.toml`/`.mthds`/`.plx` with the Pipelex formatter, adds `pipelex-tools` to dev dependencies, and documents `plxt` + the new dev CLI command in MkDocs and agent/Claude rules.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c4b0de79572f4249c33b511d160e150c89a6765. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->