### PR TITLE
feat: skip inference setup for --dry-run in agent CLI run commands

### DIFF
--- a/pipelex/cli/agent_cli/commands/run/bundle_cmd.py
+++ b/pipelex/cli/agent_cli/commands/run/bundle_cmd.py
@@ -173,7 +173,7 @@ def run_bundle_cmd(
                 agent_error(str(exc), type(exc).__name__, cause=exc)
 
         case RunnerType.PIPELEX:
-            make_pipelex_for_agent_cli(log_level=ctx.obj["log_level"])
+            make_pipelex_for_agent_cli(log_level=ctx.obj["log_level"], needs_inference=not dry_run)
 
             try:
                 result = asyncio.run(

--- a/pipelex/cli/agent_cli/commands/run/method_cmd.py
+++ b/pipelex/cli/agent_cli/commands/run/method_cmd.py
@@ -130,7 +130,7 @@ def run_method_cmd(
                 agent_error(str(exc), type(exc).__name__, cause=exc)
 
         case RunnerType.PIPELEX:
-            make_pipelex_for_agent_cli(log_level=ctx.obj["log_level"])
+            make_pipelex_for_agent_cli(log_level=ctx.obj["log_level"], needs_inference=not dry_run)
 
             try:
                 result = asyncio.run(

--- a/pipelex/cli/agent_cli/commands/run/pipe_cmd.py
+++ b/pipelex/cli/agent_cli/commands/run/pipe_cmd.py
@@ -128,7 +128,7 @@ def run_pipe_cmd(
                 agent_error(str(exc), type(exc).__name__, cause=exc)
 
         case RunnerType.PIPELEX:
-            make_pipelex_for_agent_cli(log_level=ctx.obj["log_level"])
+            make_pipelex_for_agent_cli(log_level=ctx.obj["log_level"], needs_inference=not dry_run)
 
             try:
                 result = asyncio.run(


### PR DESCRIPTION
Pass needs_inference=not dry_run to make_pipelex_for_agent_cli so that dry runs no longer require backend configuration or API keys. This enables the build skill's Phase 9 (validate & test) to work without full inference setup.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only adjust agent CLI initialization for `--dry-run` runs and should not affect actual execution paths, but could surface if inference is unexpectedly needed during dry-run.
> 
> **Overview**
> **Agent CLI `run` commands no longer require inference configuration when `--dry-run` is used.**
> 
> For the `pipelex` runner, `run bundle`, `run method`, and `run pipe` now call `make_pipelex_for_agent_cli(..., needs_inference=not dry_run)`, avoiding gateway/telemetry/API-key setup during dry runs while keeping normal runs unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3dbe435860eedd07ba9a50910756165878c793a1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->