### PR TITLE
Add optional display_name field to MTHDS package manifest

### DIFF
--- a/pipelex/cli/commands/pkg/index_cmd.py
+++ b/pipelex/cli/commands/pkg/index_cmd.py
@@ -30,8 +30,12 @@ def do_pkg_index(cache: bool = False) -> None:
         console.print("[yellow]No packages found to index.[/yellow]")
         raise typer.Exit(code=1)
 
+    has_display_name = any(entry.display_name for entry in index.entries.values())
+
     table = Table(title="Package Index", box=box.ROUNDED, show_header=True)
     table.add_column("Address", style="cyan")
+    if has_display_name:
+        table.add_column("Display Name")
     table.add_column("Version")
     table.add_column("Description")
     table.add_column("Domains", justify="right")
@@ -39,14 +43,19 @@ def do_pkg_index(cache: bool = False) -> None:
     table.add_column("Pipes", justify="right")
 
     for entry in index.entries.values():
-        table.add_row(
-            entry.address,
-            entry.version,
-            entry.description,
-            str(len(entry.domains)),
-            str(len(entry.concepts)),
-            str(len(entry.pipes)),
+        row: list[str] = [entry.address]
+        if has_display_name:
+            row.append(entry.display_name or "")
+        row.extend(
+            [
+                entry.version,
+                entry.description,
+                str(len(entry.domains)),
+                str(len(entry.concepts)),
+                str(len(entry.pipes)),
+            ]
         )
+        table.add_row(*row)
 
     console.print(table)
     console.print(f"\n[dim]{len(index.entries)} package(s) indexed.[/dim]")

--- a/pipelex/cli/commands/pkg/inspect_cmd.py
+++ b/pipelex/cli/commands/pkg/inspect_cmd.py
@@ -43,6 +43,8 @@ def do_pkg_inspect(address: str, cache: bool = False) -> None:
     info_table.add_column("Field", style="cyan")
     info_table.add_column("Value")
     info_table.add_row("Address", entry.address)
+    if entry.display_name:
+        info_table.add_row("Display Name", entry.display_name)
     info_table.add_row("Version", entry.version)
     info_table.add_row("Description", entry.description)
     if entry.authors:

--- a/pipelex/cli/commands/pkg/list_cmd.py
+++ b/pipelex/cli/commands/pkg/list_cmd.py
@@ -38,6 +38,8 @@ def do_pkg_list() -> None:
     pkg_table.add_column("Field", style="cyan")
     pkg_table.add_column("Value")
     pkg_table.add_row("Address", manifest.address)
+    if manifest.display_name:
+        pkg_table.add_row("Display Name", manifest.display_name)
     pkg_table.add_row("Version", manifest.version)
     pkg_table.add_row("Description", manifest.description)
     if manifest.authors:

--- a/pipelex/core/packages/index/index_builder.py
+++ b/pipelex/core/packages/index/index_builder.py
@@ -94,6 +94,7 @@ def build_index_entry_from_package(package_root: Path) -> PackageIndexEntry:
 
     return PackageIndexEntry(
         address=manifest.address,
+        display_name=manifest.display_name,
         version=manifest.version,
         description=manifest.description,
         authors=list(manifest.authors),

--- a/pipelex/core/packages/index/models.py
+++ b/pipelex/core/packages/index/models.py
@@ -49,6 +49,7 @@ class PackageIndexEntry(BaseModel):
     model_config = ConfigDict(frozen=True, extra="forbid")
 
     address: str
+    display_name: str | None = None
     version: str
     description: str
     authors: list[str] = Field(default_factory=list)

--- a/pipelex/core/packages/manifest.py
+++ b/pipelex/core/packages/manifest.py
@@ -174,6 +174,23 @@ class MthdsPackageManifest(BaseModel):
             raise ValueError(msg)
         return description
 
+    @field_validator("authors")
+    @classmethod
+    def validate_authors(cls, authors: list[str]) -> list[str]:
+        for index_author, author in enumerate(authors):
+            if not author.strip():
+                msg = f"Author at index {index_author} must not be empty or whitespace."
+                raise ValueError(msg)
+        return authors
+
+    @field_validator("license")
+    @classmethod
+    def validate_license(cls, license_value: str | None) -> str | None:
+        if license_value is not None and not license_value.strip():
+            msg = "License must not be empty or whitespace when provided."
+            raise ValueError(msg)
+        return license_value
+
     @field_validator("mthds_version")
     @classmethod
     def validate_mthds_version(cls, mthds_version: str | None) -> str | None:

--- a/pipelex/core/packages/manifest.py
+++ b/pipelex/core/packages/manifest.py
@@ -1,4 +1,5 @@
 import re
+import unicodedata
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
@@ -141,6 +142,7 @@ class MthdsPackageManifest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     address: str
+    display_name: str | None = None
     version: str
     description: str
     authors: list[str] = Field(default_factory=list)
@@ -165,6 +167,23 @@ class MthdsPackageManifest(BaseModel):
             msg = f"Invalid version '{version}'. Must be valid semver (e.g. '1.0.0', '2.1.3-beta.1')."
             raise ValueError(msg)
         return version
+
+    @field_validator("display_name")
+    @classmethod
+    def validate_display_name(cls, display_name: str | None) -> str | None:
+        if display_name is None:
+            return None
+        stripped = display_name.strip()
+        if not stripped:
+            msg = "Display name must not be empty or whitespace when provided."
+            raise ValueError(msg)
+        if len(stripped) > 128:
+            msg = f"Display name must not exceed 128 characters (got {len(stripped)})."
+            raise ValueError(msg)
+        if any(unicodedata.category(char) == "Cc" for char in stripped):
+            msg = "Display name must not contain control characters."
+            raise ValueError(msg)
+        return stripped
 
     @field_validator("description")
     @classmethod

--- a/pipelex/core/packages/manifest_parser.py
+++ b/pipelex/core/packages/manifest_parser.py
@@ -110,7 +110,7 @@ def parse_methods_toml(content: str) -> MthdsPackageManifest:
             raise ManifestValidationError(msg) from exc
 
     # Reject unknown keys in [package] section
-    known_package_keys = {"address", "version", "description", "authors", "license", "mthds_version"}
+    known_package_keys = {"address", "display_name", "version", "description", "authors", "license", "mthds_version"}
     unknown_keys = set(pkg.keys()) - known_package_keys
     if unknown_keys:
         msg = f"Unknown keys in [package] section: {', '.join(sorted(unknown_keys))}"
@@ -126,10 +126,13 @@ def parse_methods_toml(content: str) -> MthdsPackageManifest:
     license_str: str | None = str(license_val) if license_val is not None else None
     mthds_version_val = pkg.get("mthds_version")
     mthds_version: str | None = str(mthds_version_val) if mthds_version_val is not None else None
+    display_name_val = pkg.get("display_name")
+    display_name: str | None = str(display_name_val) if display_name_val is not None else None
 
     try:
         manifest = MthdsPackageManifest(
             address=address,
+            display_name=display_name,
             version=version,
             description=description,
             authors=authors,
@@ -159,6 +162,8 @@ def serialize_manifest_to_toml(manifest: MthdsPackageManifest) -> str:
     # [package] section
     package_table = tomlkit.table()
     package_table.add("address", manifest.address)
+    if manifest.display_name is not None:
+        package_table.add("display_name", manifest.display_name)
     package_table.add("version", manifest.version)
     package_table.add("description", manifest.description)
     if manifest.authors:

--- a/pipelex/core/packages/manifest_parser.py
+++ b/pipelex/core/packages/manifest_parser.py
@@ -34,9 +34,11 @@ def _walk_exports_table(table: dict[str, Any], prefix: str = "") -> list[DomainE
             # Check if this level has a "pipes" key (leaf domain)
             if "pipes" in value_dict:
                 pipes_value = value_dict["pipes"]
-                if isinstance(pipes_value, list):
-                    pipes_list = cast("list[str]", pipes_value)
-                    result.append(DomainExports(domain_path=current_path, pipes=pipes_list))
+                if not isinstance(pipes_value, list):
+                    msg = f"'pipes' in domain '{current_path}' must be a list, got {type(pipes_value).__name__}"
+                    raise ManifestValidationError(msg)
+                pipes_list = cast("list[str]", pipes_value)
+                result.append(DomainExports(domain_path=current_path, pipes=pipes_list))
 
                 # Also recurse into remaining sub-tables (a domain can have both pipes and sub-domains)
                 for sub_key, sub_value in value_dict.items():

--- a/pipelex/core/packages/manifest_parser.py
+++ b/pipelex/core/packages/manifest_parser.py
@@ -109,6 +109,13 @@ def parse_methods_toml(content: str) -> MthdsPackageManifest:
             msg = f"Invalid exports in METHODS.toml: {exc}"
             raise ManifestValidationError(msg) from exc
 
+    # Reject unknown keys in [package] section
+    known_package_keys = {"address", "version", "description", "authors", "license", "mthds_version"}
+    unknown_keys = set(pkg.keys()) - known_package_keys
+    if unknown_keys:
+        msg = f"Unknown keys in [package] section: {', '.join(sorted(unknown_keys))}"
+        raise ManifestValidationError(msg)
+
     # Build the manifest
     address: str = str(pkg.get("address", ""))
     version: str = str(pkg.get("version", ""))

--- a/tests/data/packages/legal_tools/METHODS.toml
+++ b/tests/data/packages/legal_tools/METHODS.toml
@@ -1,5 +1,6 @@
 [package]
 address = "github.com/pipelexlab/legal-tools"
+display_name = "Legal Tools"
 version = "1.0.0"
 description = "Legal document analysis tools"
 authors = ["PipelexLab"]

--- a/tests/unit/pipelex/core/packages/index/test_index_builder.py
+++ b/tests/unit/pipelex/core/packages/index/test_index_builder.py
@@ -23,6 +23,7 @@ class TestIndexBuilder:
         assert entry.address == "github.com/pipelexlab/legal-tools"
         assert entry.version == "1.0.0"
         assert entry.description == "Legal document analysis tools"
+        assert entry.display_name == "Legal Tools"
         assert entry.authors == ["PipelexLab"]
         assert entry.license == "MIT"
 

--- a/tests/unit/pipelex/core/packages/index/test_index_models.py
+++ b/tests/unit/pipelex/core/packages/index/test_index_models.py
@@ -53,6 +53,7 @@ class TestData:
 
     ENTRY: ClassVar[PackageIndexEntry] = PackageIndexEntry(
         address="github.com/pipelexlab/legal-tools",
+        display_name="Legal Tools",
         version="1.0.0",
         description="Legal document analysis tools",
         authors=["PipelexLab"],
@@ -139,6 +140,7 @@ class TestIndexModels:
         """PackageIndexEntry stores all expected metadata."""
         entry = TestData.ENTRY
         assert entry.address == "github.com/pipelexlab/legal-tools"
+        assert entry.display_name == "Legal Tools"
         assert entry.version == "1.0.0"
         assert entry.description == "Legal document analysis tools"
         assert entry.authors == ["PipelexLab"]

--- a/tests/unit/pipelex/core/packages/test_data.py
+++ b/tests/unit/pipelex/core/packages/test_data.py
@@ -177,6 +177,14 @@ description = "Package with a string instead of list for pipes"
 pipes = "single_pipe"
 """
 
+UNKNOWN_PACKAGE_KEYS_TOML = """\
+[package]
+address = "github.com/pipelexlab/unknown-keys"
+version = "1.0.0"
+description = "Package with unknown keys"
+homepage = "https://example.com"
+"""
+
 INVALID_HASH_LOCK_FILE_TOML = """\
 ["github.com/pipelexlab/bad-hash"]
 version = "1.0.0"

--- a/tests/unit/pipelex/core/packages/test_data.py
+++ b/tests/unit/pipelex/core/packages/test_data.py
@@ -9,6 +9,7 @@ from pipelex.core.packages.manifest import DomainExports, MthdsPackageManifest, 
 FULL_MANIFEST_TOML = """\
 [package]
 address = "github.com/pipelexlab/legal-tools"
+display_name = "Legal Tools"
 version = "1.0.0"
 description = "Legal document analysis tools"
 authors = ["PipelexLab"]
@@ -114,6 +115,7 @@ class ManifestTestData:
 
     FULL_MANIFEST: ClassVar[MthdsPackageManifest] = MthdsPackageManifest(
         address="github.com/pipelexlab/legal-tools",
+        display_name="Legal Tools",
         version="1.0.0",
         description="Legal document analysis tools",
         authors=["PipelexLab"],

--- a/tests/unit/pipelex/core/packages/test_data.py
+++ b/tests/unit/pipelex/core/packages/test_data.py
@@ -167,6 +167,16 @@ description = "Package with a reserved domain in exports"
 pipes = ["some_pipe"]
 """
 
+NON_LIST_PIPES_EXPORTS_TOML = """\
+[package]
+address = "github.com/pipelexlab/bad-pipes-type"
+version = "1.0.0"
+description = "Package with a string instead of list for pipes"
+
+[exports.legal]
+pipes = "single_pipe"
+"""
+
 INVALID_HASH_LOCK_FILE_TOML = """\
 ["github.com/pipelexlab/bad-hash"]
 version = "1.0.0"

--- a/tests/unit/pipelex/core/packages/test_manifest.py
+++ b/tests/unit/pipelex/core/packages/test_manifest.py
@@ -384,3 +384,85 @@ class TestMthdsPackageManifest:
                 version="1.0.0",
                 description=whitespace_description,
             )
+
+    # --- Display name validation ---
+
+    def test_valid_display_name(self):
+        """A valid display_name should be stored."""
+        manifest = MthdsPackageManifest(
+            address="github.com/org/repo",
+            version="1.0.0",
+            description="Test",
+            display_name="Legal Tools",
+        )
+        assert manifest.display_name == "Legal Tools"
+
+    def test_display_name_with_emoji(self):
+        """Emoji characters in display_name should pass."""
+        manifest = MthdsPackageManifest(
+            address="github.com/org/repo",
+            version="1.0.0",
+            description="Test",
+            display_name="\U0001f680 Legal Tools",
+        )
+        assert manifest.display_name == "\U0001f680 Legal Tools"
+
+    def test_none_display_name_accepted(self):
+        """display_name=None should pass validation (default)."""
+        manifest = MthdsPackageManifest(
+            address="github.com/org/repo",
+            version="1.0.0",
+            description="Test",
+            display_name=None,
+        )
+        assert manifest.display_name is None
+
+    def test_empty_display_name_fails(self):
+        """Empty display_name should fail validation."""
+        with pytest.raises(ValidationError, match="must not be empty or whitespace"):
+            MthdsPackageManifest(
+                address="github.com/org/repo",
+                version="1.0.0",
+                description="Test",
+                display_name="",
+            )
+
+    def test_whitespace_display_name_fails(self):
+        """Whitespace-only display_name should fail validation."""
+        with pytest.raises(ValidationError, match="must not be empty or whitespace"):
+            MthdsPackageManifest(
+                address="github.com/org/repo",
+                version="1.0.0",
+                description="Test",
+                display_name="   ",
+            )
+
+    def test_display_name_too_long_fails(self):
+        """display_name exceeding 128 characters should fail validation."""
+        with pytest.raises(ValidationError, match="must not exceed 128 characters"):
+            MthdsPackageManifest(
+                address="github.com/org/repo",
+                version="1.0.0",
+                description="Test",
+                display_name="x" * 129,
+            )
+
+    def test_display_name_with_control_chars_fails(self):
+        """display_name containing control characters should fail validation."""
+        with pytest.raises(ValidationError, match="must not contain control characters"):
+            MthdsPackageManifest(
+                address="github.com/org/repo",
+                version="1.0.0",
+                description="Test",
+                display_name="Legal\x00Tools",
+            )
+
+    def test_display_name_strips_whitespace(self):
+        """display_name with leading/trailing whitespace should be stripped."""
+        manifest = MthdsPackageManifest(
+            address="github.com/org/repo",
+            version="1.0.0",
+            description="Test",
+            display_name="  Legal Tools  ",
+        )
+        assert manifest.display_name == "Legal Tools"

--- a/tests/unit/pipelex/core/packages/test_manifest.py
+++ b/tests/unit/pipelex/core/packages/test_manifest.py
@@ -284,3 +284,103 @@ class TestMthdsPackageManifest:
             mthds_version=None,
         )
         assert manifest.mthds_version is None
+
+    # --- Authors validation ---
+
+    def test_empty_author_string_fails(self):
+        """An empty string in authors should fail validation."""
+        with pytest.raises(ValidationError, match="must not be empty or whitespace"):
+            MthdsPackageManifest(
+                address="github.com/org/repo",
+                version="1.0.0",
+                description="Test",
+                authors=[""],
+            )
+
+    def test_whitespace_author_string_fails(self):
+        """A whitespace-only string in authors should fail validation."""
+        with pytest.raises(ValidationError, match="must not be empty or whitespace"):
+            MthdsPackageManifest(
+                address="github.com/org/repo",
+                version="1.0.0",
+                description="Test",
+                authors=["   "],
+            )
+
+    def test_mixed_valid_and_empty_author_fails(self):
+        """A mix of valid and empty authors should fail validation."""
+        with pytest.raises(ValidationError, match="Author at index 1"):
+            MthdsPackageManifest(
+                address="github.com/org/repo",
+                version="1.0.0",
+                description="Test",
+                authors=["Alice", ""],
+            )
+
+    # --- License validation ---
+
+    def test_empty_license_string_fails(self):
+        """An empty license string should fail validation."""
+        with pytest.raises(ValidationError, match="must not be empty or whitespace"):
+            MthdsPackageManifest(
+                address="github.com/org/repo",
+                version="1.0.0",
+                description="Test",
+                license="",
+            )
+
+    def test_whitespace_license_string_fails(self):
+        """A whitespace-only license string should fail validation."""
+        with pytest.raises(ValidationError, match="must not be empty or whitespace"):
+            MthdsPackageManifest(
+                address="github.com/org/repo",
+                version="1.0.0",
+                description="Test",
+                license="   ",
+            )
+
+    # --- extra="forbid" tests ---
+
+    def test_manifest_rejects_unknown_fields(self):
+        """Unknown fields on MthdsPackageManifest should be rejected by extra='forbid'."""
+        with pytest.raises(ValidationError, match="extra_forbidden"):
+            MthdsPackageManifest(
+                address="github.com/org/repo",
+                version="1.0.0",
+                description="Test",
+                unknown_field="x",  # type: ignore[call-arg]
+            )
+
+    def test_dependency_rejects_unknown_fields(self):
+        """Unknown fields on PackageDependency should be rejected by extra='forbid'."""
+        with pytest.raises(ValidationError, match="extra_forbidden"):
+            PackageDependency(
+                address="github.com/org/dep",
+                version="1.0.0",
+                alias="my_dep",
+                unknown_field="x",  # type: ignore[call-arg]
+            )
+
+    def test_domain_exports_rejects_unknown_fields(self):
+        """Unknown fields on DomainExports should be rejected by extra='forbid'."""
+        with pytest.raises(ValidationError, match="extra_forbidden"):
+            DomainExports(
+                domain_path="legal",
+                pipes=["my_pipe"],
+                unknown_field="x",  # type: ignore[call-arg]
+            )
+
+    # --- Description whitespace variants ---
+
+    @pytest.mark.parametrize(
+        "whitespace_description",
+        ["\t", "\n", " \t\n "],
+    )
+    def test_whitespace_only_description_fails(self, whitespace_description: str):
+        """Various whitespace-only descriptions should fail validation."""
+        with pytest.raises(ValidationError, match="must not be empty"):
+            MthdsPackageManifest(
+                address="github.com/org/repo",
+                version="1.0.0",
+                description=whitespace_description,
+            )

--- a/tests/unit/pipelex/core/packages/test_manifest_parser.py
+++ b/tests/unit/pipelex/core/packages/test_manifest_parser.py
@@ -12,6 +12,7 @@ from tests.unit.pipelex.core.packages.test_data import (
     MISSING_PACKAGE_SECTION_TOML,
     MISSING_REQUIRED_FIELDS_TOML,
     MULTI_LEVEL_EXPORTS_TOML,
+    NON_LIST_PIPES_EXPORTS_TOML,
     NON_TABLE_DEPENDENCY_TOML,
     RESERVED_DOMAIN_EXPORTS_TOML,
     ManifestTestData,
@@ -99,6 +100,11 @@ class TestManifestParser:
         _ = topic  # Used for test identification
         with pytest.raises(ManifestValidationError, match="Invalid exports"):
             parse_methods_toml(toml_content)
+
+    def test_parse_non_list_pipes_raises(self):
+        """A non-list value for 'pipes' should raise ManifestValidationError, not be silently dropped."""
+        with pytest.raises(ManifestValidationError, match="must be a list"):
+            parse_methods_toml(NON_LIST_PIPES_EXPORTS_TOML)
 
     def test_parse_reserved_domain_in_exports_raises(self):
         """Reserved domain in [exports] should raise ManifestValidationError."""

--- a/tests/unit/pipelex/core/packages/test_manifest_parser.py
+++ b/tests/unit/pipelex/core/packages/test_manifest_parser.py
@@ -15,6 +15,7 @@ from tests.unit.pipelex.core.packages.test_data import (
     NON_LIST_PIPES_EXPORTS_TOML,
     NON_TABLE_DEPENDENCY_TOML,
     RESERVED_DOMAIN_EXPORTS_TOML,
+    UNKNOWN_PACKAGE_KEYS_TOML,
     ManifestTestData,
 )
 
@@ -130,3 +131,8 @@ class TestManifestParser:
         assert 'address = "github.com/pipelexlab/minimal"' in toml_str
         assert "[dependencies]" not in toml_str
         assert "[exports" not in toml_str
+
+    def test_parse_unknown_package_keys_raises(self):
+        """Unknown keys in [package] section should raise ManifestValidationError."""
+        with pytest.raises(ManifestValidationError, match="Unknown keys in \\[package\\] section"):
+            parse_methods_toml(UNKNOWN_PACKAGE_KEYS_TOML)

--- a/tests/unit/pipelex/core/packages/test_manifest_parser.py
+++ b/tests/unit/pipelex/core/packages/test_manifest_parser.py
@@ -31,6 +31,7 @@ class TestManifestParser:
         assert manifest.description == ManifestTestData.FULL_MANIFEST.description
         assert manifest.authors == ManifestTestData.FULL_MANIFEST.authors
         assert manifest.license == ManifestTestData.FULL_MANIFEST.license
+        assert manifest.display_name == ManifestTestData.FULL_MANIFEST.display_name
         assert manifest.mthds_version == ManifestTestData.FULL_MANIFEST.mthds_version
         assert len(manifest.dependencies) == 1
         assert manifest.dependencies[0].alias == "scoring_lib"
@@ -45,6 +46,7 @@ class TestManifestParser:
         manifest = parse_methods_toml(MINIMAL_MANIFEST_TOML)
         assert manifest.address == ManifestTestData.MINIMAL_MANIFEST.address
         assert manifest.version == ManifestTestData.MINIMAL_MANIFEST.version
+        assert manifest.display_name is None
         assert manifest.dependencies == []
         assert manifest.exports == []
 


### PR DESCRIPTION
## Summary

- Add an optional `display_name` field to `[package]` in METHODS.toml as a cosmetic human-friendly label for CLI output, registry listings, and error messages
- Validate: non-empty when provided, max 128 characters, no Unicode control characters, strips whitespace, emojis allowed
- Display in `pkg list`, `pkg inspect`, and `pkg index` CLI commands (Address column always shown; Display Name column added conditionally)
- Pass `display_name` through index models and builder
- Add 8 validation tests covering valid, emoji, None, empty, whitespace, too-long, control-chars, and stripping cases

## Test plan

- [x] `make agent-check` — all linting/type checking passes
- [x] `make agent-test` — all unit tests pass
- [x] Roundtrip serialization test covers display_name
- [x] Minimal manifest (no display_name) continues to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes manifest parsing/validation behavior (new rejections for malformed `pipes` values and unknown `[package]` keys) which could break previously-accepted manifests, though runtime impact is limited to package metadata and CLI output.
> 
> **Overview**
> Adds an optional `display_name` field to `METHODS.toml` package manifests, including validation (trimmed, non-empty, max length, no control chars) and TOML serialization support.
> 
> Propagates `display_name` through `PackageIndexEntry` and the index builder, and updates `pkg list`, `pkg inspect`, and `pkg index` to display it (with `pkg index` adding the column only when any entry has a value). Tightens manifest parsing by rejecting non-list `exports.*.pipes` values and unknown keys under `[package]`, with expanded unit tests and updated test fixture data.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 13319b58445dce137fd86ec0263149d1d9dd05d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->