### PR TITLE
Improve Quick Start onboarding flow in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [v0.20.4] - 2026-03-04
+
+- Improve README.md instructions for Claude Code and MTHDS skills.
+
 ## [v0.20.3] - 2026-03-04
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -42,10 +42,25 @@ Readable by humans, executable by agents. No boilerplate, no lock-in.</p>
 
 # Quick Start
 
+```bash
+pip install pipelex
+pipelex init
+```
+
 ## Path A: With Claude Code (Recommended)
 
-Install the MTHDS skills marketplace:
+Install the `mthds` npm package:
 
+```bash
+npm install -g mthds
+```
+
+Start Claude Code:
+```bash
+claude
+```
+
+Tell Claude to install the MTHDS skills marketplace:
 ```bash
 /plugin marketplace add mthds-ai/skills
 ```
@@ -73,13 +88,6 @@ Run it:
 ```
 
 ## Path B: Without Claude Code
-
-```bash
-pip install pipelex
-pipelex init
-```
-
-Then:
 
 1. Install the [VS Code extension](https://go.pipelex.com/vscode) for `.mthds` syntax highlighting
 2. Browse methods on the [MTHDS Hub](https://mthds.sh) for inspiration

--- a/README.md
+++ b/README.md
@@ -44,11 +44,20 @@ Readable by humans, executable by agents. No boilerplate, no lock-in.</p>
 
 ## Path A: With Claude Code (Recommended)
 
-Install the MTHDS skills plugin:
+Install the MTHDS skills marketplace:
 
 ```bash
 /plugin marketplace add mthds-ai/skills
+```
+
+then install the MTHDS skills plugin:
+```bash
 /plugin install mthds@mthds-ai-skills
+```
+
+then you must exit Claude Code and reopen it.
+```bash
+/exit
 ```
 
 Build your first method:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pipelex"
-version = "0.20.3"
+version = "0.20.4"
 description = "Execute composable AI methods declared in the MTHDS open standard"
 authors = [{ name = "Evotis S.A.S.", email = "oss@pipelex.com" }]
 maintainers = [{ name = "Pipelex staff", email = "oss@pipelex.com" }]

--- a/uv.lock
+++ b/uv.lock
@@ -3313,7 +3313,7 @@ wheels = [
 
 [[package]]
 name = "pipelex"
-version = "0.20.3"
+version = "0.20.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary
- Move `pip install pipelex` and `pipelex init` to the top of Quick Start so both Path A and Path B share them
- Add explicit `npm install -g mthds` and `claude` launch steps to Path A for a complete onboarding experience
- Simplify Path B by removing duplicated install steps

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Follow Path A instructions end-to-end on a fresh setup
- [ ] Follow Path B instructions end-to-end on a fresh setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only onboarding tweaks plus a version/lockfile bump, with no runtime or API behavior changes.
> 
> **Overview**
> **Quick Start docs are reorganized to be clearer and more complete.** `pip install pipelex`/`pipelex init` are moved to the top, Path A now explicitly includes installing `mthds`, launching `claude`, installing the marketplace + plugin, and restarting Claude Code; Path B removes the duplicated install/init steps.
> 
> Releases this as `v0.20.4` by updating `CHANGELOG.md`, `pyproject.toml`, and the `uv.lock` entry for `pipelex`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1445a6bd6ed7f3201ee2f22b92ee66911b947b15. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->