### PR TITLE
fix/-L library

### DIFF
--- a/pipelex/cli/agent_cli/commands/inputs/method_cmd.py
+++ b/pipelex/cli/agent_cli/commands/inputs/method_cmd.py
@@ -45,6 +45,7 @@ def inputs_method_cmd(
     pipe_code, method_library_dirs, method = resolve_method_target(
         method_name=name,
         pipe_override=pipe,
+        library_dirs=library_dir,
     )
     bundle_path: Path | None = None
     if method.mthds_files:

--- a/pipelex/cli/agent_cli/commands/run/method_cmd.py
+++ b/pipelex/cli/agent_cli/commands/run/method_cmd.py
@@ -71,6 +71,7 @@ def run_method_cmd(
     pipe_code, method_library_dirs, method = resolve_method_target(
         method_name=name,
         pipe_override=pipe,
+        library_dirs=library_dir,
     )
     bundle_path: str | None = None
     mthds_content: str | None = None

--- a/pipelex/cli/agent_cli/commands/validate/method_cmd.py
+++ b/pipelex/cli/agent_cli/commands/validate/method_cmd.py
@@ -48,6 +48,7 @@ def validate_method_cmd(
     pipe_code, method_library_dirs, method = resolve_method_target(
         method_name=name,
         pipe_override=pipe,
+        library_dirs=library_dir,
     )
     if not method.mthds_files:
         agent_error(f"Method '{name}' has no .mthds bundle files.", "MethodError")

--- a/pipelex/cli/commands/build/inputs/method_cmd.py
+++ b/pipelex/cli/commands/build/inputs/method_cmd.py
@@ -42,6 +42,7 @@ def build_inputs_method_cmd(
     pipe_code, method_library_dirs, _ = resolve_method_target(
         method_name=name,
         pipe_override=pipe,
+        library_dirs=library_dir,
     )
 
     effective_library_dir = list(method_library_dirs)

--- a/pipelex/cli/commands/build/output/method_cmd.py
+++ b/pipelex/cli/commands/build/output/method_cmd.py
@@ -66,6 +66,7 @@ def build_output_method_cmd(
     pipe_code, method_library_dirs, _ = resolve_method_target(
         method_name=name,
         pipe_override=pipe,
+        library_dirs=library_dir,
     )
 
     effective_library_dir = list(method_library_dirs)

--- a/pipelex/cli/commands/build/runner/method_cmd.py
+++ b/pipelex/cli/commands/build/runner/method_cmd.py
@@ -40,6 +40,7 @@ def build_runner_method_cmd(
     pipe_code, method_library_dirs, method = resolve_method_target(
         method_name=name,
         pipe_override=pipe,
+        library_dirs=library_dirs,
     )
     if not method.mthds_files:
         typer.secho(

--- a/pipelex/cli/commands/run/_run_core.py
+++ b/pipelex/cli/commands/run/_run_core.py
@@ -55,7 +55,6 @@ async def _execute_run(
 
     Shared between the ``method`` and ``pipe`` subcommands.
     """
-    source_description: str
     mthds_content: str | None = None
     if bundle_path:
         try:
@@ -73,18 +72,13 @@ async def _execute_run(
                     typer.secho(msg, fg=typer.colors.RED, err=True)
                     raise typer.Exit(1)
                 pipe_code = main_pipe_code
-                source_description = f"bundle '{bundle_path}' • main pipe: '{pipe_code}'"
-            else:
-                source_description = f"bundle '{bundle_path}' • pipe: '{pipe_code}'"
         except FileNotFoundError as exc:
             typer.secho(f"Failed to load bundle '{bundle_path}': {exc}", fg=typer.colors.RED, err=True)
             raise typer.Exit(1) from exc
         except (PipelexInterpreterError, MthdsDecodeError) as exc:
             typer.secho(f"Failed to parse bundle '{bundle_path}': {exc}", fg=typer.colors.RED, err=True)
             raise typer.Exit(1) from exc
-    elif pipe_code:
-        source_description = f"pipe '{pipe_code}'"
-    else:
+    elif not pipe_code:
         typer.secho("Failed to run: no pipe code specified", fg=typer.colors.RED, err=True)
         raise typer.Exit(1)
 
@@ -107,13 +101,6 @@ async def _execute_run(
             except JsonTypeError as json_type_error_exc:
                 typer.secho(f"Failed to parse input file '{inputs}': must be a valid JSON dictionary", fg=typer.colors.RED, err=True)
                 raise typer.Exit(1) from json_type_error_exc
-
-    # Execute pipeline
-    inputs_description = f" with inputs '{inputs}'" if inputs and not inputs.startswith("{") else ""
-    if dry_run:
-        typer.secho(f"\n🧪 Dry-running {source_description}{inputs_description}...\n", fg=typer.colors.YELLOW, bold=True)
-    else:
-        typer.secho(f"\n🚀 Executing {source_description}{inputs_description}...\n", fg=typer.colors.GREEN, bold=True)
 
     # Determine pipe run mode
     pipe_run_mode = PipeRunMode.DRY if dry_run else None

--- a/pipelex/cli/commands/run/method_cmd.py
+++ b/pipelex/cli/commands/run/method_cmd.py
@@ -94,6 +94,7 @@ def run_method_cmd(
     pipe_code, method_library_dirs, _ = resolve_method_target(
         method_name=name,
         pipe_override=pipe,
+        library_dirs=library_dir,
     )
 
     method_dir = Path(method_library_dirs[0])

--- a/pipelex/cli/commands/validate/_validate_core.py
+++ b/pipelex/cli/commands/validate/_validate_core.py
@@ -98,7 +98,6 @@ async def _validate_pipe_or_bundle(
         except ValidateBundleError as bundle_error:
             handle_validate_bundle_error(bundle_error, bundle_path=bundle_path)
     elif pipe_code:
-        typer.echo(f"Validating pipe '{pipe_code}'...")
         library_manager = get_library_manager()
         library_id, _ = library_manager.open_library()
         set_current_library(library_id=library_id)
@@ -108,6 +107,7 @@ async def _validate_pipe_or_bundle(
             library_manager.load_libraries(library_id=library_id, library_dirs=effective_dirs)
 
         pipe = get_required_pipe(pipe_code=pipe_code)
+        typer.echo(f"Validating pipe '{pipe_code}'...")
         get_telemetry_manager().track_event(EventName.PIPE_DRY_RUN, properties={EventProperty.PIPE_TYPE: pipe.type})
         await dry_run_pipe(
             pipe,

--- a/pipelex/cli/commands/validate/method_cmd.py
+++ b/pipelex/cli/commands/validate/method_cmd.py
@@ -39,6 +39,7 @@ def validate_method_cmd(
     pipe_code, method_library_dirs, _ = resolve_method_target(
         method_name=name,
         pipe_override=pipe,
+        library_dirs=library_dir,
     )
 
     library_dirs_paths: list[Path] = [Path(lib_dir) for lib_dir in method_library_dirs]

--- a/pipelex/cli/installed_methods.py
+++ b/pipelex/cli/installed_methods.py
@@ -194,14 +194,15 @@ def find_method_by_name(
         methods = discover_installed_methods()
 
     # Merge in methods discovered from library dirs, deduplicating by resolved path
+    all_methods = list(methods)
     if library_dirs:
-        seen_paths = {method.path.resolve() for method in methods}
+        seen_paths = {method.path.resolve() for method in all_methods}
         for lib_method in discover_methods_from_library_dirs(library_dirs):
             if lib_method.path.resolve() not in seen_paths:
-                methods.append(lib_method)
+                all_methods.append(lib_method)
                 seen_paths.add(lib_method.path.resolve())
 
-    matches = [method for method in methods if method.name == method_name]
+    matches = [method for method in all_methods if method.name == method_name]
 
     if len(matches) == 0:
         msg = f"No installed method named '{method_name}' found."

--- a/pipelex/cli/installed_methods.py
+++ b/pipelex/cli/installed_methods.py
@@ -99,15 +99,89 @@ def discover_installed_methods(
     return methods
 
 
+def _discover_method_at(method_dir: Path, seen_dirs: set[Path]) -> InstalledMethod | None:
+    """Try to discover a single method at *method_dir*.
+
+    Returns an ``InstalledMethod`` if the directory contains a ``METHODS.toml``,
+    or ``None`` otherwise. Updates *seen_dirs* in place.
+    """
+    resolved = method_dir.resolve()
+    if resolved in seen_dirs or not resolved.is_dir():
+        return None
+    seen_dirs.add(resolved)
+
+    manifest_path = resolved / MANIFEST_FILENAME
+    if not manifest_path.is_file():
+        return None
+
+    content = manifest_path.read_text(encoding="utf-8")
+    manifest = parse_methods_toml(content)
+
+    name = manifest.name if manifest.name is not None else resolved.name
+
+    mthds_files = sorted(resolved.rglob("*.mthds"))
+
+    return InstalledMethod(
+        name=name,
+        path=resolved,
+        manifest=manifest,
+        mthds_files=mthds_files,
+    )
+
+
+def discover_methods_from_library_dirs(
+    library_dirs: list[str],
+) -> list[InstalledMethod]:
+    """Discover methods from explicit library directories.
+
+    For each directory in ``library_dirs``:
+
+    - If the directory itself contains a ``METHODS.toml``, it is recognised as a
+      method (the ``-L`` flag points directly to the method directory).
+    - Otherwise, the directory is searched recursively for ``METHODS.toml`` files,
+      so ``-L .`` finds methods at any depth below the current directory.
+
+    Args:
+        library_dirs: Paths to directories that may contain methods
+
+    Returns:
+        A list of discovered installed methods, deduplicated by resolved path
+    """
+    methods: list[InstalledMethod] = []
+    seen_dirs: set[Path] = set()
+
+    for dir_str in library_dirs:
+        lib_dir = Path(dir_str).resolve()
+        if not lib_dir.is_dir():
+            continue
+
+        # First, check if the directory itself is a method
+        method = _discover_method_at(lib_dir, seen_dirs)
+        if method is not None:
+            methods.append(method)
+            continue
+
+        # Otherwise, recursively find all METHODS.toml files below this directory
+        for manifest_path in sorted(lib_dir.rglob(MANIFEST_FILENAME)):
+            method_dir = manifest_path.parent
+            sub_method = _discover_method_at(method_dir, seen_dirs)
+            if sub_method is not None:
+                methods.append(sub_method)
+
+    return methods
+
+
 def find_method_by_name(
     method_name: str,
     methods: list[InstalledMethod] | None = None,
+    library_dirs: list[str] | None = None,
 ) -> InstalledMethod:
     """Find a method by name.
 
     Args:
         method_name: The method name to search for
         methods: Pre-discovered methods list; if None, runs discovery
+        library_dirs: Additional directories to check for methods
 
     Returns:
         The matching InstalledMethod
@@ -118,6 +192,14 @@ def find_method_by_name(
     """
     if methods is None:
         methods = discover_installed_methods()
+
+    # Merge in methods discovered from library dirs, deduplicating by resolved path
+    if library_dirs:
+        seen_paths = {method.path.resolve() for method in methods}
+        for lib_method in discover_methods_from_library_dirs(library_dirs):
+            if lib_method.path.resolve() not in seen_paths:
+                methods.append(lib_method)
+                seen_paths.add(lib_method.path.resolve())
 
     matches = [method for method in methods if method.name == method_name]
 

--- a/pipelex/cli/method_resolver.py
+++ b/pipelex/cli/method_resolver.py
@@ -55,6 +55,7 @@ def _find_method_by_exported_pipe(pipe_code: str) -> InstalledMethod:
 def resolve_method_target(
     method_name: str,
     pipe_override: str | None = None,
+    library_dirs: list[str] | None = None,
 ) -> tuple[str, list[str], InstalledMethod]:
     """Resolve a method name to (pipe_code, library_dirs, method).
 
@@ -65,6 +66,7 @@ def resolve_method_target(
     Args:
         method_name: The installed method name to resolve.
         pipe_override: Optional pipe code override (takes precedence over main_pipe).
+        library_dirs: Additional directories to search for methods.
 
     Returns:
         A tuple of (pipe_code, library_dirs, installed_method) for execution.
@@ -73,7 +75,7 @@ def resolve_method_target(
         typer.Exit: On resolution errors with user-friendly messages.
     """
     try:
-        method = find_method_by_name(method_name)
+        method = find_method_by_name(method_name, library_dirs=library_dirs)
     except MethodNotFoundError as exc:
         typer.secho(
             f"Method '{method_name}' is not installed. Check installed methods with: ls ~/.mthds/methods/ or ls .mthds/methods/",

--- a/tests/unit/pipelex/cli/test_installed_methods.py
+++ b/tests/unit/pipelex/cli/test_installed_methods.py
@@ -1,0 +1,166 @@
+"""Unit tests for discover_methods_from_library_dirs and find_method_by_name with library_dirs."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from mthds.package.discovery import MANIFEST_FILENAME
+from mthds.package.manifest.parser import parse_methods_toml
+
+from pipelex.cli.installed_methods import (
+    DuplicateMethodNameError,
+    InstalledMethod,
+    MethodNotFoundError,
+    discover_methods_from_library_dirs,
+    find_method_by_name,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+MINIMAL_MANIFEST_TEMPLATE = """\
+[package]
+address = "github.com/test/{address_suffix}"
+version = "0.1.0"
+description = "A test method"
+{name_line}
+main_pipe = "test_pipe"
+"""
+
+
+def _write_manifest(method_dir: Path, name: str | None = None, address_suffix: str = "pkg") -> None:
+    """Write a minimal METHODS.toml into *method_dir*."""
+    method_dir.mkdir(parents=True, exist_ok=True)
+    name_line = f'name = "{name}"' if name else ""
+    content = MINIMAL_MANIFEST_TEMPLATE.format(address_suffix=address_suffix, name_line=name_line)
+    (method_dir / MANIFEST_FILENAME).write_text(content, encoding="utf-8")
+
+
+class TestDiscoverMethodsFromLibraryDirs:
+    """Tests for discover_methods_from_library_dirs and find_method_by_name with library_dirs."""
+
+    def test_discovers_method_with_manifest(self, tmp_path: Path) -> None:
+        """A directory containing METHODS.toml is discovered as an installed method."""
+        method_dir = tmp_path / "my-method"
+        _write_manifest(method_dir, name="my-method")
+        (method_dir / "core.mthds").write_text("# placeholder", encoding="utf-8")
+
+        results = discover_methods_from_library_dirs([str(method_dir)])
+
+        assert len(results) == 1
+        assert results[0].name == "my-method"
+        assert results[0].path == method_dir.resolve()
+        assert len(results[0].mthds_files) == 1
+        assert results[0].mthds_files[0].name == "core.mthds"
+
+    def test_skips_directory_without_manifest(self, tmp_path: Path) -> None:
+        """A directory without METHODS.toml is silently skipped."""
+        method_dir = tmp_path / "no-manifest"
+        method_dir.mkdir()
+        (method_dir / "core.mthds").write_text("# placeholder", encoding="utf-8")
+
+        results = discover_methods_from_library_dirs([str(method_dir)])
+
+        assert results == []
+
+    def test_skips_nonexistent_directory(self, tmp_path: Path) -> None:
+        """A non-existent directory path is silently skipped."""
+        results = discover_methods_from_library_dirs([str(tmp_path / "does-not-exist")])
+
+        assert results == []
+
+    def test_deduplicates_by_resolved_path(self, tmp_path: Path) -> None:
+        """The same directory passed multiple times yields only one method."""
+        method_dir = tmp_path / "dup-method"
+        _write_manifest(method_dir, name="dup-method")
+
+        results = discover_methods_from_library_dirs([str(method_dir), str(method_dir)])
+
+        assert len(results) == 1
+
+    def test_name_falls_back_to_directory_name(self, tmp_path: Path) -> None:
+        """When manifest has no 'name', the directory name is used."""
+        method_dir = tmp_path / "fallback-name"
+        _write_manifest(method_dir, name=None)
+
+        results = discover_methods_from_library_dirs([str(method_dir)])
+
+        assert len(results) == 1
+        assert results[0].name == "fallback-name"
+
+    def test_discovers_methods_in_subdirectories(self, tmp_path: Path) -> None:
+        """When -L points to a parent dir (no METHODS.toml at root), subdirs are scanned."""
+        parent_dir = tmp_path / "methods"
+        parent_dir.mkdir()
+
+        method_a = parent_dir / "method-a"
+        _write_manifest(method_a, name="method-a", address_suffix="a")
+        (method_a / "a.mthds").write_text("# placeholder", encoding="utf-8")
+
+        method_b = parent_dir / "method-b"
+        _write_manifest(method_b, name="method-b", address_suffix="b")
+        (method_b / "b.mthds").write_text("# placeholder", encoding="utf-8")
+
+        # A non-method subdirectory (no METHODS.toml) should be ignored
+        (parent_dir / "not-a-method").mkdir()
+
+        results = discover_methods_from_library_dirs([str(parent_dir)])
+
+        assert len(results) == 2
+        names = {result.name for result in results}
+        assert names == {"method-a", "method-b"}
+
+    def test_discovers_methods_nested_deeply(self, tmp_path: Path) -> None:
+        """When -L points to a grandparent dir, methods nested multiple levels deep are found."""
+        # Simulates: -L . where ./methods/cv-analyzer/METHODS.toml exists
+        root_dir = tmp_path / "project"
+        root_dir.mkdir()
+        method_dir = root_dir / "methods" / "cv-analyzer"
+        _write_manifest(method_dir, name="cv-analyzer", address_suffix="cv")
+        (method_dir / "cv.mthds").write_text("# placeholder", encoding="utf-8")
+
+        results = discover_methods_from_library_dirs([str(root_dir)])
+
+        assert len(results) == 1
+        assert results[0].name == "cv-analyzer"
+
+    def test_find_method_by_name_with_library_dirs(self, tmp_path: Path) -> None:
+        """find_method_by_name discovers a method via library_dirs when not in standard locations."""
+        method_dir = tmp_path / "lib-method"
+        _write_manifest(method_dir, name="lib-method")
+        (method_dir / "lib.mthds").write_text("# placeholder", encoding="utf-8")
+
+        result = find_method_by_name("lib-method", methods=[], library_dirs=[str(method_dir)])
+
+        assert result.name == "lib-method"
+        assert result.path == method_dir.resolve()
+
+    def test_find_method_by_name_not_found_raises(self, tmp_path: Path) -> None:
+        """MethodNotFoundError is raised when the method is absent from both standard and library dirs."""
+        method_dir = tmp_path / "other-method"
+        _write_manifest(method_dir, name="other-method")
+
+        with pytest.raises(MethodNotFoundError):
+            find_method_by_name("nonexistent", methods=[], library_dirs=[str(method_dir)])
+
+    def test_find_method_by_name_duplicate_raises(self, tmp_path: Path) -> None:
+        """DuplicateMethodNameError is raised when same name appears in standard and library dirs."""
+        method_dir = tmp_path / "dup"
+        _write_manifest(method_dir, name="dup-name", address_suffix="pkg2")
+        (method_dir / "dup.mthds").write_text("# placeholder", encoding="utf-8")
+
+        # Simulate a pre-discovered method with the same name but different path
+        other_dir = tmp_path / "other-dup"
+        _write_manifest(other_dir, name="dup-name", address_suffix="pkg3")
+
+        manifest_content = (other_dir / MANIFEST_FILENAME).read_text(encoding="utf-8")
+        pre_existing = InstalledMethod(
+            name="dup-name",
+            path=other_dir.resolve(),
+            manifest=parse_methods_toml(manifest_content),
+            mthds_files=[],
+        )
+
+        with pytest.raises(DuplicateMethodNameError):
+            find_method_by_name("dup-name", methods=[pre_existing], library_dirs=[str(method_dir)])


### PR DESCRIPTION
. Method discovery from -L directories (pipelex/cli/installed_methods.py)

  - Added _discover_method_at() helper to check a single directory for METHODS.toml
  - Added discover_methods_from_library_dirs() — recursively finds methods from -L directories:
    - If the dir itself has METHODS.toml, it's treated as a method
    - Otherwise, rglob(MANIFEST_FILENAME) finds methods at any depth below (so -L . works)
  - Updated find_method_by_name() with optional library_dirs parameter — merges library dir methods with standard methods, deduplicating by path

  2. Threading library_dirs through resolution (pipelex/cli/method_resolver.py)

  - Added library_dirs parameter to resolve_method_target(), passed to find_method_by_name()

  3. All 8 callsites updated

  - Each run method, validate method, build runner/inputs/output method, and agent CLI equivalents now pass their -L parameter to resolve_method_target()

  4. Fixed premature "Executing/Validating" messages

  - _run_core.py: Removed the premature "🚀 Executing pipe" message that printed before the pipe was verified to exist
  - _validate_core.py: Moved "Validating pipe" message to after get_required_pipe() succeeds

  5. Tests (tests/unit/pipelex/cli/test_installed_methods.py)

  - 10 tests covering: direct discovery, subdirectory scanning, deep nesting (-L . scenario), deduplication, name fallback, find_method_by_name with library dirs, not-found errors, duplicate errors