### PR TITLE
Rename search presets to provider-agnostic names

### DIFF
--- a/.pipelex-dev/test_profiles.toml
+++ b/.pipelex-dev/test_profiles.toml
@@ -206,6 +206,10 @@ google = ["nano-banana", "nano-banana-pro"]
 # --- Qwen Models ---
 qwen = ["qwen-image"]
 
+[collections.search]
+# --- Search Models ---
+linkup = ["linkup-standard", "linkup-deep"]
+
 [collections.extract]
 # --- PDF Extraction Models ---
 from_pdf = [
@@ -243,6 +247,7 @@ backends = ["azure_openai"]
 llm_models = ["gpt-4o-mini"]
 img_gen_models = []
 extract_models = []
+search_models = []
 
 ################################################################################
 # Dev Profile
@@ -253,6 +258,7 @@ backends = ["pipelex_gateway", "internal"]
 llm_models = ["claude-4.5-haiku", "gpt-4o-mini", "gemini-2.5-flash-lite"]
 img_gen_models = ["gpt-image-1-mini"]
 extract_models = ["@from_pdf"]
+search_models = ["linkup-standard"]
 
 ################################################################################
 # Coverage Profile
@@ -268,6 +274,7 @@ llm_models = [
 ]
 img_gen_models = ["gpt-image-1", "nano-banana"]
 extract_models = ["pypdfium2-extract-pdf"]
+search_models = ["linkup-standard"]
 
 ################################################################################
 # Claude Latest Profile
@@ -278,6 +285,7 @@ backends = ["anthropic", "pipelex_gateway"]
 llm_models = ["claude-4.5-*"]
 img_gen_models = []
 extract_models = []
+search_models = []
 
 ################################################################################
 # GPT No Codex Profile
@@ -288,6 +296,7 @@ backends = ["openai", "pipelex_gateway"]
 llm_models = ["gpt-*", "!*-codex", "!*-codex-*"]
 img_gen_models = ["gpt-image-*"]
 extract_models = []
+search_models = []
 
 ################################################################################
 # All Backends Profile - Test across all backends with select models
@@ -298,6 +307,7 @@ backends = ["@all"]
 llm_models = ["claude-4.5-haiku", "gpt-4o-mini", "gemini-2.5-flash-lite"]
 img_gen_models = ["gpt-image-1-mini"]
 extract_models = ["@from_pdf"]
+search_models = ["@linkup"]
 
 ################################################################################
 # Full Profile - All available models (use with caution)

--- a/.pipelex/inference/backends.toml
+++ b/.pipelex/inference/backends.toml
@@ -60,7 +60,7 @@ api_key = "${HF_TOKEN}"
 
 [linkup]
 display_name = "Linkup"
-enabled = false
+enabled = true
 api_key = "${LINKUP_API_KEY}"
 
 [mistral]

--- a/.pipelex/inference/backends.toml
+++ b/.pipelex/inference/backends.toml
@@ -60,7 +60,7 @@ api_key = "${HF_TOKEN}"
 
 [linkup]
 display_name = "Linkup"
-enabled = true
+enabled = false
 api_key = "${LINKUP_API_KEY}"
 
 [mistral]

--- a/.pipelex/inference/backends/linkup.toml
+++ b/.pipelex/inference/backends/linkup.toml
@@ -28,10 +28,10 @@ thinking_mode = "none"
 model_id = "standard"
 inputs = ["text"]
 outputs = ["structured"]
-costs = {}
+costs = { input = 0.005, output = 0 }
 
 ["linkup-deep"]
 model_id = "deep"
 inputs = ["text"]
 outputs = ["structured"]
-costs = {}
+costs = { input = 0.05, output = 0 }

--- a/.pipelex/inference/backends/linkup.toml
+++ b/.pipelex/inference/backends/linkup.toml
@@ -24,13 +24,13 @@ thinking_mode = "none"
 # SEARCH MODELS
 ################################################################################
 
-["linkup/standard"]
+["linkup-standard"]
 model_id = "standard"
 inputs = ["text"]
 outputs = ["structured"]
 costs = {}
 
-["linkup/deep"]
+["linkup-deep"]
 model_id = "deep"
 inputs = ["text"]
 outputs = ["structured"]

--- a/.pipelex/inference/backends/linkup.toml
+++ b/.pipelex/inference/backends/linkup.toml
@@ -27,11 +27,11 @@ thinking_mode = "none"
 ["linkup-standard"]
 model_id = "standard"
 inputs = ["text"]
-outputs = ["structured"]
+outputs = ["sourced-answers", "structured"]
 costs = { input = 0.005, output = 0 }
 
 ["linkup-deep"]
 model_id = "deep"
 inputs = ["text"]
-outputs = ["structured"]
+outputs = ["sourced-answers", "structured"]
 costs = { input = 0.05, output = 0 }

--- a/.pipelex/inference/backends/pipelex_gateway_models.md
+++ b/.pipelex/inference/backends/pipelex_gateway_models.md
@@ -446,13 +446,6 @@ For configuration details, see the [documentation](https://docs.pipelex.com/late
 <td style="text-align:center;background-color:rgba(76,175,80,0.15)">✅</td>
 <td style="text-align:center;background-color:rgba(76,175,80,0.15)">❌</td>
 </tr>
-<tr>
-<td>mistral-document-ai-2505</td>
-<td style="text-align:center;background-color:rgba(33,150,243,0.15)">✅</td>
-<td style="text-align:center;background-color:rgba(33,150,243,0.15)">✅</td>
-<td style="text-align:center;background-color:rgba(76,175,80,0.15)">✅</td>
-<td style="text-align:center;background-color:rgba(76,175,80,0.15)">❌</td>
-</tr>
 </tbody>
 </table>
 
@@ -522,6 +515,6 @@ For configuration details, see the [documentation](https://docs.pipelex.com/late
 
 
 > **AUTO-GENERATED FILE** - Do not edit manually.
-> Last updated: 2026-03-02T23:49:25Z
+> Last updated: 2026-03-03T18:00:27Z
 >
 > Run `pipelex-dev update-gateway-models` or `make ugm` to regenerate.

--- a/.pipelex/inference/backends/pipelex_gateway_models.md
+++ b/.pipelex/inference/backends/pipelex_gateway_models.md
@@ -515,6 +515,6 @@ For configuration details, see the [documentation](https://docs.pipelex.com/late
 
 
 > **AUTO-GENERATED FILE** - Do not edit manually.
-> Last updated: 2026-03-03T22:21:10Z
+> Last updated: 2026-03-03T23:32:10Z
 >
 > Run `pipelex-dev update-gateway-models` or `make ugm` to regenerate.

--- a/.pipelex/inference/backends/pipelex_gateway_models.md
+++ b/.pipelex/inference/backends/pipelex_gateway_models.md
@@ -515,6 +515,6 @@ For configuration details, see the [documentation](https://docs.pipelex.com/late
 
 
 > **AUTO-GENERATED FILE** - Do not edit manually.
-> Last updated: 2026-03-03T23:32:10Z
+> Last updated: 2026-03-04T00:21:08Z
 >
 > Run `pipelex-dev update-gateway-models` or `make ugm` to regenerate.

--- a/.pipelex/inference/backends/pipelex_gateway_models.md
+++ b/.pipelex/inference/backends/pipelex_gateway_models.md
@@ -515,6 +515,6 @@ For configuration details, see the [documentation](https://docs.pipelex.com/late
 
 
 > **AUTO-GENERATED FILE** - Do not edit manually.
-> Last updated: 2026-03-03T18:00:27Z
+> Last updated: 2026-03-03T22:21:10Z
 >
 > Run `pipelex-dev update-gateway-models` or `make ugm` to regenerate.

--- a/.pipelex/inference/backends/pipelex_gateway_models_plain.md
+++ b/.pipelex/inference/backends/pipelex_gateway_models_plain.md
@@ -193,6 +193,6 @@ For configuration details, see the [documentation](https://docs.pipelex.com/late
 
 
 > **AUTO-GENERATED FILE** - Do not edit manually.
-> Last updated: 2026-03-03T18:00:27Z
+> Last updated: 2026-03-03T22:21:10Z
 >
 > Run `pipelex-dev update-gateway-models` or `make ugm` to regenerate.

--- a/.pipelex/inference/backends/pipelex_gateway_models_plain.md
+++ b/.pipelex/inference/backends/pipelex_gateway_models_plain.md
@@ -193,6 +193,6 @@ For configuration details, see the [documentation](https://docs.pipelex.com/late
 
 
 > **AUTO-GENERATED FILE** - Do not edit manually.
-> Last updated: 2026-03-03T23:32:10Z
+> Last updated: 2026-03-04T00:21:08Z
 >
 > Run `pipelex-dev update-gateway-models` or `make ugm` to regenerate.

--- a/.pipelex/inference/backends/pipelex_gateway_models_plain.md
+++ b/.pipelex/inference/backends/pipelex_gateway_models_plain.md
@@ -163,9 +163,6 @@ For configuration details, see the [documentation](https://docs.pipelex.com/late
 - **deepseek-ocr**
   - inputs: image
   - outputs: pages
-- **mistral-document-ai-2505**
-  - inputs: image, pdf
-  - outputs: pages
 
 
 **About extracted pages:** Each page contains Markdown text (based on AI-interpreted layout) and optional extracted images. A single image input is treated as one page. Pipelex also wraps the `pypdfium2` library for raw text (without any AI interpretation) and images extraction and page views rendering. All these elements can be used as inputs into downstream pipes, including LLM prompts.
@@ -196,6 +193,6 @@ For configuration details, see the [documentation](https://docs.pipelex.com/late
 
 
 > **AUTO-GENERATED FILE** - Do not edit manually.
-> Last updated: 2026-03-02T23:49:25Z
+> Last updated: 2026-03-03T18:00:27Z
 >
 > Run `pipelex-dev update-gateway-models` or `make ugm` to regenerate.

--- a/.pipelex/inference/backends/pipelex_gateway_models_plain.md
+++ b/.pipelex/inference/backends/pipelex_gateway_models_plain.md
@@ -193,6 +193,6 @@ For configuration details, see the [documentation](https://docs.pipelex.com/late
 
 
 > **AUTO-GENERATED FILE** - Do not edit manually.
-> Last updated: 2026-03-03T22:21:10Z
+> Last updated: 2026-03-03T23:32:10Z
 >
 > Run `pipelex-dev update-gateway-models` or `make ugm` to regenerate.

--- a/.pipelex/inference/deck/4_search_deck.toml
+++ b/.pipelex/inference/deck/4_search_deck.toml
@@ -19,7 +19,6 @@
 ####################################################################################################
 
 [search]
-default_depth = "standard"
 choice_default = "@default-search"
 
 ####################################################################################################
@@ -34,5 +33,5 @@ default-search = "linkup-standard"
 ####################################################################################################
 
 [search.presets]
-linkup-standard = { model = "linkup-standard", depth = "standard", include_images = false, include_inline_citations = true }
-linkup-deep = { model = "linkup-deep", depth = "deep", include_images = false, include_inline_citations = true }
+standard = { model = "linkup-standard", include_images = false, include_inline_citations = true }
+deep = { model = "linkup-deep", include_images = false, include_inline_citations = true }

--- a/.pipelex/inference/deck/4_search_deck.toml
+++ b/.pipelex/inference/deck/4_search_deck.toml
@@ -27,12 +27,12 @@ choice_default = "@default-search"
 ####################################################################################################
 
 [search.aliases]
-default-search = "linkup/standard"
+default-search = "linkup-standard"
 
 ####################################################################################################
 # Search Presets
 ####################################################################################################
 
 [search.presets]
-linkup-standard = { model = "linkup/standard", depth = "standard", include_images = false, include_inline_citations = true }
-linkup-deep = { model = "linkup/deep", depth = "deep", include_images = false, include_inline_citations = true }
+linkup-standard = { model = "linkup-standard", depth = "standard", include_images = false, include_inline_citations = true }
+linkup-deep = { model = "linkup-deep", depth = "deep", include_images = false, include_inline_citations = true }

--- a/.pipelex/inference/routing_profiles.toml
+++ b/.pipelex/inference/routing_profiles.toml
@@ -28,7 +28,7 @@ active = "all_pipelex_gateway"
 description = "Use Pipelex Gateway for all its supported models"
 default = "pipelex_gateway"
 [profiles.all_pipelex_gateway.routes]
-"linkup/*" = "linkup"
+"linkup-*" = "linkup"
 
 [profiles.all_anthropic]
 description = "Use Anthropic backend for all its supported models"

--- a/.pipelex/inference/routing_profiles.toml
+++ b/.pipelex/inference/routing_profiles.toml
@@ -27,8 +27,6 @@ active = "all_pipelex_gateway"
 [profiles.all_pipelex_gateway]
 description = "Use Pipelex Gateway for all its supported models"
 default = "pipelex_gateway"
-[profiles.all_pipelex_gateway.routes]
-"linkup-*" = "linkup"
 
 [profiles.all_anthropic]
 description = "Use Anthropic backend for all its supported models"
@@ -61,6 +59,10 @@ default = "groq"
 [profiles.all_huggingface]
 description = "Use HuggingFace backend for all its supported models"
 default = "huggingface"
+
+[profiles.all_linkup]
+description = "Use Linkup backend for all its supported models"
+default = "linkup"
 
 [profiles.all_mistral]
 description = "Use Mistral backend for all its supported models"

--- a/.pipelex/pipelex.toml
+++ b/.pipelex/pipelex.toml
@@ -59,6 +59,10 @@ ranksep = 30         # Vertical spacing between ranks/levels
 initial_zoom = 1.0   # Initial zoom level (1.0 = 100%)
 pan_to_top = true    # Pan to show top of graph on load
 
+[pipelex.pipeline_execution_config.graph_config.reactflow_config.style]
+theme = "dark"
+palette = "dracula"
+
 ####################################################################################################
 # Storage Config
 ####################################################################################################

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 ## [v0.19.0] - 2026-03-02
 
 ### Added
- - **Web Search Integration**: Introduced a new `PipeSearch` operator, native support for Linkup as a search backend provider, `SearchResult` and `SearchResultContent` concepts for handling answers with citations, and Model Deck support for search models with presets (e.g., `$linkup-standard`, `$linkup-deep`), aliases, and waterfalls.
+ - **Web Search Integration**: Introduced a new `PipeSearch` operator, native support for Linkup as a search backend provider, `SearchResult` and `SearchResultContent` concepts for handling answers with citations, and Model Deck support for search models.
  - **Graph View Generation**: Added a `--view` option to `pipelex validate bundle` that generates a `ViewSpec` JSON (compatible with ReactFlow) for client-side graph rendering without writing files to disk.
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -171,8 +171,8 @@ export HELP
 	merge-check-ruff-lint merge-check-ruff-format merge-check-mypy merge-check-pyright merge-check-plxt-format merge-check-plxt-lint \
 	li check-unused-imports fix-unused-imports check-TODOs check-uv \
 	docs docs-check docs-serve-versioned docs-list docs-deploy docs-deploy-stable docs-deploy-specific-version docs-delete \
-	generate-mthds-schema gms check-mthds-schema cms \
-	update-gateway-models ugm check-gateway-models cgm up \
+	generate-mthds-schema generate-mthds-schema-quiet gms check-mthds-schema cms \
+	update-gateway-models update-gateway-models-quiet ugm check-gateway-models cgm up \
 	test-count check-test-badge \
 	serve-graph serve-graph-bg stop-graph-server view-graph sg vg \
 	docs-deploy-root
@@ -300,6 +300,9 @@ generate-mthds-schema: env
 	$(call PRINT_TITLE,"Generating MTHDS JSON Schema")
 	$(VENV_PIPELEX_DEV) generate-mthds-schema
 
+generate-mthds-schema-quiet: env
+	$(VENV_PIPELEX_DEV) generate-mthds-schema --quiet
+
 gms: generate-mthds-schema
 	@echo "> done: gms = generate-mthds-schema"
 
@@ -313,6 +316,9 @@ cms: check-mthds-schema
 update-gateway-models: env
 	$(call PRINT_TITLE,"Updating gateway models reference")
 	$(VENV_PIPELEX_DEV) update-gateway-models
+
+update-gateway-models-quiet: env
+	$(VENV_PIPELEX_DEV) update-gateway-models --quiet
 
 ugm: update-gateway-models
 	@echo "> done: ugm = update-gateway-models"
@@ -928,10 +934,10 @@ vg: view-graph
 c: format lint pyright mypy
 	@echo "> done: c = check"
 
-cc: cleanderived regenerate-test-models-quiet generate-mthds-schema c
-	@echo "> done: cc = cleanderived regenerate-test-models generate-mthds-schema format lint pyright pylint mypy"
+cc: cleanderived regenerate-test-models-quiet generate-mthds-schema-quiet update-gateway-models-quiet c
+	@echo "> done: cc = cleanderived regenerate-test-models generate-mthds-schema update-gateway-models format lint pyright pylint mypy"
 
-up: generate-mthds-schema update-gateway-models up-kit-configs rules
+up: generate-mthds-schema-quiet update-gateway-models-quiet up-kit-configs rules
 	@echo "> done: up = generate-mthds-schema update-gateway-models up-kit-configs rules"
 
 check: cc check-unused-imports check-config-sync check-rules check-urls check-gateway-models check-mthds-schema pylint

--- a/Makefile
+++ b/Makefile
@@ -935,7 +935,7 @@ c: format lint pyright mypy
 	@echo "> done: c = check"
 
 cc: cleanderived regenerate-test-models-quiet generate-mthds-schema-quiet update-gateway-models-quiet c
-	@echo "> done: cc = cleanderived regenerate-test-models generate-mthds-schema update-gateway-models format lint pyright pylint mypy"
+	@echo "> done: cc = cleanderived regenerate-test-models generate-mthds-schema update-gateway-models format lint pyright mypy"
 
 up: generate-mthds-schema-quiet update-gateway-models-quiet up-kit-configs rules
 	@echo "> done: up = generate-mthds-schema update-gateway-models up-kit-configs rules"

--- a/docs/home/6-build-reliable-ai-workflows/concepts/native-concepts.md
+++ b/docs/home/6-build-reliable-ai-workflows/concepts/native-concepts.md
@@ -310,7 +310,7 @@ type = "PipeSearch"
 description = "Search the web for information"
 inputs = { topic = "Text" }
 output = "SearchResult"
-model = "$linkup-standard"
+model = "$standard"
 prompt = "What is $topic?"
 ```
 

--- a/docs/home/6-build-reliable-ai-workflows/pipes/pipe-operators/PipeSearch.md
+++ b/docs/home/6-build-reliable-ai-workflows/pipes/pipe-operators/PipeSearch.md
@@ -25,8 +25,8 @@ PipeSearch uses the unified inference backend system to manage search providers.
 
 Common search presets:
 
-- `$linkup-standard`: Standard web search with fast results
-- `$linkup-deep`: Deep web search for more thorough results
+- `$standard`: Standard web search with fast results
+- `$deep`: Deep web search for more thorough results
 
 ### MTHDS Parameters
 
@@ -36,7 +36,7 @@ Common search presets:
 | `description` | string     | A description of the search operation.                                                                                                              | Yes      |
 | `inputs`      | dictionary | The input concept(s) for the search query, as a dictionary mapping input names to concept codes. Required when the prompt references variables.     | No       |
 | `output`      | string     | The output concept produced by the search. Must be `SearchResult` or a concept that refines `SearchResult`.                                         | Yes      |
-| `model`       | string     | The search model preset to use (e.g., `"$linkup-standard"`, `"$linkup-deep"`). Defaults to the model specified in the global config.                | No       |
+| `model`       | string     | The search model preset to use (e.g., `"$standard"`, `"$deep"`). Defaults to the model specified in the global config.                | No       |
 | `prompt`      | string     | The search query. Can be a static string or reference input variables using `$` prefix (e.g., `"What is $topic?"`).                                 | Yes      |
 
 ### Example: Static search query
@@ -48,7 +48,7 @@ This pipe performs a fixed search query without any inputs.
 type = "PipeSearch"
 description = "Search for the latest AI news"
 output = "SearchResult"
-model = "$linkup-standard"
+model = "$standard"
 prompt = "What are the latest developments in artificial intelligence?"
 ```
 
@@ -62,7 +62,7 @@ type = "PipeSearch"
 description = "Search the web for information about a topic"
 inputs = { topic = "Text" }
 output = "SearchResult"
-model = "$linkup-standard"
+model = "$standard"
 prompt = "What is $topic?"
 ```
 
@@ -76,7 +76,7 @@ type = "PipeSearch"
 description = "Perform deep research on a topic"
 inputs = { topic = "Text" }
 output = "SearchResult"
-model = "$linkup-deep"
+model = "$deep"
 prompt = "What are the main details about $topic?"
 ```
 

--- a/pipelex/builder/pipe/pipe_search_spec.py
+++ b/pipelex/builder/pipe/pipe_search_spec.py
@@ -80,7 +80,6 @@ class PipeSearchSpec(PipeSpec):
             output=base_blueprint.output,
             prompt=self.prompt,
             model=search_choice,
-            depth=None,
             include_images=None,
             max_results=None,
             from_date=None,

--- a/pipelex/cli/commands/login/command.py
+++ b/pipelex/cli/commands/login/command.py
@@ -25,7 +25,7 @@ class CallbackHandler(BaseHTTPRequestHandler):
         self._result = result
         super().__init__(*args, **kwargs)  # type: ignore[arg-type]
 
-    def do_GET(self) -> None:
+    def do_GET(self) -> None:  # pylint: disable=invalid-name
         """Handle GET /callback?api_key=xxx."""
         parsed = urlparse(self.path)
         params = parse_qs(parsed.query)

--- a/pipelex/cli/dev_cli/commands/preprocess_test_models_cmd.py
+++ b/pipelex/cli/dev_cli/commands/preprocess_test_models_cmd.py
@@ -32,7 +32,7 @@ TEST_PROFILES_PATH = Path(ConfigPaths.DEV_CONFIG_DIR_PATH) / "test_profiles.toml
 TEST_PROFILES_OVERRIDE_PATH = Path(ConfigPaths.DEV_CONFIG_DIR_PATH) / "test_profiles_override.toml"
 
 # Model types we care about
-MODEL_TYPES = ["llm", "img_gen", "text_extractor"]
+MODEL_TYPES = ["llm", "img_gen", "text_extractor", "search"]
 
 # Default model type from backend config
 DEFAULT_MODEL_TYPE = "llm"
@@ -60,6 +60,7 @@ def _extract_models_from_backend_toml(backend_path: Path) -> dict[str, list[str]
         "llm": [],
         "img_gen": [],
         "text_extractor": [],
+        "search": [],
     }
 
     for key, value in config.items():
@@ -97,7 +98,7 @@ def _fetch_gateway_models() -> dict[str, list[str]]:
         remote_config = RemoteConfigFetcher.fetch_remote_config()
         model_specs = dict(remote_config.backend_model_specs)
     except (RemoteConfigFetchError, RemoteConfigValidationError):
-        return {"llm": [], "img_gen": [], "text_extractor": []}
+        return {"llm": [], "img_gen": [], "text_extractor": [], "search": []}
 
     # Get defaults
     defaults = model_specs.get("defaults", {})
@@ -112,6 +113,7 @@ def _fetch_gateway_models() -> dict[str, list[str]]:
         "llm": [],
         "img_gen": [],
         "text_extractor": [],
+        "search": [],
     }
 
     for key, value in model_specs.items():
@@ -156,6 +158,7 @@ def _collect_all_model_availability() -> dict[str, Any]:
         "llm": {},
         "img_gen": {},
         "text_extractor": {},
+        "search": {},
     }
 
     backends_dir = Path(config_manager.backends_dir_path)
@@ -377,6 +380,7 @@ def _filter_models_by_profile(
         "llm": [],
         "img_gen": [],
         "text_extractor": [],
+        "search": [],
     }
 
     # If include_all is set, return all valid pairs
@@ -426,6 +430,7 @@ def _filter_models_by_profile(
         "llm_models": "llm",
         "img_gen_models": "img_gen",
         "extract_models": "text_extractor",
+        "search_models": "search",
     }
 
     # Model type to collection type mapping (internal name -> TOML section name)
@@ -433,6 +438,7 @@ def _filter_models_by_profile(
         "llm": "llm",
         "img_gen": "img_gen",
         "text_extractor": "extract",
+        "search": "search",
     }
 
     # Resolve model lists from profile using advanced specifiers
@@ -529,6 +535,14 @@ def _generate_fixtures_python(
     lines.append("]")
     lines.append("")
 
+    # Search combos
+    search_pairs = combo_pairs.get("search", [])
+    lines.append("SEARCH_COMBOS: list[ModelCombo] = [")
+    for model, backend in sorted(search_pairs):
+        lines.append(f"    ModelCombo({model!r}, {backend!r}),")
+    lines.append("]")
+    lines.append("")
+
     return "\n".join(lines)
 
 
@@ -568,10 +582,12 @@ def _display_summary(
     llm_total = sum(len(models) for models in availability.get("llm", {}).values())
     img_gen_total = sum(len(models) for models in availability.get("img_gen", {}).values())
     extract_total = sum(len(models) for models in availability.get("text_extractor", {}).values())
+    search_total = sum(len(models) for models in availability.get("search", {}).values())
 
     table.add_row("LLM Models", str(llm_total), str(len(combo_pairs.get("llm", []))))
     table.add_row("Image Gen Models", str(img_gen_total), str(len(combo_pairs.get("img_gen", []))))
     table.add_row("Extract Models", str(extract_total), str(len(combo_pairs.get("text_extractor", []))))
+    table.add_row("Search Models", str(search_total), str(len(combo_pairs.get("search", []))))
     table.add_row("", "", "")
     table.add_row("Total Backends", str(len(total_backends)), "-")
     table.add_row("Total Model/Backend Pairs", str(total_models), str(filtered_models))

--- a/pipelex/cogt/models/model_deck.py
+++ b/pipelex/cogt/models/model_deck.py
@@ -30,7 +30,6 @@ from pipelex.cogt.model_backends.constraints import ValuedConstraint
 from pipelex.cogt.model_backends.model_spec import InferenceModelSpec
 from pipelex.cogt.model_backends.model_type import ModelType
 from pipelex.cogt.models.model_reference import ModelReference, ModelReferenceKind, ModelReferenceParseError, ensure_model_reference
-from pipelex.cogt.search.search_depth import SearchDepth
 from pipelex.cogt.search.search_setting import SearchModelChoice, SearchSetting
 from pipelex.system.configuration.config_model import ConfigModel
 from pipelex.system.exceptions import ConfigValidationError
@@ -69,7 +68,6 @@ class ImgGenDeckBlueprint(ConfigModel):
 
 
 class SearchDeckBlueprint(ConfigModel):
-    default_depth: SearchDepth = Field(strict=False)
     aliases: dict[str, str] = Field(default_factory=dict)
     waterfalls: dict[str, list[str]] = Field(default_factory=dict)
     presets: dict[str, SearchSetting] = Field(default_factory=dict)
@@ -115,7 +113,6 @@ class ModelDeck(ConfigModel):
     img_gen_choice_default: ImgGenModelChoice
 
     # Search-specific
-    search_default_depth: SearchDepth = Field(strict=False)
     search_aliases: dict[str, str] = Field(default_factory=dict)
     search_waterfalls: dict[str, list[str]] = Field(default_factory=dict)
     search_presets: dict[str, SearchSetting] = Field(default_factory=dict)
@@ -426,7 +423,7 @@ class ModelDeck(ConfigModel):
                 )
             case ModelReferenceKind.ALIAS:
                 if alias_target := self.search_aliases.get(ref.name):
-                    return SearchSetting(model=alias_target, depth=self.search_default_depth)
+                    return SearchSetting(model=alias_target)
                 msg = f"Alias '{ref.name}' was not found in the model deck"
                 raise ModelChoiceNotFoundError(
                     message=msg,
@@ -437,7 +434,7 @@ class ModelDeck(ConfigModel):
                 )
             case ModelReferenceKind.WATERFALL:
                 if ref.name in self.search_waterfalls:
-                    return SearchSetting(model=ref.name, depth=self.search_default_depth)
+                    return SearchSetting(model=ref.name)
                 msg = f"Waterfall '{ref.name}' was not found in the model deck"
                 raise ModelChoiceNotFoundError(
                     message=msg,
@@ -449,7 +446,7 @@ class ModelDeck(ConfigModel):
             case ModelReferenceKind.HANDLE:
                 self._warn_if_ambiguous_search(ref.name)
                 if self.is_model_handle_defined(model_handle=ref.name, model_type=ModelType.SEARCH):
-                    return SearchSetting(model=ref.name, depth=self.search_default_depth)
+                    return SearchSetting(model=ref.name)
                 self._raise_handle_not_found_error(
                     ref=ref,
                     model_type=ModelType.SEARCH,

--- a/pipelex/cogt/models/model_manager.py
+++ b/pipelex/cogt/models/model_manager.py
@@ -168,7 +168,6 @@ class ModelManager(ModelManagerAbstract):
             img_gen_presets=model_deck_blueprint.img_gen.presets,
             img_gen_choice_default=model_deck_blueprint.img_gen.choice_default,
             # Search
-            search_default_depth=model_deck_blueprint.search.default_depth,
             search_aliases=model_deck_blueprint.search.aliases,
             search_waterfalls=model_deck_blueprint.search.waterfalls,
             search_presets=model_deck_blueprint.search.presets,

--- a/pipelex/cogt/search/fetch_job.py
+++ b/pipelex/cogt/search/fetch_job.py
@@ -1,0 +1,35 @@
+from datetime import datetime
+
+from pydantic import BaseModel
+from typing_extensions import override
+
+from pipelex.cogt.inference.inference_job_abstract import InferenceJobAbstract
+from pipelex.cogt.model_backends.model_spec import InferenceModelSpec
+from pipelex.cogt.search.fetch_report import FetchTokensUsage
+
+
+class FetchJobReport(BaseModel):
+    fetch_tokens_usage: FetchTokensUsage | None = None
+
+
+class FetchJob(InferenceJobAbstract):
+    job_report: FetchJobReport = FetchJobReport()
+
+    @override
+    def validate_before_execution(self):
+        pass
+
+    def fetch_job_before_start(self, inference_model: InferenceModelSpec):
+        self.job_metadata.started_at = datetime.now()
+
+        self.job_report = FetchJobReport()
+        self.job_report.fetch_tokens_usage = FetchTokensUsage(
+            job_metadata=self.job_metadata,
+            inference_model_name=inference_model.name,
+            unit_costs=inference_model.costs,
+            inference_model_id=inference_model.model_id,
+            nb_tokens_by_category={},
+        )
+
+    def fetch_job_after_complete(self):
+        self.job_metadata.completed_at = datetime.now()

--- a/pipelex/cogt/search/fetch_report.py
+++ b/pipelex/cogt/search/fetch_report.py
@@ -1,0 +1,72 @@
+from typing import Any
+
+from pydantic import BaseModel
+
+from pipelex.cogt.usage.cost_category import CostCategory, CostsByCategoryDict
+from pipelex.cogt.usage.token_category import NbTokensByCategoryDict, TokenCategory
+from pipelex.pipeline.job_metadata import JobMetadata
+from pipelex.types import StrEnum
+
+
+class FetchTokenCostReportField(StrEnum):
+    MODEL_TYPE = "model_type"
+    FETCH_NAME = "fetch_name"
+    PLATFORM_FETCH_ID = "platform_fetch_id"
+    NB_TOKENS_INPUT = "nb_tokens_input"
+    NB_TOKENS_INPUT_CACHED = "nb_tokens_input_cached"
+    NB_TOKENS_INPUT_NON_CACHED = "nb_tokens_input_non_cached"
+    NB_TOKENS_INPUT_JOINED = "nb_tokens_input_joined"
+    NB_TOKENS_OUTPUT = "nb_tokens_output"
+    COST_INPUT_CACHED = "cost_input_cached"
+    COST_INPUT_NON_CACHED = "cost_input_non_cached"
+    COST_INPUT_JOINED = "cost_input_joined"
+    COST_OUTPUT = "cost_output"
+
+    @staticmethod
+    def report_field_for_nb_tokens_by_category(token_category: TokenCategory) -> str:
+        return f"nb_tokens_{token_category}"
+
+    @staticmethod
+    def report_field_for_cost_by_category(token_category: CostCategory) -> str:
+        return f"cost_{token_category}"
+
+
+class FetchTokenCostReport(BaseModel):
+    model_type: str = "fetch"
+    job_metadata: JobMetadata
+    inference_model_name: str
+    platform_model_id: str
+
+    nb_tokens_by_category: NbTokensByCategoryDict
+    costs_by_token_category: CostsByCategoryDict
+
+    def as_flat_dictionary(self) -> dict[str, Any]:
+        the_dict: dict[str, Any] = {}
+        dict_for_job_metadata = self.job_metadata.model_dump(serialize_as_any=True)
+        the_dict.update(dict_for_job_metadata)
+        dict_for_model: dict[str, Any] = {
+            FetchTokenCostReportField.MODEL_TYPE: self.model_type,
+            FetchTokenCostReportField.FETCH_NAME: self.inference_model_name,
+            FetchTokenCostReportField.PLATFORM_FETCH_ID: self.platform_model_id,
+        }
+        the_dict.update(dict_for_model)
+        dict_for_nb_tokens = {
+            FetchTokenCostReportField.report_field_for_nb_tokens_by_category(token_category): nb_tokens
+            for token_category, nb_tokens in self.nb_tokens_by_category.items()
+        }
+        the_dict.update(dict_for_nb_tokens)
+        dict_for_costs = {
+            FetchTokenCostReportField.report_field_for_cost_by_category(token_category): cost
+            for token_category, cost in self.costs_by_token_category.items()
+        }
+        the_dict.update(dict_for_costs)
+        return the_dict
+
+
+class FetchTokensUsage(BaseModel):
+    model_type: str = "fetch"
+    job_metadata: JobMetadata
+    inference_model_name: str
+    unit_costs: CostsByCategoryDict
+    inference_model_id: str
+    nb_tokens_by_category: NbTokensByCategoryDict

--- a/pipelex/cogt/search/fetch_worker_abstract.py
+++ b/pipelex/cogt/search/fetch_worker_abstract.py
@@ -1,0 +1,27 @@
+from abc import ABC, abstractmethod
+
+from pipelex.core.stuffs.text_and_images_content import TextAndImagesContent
+
+
+class FetchWorkerAbstract(ABC):
+    @abstractmethod
+    async def fetch_url(
+        self,
+        url: str,
+        include_raw_html: bool | None = None,
+        render_js: bool | None = None,
+        extract_images: bool | None = None,
+        timeout: float | None = None,  # noqa: ASYNC109
+    ) -> TextAndImagesContent:
+        """Fetch and clean the content of a web page, returning text and optionally images.
+
+        Args:
+            url: The URL of the web page to fetch
+            include_raw_html: Whether to include the raw HTML of the webpage in the response
+            render_js: Whether to render the JavaScript of the webpage before fetching
+            extract_images: Whether to extract images from the webpage
+            timeout: The timeout for the HTTP request, in seconds
+
+        Returns:
+            TextAndImagesContent with the fetched page content
+        """

--- a/pipelex/cogt/search/fetch_worker_abstract.py
+++ b/pipelex/cogt/search/fetch_worker_abstract.py
@@ -1,13 +1,19 @@
 from abc import ABC, abstractmethod
 
 from pipelex.core.stuffs.text_and_images_content import TextAndImagesContent
+from pipelex.pipeline.job_metadata import JobMetadata
+from pipelex.reporting.reporting_protocol import ReportingProtocol
 
 
 class FetchWorkerAbstract(ABC):
+    def __init__(self, reporting_delegate: ReportingProtocol | None = None):
+        self.reporting_delegate = reporting_delegate
+
     @abstractmethod
     async def fetch_url(
         self,
         url: str,
+        job_metadata: JobMetadata,
         include_raw_html: bool | None = None,
         render_js: bool | None = None,
         extract_images: bool | None = None,
@@ -17,6 +23,7 @@ class FetchWorkerAbstract(ABC):
 
         Args:
             url: The URL of the web page to fetch
+            job_metadata: Job metadata for cost reporting
             include_raw_html: Whether to include the raw HTML of the webpage in the response
             render_js: Whether to render the JavaScript of the webpage before fetching
             extract_images: Whether to extract images from the webpage

--- a/pipelex/cogt/search/search_job.py
+++ b/pipelex/cogt/search/search_job.py
@@ -1,0 +1,35 @@
+from datetime import datetime
+
+from pydantic import BaseModel
+from typing_extensions import override
+
+from pipelex.cogt.inference.inference_job_abstract import InferenceJobAbstract
+from pipelex.cogt.model_backends.model_spec import InferenceModelSpec
+from pipelex.cogt.search.search_report import SearchTokensUsage
+
+
+class SearchJobReport(BaseModel):
+    search_tokens_usage: SearchTokensUsage | None = None
+
+
+class SearchJob(InferenceJobAbstract):
+    job_report: SearchJobReport = SearchJobReport()
+
+    @override
+    def validate_before_execution(self):
+        pass
+
+    def search_job_before_start(self, inference_model: InferenceModelSpec):
+        self.job_metadata.started_at = datetime.now()
+
+        self.job_report = SearchJobReport()
+        self.job_report.search_tokens_usage = SearchTokensUsage(
+            job_metadata=self.job_metadata,
+            inference_model_name=inference_model.name,
+            unit_costs=inference_model.costs,
+            inference_model_id=inference_model.model_id,
+            nb_tokens_by_category={},
+        )
+
+    def search_job_after_complete(self):
+        self.job_metadata.completed_at = datetime.now()

--- a/pipelex/cogt/search/search_job_factory.py
+++ b/pipelex/cogt/search/search_job_factory.py
@@ -1,0 +1,17 @@
+from pipelex.cogt.search.fetch_job import FetchJob
+from pipelex.cogt.search.search_job import SearchJob
+from pipelex.pipeline.job_metadata import JobCategory, JobMetadata
+
+
+class SearchJobFactory:
+    @classmethod
+    def make_search_job(cls, job_metadata: JobMetadata) -> SearchJob:
+        job_metadata.job_category = JobCategory.SEARCH_JOB
+        return SearchJob(job_metadata=job_metadata)
+
+
+class FetchJobFactory:
+    @classmethod
+    def make_fetch_job(cls, job_metadata: JobMetadata) -> FetchJob:
+        job_metadata.job_category = JobCategory.FETCH_JOB
+        return FetchJob(job_metadata=job_metadata)

--- a/pipelex/cogt/search/search_report.py
+++ b/pipelex/cogt/search/search_report.py
@@ -1,0 +1,72 @@
+from typing import Any
+
+from pydantic import BaseModel
+
+from pipelex.cogt.usage.cost_category import CostCategory, CostsByCategoryDict
+from pipelex.cogt.usage.token_category import NbTokensByCategoryDict, TokenCategory
+from pipelex.pipeline.job_metadata import JobMetadata
+from pipelex.types import StrEnum
+
+
+class SearchTokenCostReportField(StrEnum):
+    MODEL_TYPE = "model_type"
+    SEARCH_NAME = "search_name"
+    PLATFORM_SEARCH_ID = "platform_search_id"
+    NB_TOKENS_INPUT = "nb_tokens_input"
+    NB_TOKENS_INPUT_CACHED = "nb_tokens_input_cached"
+    NB_TOKENS_INPUT_NON_CACHED = "nb_tokens_input_non_cached"
+    NB_TOKENS_INPUT_JOINED = "nb_tokens_input_joined"
+    NB_TOKENS_OUTPUT = "nb_tokens_output"
+    COST_INPUT_CACHED = "cost_input_cached"
+    COST_INPUT_NON_CACHED = "cost_input_non_cached"
+    COST_INPUT_JOINED = "cost_input_joined"
+    COST_OUTPUT = "cost_output"
+
+    @staticmethod
+    def report_field_for_nb_tokens_by_category(token_category: TokenCategory) -> str:
+        return f"nb_tokens_{token_category}"
+
+    @staticmethod
+    def report_field_for_cost_by_category(token_category: CostCategory) -> str:
+        return f"cost_{token_category}"
+
+
+class SearchTokenCostReport(BaseModel):
+    model_type: str = "search"
+    job_metadata: JobMetadata
+    inference_model_name: str
+    platform_model_id: str
+
+    nb_tokens_by_category: NbTokensByCategoryDict
+    costs_by_token_category: CostsByCategoryDict
+
+    def as_flat_dictionary(self) -> dict[str, Any]:
+        the_dict: dict[str, Any] = {}
+        dict_for_job_metadata = self.job_metadata.model_dump(serialize_as_any=True)
+        the_dict.update(dict_for_job_metadata)
+        dict_for_model: dict[str, Any] = {
+            SearchTokenCostReportField.MODEL_TYPE: self.model_type,
+            SearchTokenCostReportField.SEARCH_NAME: self.inference_model_name,
+            SearchTokenCostReportField.PLATFORM_SEARCH_ID: self.platform_model_id,
+        }
+        the_dict.update(dict_for_model)
+        dict_for_nb_tokens = {
+            SearchTokenCostReportField.report_field_for_nb_tokens_by_category(token_category): nb_tokens
+            for token_category, nb_tokens in self.nb_tokens_by_category.items()
+        }
+        the_dict.update(dict_for_nb_tokens)
+        dict_for_costs = {
+            SearchTokenCostReportField.report_field_for_cost_by_category(token_category): cost
+            for token_category, cost in self.costs_by_token_category.items()
+        }
+        the_dict.update(dict_for_costs)
+        return the_dict
+
+
+class SearchTokensUsage(BaseModel):
+    model_type: str = "search"
+    job_metadata: JobMetadata
+    inference_model_name: str
+    unit_costs: CostsByCategoryDict
+    inference_model_id: str
+    nb_tokens_by_category: NbTokensByCategoryDict

--- a/pipelex/cogt/search/search_setting.py
+++ b/pipelex/cogt/search/search_setting.py
@@ -3,20 +3,18 @@ from typing import Annotated, Union
 from pydantic import BeforeValidator, Field
 
 from pipelex.cogt.models.model_reference import ModelReference, parse_model_reference
-from pipelex.cogt.search.search_depth import SearchDepth
 from pipelex.system.configuration.config_model import ConfigModel
 
 
 class SearchSetting(ConfigModel):
     model: str
-    depth: SearchDepth = Field(strict=False)
     include_images: bool = False
     include_inline_citations: bool = True
     max_results: int | None = Field(default=None, ge=1)
     description: str | None = None
 
     def desc(self) -> str:
-        return f"SearchSetting(model={self.model}, depth={self.depth}, max_results={self.max_results})"
+        return f"SearchSetting(model={self.model}, max_results={self.max_results})"
 
 
 # SearchModelChoice accepts SearchSetting, ModelReference, or a string (which gets parsed to ModelReference)

--- a/pipelex/cogt/search/search_worker_abstract.py
+++ b/pipelex/cogt/search/search_worker_abstract.py
@@ -3,14 +3,20 @@ from typing import Any
 
 from pipelex.cogt.search.search_setting import SearchSetting
 from pipelex.core.stuffs.search_result_content import SearchResultContent
+from pipelex.pipeline.job_metadata import JobMetadata
+from pipelex.reporting.reporting_protocol import ReportingProtocol
 
 
 class SearchWorkerAbstract(ABC):
+    def __init__(self, reporting_delegate: ReportingProtocol | None = None):
+        self.reporting_delegate = reporting_delegate
+
     @abstractmethod
     async def search_sourced_answer(
         self,
         query: str,
         search_setting: SearchSetting,
+        job_metadata: JobMetadata,
         include_domains: list[str] | None = None,
         exclude_domains: list[str] | None = None,
         from_date: str | None = None,
@@ -21,6 +27,7 @@ class SearchWorkerAbstract(ABC):
         Args:
             query: The search query text
             search_setting: Search configuration including model, depth, etc.
+            job_metadata: Job metadata for cost reporting
             include_domains: Optional list of domains to restrict search to
             exclude_domains: Optional list of domains to exclude from search
             from_date: Optional start date filter (YYYY-MM-DD)
@@ -36,6 +43,7 @@ class SearchWorkerAbstract(ABC):
         query: str,
         search_setting: SearchSetting,
         output_schema: type,
+        job_metadata: JobMetadata,
         include_domains: list[str] | None = None,
         exclude_domains: list[str] | None = None,
         from_date: str | None = None,
@@ -47,6 +55,7 @@ class SearchWorkerAbstract(ABC):
             query: The search query text
             search_setting: Search configuration including model, depth, etc.
             output_schema: Pydantic model class defining the expected output structure
+            job_metadata: Job metadata for cost reporting
             include_domains: Optional list of domains to restrict search to
             exclude_domains: Optional list of domains to exclude from search
             from_date: Optional start date filter (YYYY-MM-DD)

--- a/pipelex/cogt/search/search_worker_factory.py
+++ b/pipelex/cogt/search/search_worker_factory.py
@@ -1,7 +1,9 @@
+from pipelex.cogt.search.fetch_worker_abstract import FetchWorkerAbstract
 from pipelex.cogt.search.search_worker_abstract import SearchWorkerAbstract
 
 # Cache of search worker instances by provider prefix
 _search_workers: dict[str, SearchWorkerAbstract] = {}
+_fetch_workers: dict[str, FetchWorkerAbstract] = {}
 
 
 def get_search_worker(model_handle: str) -> SearchWorkerAbstract:
@@ -24,12 +26,38 @@ def get_search_worker(model_handle: str) -> SearchWorkerAbstract:
     worker: SearchWorkerAbstract
     match provider:
         case "linkup":
-            from pipelex.plugins.linkup.linkup_search_worker import LinkupSearchWorker  # noqa: PLC0415
+            from pipelex.plugins.linkup.linkup_worker import LinkupWorker  # noqa: PLC0415
 
-            worker = LinkupSearchWorker()
+            worker = LinkupWorker()
         case _:
             msg = f"Unknown search provider: '{provider}' (from model handle '{model_handle}')"
             raise ValueError(msg)
 
     _search_workers[provider] = worker
+    return worker
+
+
+def get_fetch_worker(provider: str) -> FetchWorkerAbstract:
+    """Get a fetch worker instance for the given provider.
+
+    Args:
+        provider: The fetch provider name (e.g., "linkup")
+
+    Returns:
+        A FetchWorkerAbstract instance for the provider
+    """
+    if provider in _fetch_workers:
+        return _fetch_workers[provider]
+
+    worker: FetchWorkerAbstract
+    match provider:
+        case "linkup":
+            from pipelex.plugins.linkup.linkup_worker import LinkupWorker  # noqa: PLC0415
+
+            worker = LinkupWorker()
+        case _:
+            msg = f"Unknown fetch provider: '{provider}'"
+            raise ValueError(msg)
+
+    _fetch_workers[provider] = worker
     return worker

--- a/pipelex/cogt/search/search_worker_factory.py
+++ b/pipelex/cogt/search/search_worker_factory.py
@@ -1,63 +1,85 @@
+from pipelex.cogt.model_backends.model_spec import InferenceModelSpec
 from pipelex.cogt.search.fetch_worker_abstract import FetchWorkerAbstract
 from pipelex.cogt.search.search_worker_abstract import SearchWorkerAbstract
-
-# Cache of search worker instances by provider prefix
-_search_workers: dict[str, SearchWorkerAbstract] = {}
-_fetch_workers: dict[str, FetchWorkerAbstract] = {}
+from pipelex.hub import get_models_manager, get_plugin_manager
+from pipelex.plugins.plugin import Plugin
 
 
-def get_search_worker(model_handle: str) -> SearchWorkerAbstract:
-    """Get a search worker instance for the given model handle.
+class SearchWorkerFactory:
+    @classmethod
+    def make_search_worker(
+        cls,
+        inference_model: InferenceModelSpec,
+    ) -> SearchWorkerAbstract:
+        """Create a search worker for the given inference model.
 
-    The model handle format is "provider/variant" (e.g., "linkup/standard", "linkup/deep").
-    The provider prefix determines which worker implementation to use.
+        Discriminates on plugin.sdk to select the appropriate implementation.
 
-    Args:
-        model_handle: The search model handle (e.g., "linkup/standard")
+        Args:
+            inference_model: The model spec from the backend configuration.
 
-    Returns:
-        A SearchWorkerAbstract instance for the provider
-    """
-    provider = model_handle.split("/", maxsplit=1)[0] if "/" in model_handle else model_handle
+        Returns:
+            A SearchWorkerAbstract instance.
+        """
+        plugin = Plugin.make_for_inference_model(inference_model=inference_model)
+        backend = get_models_manager().get_required_inference_backend(inference_model.backend_name)
+        plugin_sdk_registry = get_plugin_manager().plugin_sdk_registry
+        search_worker: SearchWorkerAbstract
+        match plugin.sdk:
+            case "linkup":
+                from pipelex.plugins.linkup.linkup_worker import LinkupWorker  # noqa: PLC0415
 
-    if provider in _search_workers:
-        return _search_workers[provider]
+                search_worker = LinkupWorker()
+            case "gateway_search":
+                from pipelex.plugins.gateway.gateway_factory import GatewayFactory  # noqa: PLC0415
+                from pipelex.plugins.gateway.gateway_search_worker import GatewaySearchWorker  # noqa: PLC0415
 
-    worker: SearchWorkerAbstract
-    match provider:
-        case "linkup":
-            from pipelex.plugins.linkup.linkup_worker import LinkupWorker  # noqa: PLC0415
+                sdk_instance = plugin_sdk_registry.get_sdk_instance(plugin=plugin) or plugin_sdk_registry.set_sdk_instance(
+                    plugin=plugin,
+                    sdk_instance=GatewayFactory.make_portkey_client(backend=backend),
+                )
+                search_worker = GatewaySearchWorker(sdk_instance=sdk_instance, inference_model=inference_model)
+            case _:
+                msg = f"Plugin '{plugin}' is not supported for search"
+                raise NotImplementedError(msg)
 
-            worker = LinkupWorker()
-        case _:
-            msg = f"Unknown search provider: '{provider}' (from model handle '{model_handle}')"
-            raise ValueError(msg)
+        return search_worker
 
-    _search_workers[provider] = worker
-    return worker
+    @classmethod
+    def make_fetch_worker(
+        cls,
+        inference_model: InferenceModelSpec,
+    ) -> FetchWorkerAbstract:
+        """Create a fetch worker for the given inference model.
 
+        Discriminates on plugin.sdk to select the appropriate implementation.
 
-def get_fetch_worker(provider: str) -> FetchWorkerAbstract:
-    """Get a fetch worker instance for the given provider.
+        Args:
+            inference_model: The model spec from the backend configuration.
 
-    Args:
-        provider: The fetch provider name (e.g., "linkup")
+        Returns:
+            A FetchWorkerAbstract instance.
+        """
+        plugin = Plugin.make_for_inference_model(inference_model=inference_model)
+        backend = get_models_manager().get_required_inference_backend(inference_model.backend_name)
+        plugin_sdk_registry = get_plugin_manager().plugin_sdk_registry
+        fetch_worker: FetchWorkerAbstract
+        match plugin.sdk:
+            case "linkup":
+                from pipelex.plugins.linkup.linkup_worker import LinkupWorker  # noqa: PLC0415
 
-    Returns:
-        A FetchWorkerAbstract instance for the provider
-    """
-    if provider in _fetch_workers:
-        return _fetch_workers[provider]
+                fetch_worker = LinkupWorker()
+            case "gateway_search":
+                from pipelex.plugins.gateway.gateway_factory import GatewayFactory  # noqa: PLC0415
+                from pipelex.plugins.gateway.gateway_fetch_worker import GatewayFetchWorker  # noqa: PLC0415
 
-    worker: FetchWorkerAbstract
-    match provider:
-        case "linkup":
-            from pipelex.plugins.linkup.linkup_worker import LinkupWorker  # noqa: PLC0415
+                sdk_instance = plugin_sdk_registry.get_sdk_instance(plugin=plugin) or plugin_sdk_registry.set_sdk_instance(
+                    plugin=plugin,
+                    sdk_instance=GatewayFactory.make_portkey_client(backend=backend),
+                )
+                fetch_worker = GatewayFetchWorker(sdk_instance=sdk_instance, inference_model=inference_model)
+            case _:
+                msg = f"Plugin '{plugin}' is not supported for fetch"
+                raise NotImplementedError(msg)
 
-            worker = LinkupWorker()
-        case _:
-            msg = f"Unknown fetch provider: '{provider}'"
-            raise ValueError(msg)
-
-    _fetch_workers[provider] = worker
-    return worker
+        return fetch_worker

--- a/pipelex/cogt/search/search_worker_factory.py
+++ b/pipelex/cogt/search/search_worker_factory.py
@@ -1,7 +1,7 @@
 from pipelex.cogt.model_backends.model_spec import InferenceModelSpec
 from pipelex.cogt.search.fetch_worker_abstract import FetchWorkerAbstract
 from pipelex.cogt.search.search_worker_abstract import SearchWorkerAbstract
-from pipelex.hub import get_models_manager, get_plugin_manager
+from pipelex.hub import get_models_manager, get_plugin_manager, get_report_delegate
 from pipelex.plugins.plugin import Plugin
 
 
@@ -29,7 +29,7 @@ class SearchWorkerFactory:
             case "linkup":
                 from pipelex.plugins.linkup.linkup_worker import LinkupWorker  # noqa: PLC0415
 
-                search_worker = LinkupWorker()
+                search_worker = LinkupWorker(inference_model=inference_model, reporting_delegate=get_report_delegate())
             case "gateway_search":
                 from pipelex.plugins.gateway.gateway_factory import GatewayFactory  # noqa: PLC0415
                 from pipelex.plugins.gateway.gateway_search_worker import GatewaySearchWorker  # noqa: PLC0415
@@ -38,7 +38,9 @@ class SearchWorkerFactory:
                     plugin=plugin,
                     sdk_instance=GatewayFactory.make_portkey_client(backend=backend),
                 )
-                search_worker = GatewaySearchWorker(sdk_instance=sdk_instance, inference_model=inference_model)
+                search_worker = GatewaySearchWorker(
+                    sdk_instance=sdk_instance, inference_model=inference_model, reporting_delegate=get_report_delegate()
+                )
             case _:
                 msg = f"Plugin '{plugin}' is not supported for search"
                 raise NotImplementedError(msg)
@@ -68,7 +70,7 @@ class SearchWorkerFactory:
             case "linkup":
                 from pipelex.plugins.linkup.linkup_worker import LinkupWorker  # noqa: PLC0415
 
-                fetch_worker = LinkupWorker()
+                fetch_worker = LinkupWorker(inference_model=inference_model, reporting_delegate=get_report_delegate())
             case "gateway_search":
                 from pipelex.plugins.gateway.gateway_factory import GatewayFactory  # noqa: PLC0415
                 from pipelex.plugins.gateway.gateway_fetch_worker import GatewayFetchWorker  # noqa: PLC0415
@@ -77,7 +79,9 @@ class SearchWorkerFactory:
                     plugin=plugin,
                     sdk_instance=GatewayFactory.make_portkey_client(backend=backend),
                 )
-                fetch_worker = GatewayFetchWorker(sdk_instance=sdk_instance, inference_model=inference_model)
+                fetch_worker = GatewayFetchWorker(
+                    sdk_instance=sdk_instance, inference_model=inference_model, reporting_delegate=get_report_delegate()
+                )
             case _:
                 msg = f"Plugin '{plugin}' is not supported for fetch"
                 raise NotImplementedError(msg)

--- a/pipelex/cogt/usage/cost_registry.py
+++ b/pipelex/cogt/usage/cost_registry.py
@@ -12,14 +12,16 @@ from pipelex.cogt.exceptions import CostRegistryError
 from pipelex.cogt.extract.extract_report import ExtractTokenCostReport, ExtractTokenCostReportField, ExtractTokensUsage
 from pipelex.cogt.img_gen.img_gen_report import ImgGenTokenCostReport, ImgGenTokenCostReportField, ImgGenTokensUsage
 from pipelex.cogt.llm.llm_report import LLMTokenCostReport, LLMTokenCostReportField, LLMTokensUsage
+from pipelex.cogt.search.fetch_report import FetchTokenCostReport, FetchTokenCostReportField, FetchTokensUsage
+from pipelex.cogt.search.search_report import SearchTokenCostReport, SearchTokenCostReportField, SearchTokensUsage
 from pipelex.cogt.usage.cost_category import CostCategory, CostsByCategoryDict
 from pipelex.cogt.usage.costs_per_token import model_cost_per_token
 from pipelex.cogt.usage.token_category import TokenCategory
 from pipelex.hub import get_console
 from pipelex.tools.typing.pydantic_utils import empty_list_factory_of
 
-TokensUsage = LLMTokensUsage | ImgGenTokensUsage | ExtractTokensUsage
-TokenCostReport = LLMTokenCostReport | ImgGenTokenCostReport | ExtractTokenCostReport
+TokensUsage = LLMTokensUsage | ImgGenTokensUsage | ExtractTokensUsage | SearchTokensUsage | FetchTokensUsage
+TokenCostReport = LLMTokenCostReport | ImgGenTokenCostReport | ExtractTokenCostReport | SearchTokenCostReport | FetchTokenCostReport
 CostRegistryRoot = list[TokenCostReport]
 
 
@@ -80,7 +82,9 @@ class CostRegistry(RootModel[CostRegistryRoot]):
             model_name = (
                 record.get(report_field.LLM_NAME)
                 or record.get(ImgGenTokenCostReportField.IMG_GEN_NAME)
-                or record.get(ExtractTokenCostReportField.EXTRACT_NAME, "unknown")
+                or record.get(ExtractTokenCostReportField.EXTRACT_NAME)
+                or record.get(SearchTokenCostReportField.SEARCH_NAME)
+                or record.get(FetchTokenCostReportField.FETCH_NAME, "unknown")
             )
             model_type = record.get(report_field.MODEL_TYPE, "llm")
             model_types[model_name] = model_type
@@ -224,6 +228,24 @@ class CostRegistry(RootModel[CostRegistryRoot]):
             )
         if isinstance(tokens_usage, ImgGenTokensUsage):
             return ImgGenTokenCostReport(
+                model_type=tokens_usage.model_type,
+                job_metadata=tokens_usage.job_metadata,
+                inference_model_name=tokens_usage.inference_model_name,
+                platform_model_id=tokens_usage.inference_model_id,
+                nb_tokens_by_category=tokens_usage.nb_tokens_by_category,
+                costs_by_token_category=costs_by_token_category,
+            )
+        if isinstance(tokens_usage, SearchTokensUsage):
+            return SearchTokenCostReport(
+                model_type=tokens_usage.model_type,
+                job_metadata=tokens_usage.job_metadata,
+                inference_model_name=tokens_usage.inference_model_name,
+                platform_model_id=tokens_usage.inference_model_id,
+                nb_tokens_by_category=tokens_usage.nb_tokens_by_category,
+                costs_by_token_category=costs_by_token_category,
+            )
+        if isinstance(tokens_usage, FetchTokensUsage):
+            return FetchTokenCostReport(
                 model_type=tokens_usage.model_type,
                 job_metadata=tokens_usage.job_metadata,
                 inference_model_name=tokens_usage.inference_model_name,

--- a/pipelex/core/stuffs/text_and_images_content.py
+++ b/pipelex/core/stuffs/text_and_images_content.py
@@ -16,6 +16,7 @@ from pipelex.tools.misc.pretty import PrettyPrintable
 class TextAndImagesContent(StuffContent):
     text: TextContent | None = Field(default=None, description="A text content")
     images: list[ImageContent] | None = Field(default=None, description="A list of images that were extracted from the text")
+    raw_html: str | None = Field(default=None, description="The raw HTML of the fetched page, if requested")
 
     @property
     @override
@@ -43,6 +44,8 @@ class TextAndImagesContent(StuffContent):
     # TODO: include the images into the HTML rendering
     @override
     def rendered_html(self) -> str:
+        if self.raw_html:
+            return self.raw_html
         if self.text:
             return self.text.rendered_html()
         return ""
@@ -62,6 +65,8 @@ class TextAndImagesContent(StuffContent):
     # TODO: include the images into the HTML rendering
     @override
     async def rendered_html_async(self) -> str:
+        if self.raw_html:
+            return self.raw_html
         if self.text:
             rendered = await self.text.rendered_html_async()
         else:

--- a/pipelex/kit/configs/inference/backends/linkup.toml
+++ b/pipelex/kit/configs/inference/backends/linkup.toml
@@ -28,10 +28,10 @@ thinking_mode = "none"
 model_id = "standard"
 inputs = ["text"]
 outputs = ["structured"]
-costs = {}
+costs = { input = 0.005, output = 0 }
 
 ["linkup-deep"]
 model_id = "deep"
 inputs = ["text"]
 outputs = ["structured"]
-costs = {}
+costs = { input = 0.05, output = 0 }

--- a/pipelex/kit/configs/inference/backends/linkup.toml
+++ b/pipelex/kit/configs/inference/backends/linkup.toml
@@ -24,13 +24,13 @@ thinking_mode = "none"
 # SEARCH MODELS
 ################################################################################
 
-["linkup/standard"]
+["linkup-standard"]
 model_id = "standard"
 inputs = ["text"]
 outputs = ["structured"]
 costs = {}
 
-["linkup/deep"]
+["linkup-deep"]
 model_id = "deep"
 inputs = ["text"]
 outputs = ["structured"]

--- a/pipelex/kit/configs/inference/backends/linkup.toml
+++ b/pipelex/kit/configs/inference/backends/linkup.toml
@@ -27,11 +27,11 @@ thinking_mode = "none"
 ["linkup-standard"]
 model_id = "standard"
 inputs = ["text"]
-outputs = ["structured"]
+outputs = ["sourced-answers", "structured"]
 costs = { input = 0.005, output = 0 }
 
 ["linkup-deep"]
 model_id = "deep"
 inputs = ["text"]
-outputs = ["structured"]
+outputs = ["sourced-answers", "structured"]
 costs = { input = 0.05, output = 0 }

--- a/pipelex/kit/configs/inference/backends/pipelex_gateway_models.md
+++ b/pipelex/kit/configs/inference/backends/pipelex_gateway_models.md
@@ -446,13 +446,6 @@ For configuration details, see the [documentation](https://docs.pipelex.com/late
 <td style="text-align:center;background-color:rgba(76,175,80,0.15)">✅</td>
 <td style="text-align:center;background-color:rgba(76,175,80,0.15)">❌</td>
 </tr>
-<tr>
-<td>mistral-document-ai-2505</td>
-<td style="text-align:center;background-color:rgba(33,150,243,0.15)">✅</td>
-<td style="text-align:center;background-color:rgba(33,150,243,0.15)">✅</td>
-<td style="text-align:center;background-color:rgba(76,175,80,0.15)">✅</td>
-<td style="text-align:center;background-color:rgba(76,175,80,0.15)">❌</td>
-</tr>
 </tbody>
 </table>
 
@@ -522,6 +515,6 @@ For configuration details, see the [documentation](https://docs.pipelex.com/late
 
 
 > **AUTO-GENERATED FILE** - Do not edit manually.
-> Last updated: 2026-03-02T23:49:25Z
+> Last updated: 2026-03-03T18:00:27Z
 >
 > Run `pipelex-dev update-gateway-models` or `make ugm` to regenerate.

--- a/pipelex/kit/configs/inference/backends/pipelex_gateway_models.md
+++ b/pipelex/kit/configs/inference/backends/pipelex_gateway_models.md
@@ -515,6 +515,6 @@ For configuration details, see the [documentation](https://docs.pipelex.com/late
 
 
 > **AUTO-GENERATED FILE** - Do not edit manually.
-> Last updated: 2026-03-03T18:00:27Z
+> Last updated: 2026-03-03T22:21:10Z
 >
 > Run `pipelex-dev update-gateway-models` or `make ugm` to regenerate.

--- a/pipelex/kit/configs/inference/backends/pipelex_gateway_models_plain.md
+++ b/pipelex/kit/configs/inference/backends/pipelex_gateway_models_plain.md
@@ -193,6 +193,6 @@ For configuration details, see the [documentation](https://docs.pipelex.com/late
 
 
 > **AUTO-GENERATED FILE** - Do not edit manually.
-> Last updated: 2026-03-03T18:00:27Z
+> Last updated: 2026-03-03T22:21:10Z
 >
 > Run `pipelex-dev update-gateway-models` or `make ugm` to regenerate.

--- a/pipelex/kit/configs/inference/backends/pipelex_gateway_models_plain.md
+++ b/pipelex/kit/configs/inference/backends/pipelex_gateway_models_plain.md
@@ -163,9 +163,6 @@ For configuration details, see the [documentation](https://docs.pipelex.com/late
 - **deepseek-ocr**
   - inputs: image
   - outputs: pages
-- **mistral-document-ai-2505**
-  - inputs: image, pdf
-  - outputs: pages
 
 
 **About extracted pages:** Each page contains Markdown text (based on AI-interpreted layout) and optional extracted images. A single image input is treated as one page. Pipelex also wraps the `pypdfium2` library for raw text (without any AI interpretation) and images extraction and page views rendering. All these elements can be used as inputs into downstream pipes, including LLM prompts.
@@ -196,6 +193,6 @@ For configuration details, see the [documentation](https://docs.pipelex.com/late
 
 
 > **AUTO-GENERATED FILE** - Do not edit manually.
-> Last updated: 2026-03-02T23:49:25Z
+> Last updated: 2026-03-03T18:00:27Z
 >
 > Run `pipelex-dev update-gateway-models` or `make ugm` to regenerate.

--- a/pipelex/kit/configs/inference/deck/4_search_deck.toml
+++ b/pipelex/kit/configs/inference/deck/4_search_deck.toml
@@ -19,7 +19,6 @@
 ####################################################################################################
 
 [search]
-default_depth = "standard"
 choice_default = "@default-search"
 
 ####################################################################################################
@@ -34,5 +33,5 @@ default-search = "linkup-standard"
 ####################################################################################################
 
 [search.presets]
-linkup-standard = { model = "linkup-standard", depth = "standard", include_images = false, include_inline_citations = true }
-linkup-deep = { model = "linkup-deep", depth = "deep", include_images = false, include_inline_citations = true }
+standard = { model = "linkup-standard", include_images = false, include_inline_citations = true }
+deep = { model = "linkup-deep", include_images = false, include_inline_citations = true }

--- a/pipelex/kit/configs/inference/deck/4_search_deck.toml
+++ b/pipelex/kit/configs/inference/deck/4_search_deck.toml
@@ -27,12 +27,12 @@ choice_default = "@default-search"
 ####################################################################################################
 
 [search.aliases]
-default-search = "linkup/standard"
+default-search = "linkup-standard"
 
 ####################################################################################################
 # Search Presets
 ####################################################################################################
 
 [search.presets]
-linkup-standard = { model = "linkup/standard", depth = "standard", include_images = false, include_inline_citations = true }
-linkup-deep = { model = "linkup/deep", depth = "deep", include_images = false, include_inline_citations = true }
+linkup-standard = { model = "linkup-standard", depth = "standard", include_images = false, include_inline_citations = true }
+linkup-deep = { model = "linkup-deep", depth = "deep", include_images = false, include_inline_citations = true }

--- a/pipelex/kit/configs/inference/routing_profiles.toml
+++ b/pipelex/kit/configs/inference/routing_profiles.toml
@@ -28,7 +28,7 @@ active = "all_pipelex_gateway"
 description = "Use Pipelex Gateway for all its supported models"
 default = "pipelex_gateway"
 [profiles.all_pipelex_gateway.routes]
-"linkup/*" = "linkup"
+"linkup-*" = "linkup"
 
 [profiles.all_anthropic]
 description = "Use Anthropic backend for all its supported models"

--- a/pipelex/kit/configs/inference/routing_profiles.toml
+++ b/pipelex/kit/configs/inference/routing_profiles.toml
@@ -27,8 +27,6 @@ active = "all_pipelex_gateway"
 [profiles.all_pipelex_gateway]
 description = "Use Pipelex Gateway for all its supported models"
 default = "pipelex_gateway"
-[profiles.all_pipelex_gateway.routes]
-"linkup-*" = "linkup"
 
 [profiles.all_anthropic]
 description = "Use Anthropic backend for all its supported models"
@@ -61,6 +59,10 @@ default = "groq"
 [profiles.all_huggingface]
 description = "Use HuggingFace backend for all its supported models"
 default = "huggingface"
+
+[profiles.all_linkup]
+description = "Use Linkup backend for all its supported models"
+default = "linkup"
 
 [profiles.all_mistral]
 description = "Use Mistral backend for all its supported models"

--- a/pipelex/kit/configs/pipelex.toml
+++ b/pipelex/kit/configs/pipelex.toml
@@ -59,6 +59,10 @@ ranksep = 30         # Vertical spacing between ranks/levels
 initial_zoom = 1.0   # Initial zoom level (1.0 = 100%)
 pan_to_top = true    # Pan to show top of graph on load
 
+[pipelex.pipeline_execution_config.graph_config.reactflow_config.style]
+theme = "dark"
+palette = "dracula"
+
 ####################################################################################################
 # Storage Config
 ####################################################################################################

--- a/pipelex/pipe_operators/search/pipe_search.py
+++ b/pipelex/pipe_operators/search/pipe_search.py
@@ -121,6 +121,7 @@ class PipeSearch(PipeOperator[PipeSearchOutput]):
             content = await worker.search_sourced_answer(
                 query=query_text,
                 search_setting=search_setting,
+                job_metadata=job_metadata,
                 include_domains=self.include_domains,
                 exclude_domains=self.exclude_domains,
                 from_date=self.from_date,
@@ -132,6 +133,7 @@ class PipeSearch(PipeOperator[PipeSearchOutput]):
                 query=query_text,
                 search_setting=search_setting,
                 output_schema=output_structure_class,
+                job_metadata=job_metadata,
                 include_domains=self.include_domains,
                 exclude_domains=self.exclude_domains,
                 from_date=self.from_date,

--- a/pipelex/pipe_operators/search/pipe_search.py
+++ b/pipelex/pipe_operators/search/pipe_search.py
@@ -7,7 +7,6 @@ from pipelex.cogt.content_generation.dry_run_factory import DryRunFactory
 from pipelex.cogt.exceptions import ModelChoiceNotFoundError
 from pipelex.cogt.model_backends.model_type import ModelType
 from pipelex.cogt.models.model_deck_check import check_search_choice_with_deck
-from pipelex.cogt.search.search_depth import SearchDepth
 from pipelex.cogt.search.search_setting import SearchModelChoice, SearchSetting
 from pipelex.cogt.search.search_worker_factory import SearchWorkerFactory
 from pipelex.cogt.templating.template_blueprint import TemplateBlueprint
@@ -35,7 +34,6 @@ class PipeSearch(PipeOperator[PipeSearchOutput]):
     type: Literal["PipeSearch"] = "PipeSearch"
     search_choice: SearchModelChoice | None
     prompt_blueprint: TemplateBlueprint
-    depth_override: SearchDepth | None = None
     include_images_override: bool | None = None
     max_results_override: int | None = None
     from_date: str | None = None
@@ -105,8 +103,6 @@ class PipeSearch(PipeOperator[PipeSearchOutput]):
             search_setting = search_setting.model_copy(update={"model": resolved_model_handle})
 
         # 4. Apply pipe-level overrides
-        if self.depth_override is not None:
-            search_setting = search_setting.model_copy(update={"depth": self.depth_override})
         if self.include_images_override is not None:
             search_setting = search_setting.model_copy(update={"include_images": self.include_images_override})
         if self.max_results_override is not None:

--- a/pipelex/pipe_operators/search/pipe_search.py
+++ b/pipelex/pipe_operators/search/pipe_search.py
@@ -9,7 +9,7 @@ from pipelex.cogt.model_backends.model_type import ModelType
 from pipelex.cogt.models.model_deck_check import check_search_choice_with_deck
 from pipelex.cogt.search.search_depth import SearchDepth
 from pipelex.cogt.search.search_setting import SearchModelChoice, SearchSetting
-from pipelex.cogt.search.search_worker_factory import get_search_worker
+from pipelex.cogt.search.search_worker_factory import SearchWorkerFactory
 from pipelex.cogt.templating.template_blueprint import TemplateBlueprint
 from pipelex.cogt.templating.template_rendering import render_template
 from pipelex.core.memory.working_memory import WorkingMemory
@@ -113,7 +113,7 @@ class PipeSearch(PipeOperator[PipeSearchOutput]):
             search_setting = search_setting.model_copy(update={"max_results": self.max_results_override})
 
         # 5. Get search worker from factory
-        worker = get_search_worker(model_handle=search_setting.model)
+        worker = SearchWorkerFactory.make_search_worker(inference_model=inference_model)
 
         # 6. Execute search based on output type
         content: StuffContent

--- a/pipelex/pipe_operators/search/pipe_search_blueprint.py
+++ b/pipelex/pipe_operators/search/pipe_search_blueprint.py
@@ -2,7 +2,6 @@ from typing import Literal
 
 from typing_extensions import override
 
-from pipelex.cogt.search.search_depth import SearchDepth
 from pipelex.cogt.search.search_setting import SearchModelChoice
 from pipelex.cogt.templating.template_category import TemplateCategory
 from pipelex.cogt.templating.template_preprocessor import preprocess_template
@@ -18,7 +17,6 @@ class PipeSearchBlueprint(PipeBlueprint):
     pipe_category: Literal["PipeOperator"] = "PipeOperator"
     prompt: str
     model: SearchModelChoice | None = None
-    depth: SearchDepth | None = None
     include_images: bool | None = None
     max_results: int | None = None
     from_date: str | None = None

--- a/pipelex/pipe_operators/search/pipe_search_factory.py
+++ b/pipelex/pipe_operators/search/pipe_search_factory.py
@@ -50,7 +50,6 @@ class PipeSearchFactory(PipeFactoryProtocol[PipeSearchBlueprint, PipeSearch]):
             inputs=inputs,
             search_choice=blueprint.model,
             prompt_blueprint=prompt_blueprint,
-            depth_override=blueprint.depth,
             include_images_override=blueprint.include_images,
             max_results_override=blueprint.max_results,
             from_date=blueprint.from_date,

--- a/pipelex/pipelex.toml
+++ b/pipelex/pipelex.toml
@@ -74,8 +74,8 @@ image-text-extractor = "@default-extract-image"
 full-document-extractor = "@default-extract-document"
 
 [pipelex.builder_config.talent_preset_mappings.search]
-web-search = "$linkup-standard"
-web-search-deep = "$linkup-deep"
+web-search = "$standard"
+web-search-deep = "$deep"
 
 [pipelex.feature_config]
 # WIP/Experimental feature flags

--- a/pipelex/pipeline/job_metadata.py
+++ b/pipelex/pipeline/job_metadata.py
@@ -14,6 +14,8 @@ class JobCategory(StrEnum):
     IMG_GEN_JOB = "img_gen_job"
     JINJA2_JOB = "jinja2_job"
     EXTRACT_JOB = "extract_job"
+    SEARCH_JOB = "search_job"
+    FETCH_JOB = "fetch_job"
 
 
 class UnitJobId(StrEnum):
@@ -21,18 +23,23 @@ class UnitJobId(StrEnum):
     LLM_GEN_OBJECT = "llm_gen_object"
     IMG_GEN_TEXT_TO_IMAGE = "img_gen_text_to_image"
     EXTRACT_PAGES = "extract_pages"
+    SEARCH_SOURCED_ANSWER = "search_sourced_answer"
+    SEARCH_STRUCTURED = "search_structured"
+    FETCH_URL = "fetch_url"
 
     @property
     def model_kind(self) -> str:
         match self:
-            case UnitJobId.LLM_GEN_TEXT:
-                return "LLM"
-            case UnitJobId.LLM_GEN_OBJECT:
+            case UnitJobId.LLM_GEN_TEXT | UnitJobId.LLM_GEN_OBJECT:
                 return "LLM"
             case UnitJobId.IMG_GEN_TEXT_TO_IMAGE:
                 return "ImgGen"
             case UnitJobId.EXTRACT_PAGES:
                 return "Extract"
+            case UnitJobId.SEARCH_SOURCED_ANSWER | UnitJobId.SEARCH_STRUCTURED:
+                return "Search"
+            case UnitJobId.FETCH_URL:
+                return "Fetch"
 
 
 class JobMetadata(BaseModel):

--- a/pipelex/plugins/gateway/gateway_exceptions.py
+++ b/pipelex/plugins/gateway/gateway_exceptions.py
@@ -19,3 +19,7 @@ class GatewayDeckError(GatewayError):
 
 class GatewayExtractResponseError(GatewayError):
     pass
+
+
+class GatewaySearchResponseError(GatewayError):
+    pass

--- a/pipelex/plugins/gateway/gateway_fetch_worker.py
+++ b/pipelex/plugins/gateway/gateway_fetch_worker.py
@@ -10,15 +10,20 @@ from typing_extensions import override
 from pipelex import log
 from pipelex.cogt.exceptions import SdkTypeError
 from pipelex.cogt.model_backends.model_spec import InferenceModelSpec
+from pipelex.cogt.search.fetch_job import FetchJob
 from pipelex.cogt.search.fetch_worker_abstract import FetchWorkerAbstract
+from pipelex.cogt.search.search_job_factory import FetchJobFactory
+from pipelex.cogt.usage.token_category import NbTokensByCategoryDict, TokenCategory
 from pipelex.config import get_config
 from pipelex.core.stuffs.image_content import ImageContent
 from pipelex.core.stuffs.text_and_images_content import TextAndImagesContent
 from pipelex.core.stuffs.text_content import TextContent
+from pipelex.pipeline.job_metadata import JobMetadata, UnitJobId
 from pipelex.plugins.gateway.gateway_deck import GatewayDeck
 from pipelex.plugins.gateway.gateway_exceptions import GatewaySearchResponseError
 from pipelex.plugins.gateway.gateway_factory import GatewayFactory
 from pipelex.plugins.gateway.gateway_search_schemas import GatewayFetchRequestParams
+from pipelex.reporting.reporting_protocol import ReportingProtocol
 
 
 class GatewayFetchWorker(FetchWorkerAbstract):
@@ -28,7 +33,10 @@ class GatewayFetchWorker(FetchWorkerAbstract):
         self,
         sdk_instance: Any,
         inference_model: InferenceModelSpec,
+        reporting_delegate: ReportingProtocol | None = None,
     ):
+        super().__init__(reporting_delegate=reporting_delegate)
+
         if not isinstance(sdk_instance, AsyncPortkey):
             msg = f"Provided sdk_instance for {self.__class__.__name__} is not of type AsyncPortkey: it's a '{type(sdk_instance)}'"
             raise SdkTypeError(msg)
@@ -55,11 +63,16 @@ class GatewayFetchWorker(FetchWorkerAbstract):
     async def fetch_url(
         self,
         url: str,
+        job_metadata: JobMetadata,
         include_raw_html: bool | None = None,
         render_js: bool | None = None,
         extract_images: bool | None = None,
         timeout: float | None = None,  # noqa: ASYNC109
     ) -> TextAndImagesContent:
+        job_metadata.unit_job_id = UnitJobId.FETCH_URL
+        fetch_job = FetchJobFactory.make_fetch_job(job_metadata=job_metadata)
+        fetch_job.fetch_job_before_start(inference_model=self.inference_model)
+
         params = GatewayFetchRequestParams(
             url=url,
             include_raw_html=include_raw_html,
@@ -98,10 +111,16 @@ class GatewayFetchWorker(FetchWorkerAbstract):
             msg = "Response is not of type GenericResponse"
             raise TypeError(msg)
 
-        # Extract content from response
+        self._extract_usage(response=response, fetch_job=fetch_job)
+        fetch_job.fetch_job_after_complete()
+        if self.reporting_delegate:
+            self.reporting_delegate.report_inference_job(inference_job=fetch_job)
+
+        # Extract content from response — use dict access (GenericResponse uses extra="allow")
         try:
-            raw_content = cast("object", response.choices[0].message.content)  # type: ignore[attr-defined]  # pyright: ignore[reportAttributeAccessIssue, reportUnknownMemberType]
-        except (AttributeError, IndexError) as exc:
+            choice: dict[str, Any] = response.choices[0]  # type: ignore[attr-defined]  # pyright: ignore[reportAttributeAccessIssue, reportUnknownMemberType]
+            raw_content = cast("object", choice["message"]["content"])
+        except (KeyError, IndexError, TypeError) as exc:
             msg = "Could not extract content from gateway fetch response"
             raise GatewaySearchResponseError(msg) from exc
 
@@ -129,6 +148,18 @@ class GatewayFetchWorker(FetchWorkerAbstract):
             images=images or None,
             raw_html=result_dict.get("raw_html"),
         )
+
+    def _extract_usage(self, response: GenericResponse, fetch_job: FetchJob) -> None:
+        """Extract token usage from the GenericResponse and populate the fetch job report."""
+        response_dict: dict[str, Any] = response.model_dump(serialize_as_any=True)
+        fetch_tokens_usage = fetch_job.job_report.fetch_tokens_usage
+        if (usage_dict := response_dict.get("usage")) and fetch_tokens_usage:
+            nb_tokens: NbTokensByCategoryDict = {}
+            if input_tokens := usage_dict.get("prompt_tokens") or usage_dict.get("input_tokens"):
+                nb_tokens[TokenCategory.INPUT] = input_tokens
+            if output_tokens := usage_dict.get("completion_tokens") or usage_dict.get("output_tokens"):
+                nb_tokens[TokenCategory.OUTPUT] = output_tokens
+            fetch_tokens_usage.nb_tokens_by_category = nb_tokens
 
     def _is_retryable_portkey_error(self, exc: BaseException) -> bool:
         if isinstance(exc, portkey_exceptions.NotFoundError):

--- a/pipelex/plugins/gateway/gateway_fetch_worker.py
+++ b/pipelex/plugins/gateway/gateway_fetch_worker.py
@@ -1,0 +1,148 @@
+import json
+from typing import Any, cast
+
+from portkey_ai import AsyncPortkey
+from portkey_ai.api_resources import exceptions as portkey_exceptions
+from portkey_ai.api_resources.utils import GenericResponse
+from tenacity import AsyncRetrying, RetryCallState, retry_if_exception, stop_after_attempt, wait_random_exponential
+from typing_extensions import override
+
+from pipelex import log
+from pipelex.cogt.exceptions import SdkTypeError
+from pipelex.cogt.model_backends.model_spec import InferenceModelSpec
+from pipelex.cogt.search.fetch_worker_abstract import FetchWorkerAbstract
+from pipelex.config import get_config
+from pipelex.core.stuffs.image_content import ImageContent
+from pipelex.core.stuffs.text_and_images_content import TextAndImagesContent
+from pipelex.core.stuffs.text_content import TextContent
+from pipelex.plugins.gateway.gateway_deck import GatewayDeck
+from pipelex.plugins.gateway.gateway_exceptions import GatewaySearchResponseError
+from pipelex.plugins.gateway.gateway_factory import GatewayFactory
+from pipelex.plugins.gateway.gateway_search_schemas import GatewayFetchRequestParams
+
+
+class GatewayFetchWorker(FetchWorkerAbstract):
+    """Fetch worker that routes through Portkey to the pipelex-relay LinkUp fetch endpoint."""
+
+    def __init__(
+        self,
+        sdk_instance: Any,
+        inference_model: InferenceModelSpec,
+    ):
+        if not isinstance(sdk_instance, AsyncPortkey):
+            msg = f"Provided sdk_instance for {self.__class__.__name__} is not of type AsyncPortkey: it's a '{type(sdk_instance)}'"
+            raise SdkTypeError(msg)
+
+        self.portkey_client: AsyncPortkey = sdk_instance
+        self.inference_model = inference_model
+        self._tenacity_config = get_config().cogt.tenacity_config
+
+    def _make_retryer(self) -> AsyncRetrying:
+        """Create a fresh AsyncRetrying instance for each call."""
+        return AsyncRetrying(
+            retry=retry_if_exception(self._is_retryable_portkey_error),
+            before_sleep=self._log_retry,
+            wait=wait_random_exponential(
+                multiplier=self._tenacity_config.wait_multiplier,
+                max=self._tenacity_config.wait_max,
+                exp_base=self._tenacity_config.wait_exp_base,
+            ),
+            reraise=True,
+            stop=stop_after_attempt(self._tenacity_config.max_retries),
+        )
+
+    @override
+    async def fetch_url(
+        self,
+        url: str,
+        include_raw_html: bool | None = None,
+        render_js: bool | None = None,
+        extract_images: bool | None = None,
+        timeout: float | None = None,  # noqa: ASYNC109
+    ) -> TextAndImagesContent:
+        params = GatewayFetchRequestParams(
+            url=url,
+            include_raw_html=include_raw_html,
+            render_js=render_js,
+            extract_images=extract_images,
+            timeout=timeout,
+        )
+
+        config_id = GatewayDeck.get_config_id(headers=self.inference_model.extra_headers or {})
+        log.dev(f"Fetch via gateway config '{config_id}'")
+
+        messages: list[dict[str, str]] = [{"role": "user", "content": params.model_dump_json()}]
+
+        attempt_number = 0
+        response: GenericResponse | None = None
+        retryer = self._make_retryer()
+        try:
+            async for attempt in retryer:
+                with attempt:
+                    attempt_number += 1
+                    response = await self.portkey_client.with_options(config=config_id).post(  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
+                        "/chat/completions",
+                        model="linkup/fetch",
+                        messages=messages,
+                    )
+        except portkey_exceptions.APIError as exc:
+            error_summary = GatewayFactory.make_error_summary_from_portkey_error(exc)
+            msg = f"Fetch service error after {attempt_number} attempt(s): {error_summary}"
+            raise GatewaySearchResponseError(msg) from exc
+
+        if response is None:
+            msg = f"Could not get a fetch response via Portkey after {attempt_number} attempts"
+            raise GatewaySearchResponseError(msg)
+
+        if not isinstance(response, GenericResponse):
+            msg = "Response is not of type GenericResponse"
+            raise TypeError(msg)
+
+        # Extract content from response
+        try:
+            raw_content = cast("object", response.choices[0].message.content)  # type: ignore[attr-defined]  # pyright: ignore[reportAttributeAccessIssue, reportUnknownMemberType]
+        except (AttributeError, IndexError) as exc:
+            msg = "Could not extract content from gateway fetch response"
+            raise GatewaySearchResponseError(msg) from exc
+
+        if not isinstance(raw_content, str):
+            msg = f"Expected string content in fetch response, got {type(raw_content)}"
+            raise GatewaySearchResponseError(msg)
+        content_str: str = raw_content
+
+        result_dict: dict[str, Any] = json.loads(content_str)
+
+        text = TextContent(text=result_dict["markdown"]) if result_dict.get("markdown") else None
+
+        images: list[ImageContent] | None = None
+        if result_dict.get("images") is not None:
+            images = [
+                ImageContent(
+                    url=image["url"],
+                    caption=image.get("alt"),
+                )
+                for image in result_dict["images"]
+            ]
+
+        return TextAndImagesContent(
+            text=text,
+            images=images or None,
+            raw_html=result_dict.get("raw_html"),
+        )
+
+    def _is_retryable_portkey_error(self, exc: BaseException) -> bool:
+        if isinstance(exc, portkey_exceptions.NotFoundError):
+            msg = str(exc).lower()
+            return "specified deployment could not be found" in msg
+        return False
+
+    def _log_retry(self, retry_state: RetryCallState) -> None:
+        """Called before sleeping between retries."""
+        if not retry_state.outcome:
+            log.error("Tenacity retry state outcome is None")
+            return
+        exc = retry_state.outcome.exception()
+        attempt = retry_state.attempt_number
+        wait_duration = retry_state.next_action.sleep if retry_state.next_action else 0.0
+        log.dev(f"{self.__class__.__name__} retry #{attempt} for fetch due to '{type(exc).__name__}'.")
+        log.verbose(f"Wait duration before next attempt: {wait_duration:.4f}s")

--- a/pipelex/plugins/gateway/gateway_search_schemas.py
+++ b/pipelex/plugins/gateway/gateway_search_schemas.py
@@ -1,11 +1,13 @@
 from pydantic import BaseModel, Field
 
+from pipelex.cogt.search.search_depth import SearchDepth
+
 
 class GatewaySearchRequestParams(BaseModel):
     """Parameters for a web search request sent to the relay."""
 
     query: str = Field(description="The search query text")
-    depth: str = Field(default="standard", description="Search depth: 'standard' or 'deep'")
+    depth: SearchDepth = Field(default=SearchDepth.STANDARD, strict=False, description="Search depth: 'standard' or 'deep'")
     include_images: bool = Field(default=False, description="Whether to include images in results")
     include_inline_citations: bool = Field(default=True, description="Whether to include inline citations")
     max_results: int | None = Field(default=None, description="Maximum number of results to return")

--- a/pipelex/plugins/gateway/gateway_search_schemas.py
+++ b/pipelex/plugins/gateway/gateway_search_schemas.py
@@ -1,0 +1,26 @@
+from pydantic import BaseModel, Field
+
+
+class GatewaySearchRequestParams(BaseModel):
+    """Parameters for a web search request sent to the relay."""
+
+    query: str = Field(description="The search query text")
+    depth: str = Field(default="standard", description="Search depth: 'standard' or 'deep'")
+    include_images: bool = Field(default=False, description="Whether to include images in results")
+    include_inline_citations: bool = Field(default=True, description="Whether to include inline citations")
+    max_results: int | None = Field(default=None, description="Maximum number of results to return")
+    include_domains: list[str] | None = Field(default=None, description="Restrict search to these domains")
+    exclude_domains: list[str] | None = Field(default=None, description="Exclude these domains from search")
+    from_date: str | None = Field(default=None, description="Start date filter (YYYY-MM-DD)")
+    to_date: str | None = Field(default=None, description="End date filter (YYYY-MM-DD)")
+    output_schema: dict[str, object] | None = Field(default=None, description="JSON Schema for structured search output")
+
+
+class GatewayFetchRequestParams(BaseModel):
+    """Parameters for a web page fetch request sent to the relay."""
+
+    url: str = Field(description="The URL to fetch")
+    include_raw_html: bool | None = Field(default=None, description="Whether to include raw HTML in response")
+    render_js: bool | None = Field(default=None, description="Whether to render JavaScript before fetching")
+    extract_images: bool | None = Field(default=None, description="Whether to extract images from the page")
+    timeout: float | None = Field(default=None, description="Request timeout in seconds")

--- a/pipelex/plugins/gateway/gateway_search_worker.py
+++ b/pipelex/plugins/gateway/gateway_search_worker.py
@@ -75,7 +75,7 @@ class GatewaySearchWorker(SearchWorkerAbstract):
 
         params = GatewaySearchRequestParams(
             query=query,
-            depth=search_setting.depth,
+            depth=self.inference_model.model_id,
             include_images=search_setting.include_images,
             include_inline_citations=search_setting.include_inline_citations,
             max_results=search_setting.max_results,
@@ -86,7 +86,7 @@ class GatewaySearchWorker(SearchWorkerAbstract):
         )
 
         response = await self._call_relay(
-            model="linkup/sourced-answer",
+            model=self.inference_model.model_id,
             content=params.model_dump_json(),
         )
 
@@ -137,7 +137,7 @@ class GatewaySearchWorker(SearchWorkerAbstract):
 
         params = GatewaySearchRequestParams(
             query=query,
-            depth=search_setting.depth,
+            depth=self.inference_model.model_id,
             include_images=search_setting.include_images,
             include_inline_citations=search_setting.include_inline_citations,
             max_results=search_setting.max_results,
@@ -149,7 +149,7 @@ class GatewaySearchWorker(SearchWorkerAbstract):
         )
 
         response = await self._call_relay(
-            model="linkup/structured",
+            model=self.inference_model.model_id,
             content=params.model_dump_json(),
         )
 

--- a/pipelex/plugins/gateway/gateway_search_worker.py
+++ b/pipelex/plugins/gateway/gateway_search_worker.py
@@ -177,14 +177,19 @@ class GatewaySearchWorker(SearchWorkerAbstract):
         return response
 
     def _extract_content(self, response: GenericResponse) -> str:
-        """Extract the content string from a GenericResponse."""
+        """Extract the content string from a GenericResponse.
+
+        GenericResponse uses Pydantic's extra="allow", so `choices` is a raw
+        list[dict] rather than a list of typed objects — use dict access.
+        """
         try:
-            content = cast("object", response.choices[0].message.content)  # type: ignore[attr-defined]  # pyright: ignore[reportAttributeAccessIssue, reportUnknownMemberType]
+            choice: dict[str, Any] = response.choices[0]  # type: ignore[attr-defined]  # pyright: ignore[reportAttributeAccessIssue, reportUnknownMemberType]
+            content = cast("object", choice["message"]["content"])
             if not isinstance(content, str):
                 msg = f"Expected string content in response, got {type(content)}"
                 raise GatewaySearchResponseError(msg)
             return content
-        except (AttributeError, IndexError) as exc:
+        except (KeyError, IndexError, TypeError) as exc:
             msg = "Could not extract content from gateway search response"
             raise GatewaySearchResponseError(msg) from exc
 

--- a/pipelex/plugins/gateway/gateway_search_worker.py
+++ b/pipelex/plugins/gateway/gateway_search_worker.py
@@ -10,14 +10,19 @@ from typing_extensions import override
 from pipelex import log
 from pipelex.cogt.exceptions import SdkTypeError
 from pipelex.cogt.model_backends.model_spec import InferenceModelSpec
+from pipelex.cogt.search.search_job import SearchJob
+from pipelex.cogt.search.search_job_factory import SearchJobFactory
 from pipelex.cogt.search.search_setting import SearchSetting
 from pipelex.cogt.search.search_worker_abstract import SearchWorkerAbstract
+from pipelex.cogt.usage.token_category import NbTokensByCategoryDict, TokenCategory
 from pipelex.config import get_config
 from pipelex.core.stuffs.search_result_content import SearchResultContent, SearchSourceContent
+from pipelex.pipeline.job_metadata import JobMetadata, UnitJobId
 from pipelex.plugins.gateway.gateway_deck import GatewayDeck
 from pipelex.plugins.gateway.gateway_exceptions import GatewaySearchResponseError
 from pipelex.plugins.gateway.gateway_factory import GatewayFactory
 from pipelex.plugins.gateway.gateway_search_schemas import GatewaySearchRequestParams
+from pipelex.reporting.reporting_protocol import ReportingProtocol
 
 
 class GatewaySearchWorker(SearchWorkerAbstract):
@@ -27,7 +32,10 @@ class GatewaySearchWorker(SearchWorkerAbstract):
         self,
         sdk_instance: Any,
         inference_model: InferenceModelSpec,
+        reporting_delegate: ReportingProtocol | None = None,
     ):
+        super().__init__(reporting_delegate=reporting_delegate)
+
         if not isinstance(sdk_instance, AsyncPortkey):
             msg = f"Provided sdk_instance for {self.__class__.__name__} is not of type AsyncPortkey: it's a '{type(sdk_instance)}'"
             raise SdkTypeError(msg)
@@ -55,11 +63,16 @@ class GatewaySearchWorker(SearchWorkerAbstract):
         self,
         query: str,
         search_setting: SearchSetting,
+        job_metadata: JobMetadata,
         include_domains: list[str] | None = None,
         exclude_domains: list[str] | None = None,
         from_date: str | None = None,
         to_date: str | None = None,
     ) -> SearchResultContent:
+        job_metadata.unit_job_id = UnitJobId.SEARCH_SOURCED_ANSWER
+        search_job = SearchJobFactory.make_search_job(job_metadata=job_metadata)
+        search_job.search_job_before_start(inference_model=self.inference_model)
+
         params = GatewaySearchRequestParams(
             query=query,
             depth=search_setting.depth,
@@ -76,6 +89,11 @@ class GatewaySearchWorker(SearchWorkerAbstract):
             model="linkup/sourced-answer",
             content=params.model_dump_json(),
         )
+
+        self._extract_usage(response=response, search_job=search_job)
+        search_job.search_job_after_complete()
+        if self.reporting_delegate:
+            self.reporting_delegate.report_inference_job(inference_job=search_job)
 
         content_str = self._extract_content(response)
         result_dict: dict[str, Any] = json.loads(content_str)
@@ -100,11 +118,16 @@ class GatewaySearchWorker(SearchWorkerAbstract):
         query: str,
         search_setting: SearchSetting,
         output_schema: type,
+        job_metadata: JobMetadata,
         include_domains: list[str] | None = None,
         exclude_domains: list[str] | None = None,
         from_date: str | None = None,
         to_date: str | None = None,
     ) -> dict[str, Any]:
+        job_metadata.unit_job_id = UnitJobId.SEARCH_STRUCTURED
+        search_job = SearchJobFactory.make_search_job(job_metadata=job_metadata)
+        search_job.search_job_before_start(inference_model=self.inference_model)
+
         # Convert Pydantic model class to JSON Schema dict for the relay
         schema_dict: dict[str, Any]
         if hasattr(output_schema, "model_json_schema"):
@@ -130,9 +153,26 @@ class GatewaySearchWorker(SearchWorkerAbstract):
             content=params.model_dump_json(),
         )
 
+        self._extract_usage(response=response, search_job=search_job)
+        search_job.search_job_after_complete()
+        if self.reporting_delegate:
+            self.reporting_delegate.report_inference_job(inference_job=search_job)
+
         content_str = self._extract_content(response)
         result: dict[str, Any] = json.loads(content_str)
         return result
+
+    def _extract_usage(self, response: GenericResponse, search_job: SearchJob) -> None:
+        """Extract token usage from the GenericResponse and populate the search job report."""
+        response_dict: dict[str, Any] = response.model_dump(serialize_as_any=True)
+        search_tokens_usage = search_job.job_report.search_tokens_usage
+        if (usage_dict := response_dict.get("usage")) and search_tokens_usage:
+            nb_tokens: NbTokensByCategoryDict = {}
+            if input_tokens := usage_dict.get("prompt_tokens") or usage_dict.get("input_tokens"):
+                nb_tokens[TokenCategory.INPUT] = input_tokens
+            if output_tokens := usage_dict.get("completion_tokens") or usage_dict.get("output_tokens"):
+                nb_tokens[TokenCategory.OUTPUT] = output_tokens
+            search_tokens_usage.nb_tokens_by_category = nb_tokens
 
     async def _call_relay(self, model: str, content: str) -> GenericResponse:
         """Send a request through Portkey to the relay.

--- a/pipelex/plugins/gateway/gateway_search_worker.py
+++ b/pipelex/plugins/gateway/gateway_search_worker.py
@@ -10,6 +10,7 @@ from typing_extensions import override
 from pipelex import log
 from pipelex.cogt.exceptions import SdkTypeError
 from pipelex.cogt.model_backends.model_spec import InferenceModelSpec
+from pipelex.cogt.search.search_depth import SearchDepth
 from pipelex.cogt.search.search_job import SearchJob
 from pipelex.cogt.search.search_job_factory import SearchJobFactory
 from pipelex.cogt.search.search_setting import SearchSetting
@@ -75,7 +76,7 @@ class GatewaySearchWorker(SearchWorkerAbstract):
 
         params = GatewaySearchRequestParams(
             query=query,
-            depth=self.inference_model.model_id,
+            depth=SearchDepth(self.inference_model.model_id),
             include_images=search_setting.include_images,
             include_inline_citations=search_setting.include_inline_citations,
             max_results=search_setting.max_results,
@@ -133,11 +134,12 @@ class GatewaySearchWorker(SearchWorkerAbstract):
         if hasattr(output_schema, "model_json_schema"):
             schema_dict = cast("dict[str, Any]", output_schema.model_json_schema())  # pyright: ignore[reportUnknownMemberType]
         else:
-            schema_dict = {}
+            msg = f"output_schema must be a Pydantic model class with model_json_schema(), got {output_schema}"
+            raise SdkTypeError(msg)
 
         params = GatewaySearchRequestParams(
             query=query,
-            depth=self.inference_model.model_id,
+            depth=SearchDepth(self.inference_model.model_id),
             include_images=search_setting.include_images,
             include_inline_citations=search_setting.include_inline_citations,
             max_results=search_setting.max_results,

--- a/pipelex/plugins/gateway/gateway_search_worker.py
+++ b/pipelex/plugins/gateway/gateway_search_worker.py
@@ -1,0 +1,206 @@
+import json
+from typing import Any, cast
+
+from portkey_ai import AsyncPortkey
+from portkey_ai.api_resources import exceptions as portkey_exceptions
+from portkey_ai.api_resources.utils import GenericResponse
+from tenacity import AsyncRetrying, RetryCallState, retry_if_exception, stop_after_attempt, wait_random_exponential
+from typing_extensions import override
+
+from pipelex import log
+from pipelex.cogt.exceptions import SdkTypeError
+from pipelex.cogt.model_backends.model_spec import InferenceModelSpec
+from pipelex.cogt.search.search_setting import SearchSetting
+from pipelex.cogt.search.search_worker_abstract import SearchWorkerAbstract
+from pipelex.config import get_config
+from pipelex.core.stuffs.search_result_content import SearchResultContent, SearchSourceContent
+from pipelex.plugins.gateway.gateway_deck import GatewayDeck
+from pipelex.plugins.gateway.gateway_exceptions import GatewaySearchResponseError
+from pipelex.plugins.gateway.gateway_factory import GatewayFactory
+from pipelex.plugins.gateway.gateway_search_schemas import GatewaySearchRequestParams
+
+
+class GatewaySearchWorker(SearchWorkerAbstract):
+    """Search worker that routes through Portkey to the pipelex-relay LinkUp endpoints."""
+
+    def __init__(
+        self,
+        sdk_instance: Any,
+        inference_model: InferenceModelSpec,
+    ):
+        if not isinstance(sdk_instance, AsyncPortkey):
+            msg = f"Provided sdk_instance for {self.__class__.__name__} is not of type AsyncPortkey: it's a '{type(sdk_instance)}'"
+            raise SdkTypeError(msg)
+
+        self.portkey_client: AsyncPortkey = sdk_instance
+        self.inference_model = inference_model
+        self._tenacity_config = get_config().cogt.tenacity_config
+
+    def _make_retryer(self) -> AsyncRetrying:
+        """Create a fresh AsyncRetrying instance for each call."""
+        return AsyncRetrying(
+            retry=retry_if_exception(self._is_retryable_portkey_error),
+            before_sleep=self._log_retry,
+            wait=wait_random_exponential(
+                multiplier=self._tenacity_config.wait_multiplier,
+                max=self._tenacity_config.wait_max,
+                exp_base=self._tenacity_config.wait_exp_base,
+            ),
+            reraise=True,
+            stop=stop_after_attempt(self._tenacity_config.max_retries),
+        )
+
+    @override
+    async def search_sourced_answer(
+        self,
+        query: str,
+        search_setting: SearchSetting,
+        include_domains: list[str] | None = None,
+        exclude_domains: list[str] | None = None,
+        from_date: str | None = None,
+        to_date: str | None = None,
+    ) -> SearchResultContent:
+        params = GatewaySearchRequestParams(
+            query=query,
+            depth=search_setting.depth,
+            include_images=search_setting.include_images,
+            include_inline_citations=search_setting.include_inline_citations,
+            max_results=search_setting.max_results,
+            include_domains=include_domains,
+            exclude_domains=exclude_domains,
+            from_date=from_date,
+            to_date=to_date,
+        )
+
+        response = await self._call_relay(
+            model="linkup/sourced-answer",
+            content=params.model_dump_json(),
+        )
+
+        content_str = self._extract_content(response)
+        result_dict: dict[str, Any] = json.loads(content_str)
+
+        sources = [
+            SearchSourceContent(
+                name=source["name"],
+                url=source["url"],
+                snippet=source["snippet"],
+            )
+            for source in result_dict.get("sources", [])
+        ]
+
+        return SearchResultContent(
+            answer=result_dict["answer"],
+            sources=sources,
+        )
+
+    @override
+    async def search_structured(
+        self,
+        query: str,
+        search_setting: SearchSetting,
+        output_schema: type,
+        include_domains: list[str] | None = None,
+        exclude_domains: list[str] | None = None,
+        from_date: str | None = None,
+        to_date: str | None = None,
+    ) -> dict[str, Any]:
+        # Convert Pydantic model class to JSON Schema dict for the relay
+        schema_dict: dict[str, Any]
+        if hasattr(output_schema, "model_json_schema"):
+            schema_dict = cast("dict[str, Any]", output_schema.model_json_schema())  # pyright: ignore[reportUnknownMemberType]
+        else:
+            schema_dict = {}
+
+        params = GatewaySearchRequestParams(
+            query=query,
+            depth=search_setting.depth,
+            include_images=search_setting.include_images,
+            include_inline_citations=search_setting.include_inline_citations,
+            max_results=search_setting.max_results,
+            include_domains=include_domains,
+            exclude_domains=exclude_domains,
+            from_date=from_date,
+            to_date=to_date,
+            output_schema=schema_dict,
+        )
+
+        response = await self._call_relay(
+            model="linkup/structured",
+            content=params.model_dump_json(),
+        )
+
+        content_str = self._extract_content(response)
+        result: dict[str, Any] = json.loads(content_str)
+        return result
+
+    async def _call_relay(self, model: str, content: str) -> GenericResponse:
+        """Send a request through Portkey to the relay.
+
+        Args:
+            model: The relay model identifier (e.g., "linkup-sourced-answer")
+            content: JSON-encoded request parameters
+
+        Returns:
+            The Portkey GenericResponse
+        """
+        config_id = GatewayDeck.get_config_id(headers=self.inference_model.extra_headers or {})
+        log.dev(f"Search via gateway config '{config_id}' with model '{model}'")
+
+        messages: list[dict[str, str]] = [{"role": "user", "content": content}]
+
+        attempt_number = 0
+        response: GenericResponse | None = None
+        retryer = self._make_retryer()
+        try:
+            async for attempt in retryer:
+                with attempt:
+                    attempt_number += 1
+                    response = await self.portkey_client.with_options(config=config_id).post(  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
+                        "/chat/completions",
+                        model=model,
+                        messages=messages,
+                    )
+        except portkey_exceptions.APIError as exc:
+            error_summary = GatewayFactory.make_error_summary_from_portkey_error(exc)
+            msg = f"Search service error for model '{model}' after {attempt_number} attempt(s): {error_summary}"
+            raise GatewaySearchResponseError(msg) from exc
+
+        if response is None:
+            msg = f"Could not get a response for model '{model}' via Portkey after {attempt_number} attempts"
+            raise GatewaySearchResponseError(msg)
+
+        if not isinstance(response, GenericResponse):
+            msg = "Response is not of type GenericResponse"
+            raise TypeError(msg)
+
+        return response
+
+    def _extract_content(self, response: GenericResponse) -> str:
+        """Extract the content string from a GenericResponse."""
+        try:
+            content = cast("object", response.choices[0].message.content)  # type: ignore[attr-defined]  # pyright: ignore[reportAttributeAccessIssue, reportUnknownMemberType]
+            if not isinstance(content, str):
+                msg = f"Expected string content in response, got {type(content)}"
+                raise GatewaySearchResponseError(msg)
+            return content
+        except (AttributeError, IndexError) as exc:
+            msg = "Could not extract content from gateway search response"
+            raise GatewaySearchResponseError(msg) from exc
+
+    def _is_retryable_portkey_error(self, exc: BaseException) -> bool:
+        if isinstance(exc, portkey_exceptions.NotFoundError):
+            msg = str(exc).lower()
+            return "specified deployment could not be found" in msg
+        return False
+
+    def _log_retry(self, retry_state: RetryCallState) -> None:
+        """Called before sleeping between retries."""
+        if not retry_state.outcome:
+            log.error("Tenacity retry state outcome is None")
+            return
+        exc = retry_state.outcome.exception()
+        attempt = retry_state.attempt_number
+        wait_duration = retry_state.next_action.sleep if retry_state.next_action else 0.0
+        log.dev(f"{self.__class__.__name__} retry #{attempt} for search due to '{type(exc).__name__}'.")
+        log.verbose(f"Wait duration before next attempt: {wait_duration:.4f}s")

--- a/pipelex/plugins/linkup/linkup_search_worker.py
+++ b/pipelex/plugins/linkup/linkup_search_worker.py
@@ -1,4 +1,3 @@
-import asyncio
 from datetime import date
 from typing import Any
 
@@ -14,7 +13,7 @@ from pipelex.hub import get_secrets_provider
 class LinkupSearchWorker(SearchWorkerAbstract):
     def __init__(self) -> None:
         api_key = get_secrets_provider().get_secret(secret_id="LINKUP_API_KEY")
-        self._client = LinkupClient(api_key=api_key)
+        self._linkup_client = LinkupClient(api_key=api_key)
 
     def _parse_date(self, date_str: str | None) -> date | None:
         if date_str is None:
@@ -32,8 +31,7 @@ class LinkupSearchWorker(SearchWorkerAbstract):
         to_date: str | None = None,
     ) -> SearchResultContent:
         depth_value = search_setting.depth
-        response: LinkupSourcedAnswer = await asyncio.to_thread(
-            self._client.search,
+        response: LinkupSourcedAnswer = await self._linkup_client.async_search(
             query=query,
             depth=depth_value,  # type: ignore[arg-type]
             output_type="sourcedAnswer",
@@ -73,8 +71,7 @@ class LinkupSearchWorker(SearchWorkerAbstract):
         to_date: str | None = None,
     ) -> dict[str, Any]:
         depth_value = search_setting.depth
-        response = await asyncio.to_thread(
-            self._client.search,
+        response = await self._linkup_client.async_search(
             query=query,
             depth=depth_value,  # type: ignore[arg-type]
             output_type="structured",

--- a/pipelex/plugins/linkup/linkup_worker.py
+++ b/pipelex/plugins/linkup/linkup_worker.py
@@ -4,18 +4,30 @@ from typing import Any
 from linkup import LinkupClient, LinkupFetchResponse, LinkupSourcedAnswer
 from typing_extensions import override
 
+from pipelex.cogt.model_backends.model_spec import InferenceModelSpec
 from pipelex.cogt.search.fetch_worker_abstract import FetchWorkerAbstract
+from pipelex.cogt.search.search_job_factory import FetchJobFactory, SearchJobFactory
 from pipelex.cogt.search.search_setting import SearchSetting
 from pipelex.cogt.search.search_worker_abstract import SearchWorkerAbstract
+from pipelex.cogt.usage.token_category import TokenCategory
 from pipelex.core.stuffs.image_content import ImageContent
 from pipelex.core.stuffs.search_result_content import SearchResultContent, SearchSourceContent
 from pipelex.core.stuffs.text_and_images_content import TextAndImagesContent
 from pipelex.core.stuffs.text_content import TextContent
 from pipelex.hub import get_secrets_provider
+from pipelex.pipeline.job_metadata import JobMetadata, UnitJobId
+from pipelex.reporting.reporting_protocol import ReportingProtocol
 
 
 class LinkupWorker(SearchWorkerAbstract, FetchWorkerAbstract):
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        inference_model: InferenceModelSpec,
+        reporting_delegate: ReportingProtocol | None = None,
+    ) -> None:
+        SearchWorkerAbstract.__init__(self, reporting_delegate=reporting_delegate)
+        FetchWorkerAbstract.__init__(self, reporting_delegate=reporting_delegate)
+        self.inference_model = inference_model
         api_key = get_secrets_provider().get_secret(secret_id="LINKUP_API_KEY")
         self._linkup_client = LinkupClient(api_key=api_key)
 
@@ -29,11 +41,16 @@ class LinkupWorker(SearchWorkerAbstract, FetchWorkerAbstract):
         self,
         query: str,
         search_setting: SearchSetting,
+        job_metadata: JobMetadata,
         include_domains: list[str] | None = None,
         exclude_domains: list[str] | None = None,
         from_date: str | None = None,
         to_date: str | None = None,
     ) -> SearchResultContent:
+        job_metadata.unit_job_id = UnitJobId.SEARCH_SOURCED_ANSWER
+        search_job = SearchJobFactory.make_search_job(job_metadata=job_metadata)
+        search_job.search_job_before_start(inference_model=self.inference_model)
+
         depth_value = search_setting.depth
         response: LinkupSourcedAnswer = await self._linkup_client.async_search(
             query=query,
@@ -47,6 +64,13 @@ class LinkupWorker(SearchWorkerAbstract, FetchWorkerAbstract):
             from_date=self._parse_date(from_date),
             to_date=self._parse_date(to_date),
         )
+
+        # Per-request cost model: costs are defined per million, so 1 request = 1_000_000
+        if search_tokens_usage := search_job.job_report.search_tokens_usage:
+            search_tokens_usage.nb_tokens_by_category = {TokenCategory.INPUT: 1_000_000, TokenCategory.OUTPUT: 1_000_000}
+        search_job.search_job_after_complete()
+        if self.reporting_delegate:
+            self.reporting_delegate.report_inference_job(inference_job=search_job)
 
         sources: list[SearchSourceContent] = []
         for source in response.sources:
@@ -69,11 +93,16 @@ class LinkupWorker(SearchWorkerAbstract, FetchWorkerAbstract):
         query: str,
         search_setting: SearchSetting,
         output_schema: type,
+        job_metadata: JobMetadata,
         include_domains: list[str] | None = None,
         exclude_domains: list[str] | None = None,
         from_date: str | None = None,
         to_date: str | None = None,
     ) -> dict[str, Any]:
+        job_metadata.unit_job_id = UnitJobId.SEARCH_STRUCTURED
+        search_job = SearchJobFactory.make_search_job(job_metadata=job_metadata)
+        search_job.search_job_before_start(inference_model=self.inference_model)
+
         depth_value = search_setting.depth
         response = await self._linkup_client.async_search(
             query=query,
@@ -89,6 +118,13 @@ class LinkupWorker(SearchWorkerAbstract, FetchWorkerAbstract):
             include_sources=True,
         )
 
+        # Per-request cost model: costs are defined per million, so 1 request = 1_000_000
+        if search_tokens_usage := search_job.job_report.search_tokens_usage:
+            search_tokens_usage.nb_tokens_by_category = {TokenCategory.INPUT: 1_000_000, TokenCategory.OUTPUT: 1_000_000}
+        search_job.search_job_after_complete()
+        if self.reporting_delegate:
+            self.reporting_delegate.report_inference_job(inference_job=search_job)
+
         # If response is a Pydantic model, convert to dict
         if hasattr(response, "model_dump"):
             result: dict[str, Any] = response.model_dump()
@@ -99,11 +135,16 @@ class LinkupWorker(SearchWorkerAbstract, FetchWorkerAbstract):
     async def fetch_url(
         self,
         url: str,
+        job_metadata: JobMetadata,
         include_raw_html: bool | None = None,
         render_js: bool | None = None,
         extract_images: bool | None = None,
         timeout: float | None = None,  # noqa: ASYNC109
     ) -> TextAndImagesContent:
+        job_metadata.unit_job_id = UnitJobId.FETCH_URL
+        fetch_job = FetchJobFactory.make_fetch_job(job_metadata=job_metadata)
+        fetch_job.fetch_job_before_start(inference_model=self.inference_model)
+
         response: LinkupFetchResponse = await self._linkup_client.async_fetch(
             url=url,
             include_raw_html=include_raw_html,
@@ -111,6 +152,13 @@ class LinkupWorker(SearchWorkerAbstract, FetchWorkerAbstract):
             extract_images=extract_images,
             timeout=timeout,
         )
+
+        # Per-request cost model: costs are defined per million, so 1 request = 1_000_000
+        if fetch_tokens_usage := fetch_job.job_report.fetch_tokens_usage:
+            fetch_tokens_usage.nb_tokens_by_category = {TokenCategory.INPUT: 1_000_000, TokenCategory.OUTPUT: 1_000_000}
+        fetch_job.fetch_job_after_complete()
+        if self.reporting_delegate:
+            self.reporting_delegate.report_inference_job(inference_job=fetch_job)
 
         text = TextContent(text=response.markdown) if response.markdown else None
 

--- a/pipelex/plugins/linkup/linkup_worker.py
+++ b/pipelex/plugins/linkup/linkup_worker.py
@@ -6,6 +6,7 @@ from typing_extensions import override
 
 from pipelex.cogt.model_backends.model_spec import InferenceModelSpec
 from pipelex.cogt.search.fetch_worker_abstract import FetchWorkerAbstract
+from pipelex.cogt.search.search_depth import SearchDepth
 from pipelex.cogt.search.search_job_factory import FetchJobFactory, SearchJobFactory
 from pipelex.cogt.search.search_setting import SearchSetting
 from pipelex.cogt.search.search_worker_abstract import SearchWorkerAbstract
@@ -51,10 +52,10 @@ class LinkupWorker(SearchWorkerAbstract, FetchWorkerAbstract):
         search_job = SearchJobFactory.make_search_job(job_metadata=job_metadata)
         search_job.search_job_before_start(inference_model=self.inference_model)
 
-        depth_value = self.inference_model.model_id
+        depth_value = SearchDepth(self.inference_model.model_id)
         response: LinkupSourcedAnswer = await self._linkup_client.async_search(
             query=query,
-            depth=depth_value,  # type: ignore[arg-type]
+            depth=depth_value,  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
             output_type="sourcedAnswer",
             include_images=search_setting.include_images,
             include_inline_citations=search_setting.include_inline_citations,
@@ -103,10 +104,10 @@ class LinkupWorker(SearchWorkerAbstract, FetchWorkerAbstract):
         search_job = SearchJobFactory.make_search_job(job_metadata=job_metadata)
         search_job.search_job_before_start(inference_model=self.inference_model)
 
-        depth_value = self.inference_model.model_id
+        depth_value = SearchDepth(self.inference_model.model_id)
         response = await self._linkup_client.async_search(
             query=query,
-            depth=depth_value,  # type: ignore[arg-type]
+            depth=depth_value,  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
             output_type="structured",
             structured_output_schema=output_schema,
             include_images=search_setting.include_images,

--- a/pipelex/plugins/linkup/linkup_worker.py
+++ b/pipelex/plugins/linkup/linkup_worker.py
@@ -51,7 +51,7 @@ class LinkupWorker(SearchWorkerAbstract, FetchWorkerAbstract):
         search_job = SearchJobFactory.make_search_job(job_metadata=job_metadata)
         search_job.search_job_before_start(inference_model=self.inference_model)
 
-        depth_value = search_setting.depth
+        depth_value = self.inference_model.model_id
         response: LinkupSourcedAnswer = await self._linkup_client.async_search(
             query=query,
             depth=depth_value,  # type: ignore[arg-type]
@@ -103,7 +103,7 @@ class LinkupWorker(SearchWorkerAbstract, FetchWorkerAbstract):
         search_job = SearchJobFactory.make_search_job(job_metadata=job_metadata)
         search_job.search_job_before_start(inference_model=self.inference_model)
 
-        depth_value = search_setting.depth
+        depth_value = self.inference_model.model_id
         response = await self._linkup_client.async_search(
             query=query,
             depth=depth_value,  # type: ignore[arg-type]

--- a/pipelex/plugins/linkup/linkup_worker.py
+++ b/pipelex/plugins/linkup/linkup_worker.py
@@ -1,16 +1,20 @@
 from datetime import date
 from typing import Any
 
-from linkup import LinkupClient, LinkupSourcedAnswer
+from linkup import LinkupClient, LinkupFetchResponse, LinkupSourcedAnswer
 from typing_extensions import override
 
+from pipelex.cogt.search.fetch_worker_abstract import FetchWorkerAbstract
 from pipelex.cogt.search.search_setting import SearchSetting
 from pipelex.cogt.search.search_worker_abstract import SearchWorkerAbstract
+from pipelex.core.stuffs.image_content import ImageContent
 from pipelex.core.stuffs.search_result_content import SearchResultContent, SearchSourceContent
+from pipelex.core.stuffs.text_and_images_content import TextAndImagesContent
+from pipelex.core.stuffs.text_content import TextContent
 from pipelex.hub import get_secrets_provider
 
 
-class LinkupSearchWorker(SearchWorkerAbstract):
+class LinkupWorker(SearchWorkerAbstract, FetchWorkerAbstract):
     def __init__(self) -> None:
         api_key = get_secrets_provider().get_secret(secret_id="LINKUP_API_KEY")
         self._linkup_client = LinkupClient(api_key=api_key)
@@ -90,3 +94,38 @@ class LinkupSearchWorker(SearchWorkerAbstract):
             result: dict[str, Any] = response.model_dump()
             return result
         return dict(response)  # type: ignore[arg-type]
+
+    @override
+    async def fetch_url(
+        self,
+        url: str,
+        include_raw_html: bool | None = None,
+        render_js: bool | None = None,
+        extract_images: bool | None = None,
+        timeout: float | None = None,  # noqa: ASYNC109
+    ) -> TextAndImagesContent:
+        response: LinkupFetchResponse = await self._linkup_client.async_fetch(
+            url=url,
+            include_raw_html=include_raw_html,
+            render_js=render_js,
+            extract_images=extract_images,
+            timeout=timeout,
+        )
+
+        text = TextContent(text=response.markdown) if response.markdown else None
+
+        images: list[ImageContent] | None = None
+        if response.images is not None:
+            images = [
+                ImageContent(
+                    url=image.url,
+                    caption=image.alt or None,
+                )
+                for image in response.images
+            ]
+
+        return TextAndImagesContent(
+            text=text,
+            images=images or None,
+            raw_html=response.raw_html,
+        )

--- a/pipelex/reporting/reporting_manager.py
+++ b/pipelex/reporting/reporting_manager.py
@@ -12,6 +12,10 @@ from pipelex.cogt.img_gen.img_gen_report import ImgGenTokensUsage
 from pipelex.cogt.inference.inference_job_abstract import InferenceJobAbstract
 from pipelex.cogt.llm.llm_job import LLMJob
 from pipelex.cogt.llm.llm_report import LLMTokensUsage
+from pipelex.cogt.search.fetch_job import FetchJob
+from pipelex.cogt.search.fetch_report import FetchTokensUsage
+from pipelex.cogt.search.search_job import SearchJob
+from pipelex.cogt.search.search_report import SearchTokensUsage
 from pipelex.cogt.usage.cost_registry import CostRegistry
 from pipelex.config import get_config
 from pipelex.pipeline.pipeline_models import SpecialPipelineId
@@ -22,7 +26,7 @@ from pipelex.tools.typing.pydantic_utils import empty_list_factory_of
 if TYPE_CHECKING:
     from pathlib import Path
 
-TokensUsage = LLMTokensUsage | ImgGenTokensUsage | ExtractTokensUsage
+TokensUsage = LLMTokensUsage | ImgGenTokensUsage | ExtractTokensUsage | SearchTokensUsage | FetchTokensUsage
 UsageRegistryRoot = list[TokensUsage]
 
 
@@ -106,6 +110,34 @@ class ReportingManager(ReportingProtocol):
             extract_token_cost_report = CostRegistry.complete_cost_report(tokens_usage=extract_tokens_usage)
             log.verbose(extract_token_cost_report, title="Token Cost report")
 
+    def _report_search_job(self, search_job: SearchJob):
+        search_tokens_usage = search_job.job_report.search_tokens_usage
+
+        if not search_tokens_usage:
+            log.warning("Search job has no search_tokens_usage")
+            return
+
+        pipeline_run_id = search_job.job_metadata.pipeline_run_id
+        self._get_registry(pipeline_run_id).add_tokens_usage(search_tokens_usage)
+
+        if self._reporting_config.is_log_costs_to_console:
+            search_token_cost_report = CostRegistry.complete_cost_report(tokens_usage=search_tokens_usage)
+            log.verbose(search_token_cost_report, title="Token Cost report")
+
+    def _report_fetch_job(self, fetch_job: FetchJob):
+        fetch_tokens_usage = fetch_job.job_report.fetch_tokens_usage
+
+        if not fetch_tokens_usage:
+            log.warning("Fetch job has no fetch_tokens_usage")
+            return
+
+        pipeline_run_id = fetch_job.job_metadata.pipeline_run_id
+        self._get_registry(pipeline_run_id).add_tokens_usage(fetch_tokens_usage)
+
+        if self._reporting_config.is_log_costs_to_console:
+            fetch_token_cost_report = CostRegistry.complete_cost_report(tokens_usage=fetch_tokens_usage)
+            log.verbose(fetch_token_cost_report, title="Token Cost report")
+
     ############################################################
     # ReportingProtocol
     ############################################################
@@ -126,6 +158,10 @@ class ReportingManager(ReportingProtocol):
             self._report_img_gen_job(img_gen_job=inference_job)
         elif isinstance(inference_job, ExtractJob):
             self._report_extract_job(extract_job=inference_job)
+        elif isinstance(inference_job, SearchJob):
+            self._report_search_job(search_job=inference_job)
+        elif isinstance(inference_job, FetchJob):
+            self._report_fetch_job(fetch_job=inference_job)
         else:
             log.warning(f"ReportingManager does not support reporting for inference job type: {type(inference_job).__name__}")
 

--- a/pipelex/system/pipelex_service/pipelex_details.py
+++ b/pipelex/system/pipelex_service/pipelex_details.py
@@ -2,7 +2,7 @@ from pipelex.tools.misc.hash_utils import hash_sha256
 
 
 class PipelexDetails:
-    REMOTE_CONFIG_URL = "https://pipelex-config.s3.eu-west-3.amazonaws.com/pipelex_remote_config_05.json"
+    REMOTE_CONFIG_URL = "https://pipelex-config.s3.eu-west-3.amazonaws.com/pipelex_remote_config_06.json"
     PIPELEX_GATEWAY_API_KEY_VAR = "PIPELEX_GATEWAY_API_KEY"
 
     @classmethod

--- a/tests/e2e/pipelex/pipes/pipe_operators/pipe_search/pipe_search.mthds
+++ b/tests/e2e/pipelex/pipes/pipe_operators/pipe_search/pipe_search.mthds
@@ -6,7 +6,7 @@ type        = "PipeSearch"
 description = "Search the web for recent news"
 inputs      = { topic = "Text" }
 output      = "SearchResult"
-model       = "$linkup-standard"
+model       = "$standard"
 prompt      = "What's the latest news about $topic in the last 24 hours?"
 
 [pipe.search_sourced_e2e_using_preset]
@@ -14,7 +14,7 @@ type        = "PipeSearch"
 description = "Search the web for sourced information using the standard preset"
 inputs      = { topic = "Text" }
 output      = "SearchResult"
-model       = "$linkup-standard"
+model       = "$standard"
 prompt      = "What is $topic?"
 
 [pipe.search_sourced_e2e_deep]
@@ -22,5 +22,5 @@ type        = "PipeSearch"
 description = "Search the web for sourced information using the deep preset"
 inputs      = { topic = "Text" }
 output      = "SearchResult"
-model       = "$linkup-deep"
+model       = "$deep"
 prompt      = "What are the main details about $topic?"

--- a/tests/integration/pipelex/cogt/test_data.py
+++ b/tests/integration/pipelex/cogt/test_data.py
@@ -246,7 +246,8 @@ class SearchTestCases:
     """Test cases for search integration tests."""
 
     SOURCED_ANSWER_QUERIES: ClassVar[list[tuple[str, str]]] = [  # topic, query
-        ("Middle East", "Latest events in the middle east"),
+        ("Declarative languages", "What makes declarative languages different from imperative languages?"),
+        # ("Middle East", "Latest events in the middle east"),
         # ("Capital of France", "What is the capital of France?"),
         # ("Python creator", "Who created the Python programming language?"),
     ]

--- a/tests/integration/pipelex/cogt/test_data.py
+++ b/tests/integration/pipelex/cogt/test_data.py
@@ -234,6 +234,14 @@ class SerDeTestLLMCases:
     ]
 
 
+class FetchTestCases:
+    """Test cases for fetch integration tests."""
+
+    FETCH_URLS: ClassVar[list[tuple[str, str]]] = [  # topic, url
+        ("Wikipedia Python", "https://en.wikipedia.org/wiki/Python_(programming_language)"),
+    ]
+
+
 class SearchTestCases:
     """Test cases for search integration tests."""
 

--- a/tests/integration/pipelex/cogt/test_data.py
+++ b/tests/integration/pipelex/cogt/test_data.py
@@ -244,8 +244,8 @@ class SearchTestCases:
     ]
 
     STRUCTURED_QUERIES: ClassVar[list[tuple[str, str]]] = [  # topic, query
-        ("Python language", "What is the Python programming language and what are its main features?"),
-        ("Machine learning", "What is machine learning and its main applications?"),
+        ("Middle East", "Latest events in the middle east"),
+        # ("Python language", "What is the Python programming language and what are its main features?"),
     ]
 
 

--- a/tests/integration/pipelex/cogt/test_fetch.py
+++ b/tests/integration/pipelex/cogt/test_fetch.py
@@ -60,4 +60,5 @@ class TestFetch:
         assert result.text is not None, "Expected non-empty text content"
         assert result.images is not None, "Expected images to be present when requested"
         assert isinstance(result.images, list), "Expected images to be a list"
+        assert len(result.images) > 0, "Expected images list to be non-empty"
         get_report_delegate().generate_report()

--- a/tests/integration/pipelex/cogt/test_fetch.py
+++ b/tests/integration/pipelex/cogt/test_fetch.py
@@ -1,0 +1,50 @@
+import pytest
+
+from pipelex import pretty_print
+from pipelex.cogt.search.search_worker_factory import get_fetch_worker
+from tests.integration.pipelex.cogt.test_data import FetchTestCases
+
+
+@pytest.mark.search
+@pytest.mark.inference
+@pytest.mark.asyncio(loop_scope="class")
+class TestFetch:
+    @pytest.mark.parametrize(
+        ("topic", "url"),
+        FetchTestCases.FETCH_URLS,
+    )
+    async def test_fetch_url(self, topic: str, url: str) -> None:
+        """Verify that fetch_url returns non-empty text content."""
+        worker = get_fetch_worker("linkup")
+        result = await worker.fetch_url(url=url)
+        pretty_print(result, title=f"Fetch Result ({topic})")
+        assert result.text is not None, "Expected non-empty text content"
+        assert len(result.text.text) > 0, "Expected text to have content"
+        assert result.raw_html is None, "Expected raw_html to be None when not requested"
+        assert result.images is None, "Expected images to be None when not requested"
+
+    @pytest.mark.parametrize(
+        ("topic", "url"),
+        FetchTestCases.FETCH_URLS,
+    )
+    async def test_fetch_url_with_raw_html(self, topic: str, url: str) -> None:
+        """Verify that fetch_url returns raw HTML when requested."""
+        worker = get_fetch_worker("linkup")
+        result = await worker.fetch_url(url=url, include_raw_html=True)
+        pretty_print(result, title=f"Fetch Result with HTML ({topic})")
+        assert result.text is not None, "Expected non-empty text content"
+        assert result.raw_html is not None, "Expected raw_html to be present when requested"
+        assert len(result.raw_html) > 0, "Expected raw_html to have content"
+
+    @pytest.mark.parametrize(
+        ("topic", "url"),
+        FetchTestCases.FETCH_URLS,
+    )
+    async def test_fetch_url_with_images(self, topic: str, url: str) -> None:
+        """Verify that fetch_url returns images when requested."""
+        worker = get_fetch_worker("linkup")
+        result = await worker.fetch_url(url=url, extract_images=True)
+        pretty_print(result, title=f"Fetch Result with Images ({topic})")
+        assert result.text is not None, "Expected non-empty text content"
+        assert result.images is not None, "Expected images to be present when requested"
+        assert isinstance(result.images, list), "Expected images to be a list"

--- a/tests/integration/pipelex/cogt/test_fetch.py
+++ b/tests/integration/pipelex/cogt/test_fetch.py
@@ -1,8 +1,11 @@
 import pytest
 
 from pipelex import pretty_print
-from pipelex.cogt.search.search_worker_factory import get_fetch_worker
+from pipelex.cogt.model_backends.model_type import ModelType
+from pipelex.cogt.search.search_worker_factory import SearchWorkerFactory
+from pipelex.hub import get_model_deck
 from tests.integration.pipelex.cogt.test_data import FetchTestCases
+from tests.integration.pipelex.fixtures.model_combo import ModelCombo
 
 
 @pytest.mark.search
@@ -13,9 +16,11 @@ class TestFetch:
         ("topic", "url"),
         FetchTestCases.FETCH_URLS,
     )
-    async def test_fetch_url(self, topic: str, url: str) -> None:
+    async def test_fetch_url(self, search_combo: ModelCombo, topic: str, url: str) -> None:
         """Verify that fetch_url returns non-empty text content."""
-        worker = get_fetch_worker("linkup")
+        model_deck = get_model_deck()
+        inference_model = model_deck.get_required_inference_model(model_handle=search_combo.handle, model_type=ModelType.SEARCH)
+        worker = SearchWorkerFactory.make_fetch_worker(inference_model=inference_model)
         result = await worker.fetch_url(url=url)
         pretty_print(result, title=f"Fetch Result ({topic})")
         assert result.text is not None, "Expected non-empty text content"
@@ -27,9 +32,11 @@ class TestFetch:
         ("topic", "url"),
         FetchTestCases.FETCH_URLS,
     )
-    async def test_fetch_url_with_raw_html(self, topic: str, url: str) -> None:
+    async def test_fetch_url_with_raw_html(self, search_combo: ModelCombo, topic: str, url: str) -> None:
         """Verify that fetch_url returns raw HTML when requested."""
-        worker = get_fetch_worker("linkup")
+        model_deck = get_model_deck()
+        inference_model = model_deck.get_required_inference_model(model_handle=search_combo.handle, model_type=ModelType.SEARCH)
+        worker = SearchWorkerFactory.make_fetch_worker(inference_model=inference_model)
         result = await worker.fetch_url(url=url, include_raw_html=True)
         pretty_print(result, title=f"Fetch Result with HTML ({topic})")
         assert result.text is not None, "Expected non-empty text content"
@@ -40,9 +47,11 @@ class TestFetch:
         ("topic", "url"),
         FetchTestCases.FETCH_URLS,
     )
-    async def test_fetch_url_with_images(self, topic: str, url: str) -> None:
+    async def test_fetch_url_with_images(self, search_combo: ModelCombo, topic: str, url: str) -> None:
         """Verify that fetch_url returns images when requested."""
-        worker = get_fetch_worker("linkup")
+        model_deck = get_model_deck()
+        inference_model = model_deck.get_required_inference_model(model_handle=search_combo.handle, model_type=ModelType.SEARCH)
+        worker = SearchWorkerFactory.make_fetch_worker(inference_model=inference_model)
         result = await worker.fetch_url(url=url, extract_images=True)
         pretty_print(result, title=f"Fetch Result with Images ({topic})")
         assert result.text is not None, "Expected non-empty text content"

--- a/tests/integration/pipelex/cogt/test_fetch.py
+++ b/tests/integration/pipelex/cogt/test_fetch.py
@@ -3,7 +3,8 @@ import pytest
 from pipelex import pretty_print
 from pipelex.cogt.model_backends.model_type import ModelType
 from pipelex.cogt.search.search_worker_factory import SearchWorkerFactory
-from pipelex.hub import get_model_deck
+from pipelex.hub import get_model_deck, get_report_delegate
+from pipelex.pipeline.job_metadata import JobMetadata
 from tests.integration.pipelex.cogt.test_data import FetchTestCases
 from tests.integration.pipelex.fixtures.model_combo import ModelCombo
 
@@ -16,44 +17,47 @@ class TestFetch:
         ("topic", "url"),
         FetchTestCases.FETCH_URLS,
     )
-    async def test_fetch_url(self, search_combo: ModelCombo, topic: str, url: str) -> None:
+    async def test_fetch_url(self, search_combo: ModelCombo, job_metadata: JobMetadata, topic: str, url: str) -> None:
         """Verify that fetch_url returns non-empty text content."""
         model_deck = get_model_deck()
         inference_model = model_deck.get_required_inference_model(model_handle=search_combo.handle, model_type=ModelType.SEARCH)
         worker = SearchWorkerFactory.make_fetch_worker(inference_model=inference_model)
-        result = await worker.fetch_url(url=url)
+        result = await worker.fetch_url(url=url, job_metadata=job_metadata)
         pretty_print(result, title=f"Fetch Result ({topic})")
         assert result.text is not None, "Expected non-empty text content"
         assert len(result.text.text) > 0, "Expected text to have content"
         assert result.raw_html is None, "Expected raw_html to be None when not requested"
         assert result.images is None, "Expected images to be None when not requested"
+        get_report_delegate().generate_report()
 
     @pytest.mark.parametrize(
         ("topic", "url"),
         FetchTestCases.FETCH_URLS,
     )
-    async def test_fetch_url_with_raw_html(self, search_combo: ModelCombo, topic: str, url: str) -> None:
+    async def test_fetch_url_with_raw_html(self, search_combo: ModelCombo, job_metadata: JobMetadata, topic: str, url: str) -> None:
         """Verify that fetch_url returns raw HTML when requested."""
         model_deck = get_model_deck()
         inference_model = model_deck.get_required_inference_model(model_handle=search_combo.handle, model_type=ModelType.SEARCH)
         worker = SearchWorkerFactory.make_fetch_worker(inference_model=inference_model)
-        result = await worker.fetch_url(url=url, include_raw_html=True)
+        result = await worker.fetch_url(url=url, job_metadata=job_metadata, include_raw_html=True)
         pretty_print(result, title=f"Fetch Result with HTML ({topic})")
         assert result.text is not None, "Expected non-empty text content"
         assert result.raw_html is not None, "Expected raw_html to be present when requested"
         assert len(result.raw_html) > 0, "Expected raw_html to have content"
+        get_report_delegate().generate_report()
 
     @pytest.mark.parametrize(
         ("topic", "url"),
         FetchTestCases.FETCH_URLS,
     )
-    async def test_fetch_url_with_images(self, search_combo: ModelCombo, topic: str, url: str) -> None:
+    async def test_fetch_url_with_images(self, search_combo: ModelCombo, job_metadata: JobMetadata, topic: str, url: str) -> None:
         """Verify that fetch_url returns images when requested."""
         model_deck = get_model_deck()
         inference_model = model_deck.get_required_inference_model(model_handle=search_combo.handle, model_type=ModelType.SEARCH)
         worker = SearchWorkerFactory.make_fetch_worker(inference_model=inference_model)
-        result = await worker.fetch_url(url=url, extract_images=True)
+        result = await worker.fetch_url(url=url, job_metadata=job_metadata, extract_images=True)
         pretty_print(result, title=f"Fetch Result with Images ({topic})")
         assert result.text is not None, "Expected non-empty text content"
         assert result.images is not None, "Expected images to be present when requested"
         assert isinstance(result.images, list), "Expected images to be a list"
+        get_report_delegate().generate_report()

--- a/tests/integration/pipelex/cogt/test_search.py
+++ b/tests/integration/pipelex/cogt/test_search.py
@@ -3,7 +3,6 @@ from pydantic import BaseModel
 
 from pipelex import pretty_print
 from pipelex.cogt.model_backends.model_type import ModelType
-from pipelex.cogt.search.search_depth import SearchDepth
 from pipelex.cogt.search.search_setting import SearchSetting
 from pipelex.cogt.search.search_worker_factory import SearchWorkerFactory
 from pipelex.hub import get_model_deck, get_report_delegate
@@ -33,7 +32,6 @@ class TestSearch:
         worker = SearchWorkerFactory.make_search_worker(inference_model=inference_model)
         search_setting = SearchSetting(
             model=search_combo.handle,
-            depth=SearchDepth.STANDARD,
             max_results=2,
         )
         result = await worker.search_sourced_answer(
@@ -60,7 +58,6 @@ class TestSearch:
         worker = SearchWorkerFactory.make_search_worker(inference_model=inference_model)
         search_setting = SearchSetting(
             model=search_combo.handle,
-            depth=SearchDepth.STANDARD,
         )
         result = await worker.search_structured(
             query=query,

--- a/tests/integration/pipelex/cogt/test_search.py
+++ b/tests/integration/pipelex/cogt/test_search.py
@@ -58,6 +58,10 @@ class TestSearch:
         )
         pretty_print(result, title=f"Structured Search Result ({topic})")
         assert isinstance(result, dict), "Expected a dict result"
-        assert "title" in result, "Expected 'title' key in result"
-        assert "summary" in result, "Expected 'summary' key in result"
-        assert "key_points" in result, "Expected 'key_points' key in result"
+        assert "data" in result, "Expected 'data' key in result"
+        assert "sources" in result, "Expected 'sources' key in result"
+        data = result["data"]
+        assert "title" in data, "Expected 'title' key in data"
+        assert "summary" in data, "Expected 'summary' key in data"
+        assert "key_points" in data, "Expected 'key_points' key in data"
+        assert len(result["sources"]) > 0, "Expected at least one source"

--- a/tests/integration/pipelex/cogt/test_search.py
+++ b/tests/integration/pipelex/cogt/test_search.py
@@ -2,10 +2,13 @@ import pytest
 from pydantic import BaseModel
 
 from pipelex import pretty_print
+from pipelex.cogt.model_backends.model_type import ModelType
 from pipelex.cogt.search.search_depth import SearchDepth
 from pipelex.cogt.search.search_setting import SearchSetting
-from pipelex.cogt.search.search_worker_factory import get_search_worker
+from pipelex.cogt.search.search_worker_factory import SearchWorkerFactory
+from pipelex.hub import get_model_deck
 from tests.integration.pipelex.cogt.test_data import SearchTestCases
+from tests.integration.pipelex.fixtures.model_combo import ModelCombo
 
 
 class TopicSummary(BaseModel):
@@ -22,11 +25,13 @@ class TestSearch:
         ("topic", "query"),
         SearchTestCases.SOURCED_ANSWER_QUERIES,
     )
-    async def test_search_sourced_answer(self, topic: str, query: str) -> None:
+    async def test_search_sourced_answer(self, search_combo: ModelCombo, topic: str, query: str) -> None:
         """Verify that search_sourced_answer returns a non-empty answer with sources."""
-        worker = get_search_worker("linkup/standard")
+        model_deck = get_model_deck()
+        inference_model = model_deck.get_required_inference_model(model_handle=search_combo.handle, model_type=ModelType.SEARCH)
+        worker = SearchWorkerFactory.make_search_worker(inference_model=inference_model)
         search_setting = SearchSetting(
-            model="linkup/standard",
+            model=search_combo.handle,
             depth=SearchDepth.STANDARD,
         )
         result = await worker.search_sourced_answer(
@@ -44,11 +49,13 @@ class TestSearch:
         ("topic", "query"),
         SearchTestCases.STRUCTURED_QUERIES,
     )
-    async def test_search_structured(self, topic: str, query: str) -> None:
+    async def test_search_structured(self, search_combo: ModelCombo, topic: str, query: str) -> None:
         """Verify that search_structured returns a dict with the expected schema keys."""
-        worker = get_search_worker("linkup/standard")
+        model_deck = get_model_deck()
+        inference_model = model_deck.get_required_inference_model(model_handle=search_combo.handle, model_type=ModelType.SEARCH)
+        worker = SearchWorkerFactory.make_search_worker(inference_model=inference_model)
         search_setting = SearchSetting(
-            model="linkup/standard",
+            model=search_combo.handle,
             depth=SearchDepth.STANDARD,
         )
         result = await worker.search_structured(

--- a/tests/integration/pipelex/cogt/test_search.py
+++ b/tests/integration/pipelex/cogt/test_search.py
@@ -7,6 +7,7 @@ from pipelex.cogt.search.search_depth import SearchDepth
 from pipelex.cogt.search.search_setting import SearchSetting
 from pipelex.cogt.search.search_worker_factory import SearchWorkerFactory
 from pipelex.hub import get_model_deck, get_report_delegate
+from pipelex.pipeline.job_metadata import JobMetadata
 from tests.integration.pipelex.cogt.test_data import SearchTestCases
 from tests.integration.pipelex.fixtures.model_combo import ModelCombo
 
@@ -25,7 +26,7 @@ class TestSearch:
         ("topic", "query"),
         SearchTestCases.SOURCED_ANSWER_QUERIES,
     )
-    async def test_search_sourced_answer(self, search_combo: ModelCombo, topic: str, query: str) -> None:
+    async def test_search_sourced_answer(self, search_combo: ModelCombo, job_metadata: JobMetadata, topic: str, query: str) -> None:
         """Verify that search_sourced_answer returns a non-empty answer with sources."""
         model_deck = get_model_deck()
         inference_model = model_deck.get_required_inference_model(model_handle=search_combo.handle, model_type=ModelType.SEARCH)
@@ -38,6 +39,7 @@ class TestSearch:
         result = await worker.search_sourced_answer(
             query=query,
             search_setting=search_setting,
+            job_metadata=job_metadata,
         )
         pretty_print(result, title=f"Sourced Answer Result ({topic})")
         assert result.answer, "Expected a non-empty answer"
@@ -51,7 +53,7 @@ class TestSearch:
         ("topic", "query"),
         SearchTestCases.STRUCTURED_QUERIES,
     )
-    async def test_search_structured(self, search_combo: ModelCombo, topic: str, query: str) -> None:
+    async def test_search_structured(self, search_combo: ModelCombo, job_metadata: JobMetadata, topic: str, query: str) -> None:
         """Verify that search_structured returns a dict with the expected schema keys."""
         model_deck = get_model_deck()
         inference_model = model_deck.get_required_inference_model(model_handle=search_combo.handle, model_type=ModelType.SEARCH)
@@ -64,6 +66,7 @@ class TestSearch:
             query=query,
             search_setting=search_setting,
             output_schema=TopicSummary,
+            job_metadata=job_metadata,
         )
         pretty_print(result, title=f"Structured Search Result ({topic})")
         assert isinstance(result, dict), "Expected a dict result"
@@ -74,3 +77,4 @@ class TestSearch:
         assert "summary" in data, "Expected 'summary' key in data"
         assert "key_points" in data, "Expected 'key_points' key in data"
         assert len(result["sources"]) > 0, "Expected at least one source"
+        get_report_delegate().generate_report()

--- a/tests/integration/pipelex/cogt/test_search.py
+++ b/tests/integration/pipelex/cogt/test_search.py
@@ -6,7 +6,7 @@ from pipelex.cogt.model_backends.model_type import ModelType
 from pipelex.cogt.search.search_depth import SearchDepth
 from pipelex.cogt.search.search_setting import SearchSetting
 from pipelex.cogt.search.search_worker_factory import SearchWorkerFactory
-from pipelex.hub import get_model_deck
+from pipelex.hub import get_model_deck, get_report_delegate
 from tests.integration.pipelex.cogt.test_data import SearchTestCases
 from tests.integration.pipelex.fixtures.model_combo import ModelCombo
 
@@ -33,6 +33,7 @@ class TestSearch:
         search_setting = SearchSetting(
             model=search_combo.handle,
             depth=SearchDepth.STANDARD,
+            max_results=2,
         )
         result = await worker.search_sourced_answer(
             query=query,
@@ -44,6 +45,7 @@ class TestSearch:
         for source in result.sources:
             assert source.name, "Expected source to have a name"
             assert source.url, "Expected source to have a URL"
+        get_report_delegate().generate_report()
 
     @pytest.mark.parametrize(
         ("topic", "query"),

--- a/tests/integration/pipelex/conftest.py
+++ b/tests/integration/pipelex/conftest.py
@@ -8,6 +8,7 @@ from .fixtures.combo_fixtures import (
     extract_combo,
     img_gen_combo,
     llm_combo,
+    search_combo,
 )
 from .fixtures.extract_fixtures import (
     extract_choice_for_image,
@@ -33,6 +34,7 @@ __all__ = [
     "llm_combo",
     "img_gen_combo",
     "extract_combo",
+    "search_combo",
     # Plugin fixtures
     "plugin_for_openai",
     "plugin_for_anthropic",

--- a/tests/integration/pipelex/fixtures/combo_fixtures.py
+++ b/tests/integration/pipelex/fixtures/combo_fixtures.py
@@ -34,6 +34,7 @@ from tests.integration.pipelex.fixtures.model_selection import (
     get_extract_combos,
     get_img_gen_combos,
     get_llm_combos,
+    get_search_combos,
 )
 
 
@@ -143,6 +144,21 @@ def extract_combo(request: pytest.FixtureRequest):
 
     Yields:
         ModelCombo(handle, backend) for extraction.
+    """
+    combo: ModelCombo = request.param
+    monkeypatch, temp_dir = _setup_routing_for_backend(combo.backend)
+
+    yield combo
+
+    _cleanup_routing(monkeypatch, temp_dir)
+
+
+@pytest.fixture(scope="module", params=get_search_combos())
+def search_combo(request: pytest.FixtureRequest):
+    """Provides a valid ModelCombo(handle, backend) for search with routing configured.
+
+    Yields:
+        ModelCombo(handle, backend) for search.
     """
     combo: ModelCombo = request.param
     monkeypatch, temp_dir = _setup_routing_for_backend(combo.backend)

--- a/tests/integration/pipelex/fixtures/model_selection.py
+++ b/tests/integration/pipelex/fixtures/model_selection.py
@@ -83,3 +83,21 @@ def get_extract_combos() -> list[ModelCombo]:
     )
 
     return list(EXTRACT_COMBOS)
+
+
+@cache
+def get_search_combos() -> list[ModelCombo]:
+    """Get the list of valid (search_model, backend) combinations.
+
+    Returns:
+        List of ModelCombo(handle, backend).
+
+    Raises:
+        FileNotFoundError: If the generated fixtures file does not exist.
+    """
+    _ensure_generated_fixtures_exist()
+    from tests.integration.pipelex.fixtures._generated_model_sets import (  # noqa: PLC0415
+        SEARCH_COMBOS,  # noqa: PLC2701
+    )
+
+    return list(SEARCH_COMBOS)

--- a/tests/unit/pipelex/cogt/models/test_model_deck.py
+++ b/tests/unit/pipelex/cogt/models/test_model_deck.py
@@ -8,7 +8,6 @@ from pipelex.cogt.llm.thinking_mode import ThinkingMode
 from pipelex.cogt.model_backends.model_spec import InferenceModelSpec
 from pipelex.cogt.model_backends.model_type import ModelType
 from pipelex.cogt.models.model_deck import ModelDeck
-from pipelex.cogt.search.search_depth import SearchDepth
 from pipelex.cogt.usage.cost_category import CostCategory
 from pipelex.system.runtime import ProblemReaction
 
@@ -58,7 +57,6 @@ class TestModelDeckGetOptionalInferenceModel:
             img_gen_presets={},
             img_gen_choice_default="gen_image_basic",
             # Search-specific
-            search_default_depth=SearchDepth.STANDARD,
             search_choice_default="@default-search",
             model_deck_config=ModelDeckConfig(is_model_fallback_enabled=is_model_fallback_enabled, missing_presets_reaction=ProblemReaction.NONE),
         )
@@ -336,7 +334,6 @@ class TestModelDeckPrefixedAliasReferences:
             img_gen_presets={},
             img_gen_choice_default="gen_image_basic",
             # Search-specific
-            search_default_depth=SearchDepth.STANDARD,
             search_choice_default="@default-search",
             model_deck_config=ModelDeckConfig(is_model_fallback_enabled=is_model_fallback_enabled, missing_presets_reaction=ProblemReaction.NONE),
         )
@@ -490,7 +487,6 @@ class TestModelDeckGetLLMSettingWithPresets:
             img_gen_presets={},
             img_gen_choice_default="gen_image_basic",
             # Search-specific
-            search_default_depth=SearchDepth.STANDARD,
             search_choice_default="@default-search",
             model_deck_config=ModelDeckConfig(is_model_fallback_enabled=False, missing_presets_reaction=ProblemReaction.NONE),
         )

--- a/tests/unit/pipelex/core/stuffs/page_content/test_data.py
+++ b/tests/unit/pipelex/core/stuffs/page_content/test_data.py
@@ -19,6 +19,7 @@ class TestData:
         "text_and_images": {
             "text": {"text": "Page content text"},
             "images": None,
+            "raw_html": None,
         },
         "page_view": None,
     }
@@ -28,6 +29,7 @@ class TestData:
         "text_and_images": {
             "text": {"text": "Page content text"},
             "images": None,
+            "raw_html": None,
         },
         "page_view": {
             "url": URLs.png_example_1,
@@ -42,7 +44,11 @@ class TestData:
     }
 
     # Expected outputs for render methods
-    EXPECTED_RENDERED_MARKDOWN = "# text_and_images\n\n## text: ### text: Page content text\n\n## images: None\n\n# page_view: None"
-    EXPECTED_RENDERED_FOR_PROMPT = "# text_and_images\n\n## text: ### text: Page content text\n\n## images: None\n\n# page_view: None"
+    EXPECTED_RENDERED_MARKDOWN = (
+        "# text_and_images\n\n## text: ### text: Page content text\n\n## images: None\n\n## raw_html: None\n\n# page_view: None"
+    )
+    EXPECTED_RENDERED_FOR_PROMPT = (
+        "# text_and_images\n\n## text: ### text: Page content text\n\n## images: None\n\n## raw_html: None\n\n# page_view: None"
+    )
     # TextAndImagesContent.rendered_html returns the text content (table format, skips None values)
     EXPECTED_RENDERED_HTML = "<table><tr><th>text_and_images</th><td>Page content text</td></tr></table>"

--- a/tests/unit/pipelex/core/stuffs/text_and_images_content/test_data.py
+++ b/tests/unit/pipelex/core/stuffs/text_and_images_content/test_data.py
@@ -17,6 +17,7 @@ class TestData:
     EXPECTED_SMART_DUMP_TEXT_ONLY: ClassVar[dict[str, Any]] = {
         "text": {"text": "Hello World"},
         "images": None,
+        "raw_html": None,
     }
 
     # Expected outputs for smart_dump (text and images)
@@ -44,6 +45,7 @@ class TestData:
                 "filename": None,
             },
         ],
+        "raw_html": None,
     }
 
     # Expected outputs for render methods
@@ -54,5 +56,5 @@ class TestData:
     EXPECTED_RENDERED_HTML = "Hello World"
 
     # Empty content test cases
-    EXPECTED_SMART_DUMP_EMPTY: ClassVar[dict[str, Any]] = {"text": None, "images": None}
+    EXPECTED_SMART_DUMP_EMPTY: ClassVar[dict[str, Any]] = {"text": None, "images": None, "raw_html": None}
     EXPECTED_RENDERED_PLAIN_EMPTY = ""


### PR DESCRIPTION
## Summary
- Renamed search model presets from provider-specific names (`$linkup-standard`, `$linkup-deep`) to provider-agnostic names (`$standard`, `$deep`) across config, docs, and tests
- Updated CHANGELOG to reflect the simplified model deck description

## Test plan
- [ ] Verify `make agent-check` passes
- [ ] Verify search e2e tests still resolve the renamed presets correctly
- [ ] Confirm docs render properly with updated preset names

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk: refactors search model-deck settings/presets and replaces the search worker plumbing, plus adds new Portkey/Gateway search+fetch workers and cost reporting paths that could affect runtime behavior and accounting.
> 
> **Overview**
> Search presets are renamed from provider-specific (`$linkup-standard`/`$linkup-deep`, `linkup/standard`) to provider-agnostic (`$standard`/`$deep`, `linkup-standard`/`linkup-deep`) across model deck config, builder mappings, docs, e2e/integration tests, and test profiles.
> 
> Search execution is refactored to remove deck-level `default_depth`/per-pipe `depth` overrides and to route via a new `SearchWorkerFactory` that instantiates either a unified `LinkupWorker` (direct SDK) or new Portkey/Gateway-backed `GatewaySearchWorker`/`GatewayFetchWorker`; this also introduces first-class **fetch URL** support (`TextAndImagesContent.raw_html`) and adds search/fetch job categories and token/cost reporting (`SearchJob`/`FetchJob`, `CostRegistry`, `ReportingManager`).
> 
> Tooling/config updates include adding `search` to generated model fixtures, a new `profiles.all_linkup` routing profile, quiet Makefile targets for schema/model updates, minor docs/changelog tweaks, and regenerating gateway model reference files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e08277e294ee2d946a2830f82ab17156c2be9a46. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->