### PR TITLE
Release v0.18.5

### DIFF
--- a/.github/workflows/doc-check.yml
+++ b/.github/workflows/doc-check.yml
@@ -2,14 +2,25 @@ name: Documentation Check
 
 on:
   pull_request:
-    branches:
-      - main
-    paths:
-      - 'docs/**'
-      - 'mkdocs.yml'
 
 jobs:
+  check-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      should-run: ${{ github.base_ref == 'main' || steps.filter.outputs.docs == 'true' }}
+    steps:
+      - uses: dorny/paths-filter@v3
+        id: filter
+        if: github.base_ref != 'main'
+        with:
+          filters: |
+            docs:
+              - 'docs/**'
+              - 'mkdocs.yml'
+
   doc-check:
+    needs: check-changes
+    if: needs.check-changes.outputs.should-run == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -26,4 +37,4 @@ jobs:
           pip install mkdocs==1.6.1 mkdocs-material==9.6.14 mkdocs-glightbox==0.4.0 mkdocs-meta-manager==1.1.0
 
       - name: Check documentation build
-        run: mkdocs build --strict 
+        run: mkdocs build --strict

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v0.18.5] - 2026-03-01
+
+### Changed
+
+- `pipelex-agent assemble` command now outputs JSON to stdout by default.
+
 ## [v0.18.4] - 2026-03-01
 
 ### Added

