### PR TITLE
Fix _build_error_source crash when exception has no traceback

### DIFF
--- a/pipelex/cli/agent_cli/commands/agent_output.py
+++ b/pipelex/cli/agent_cli/commands/agent_output.py
@@ -108,6 +108,10 @@ def _build_error_source(exc: BaseException) -> list[str]:
     sources: list[str] = []
     current: BaseException | None = exc
     while current is not None:
+        if current.__traceback__ is None:
+            sources.append(f"{type(current).__name__} (no traceback)")
+            current = current.__cause__
+            continue
         tbe = traceback.extract_tb(current.__traceback__)
         if tbe:
             frame = tbe[-1]  # default fallback

--- a/tests/unit/pipelex/cli/test_agent_output.py
+++ b/tests/unit/pipelex/cli/test_agent_output.py
@@ -10,6 +10,7 @@ import typer
 
 from pipelex.cli.agent_cli.commands.agent_output import (
     AGENT_ERROR_HINTS,
+    _build_error_source,  # noqa: PLC2701  # pyright: ignore[reportPrivateUsage]
     agent_error,
     agent_success,
     extract_validation_errors,
@@ -202,3 +203,60 @@ class TestAgentOutput:
         exc = ValidateBundleError(message="no details")
         result = extract_validation_errors(exc)
         assert result == []
+
+    # -------------------------------------------------------------------------
+    # _build_error_source tests
+    # -------------------------------------------------------------------------
+
+    def test_build_error_source_with_none_traceback(self) -> None:
+        """_build_error_source should handle exceptions with no traceback (constructed but never raised)."""
+        exc = RuntimeError("constructed, not raised")
+        assert exc.__traceback__ is None
+
+        sources = _build_error_source(exc)
+        assert len(sources) == 1
+        assert "RuntimeError" in sources[0]
+        assert "no traceback" in sources[0]
+
+    def test_build_error_source_with_chained_none_tracebacks(self) -> None:
+        """_build_error_source should handle a cause chain where all exceptions lack tracebacks."""
+        cause = ValueError("root cause")
+        outer = RuntimeError("wrapper")
+        outer.__cause__ = cause
+        assert cause.__traceback__ is None
+        assert outer.__traceback__ is None
+
+        sources = _build_error_source(outer)
+        assert len(sources) == 2
+        assert "RuntimeError" in sources[0]
+        assert "no traceback" in sources[0]
+        assert "ValueError" in sources[1]
+        assert "no traceback" in sources[1]
+
+    def test_build_error_source_with_real_traceback(self) -> None:
+        """_build_error_source should extract location info from a raised exception."""
+        try:
+            msg = "actually raised"
+            raise RuntimeError(msg)
+        except RuntimeError as exc:
+            sources = _build_error_source(exc)
+
+        assert len(sources) == 1
+        assert "RuntimeError" in sources[0]
+        assert "no traceback" not in sources[0]
+        assert "test_agent_output.py" in sources[0]
+
+    def test_agent_error_with_no_traceback_cause(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """agent_error should emit valid JSON even when cause has no traceback."""
+        cause = RuntimeError("constructed, not raised")
+        assert cause.__traceback__ is None
+
+        with pytest.raises(typer.Exit) as exc_info:
+            agent_error("something broke", "RuntimeError", cause=cause)
+        assert exc_info.value.exit_code == 1
+
+        parsed = json.loads(capsys.readouterr().err)
+        assert parsed["error"] is True
+        assert "error_source" in parsed
+        assert len(parsed["error_source"]) == 1
+        assert "no traceback" in parsed["error_source"][0]


### PR DESCRIPTION
## Summary

- Guard `__traceback__` being `None` before calling `traceback.extract_tb()` in `_build_error_source()`. If `agent_error()` is invoked with a `cause` that was constructed but never raised (or otherwise has no traceback), the function now explicitly short-circuits with `"(no traceback)"` instead of relying on undocumented CPython behavior.
- Add 4 unit tests for `_build_error_source` covering: `None` traceback, chained `None` tracebacks, real traceback extraction, and end-to-end via `agent_error()`.

## Test plan

- [x] All existing tests pass (`make agent-test`)
- [x] All linting/type checks pass (`make agent-check`)
- [ ] Verify `agent_error()` with a constructed-but-not-raised exception emits valid JSON to stderr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive change in error-reporting code plus additional tests; behavior only changes for exceptions lacking tracebacks.
> 
> **Overview**
> Fixes a crash in agent CLI JSON error reporting by making `_build_error_source` explicitly handle exceptions (and their `__cause__` chain) with `__traceback__ is None`, emitting `"(no traceback)"` entries instead of calling `traceback.extract_tb()`.
> 
> Adds focused unit tests covering no-traceback exceptions, chained no-traceback causes, normal raised-exception source extraction, and an end-to-end `agent_error()` case to ensure valid JSON output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c8f4516881350e6216d42fda510fe2237e15550b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->