### PR TITLE
Release v0.20.1

### DIFF
--- a/.pipelex-dev/test_profiles.toml
+++ b/.pipelex-dev/test_profiles.toml
@@ -265,7 +265,7 @@ search_models = ["linkup-standard"]
 ################################################################################
 [profiles.coverage]
 description = "One model per backend for coverage"
-backends = ["anthropic", "openai", "google", "mistral", "internal"]
+backends = ["anthropic", "openai", "google", "mistral", "linkup", "internal"]
 llm_models = [
   "claude-4.5-haiku",
   "gpt-4o-mini",

--- a/.pipelex/inference/backends/pipelex_gateway_models.md
+++ b/.pipelex/inference/backends/pipelex_gateway_models.md
@@ -515,6 +515,6 @@ For configuration details, see the [documentation](https://docs.pipelex.com/late
 
 
 > **AUTO-GENERATED FILE** - Do not edit manually.
-> Last updated: 2026-03-04T00:21:08Z
+> Last updated: 2026-03-04T07:00:39Z
 >
 > Run `pipelex-dev update-gateway-models` or `make ugm` to regenerate.

--- a/.pipelex/inference/backends/pipelex_gateway_models_plain.md
+++ b/.pipelex/inference/backends/pipelex_gateway_models_plain.md
@@ -193,6 +193,6 @@ For configuration details, see the [documentation](https://docs.pipelex.com/late
 
 
 > **AUTO-GENERATED FILE** - Do not edit manually.
-> Last updated: 2026-03-04T00:21:08Z
+> Last updated: 2026-03-04T07:00:39Z
 >
 > Run `pipelex-dev update-gateway-models` or `make ugm` to regenerate.

--- a/.pipelex/pipelex.toml
+++ b/.pipelex/pipelex.toml
@@ -68,7 +68,7 @@ palette = "dracula"
 ####################################################################################################
 
 [pipelex.storage_config]
-# Storage method: "local", "in_memory" (default), "s3", or "gcp"
+# Storage method: "local", "in_memory", "s3", or "gcp"
 method = "local"
 # Whether to fetch remote HTTP URLs and store them locally
 is_fetch_remote_content_enabled = true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [v0.20.1] - 2026-03-03
+
+### Changed
+
+- **Cost Report Consistency**: Renamed `platform_llm_id` field to `platform_model_id` in `LLMTokenCostReport`, aligning with all other report types (ImgGen, Extract, Search, Fetch) that already use `platform_model_id`.
+- **Test Coverage**: Added `linkup` backend to the coverage test profile.
+
 ## [v0.20.0] - 2026-03-03
 
 ### Added

--- a/pipelex/kit/configs/pipelex.toml
+++ b/pipelex/kit/configs/pipelex.toml
@@ -68,7 +68,7 @@ palette = "dracula"
 ####################################################################################################
 
 [pipelex.storage_config]
-# Storage method: "local", "in_memory" (default), "s3", or "gcp"
+# Storage method: "local", "in_memory", "s3", or "gcp"
 method = "local"
 # Whether to fetch remote HTTP URLs and store them locally
 is_fetch_remote_content_enabled = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pipelex"
-version = "0.20.0"
+version = "0.20.1"
 description = "Execute composable AI methods declared in the MTHDS open standard"
 authors = [{ name = "Evotis S.A.S.", email = "oss@pipelex.com" }]
 maintainers = [{ name = "Pipelex staff", email = "oss@pipelex.com" }]

--- a/uv.lock
+++ b/uv.lock
@@ -3313,7 +3313,7 @@ wheels = [
 
 [[package]]
 name = "pipelex"
-version = "0.20.0"
+version = "0.20.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary
- Renamed `platform_llm_id` field to `platform_model_id` in `LLMTokenCostReport` for consistency with all other report types (ImgGen, Extract, Search, Fetch)
- Added `linkup` backend to the coverage test profile
- Fixed stale "(default)" annotation in storage config comment
- Bumped version to 0.20.1 and regenerated gateway models

## Test plan
- [x] `make agent-check` passes
- [x] `make agent-test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to version/changelog updates, config comment tweaks, and test profile coverage expansion (may affect CI expectations).
> 
> **Overview**
> Cuts release `v0.20.1` by bumping `pyproject.toml`/`uv.lock` versions and adding a `CHANGELOG.md` entry describing the release changes.
> 
> Updates test coverage configuration by including the `linkup` backend in the `coverage` test profile.
> 
> Cleans up storage config template comments in `.pipelex/pipelex.toml` and `pipelex/kit/configs/pipelex.toml`, and regenerates the auto-generated Pipelex Gateway model catalog files (timestamp update only).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aae1b8528dab3f41e264de6fdcca9b94abe3d6c7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->