--- a/pipelex/cli/agent_cli/commands/assemble_cmd.py
+++ b/pipelex/cli/agent_cli/commands/assemble_cmd.py
@@ -68,9 +68,9 @@ def assemble_cmd(
         typer.Option("--main-pipe", "-m", help="Main pipe code for the bundle"),
     ],
     output: Annotated[
-        str,
-        typer.Option("--output", "-o", help="Output file path for the assembled bundle (.mthds)"),
-    ],
+        str | None,
+        typer.Option("--output", "-o", help="Output file path (.mthds). Omit to return TOML in JSON response."),
+    ] = None,
     description: Annotated[
         str | None,
         typer.Option("--description", help="Description of the bundle"),
@@ -98,11 +98,10 @@ def assemble_cmd(
 
     Examples:
         pipelex-agent assemble --domain my_domain --main-pipe main
-            --concepts concepts.toml --pipes pipes.toml --output bundle.mthds
+            --concepts concepts.toml --pipes pipes.toml
 
         pipelex-agent assemble --domain my_domain --main-pipe main
-            --concepts '[concept.MyInput]' --pipes '[pipe.main]'
-            --output bundle.mthds
+            --concepts concepts.toml --pipes pipes.toml --output bundle.mthds
     """
     try:
         # Create base document with domain header
@@ -139,25 +138,33 @@ def assemble_cmd(
                 except Exception as exc:
                     agent_error(f"Failed to load pipes from '{pipe_source}': {exc}", "PipeLoadError", cause=exc)
 
-        # Write output file
-        output_path = Path(output)
-        output_path.parent.mkdir(parents=True, exist_ok=True)
+        toml_content = tomlkit.dumps(doc)
+        if not toml_content.endswith("\n"):
+            toml_content += "\n"
 
-        with open(output_path, "w", encoding="utf-8") as out_file:
-            tomlkit.dump(doc, out_file)
-
-        # Ensure file ends with newline (POSIX standard)
-        with open(output_path, "a", encoding="utf-8") as out_file:
-            out_file.write("\n")
-
-        agent_success(
-            {
-                "success": True,
-                "bundle_path": str(output_path.resolve()),
-                "domain": domain,
-                "main_pipe": main_pipe,
-            }
-        )
+        if output is None:
+            # Stdout mode (default): return TOML in JSON response
+            agent_success(
+                {
+                    "success": True,
+                    "toml": toml_content,
+                    "domain": domain,
+                    "main_pipe": main_pipe,
+                }
+            )
+        else:
+            # File mode: write to disk
+            output_path = Path(output)
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            Path(output_path).write_text(toml_content, encoding="utf-8")
+            agent_success(
+                {
+                    "success": True,
+                    "bundle_path": str(output_path.resolve()),
+                    "domain": domain,
+                    "main_pipe": main_pipe,
+                }
+            )
 
     except typer.Exit:
         raise

--- a/pipelex/cli/agent_cli/commands/run/bundle_cmd.py
+++ b/pipelex/cli/agent_cli/commands/run/bundle_cmd.py
@@ -173,7 +173,7 @@ def run_bundle_cmd(
                 agent_error(str(exc), type(exc).__name__, cause=exc)
 
         case RunnerType.PIPELEX:
-            make_pipelex_for_agent_cli(log_level=ctx.obj["log_level"])
+            make_pipelex_for_agent_cli(log_level=ctx.obj["log_level"], needs_inference=not dry_run)
 
             try:
                 result = asyncio.run(

--- a/pipelex/cli/agent_cli/commands/run/method_cmd.py
+++ b/pipelex/cli/agent_cli/commands/run/method_cmd.py
@@ -130,7 +130,7 @@ def run_method_cmd(
                 agent_error(str(exc), type(exc).__name__, cause=exc)
 
         case RunnerType.PIPELEX:
-            make_pipelex_for_agent_cli(log_level=ctx.obj["log_level"])
+            make_pipelex_for_agent_cli(log_level=ctx.obj["log_level"], needs_inference=not dry_run)
 
             try:
                 result = asyncio.run(

--- a/pipelex/cli/agent_cli/commands/run/pipe_cmd.py
+++ b/pipelex/cli/agent_cli/commands/run/pipe_cmd.py
@@ -128,7 +128,7 @@ def run_pipe_cmd(
                 agent_error(str(exc), type(exc).__name__, cause=exc)
 
         case RunnerType.PIPELEX:
-            make_pipelex_for_agent_cli(log_level=ctx.obj["log_level"])
+            make_pipelex_for_agent_cli(log_level=ctx.obj["log_level"], needs_inference=not dry_run)
 
             try:
                 result = asyncio.run(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pipelex"
-version = "0.18.4"
+version = "0.18.5"
 description = "Execute composable AI methods declared in the MTHDS open standard"
 authors = [{ name = "Evotis S.A.S.", email = "oss@pipelex.com" }]
 maintainers = [{ name = "Pipelex staff", email = "oss@pipelex.com" }]

--- a/uv.lock
+++ b/uv.lock
@@ -3300,7 +3300,7 @@ wheels = [
 
 [[package]]
 name = "pipelex"
-version = "0.18.4"
+version = "0.18.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

- Bump version to 0.18.5
- Update CHANGELOG: `pipelex-agent assemble` command now outputs JSON to stdout by default

## Test plan

- [ ] Verify `make agent-check` passes
- [ ] Verify `make agent-test` passes
- [ ] Confirm `pipelex-agent assemble` outputs JSON to stdout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `pipelex-agent assemble` CLI contract (default stdout JSON now includes embedded TOML unless `--output` is provided) and adjusts agent run commands to skip inference initialization during `--dry-run`, which may affect tooling expectations and execution setup.
> 
> **Overview**
> **Releases `v0.18.5`** (version bump in `pyproject.toml`/`uv.lock`) and documents the release in `CHANGELOG.md`.
> 
> `pipelex-agent assemble` now **defaults to stdout mode**: when `--output` is omitted it returns the assembled bundle TOML string inside the JSON success payload; when `--output` is provided it writes the file and returns `bundle_path`.
> 
> Agent `run` commands (`bundle`/`method`/`pipe`) now pass `needs_inference=not dry_run` to `make_pipelex_for_agent_cli`, avoiding full inference setup during `--dry-run`.
> 
> CI `doc-check` workflow now runs conditionally via a `paths-filter` gate, instead of only triggering on docs-only path changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0d0cadd0d9bdb57670841f390478465b5194440c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->