### PR TITLE
Fix/config manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- **Config paths use `pathlib.Path`**: All `ConfigLoader` properties and methods now return `Path` instead of `str`. Consumer code across the config system (doctor, init, backends, routing, credentials, telemetry, agent CLI) updated accordingly.
+- **Layered config resolution for `pipelex doctor` and `pipelex init`**: Config files are now resolved with project-first, global-fallback layering per file. Fixed `replace_backend_file` using CWD-relative path that broke when run from another directory.
+- **Gateway terms are explicitly global**: `update_service_terms_acceptance` now targets `~/.pipelex/` by default, since gateway terms are a user-level agreement, not project-level.
+
 ## [v0.20.4] - 2026-03-04
 
 - Improve README.md instructions for Claude Code and MTHDS skills.

--- a/pipelex/cli/agent_cli/commands/doctor_cmd.py
+++ b/pipelex/cli/agent_cli/commands/doctor_cmd.py
@@ -35,7 +35,8 @@ def agent_doctor_cmd(
     Use --global/-g to force checking the global ~/.pipelex/ directory.
     """
     try:
-        config_dir = config_manager.global_config_dir if global_ else config_manager.pipelex_config_dir
+        # When --global, force checking ~/.pipelex/ only; otherwise use layered resolution
+        config_dir = config_manager.global_config_dir if global_ else None
 
         config_healthy, config_missing_count, config_message = check_config_files(config_dir=config_dir)
         telemetry_healthy, telemetry_message = check_telemetry_config(config_dir=config_dir)

--- a/pipelex/cli/agent_cli/commands/init_cmd.py
+++ b/pipelex/cli/agent_cli/commands/init_cmd.py
@@ -1,8 +1,8 @@
 """Agent CLI init command -- non-interactive Pipelex initialization."""
 
 import json
-import os
 import shutil
+from pathlib import Path
 from typing import Annotated, Any, cast
 
 import typer
@@ -55,7 +55,7 @@ def _parse_config_arg(config_arg: str | None) -> dict[str, Any]:
     return {}
 
 
-def _resolve_target_dir(global_: bool) -> str:
+def _resolve_target_dir(global_: bool) -> Path:
     """Resolve the target directory for initialization.
 
     Args:
@@ -74,14 +74,14 @@ def _resolve_target_dir(global_: bool) -> str:
             "Use --global/-g to target the global ~/.pipelex/ directory.",
             "ArgumentError",
         )
-    return os.path.join(project_root, ".pipelex")
+    return project_root / ".pipelex"
 
 
 def _configure_backends(
     config: dict[str, Any],
     backends_toml_path: str,
     template_backends_path: str,
-    target_dir: str,
+    target_dir: Path,
 ) -> list[str]:
     """Configure backends in backends.toml based on config input.
 
@@ -131,7 +131,7 @@ def _configure_backends(
     return requested_backends
 
 
-def _configure_routing(selected_backend_keys: list[str], config: dict[str, Any], target_dir: str) -> str:
+def _configure_routing(selected_backend_keys: list[str], config: dict[str, Any], target_dir: Path) -> str:
     """Configure routing profile based on selected backends and config.
 
     Args:
@@ -142,7 +142,7 @@ def _configure_routing(selected_backend_keys: list[str], config: dict[str, Any],
     Returns:
         Name of the active routing profile.
     """
-    routing_profiles_toml_path = os.path.join(target_dir, "inference", "routing_profiles.toml")
+    routing_profiles_toml_path = str(target_dir / "inference" / "routing_profiles.toml")
 
     if not path_exists(routing_profiles_toml_path):
         agent_error("routing_profiles.toml not found after config initialization", "InitConfigError")
@@ -220,7 +220,7 @@ def _configure_routing(selected_backend_keys: list[str], config: dict[str, Any],
     return "custom_routing"
 
 
-def _configure_telemetry(target_dir: str, config: dict[str, Any]) -> str:
+def _configure_telemetry(target_dir: Path, config: dict[str, Any]) -> str:
     """Copy telemetry template to target directory and apply telemetry_mode if specified.
 
     Args:
@@ -230,13 +230,13 @@ def _configure_telemetry(target_dir: str, config: dict[str, Any]) -> str:
     Returns:
         The telemetry mode that was set.
     """
-    telemetry_config_path = os.path.join(target_dir, TELEMETRY_CONFIG_FILE_NAME)
-    template_path = os.path.join(str(get_kit_configs_dir()), TELEMETRY_CONFIG_FILE_NAME)
+    telemetry_config_path = target_dir / TELEMETRY_CONFIG_FILE_NAME
+    template_path = Path(str(get_kit_configs_dir() / TELEMETRY_CONFIG_FILE_NAME))
 
-    if not path_exists(str(template_path)):
+    if not template_path.exists():
         agent_error("Telemetry template not found in kit configs", "InitConfigError")
 
-    os.makedirs(os.path.dirname(telemetry_config_path), exist_ok=True)
+    telemetry_config_path.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy(template_path, telemetry_config_path)
 
     # Apply telemetry_mode if specified
@@ -316,11 +316,11 @@ def agent_init_cmd(
         target_dir = _resolve_target_dir(global_)
 
         # Step 1: Copy config files
-        config_files_copied = init_config(reset=True, target_dir=target_dir)
+        config_files_copied = init_config(reset=True, target_dir=str(target_dir))
 
         # Step 2: Configure backends
-        template_backends_path = os.path.join(str(get_kit_configs_dir()), "inference", "backends.toml")
-        backends_toml_path = os.path.join(target_dir, "inference", "backends.toml")
+        template_backends_path = str(get_kit_configs_dir() / "inference" / "backends.toml")
+        backends_toml_path = str(target_dir / "inference" / "backends.toml")
         backends_enabled = _configure_backends(parsed_config, backends_toml_path, template_backends_path, target_dir)
 
         # Step 3: Configure routing
@@ -333,7 +333,7 @@ def agent_init_cmd(
         agent_success(
             {
                 "success": True,
-                "target_dir": target_dir,
+                "target_dir": str(target_dir),
                 "config_files_copied": config_files_copied,
                 "backends_enabled": backends_enabled,
                 "routing_profile": routing_profile,

--- a/pipelex/cli/commands/doctor_cmd.py
+++ b/pipelex/cli/commands/doctor_cmd.py
@@ -57,7 +57,7 @@ class BackendFileReport(BaseModel):
     has_kit_template: bool = False
 
 
-def check_config_files(config_dir: str | None = None) -> tuple[bool, int, str]:
+def check_config_files(config_dir: Path | None = None) -> tuple[bool, int, str]:
     """Check if configuration files are present and main config is valid.
 
     Args:
@@ -71,7 +71,7 @@ def check_config_files(config_dir: str | None = None) -> tuple[bool, int, str]:
 
     # Check for missing files
     try:
-        missing_count = init_config(reset=False, dry_run=True, target_dir=effective_config_dir)
+        missing_count = init_config(reset=False, dry_run=True, target_dir=str(effective_config_dir))
     except Exception as exc:
         return False, 0, f"Error checking config files: {exc}"
 
@@ -99,7 +99,7 @@ def check_config_files(config_dir: str | None = None) -> tuple[bool, int, str]:
     return False, missing_count, f"{missing_count} configuration file(s) missing"
 
 
-def check_telemetry_config(config_dir: str | None = None) -> tuple[bool, str]:
+def check_telemetry_config(config_dir: Path | None = None) -> tuple[bool, str]:
     """Check if telemetry configuration is valid.
 
     Args:
@@ -128,7 +128,7 @@ def check_telemetry_config(config_dir: str | None = None) -> tuple[bool, str]:
         return False, "Invalid configuration - run 'pipelex init telemetry' to fix"
 
 
-def check_backend_credentials(config_dir: str | None = None) -> tuple[bool, dict[str, BackendCredentialsReport], str]:
+def check_backend_credentials(config_dir: Path | None = None) -> tuple[bool, dict[str, BackendCredentialsReport], str]:
     """Check if backend credentials are properly configured.
 
     Args:
@@ -226,12 +226,13 @@ def check_kit_template_exists(backend_name: str) -> bool:
         return False
 
 
-def replace_backend_file(backend_name: str, dry_run: bool = False) -> bool:
+def replace_backend_file(backend_name: str, dry_run: bool = False, config_dir: Path | None = None) -> bool:
     """Replace a backend configuration file with the kit template.
 
     Args:
         backend_name: Name of the backend to replace
         dry_run: If True, only report what would be done without actually doing it
+        config_dir: Explicit config directory path. If None, uses config_manager.pipelex_config_dir.
 
     Returns:
         True if successful, False otherwise
@@ -248,7 +249,8 @@ def replace_backend_file(backend_name: str, dry_run: bool = False) -> bool:
         template_content = template_file.read_text(encoding="utf-8")
 
         # Determine target path
-        target_dir = Path(".pipelex") / "inference" / "backends"
+        resolved_config_dir = config_dir or config_manager.pipelex_config_dir
+        target_dir = Path(resolved_config_dir) / "inference" / "backends"
         target_file = target_dir / f"{backend_name}.toml"
 
         if dry_run:
@@ -265,7 +267,7 @@ def replace_backend_file(backend_name: str, dry_run: bool = False) -> bool:
         return False
 
 
-def check_backend_files(config_dir: str | None = None) -> tuple[bool, dict[str, BackendFileReport], str]:
+def check_backend_files(config_dir: Path | None = None) -> tuple[bool, dict[str, BackendFileReport], str]:
     """Check individual backend configuration files for validity.
 
     Args:
@@ -328,8 +330,8 @@ def check_backend_files(config_dir: str | None = None) -> tuple[bool, dict[str, 
             # Try to load just this backend's specs
             temp_library.load(
                 secrets_provider=secrets_provider,
-                backends_library_path=backends_toml_path,
-                backends_dir_path=backends_dir_path,
+                backends_library_path=str(backends_toml_path),
+                backends_dir_path=str(backends_dir_path),
                 include_disabled=False,
             )
 
@@ -588,7 +590,7 @@ def display_health_report(
             console.print()
 
 
-def check_models(config_dir: str | None = None) -> tuple[bool, str, dict[str, BackendFileReport]]:
+def check_models(config_dir: Path | None = None) -> tuple[bool, str, dict[str, BackendFileReport]]:
     """Check if models are valid, including backend file validation.
 
     Args:

--- a/pipelex/cli/commands/doctor_cmd.py
+++ b/pipelex/cli/commands/doctor_cmd.py
@@ -61,14 +61,17 @@ def check_config_files(config_dir: str | None = None) -> tuple[bool, int, str]:
     """Check if configuration files are present and main config is valid.
 
     Args:
-        config_dir: Explicit config directory path. If None, uses CWD-relative .pipelex/.
+        config_dir: Explicit config directory override (e.g. for --global).
+            If None, uses layered resolution (project .pipelex/ → global ~/.pipelex/).
 
     Returns:
         Tuple of (is_healthy, missing_count, message)
     """
+    effective_config_dir = config_dir or config_manager.pipelex_config_dir
+
     # Check for missing files
     try:
-        missing_count = init_config(reset=False, dry_run=True, target_dir=config_dir)
+        missing_count = init_config(reset=False, dry_run=True, target_dir=effective_config_dir)
     except Exception as exc:
         return False, 0, f"Error checking config files: {exc}"
 
@@ -76,7 +79,7 @@ def check_config_files(config_dir: str | None = None) -> tuple[bool, int, str]:
     # Note: load_config() uses config_manager's own resolution chain (package → global → project)
     # which may differ from config_dir when --global is used. This is acceptable for a diagnostic
     # check — the existence check guards the path, while load_config() validates the merged config.
-    pipelex_config_path = os.path.join(config_dir, "pipelex.toml") if config_dir else ".pipelex/pipelex.toml"
+    pipelex_config_path = config_manager.resolve_config_file("pipelex.toml", config_dir=config_dir)
     if path_exists(pipelex_config_path):
         try:
             # Suppress stderr and stdout to prevent tracebacks from being printed
@@ -100,12 +103,13 @@ def check_telemetry_config(config_dir: str | None = None) -> tuple[bool, str]:
     """Check if telemetry configuration is valid.
 
     Args:
-        config_dir: Explicit config directory path. If None, uses CWD-relative .pipelex/.
+        config_dir: Explicit config directory override (e.g. for --global).
+            If None, uses layered resolution (project .pipelex/ → global ~/.pipelex/).
 
     Returns:
         Tuple of (is_healthy, message)
     """
-    telemetry_config_path = os.path.join(config_dir, TELEMETRY_CONFIG_FILE_NAME) if config_dir else f".pipelex/{TELEMETRY_CONFIG_FILE_NAME}"
+    telemetry_config_path = config_manager.resolve_config_file(TELEMETRY_CONFIG_FILE_NAME, config_dir=config_dir)
 
     try:
         toml_doc = load_toml_from_path(telemetry_config_path)
@@ -128,12 +132,13 @@ def check_backend_credentials(config_dir: str | None = None) -> tuple[bool, dict
     """Check if backend credentials are properly configured.
 
     Args:
-        config_dir: Explicit config directory path. If None, uses CWD-relative .pipelex/.
+        config_dir: Explicit config directory override (e.g. for --global).
+            If None, uses layered resolution (project .pipelex/ → global ~/.pipelex/).
 
     Returns:
         Tuple of (is_healthy, backend_reports_dict, summary_message)
     """
-    backends_toml_path = os.path.join(config_dir, "inference", "backends.toml") if config_dir else ".pipelex/inference/backends.toml"
+    backends_toml_path = config_manager.resolve_config_file(os.path.join("inference", "backends.toml"), config_dir=config_dir)
 
     if not path_exists(backends_toml_path):
         return False, {}, "Backend configuration file not found"
@@ -264,18 +269,19 @@ def check_backend_files(config_dir: str | None = None) -> tuple[bool, dict[str, 
     """Check individual backend configuration files for validity.
 
     Args:
-        config_dir: Explicit config directory path. If None, uses CWD-relative .pipelex/.
+        config_dir: Explicit config directory override (e.g. for --global).
+            If None, uses layered resolution (project .pipelex/ → global ~/.pipelex/).
 
     Returns:
         Tuple of (is_healthy, backend_file_reports_dict, summary_message)
     """
-    backends_dir_path = os.path.join(config_dir, "inference", "backends") if config_dir else ".pipelex/inference/backends"
+    backends_dir_path = config_manager.resolve_config_file(os.path.join("inference", "backends"), config_dir=config_dir)
 
     if not path_exists(backends_dir_path):
         return True, {}, "No backend files to check"
 
     # Get list of enabled backends from backends.toml
-    backends_toml_path = os.path.join(config_dir, "inference", "backends.toml") if config_dir else ".pipelex/inference/backends.toml"
+    backends_toml_path = config_manager.resolve_config_file(os.path.join("inference", "backends.toml"), config_dir=config_dir)
     if not path_exists(backends_toml_path):
         return True, {}, "No backends.toml to check"
 
@@ -586,7 +592,8 @@ def check_models(config_dir: str | None = None) -> tuple[bool, str, dict[str, Ba
     """Check if models are valid, including backend file validation.
 
     Args:
-        config_dir: Explicit config directory path. If None, uses CWD-relative .pipelex/.
+        config_dir: Explicit config directory override (e.g. for --global).
+            If None, uses layered resolution (project .pipelex/ → global ~/.pipelex/).
 
     Returns:
         Tuple of (is_healthy, message, backend_file_reports)
@@ -684,7 +691,7 @@ def do_doctor_cmd(
     Args:
         fix: If True, offer to fix detected issues interactively
     """
-    # Run health checks
+    # Run health checks (config_dir=None uses layered resolution: project → global)
     config_healthy, config_missing_count, config_message = check_config_files()
     telemetry_healthy, telemetry_message = check_telemetry_config()
     backends_healthy, backend_credential_reports, backends_message = check_backend_credentials()

--- a/pipelex/cli/commands/init/backends.py
+++ b/pipelex/cli/commands/init/backends.py
@@ -1,6 +1,6 @@
 """Backend configuration logic for the init command."""
 
-import os
+from pathlib import Path
 from typing import Any
 
 from rich.markup import escape
@@ -89,7 +89,7 @@ def disable_gateway_backend(backends_toml_path: str) -> None:
         save_toml_to_path(toml_doc, backends_toml_path)
 
 
-def customize_backends_config(is_first_time_setup: bool = False, target_config_dir: str | None = None) -> None:
+def customize_backends_config(is_first_time_setup: bool = False, target_config_dir: Path | None = None) -> None:
     """Interactively customize which inference backends are enabled in backends.toml.
 
     Args:
@@ -98,8 +98,8 @@ def customize_backends_config(is_first_time_setup: bool = False, target_config_d
     """
     console = get_console()
     effective_config_dir = target_config_dir or config_manager.pipelex_config_dir
-    backends_toml_path = os.path.join(effective_config_dir, "inference", "backends.toml")
-    template_backends_path = os.path.join(str(get_kit_configs_dir()), "inference", "backends.toml")
+    backends_toml_path = str(effective_config_dir / "inference" / "backends.toml")
+    template_backends_path = str(get_kit_configs_dir() / "inference" / "backends.toml")
 
     if not path_exists(backends_toml_path):
         console.print("[yellow]⚠ Warning: backends.toml not found, skipping backend customization[/yellow]")
@@ -143,10 +143,10 @@ def customize_backends_config(is_first_time_setup: bool = False, target_config_d
 
             if gateway_accepted:
                 display_gateway_accepted_message(console)
-                update_service_terms_acceptance(accepted=True)
+                update_service_terms_acceptance(accepted=True, config_dir=config_manager.global_config_dir)
             else:
                 display_gateway_declined_message(console)
-                update_service_terms_acceptance(accepted=False)
+                update_service_terms_acceptance(accepted=False, config_dir=config_manager.global_config_dir)
 
                 # Remove pipelex_gateway from selected indices
                 selected_indices = [idx for idx in selected_indices if backend_options[idx][0] != PipelexBackend.GATEWAY]

--- a/pipelex/cli/commands/init/backends.py
+++ b/pipelex/cli/commands/init/backends.py
@@ -89,14 +89,16 @@ def disable_gateway_backend(backends_toml_path: str) -> None:
         save_toml_to_path(toml_doc, backends_toml_path)
 
 
-def customize_backends_config(is_first_time_setup: bool = False) -> None:
+def customize_backends_config(is_first_time_setup: bool = False, target_config_dir: str | None = None) -> None:
     """Interactively customize which inference backends are enabled in backends.toml.
 
     Args:
         is_first_time_setup: Whether this is the first time backends.toml is being set up.
+        target_config_dir: Explicit target .pipelex directory. If None, uses config_manager.pipelex_config_dir.
     """
     console = get_console()
-    backends_toml_path = os.path.join(config_manager.pipelex_config_dir, "inference", "backends.toml")
+    effective_config_dir = target_config_dir or config_manager.pipelex_config_dir
+    backends_toml_path = os.path.join(effective_config_dir, "inference", "backends.toml")
     template_backends_path = os.path.join(str(get_kit_configs_dir()), "inference", "backends.toml")
 
     if not path_exists(backends_toml_path):

--- a/pipelex/cli/commands/init/command.py
+++ b/pipelex/cli/commands/init/command.py
@@ -2,6 +2,7 @@
 
 import os
 import shutil
+from pathlib import Path
 
 import typer
 from rich.console import Console
@@ -57,8 +58,8 @@ def _check_gateway_terms_if_needed(console: Console, backends_toml_path: str) ->
     if PipelexBackend.GATEWAY not in selected_backend_keys:
         return
 
-    # Gateway is enabled - check if terms are already accepted
-    pipelex_service_config = load_pipelex_service_config_if_exists(config_dir=config_manager.pipelex_config_dir)
+    # Gateway is enabled - check if terms are already accepted (always global)
+    pipelex_service_config = load_pipelex_service_config_if_exists(config_dir=config_manager.global_config_dir)
     if pipelex_service_config is not None and pipelex_service_config.agreement.terms_accepted:
         return
 
@@ -67,10 +68,10 @@ def _check_gateway_terms_if_needed(console: Console, backends_toml_path: str) ->
 
     if gateway_accepted:
         display_gateway_accepted_message(console)
-        update_service_terms_acceptance(accepted=True)
+        update_service_terms_acceptance(accepted=True, config_dir=config_manager.global_config_dir)
     else:
         display_gateway_declined_message(console)
-        update_service_terms_acceptance(accepted=False)
+        update_service_terms_acceptance(accepted=False, config_dir=config_manager.global_config_dir)
         # Actually disable the gateway in backends.toml
         disable_gateway_backend(backends_toml_path)
 
@@ -84,7 +85,7 @@ def determine_needs(
     backends_toml_path: str,
     routing_profiles_toml_path: str,
     telemetry_config_path: str,
-    target_config_dir: str | None = None,
+    target_config_dir: Path | None = None,
 ) -> tuple[bool, bool, bool, bool]:
     """Determine what needs to be initialized based on current state.
 
@@ -102,7 +103,9 @@ def determine_needs(
     Returns:
         Tuple of (needs_config, needs_inference, needs_routing, needs_telemetry) booleans.
     """
-    nb_missing_config_files = init_config(reset=False, dry_run=True, target_dir=target_config_dir) if check_config else 0
+    nb_missing_config_files = (
+        init_config(reset=False, dry_run=True, target_dir=str(target_config_dir) if target_config_dir else None) if check_config else 0
+    )
     needs_config = check_config and (nb_missing_config_files > 0 or reset)
     needs_inference = check_inference and (not path_exists(backends_toml_path) or reset)
     needs_routing = check_routing and (not path_exists(routing_profiles_toml_path) or reset)
@@ -172,7 +175,7 @@ def execute_initialization(
     backends_toml_path: str,
     telemetry_config_path: str,
     is_first_time_backends_setup: bool,
-    target_config_dir: str | None = None,
+    target_config_dir: Path | None = None,
 ):
     """Execute the initialization steps.
 
@@ -198,7 +201,7 @@ def execute_initialization(
         backends_existed_before = path_exists(backends_toml_path)
 
         console.print()
-        init_config(reset=reset, target_dir=target_config_dir)
+        init_config(reset=reset, target_dir=str(target_config_dir) if target_config_dir else None)
 
         # init_config skips the inference/ directory (handled independently by the inference step).
         # Detect first-time setup: if backends.toml didn't exist before, inference needs to be set up.
@@ -221,39 +224,39 @@ def execute_initialization(
 
         # Copy the inference template files when resetting (init_config skips inference/)
         if reset:
-            template_inference_dir = os.path.join(str(get_kit_configs_dir()), "inference")
+            template_inference_dir = Path(str(get_kit_configs_dir())) / "inference"
             effective_config_dir = target_config_dir or config_manager.pipelex_config_dir
-            target_inference_dir = os.path.join(effective_config_dir, "inference")
+            target_inference_dir = effective_config_dir / "inference"
 
             # Reset backends.toml
-            template_backends_path = os.path.join(template_inference_dir, "backends.toml")
-            os.makedirs(os.path.dirname(backends_toml_path), exist_ok=True)
+            template_backends_path = template_inference_dir / "backends.toml"
+            Path(backends_toml_path).parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(template_backends_path, backends_toml_path)
 
             # Reset all individual backend files in backends/ directory
-            template_backends_dir = os.path.join(template_inference_dir, "backends")
-            target_backends_dir = os.path.join(target_inference_dir, "backends")
-            os.makedirs(target_backends_dir, exist_ok=True)
+            template_backends_dir = template_inference_dir / "backends"
+            target_backends_dir = target_inference_dir / "backends"
+            target_backends_dir.mkdir(parents=True, exist_ok=True)
             for backend_file in os.listdir(template_backends_dir):
                 if backend_file.endswith(".toml"):
-                    src_path = os.path.join(template_backends_dir, backend_file)
-                    dst_path = os.path.join(target_backends_dir, backend_file)
+                    src_path = template_backends_dir / backend_file
+                    dst_path = target_backends_dir / backend_file
                     shutil.copy2(src_path, dst_path)
 
             # Reset deck/ directory files (model deck configurations)
-            template_deck_dir = os.path.join(template_inference_dir, "deck")
-            target_deck_dir = os.path.join(target_inference_dir, "deck")
-            os.makedirs(target_deck_dir, exist_ok=True)
+            template_deck_dir = template_inference_dir / "deck"
+            target_deck_dir = target_inference_dir / "deck"
+            target_deck_dir.mkdir(parents=True, exist_ok=True)
             for deck_file in os.listdir(template_deck_dir):
                 if deck_file.endswith(".toml"):
-                    src_path = os.path.join(template_deck_dir, deck_file)
-                    dst_path = os.path.join(target_deck_dir, deck_file)
+                    src_path = template_deck_dir / deck_file
+                    dst_path = target_deck_dir / deck_file
                     shutil.copy2(src_path, dst_path)
 
             # Reset routing_profiles.toml
-            template_routing_path = os.path.join(template_inference_dir, "routing_profiles.toml")
-            target_routing_path = os.path.join(target_inference_dir, "routing_profiles.toml")
-            if os.path.exists(template_routing_path):
+            template_routing_path = template_inference_dir / "routing_profiles.toml"
+            target_routing_path = target_inference_dir / "routing_profiles.toml"
+            if template_routing_path.exists():
                 shutil.copy2(template_routing_path, target_routing_path)
                 console.print("✅ Reset routing_profiles.toml from template")
 
@@ -265,7 +268,7 @@ def execute_initialization(
         if not check_routing:
             selected_backend_keys = get_selected_backend_keys(backends_toml_path)
             if selected_backend_keys:
-                customize_routing_profile(selected_backend_keys)
+                customize_routing_profile(selected_backend_keys, target_config_dir=target_config_dir)
 
     # Step 2.5: Prompt for missing credentials
     if check_credentials:
@@ -278,14 +281,14 @@ def execute_initialization(
         # If reset is True, copy the template file first
         if reset:
             effective_config_dir_for_routing = target_config_dir or config_manager.pipelex_config_dir
-            routing_profiles_toml_path = os.path.join(effective_config_dir_for_routing, "inference", "routing_profiles.toml")
-            template_routing_path = os.path.join(str(get_kit_configs_dir()), "inference", "routing_profiles.toml")
+            routing_profiles_toml_path = str(effective_config_dir_for_routing / "inference" / "routing_profiles.toml")
+            template_routing_path = Path(str(get_kit_configs_dir())) / "inference" / "routing_profiles.toml"
             shutil.copy2(template_routing_path, routing_profiles_toml_path)
             console.print("✅ Reset routing_profiles.toml from template")
 
         selected_backend_keys = get_selected_backend_keys(backends_toml_path)
         if selected_backend_keys:
-            customize_routing_profile(selected_backend_keys)
+            customize_routing_profile(selected_backend_keys, target_config_dir=target_config_dir)
         else:
             console.print("[yellow]⚠ Warning: No backends enabled. Please run 'pipelex init inference' first.[/yellow]")
 
@@ -313,8 +316,8 @@ def _init_agreement(console: Console) -> None:
         console.print()
         return
 
-    # Check current terms acceptance status
-    pipelex_service_config = load_pipelex_service_config_if_exists(config_dir=config_manager.pipelex_config_dir)
+    # Check current terms acceptance status (always global)
+    pipelex_service_config = load_pipelex_service_config_if_exists(config_dir=config_manager.global_config_dir)
 
     if pipelex_service_config is not None and pipelex_service_config.agreement.terms_accepted:
         console.print()
@@ -335,12 +338,12 @@ def _init_agreement(console: Console) -> None:
 
     if accepted:
         display_gateway_accepted_message(console)
-        update_service_terms_acceptance(accepted=True)
+        update_service_terms_acceptance(accepted=True, config_dir=config_manager.global_config_dir)
     else:
         display_gateway_declined_message(console)
-        update_service_terms_acceptance(accepted=False)
+        update_service_terms_acceptance(accepted=False, config_dir=config_manager.global_config_dir)
         # Disable the gateway since terms were declined
-        backends_toml_path = os.path.join(config_manager.pipelex_config_dir, "inference", "backends.toml")
+        backends_toml_path = str(config_manager.pipelex_config_dir / "inference" / "backends.toml")
         if path_exists(backends_toml_path):
             disable_gateway_backend(backends_toml_path)
 
@@ -371,7 +374,7 @@ def init_cmd(
 
     # Handle credentials-only flow separately (no reset needed)
     if focus == InitFocus.CREDENTIALS:
-        backends_toml_path = os.path.join(config_manager.pipelex_config_dir, "inference", "backends.toml")
+        backends_toml_path = str(config_manager.pipelex_config_dir / "inference" / "backends.toml")
         if not path_exists(backends_toml_path):
             console.print()
             console.print("[yellow]No backends.toml found. Please run 'pipelex init' first.[/yellow]")
@@ -389,18 +392,18 @@ def init_cmd(
         # --local: create at project root, fall back to CWD
         project_root = config_manager.project_root
         if project_root is not None:
-            target_config_dir = os.path.join(project_root, ".pipelex")
+            target_config_dir = project_root / ".pipelex"
         else:
-            target_config_dir = os.path.join(os.getcwd(), ".pipelex")
+            target_config_dir = Path.cwd() / ".pipelex"
     else:
         # Default: create global config at ~/.pipelex/
         target_config_dir = config_manager.global_config_dir
     console.print(f"[dim]Target directory: {target_config_dir}[/dim]")
 
     pipelex_config_dir = target_config_dir
-    telemetry_config_path = os.path.join(pipelex_config_dir, TELEMETRY_CONFIG_FILE_NAME)
-    backends_toml_path = os.path.join(pipelex_config_dir, "inference", "backends.toml")
-    routing_profiles_toml_path = os.path.join(pipelex_config_dir, "inference", "routing_profiles.toml")
+    telemetry_config_path = str(pipelex_config_dir / TELEMETRY_CONFIG_FILE_NAME)
+    backends_toml_path = str(pipelex_config_dir / "inference" / "backends.toml")
+    routing_profiles_toml_path = str(pipelex_config_dir / "inference" / "routing_profiles.toml")
 
     # Determine what to check based on focus parameter
     check_config = focus in {InitFocus.ALL, InitFocus.CONFIG}

--- a/pipelex/cli/commands/init/command.py
+++ b/pipelex/cli/commands/init/command.py
@@ -259,7 +259,7 @@ def execute_initialization(
 
             first_time_setup = True  # Treat as first-time setup since we just replaced the files
 
-        customize_backends_config(is_first_time_setup=first_time_setup)
+        customize_backends_config(is_first_time_setup=first_time_setup, target_config_dir=target_config_dir)
 
         # Automatically set up routing after backends (unless routing is the specific focus)
         if not check_routing:

--- a/pipelex/cli/commands/init/config_files.py
+++ b/pipelex/cli/commands/init/config_files.py
@@ -29,7 +29,7 @@ def init_config(reset: bool = False, dry_run: bool = False, target_dir: str | No
         The number of files copied.
     """
     config_template_dir = str(get_kit_configs_dir())
-    target_config_dir = target_dir or config_manager.pipelex_config_dir
+    target_config_dir = target_dir or str(config_manager.pipelex_config_dir)
 
     os.makedirs(target_config_dir, exist_ok=True)
 

--- a/pipelex/cli/commands/init/credentials.py
+++ b/pipelex/cli/commands/init/credentials.py
@@ -17,7 +17,7 @@ from pipelex.tools.misc.toml_utils import load_toml_from_path
 
 def get_global_env_path() -> Path:
     """Return the path to the global credentials file (~/.pipelex/.env)."""
-    return Path(config_manager.global_config_dir) / ".env"
+    return config_manager.global_config_dir / ".env"
 
 
 def read_env_file(env_path: Path) -> dict[str, str]:

--- a/pipelex/cli/commands/init/routing.py
+++ b/pipelex/cli/commands/init/routing.py
@@ -1,6 +1,6 @@
 """Routing profile configuration logic for the init command."""
 
-import os
+from pathlib import Path
 from typing import Any, cast
 
 from rich.markup import escape
@@ -65,16 +65,18 @@ def _migrate_profile_to_official_backend(profile: dict[str, Any]) -> None:
             optional_routes[pattern] = official_backend
 
 
-def customize_routing_profile(selected_backend_keys: list[str]) -> None:
+def customize_routing_profile(selected_backend_keys: list[str], target_config_dir: Path | None = None) -> None:
     """Interactively customize routing profile based on selected backends.
 
     Args:
         selected_backend_keys: List of backend keys that are enabled.
+        target_config_dir: Explicit target .pipelex directory. If None, uses config_manager.pipelex_config_dir.
     """
     console = get_console()
-    routing_profiles_toml_path = os.path.join(config_manager.pipelex_config_dir, "inference", "routing_profiles.toml")
-    template_routing_path = os.path.join(str(get_kit_configs_dir()), "inference", "routing_profiles.toml")
-    backends_toml_path = os.path.join(config_manager.pipelex_config_dir, "inference", "backends.toml")
+    effective_config_dir = target_config_dir or config_manager.pipelex_config_dir
+    routing_profiles_toml_path = str(effective_config_dir / "inference" / "routing_profiles.toml")
+    template_routing_path = str(get_kit_configs_dir() / "inference" / "routing_profiles.toml")
+    backends_toml_path = str(effective_config_dir / "inference" / "backends.toml")
 
     if not path_exists(routing_profiles_toml_path):
         console.print("[yellow]⚠ Warning: routing_profiles.toml not found, skipping routing customization[/yellow]")
@@ -88,7 +90,7 @@ def customize_routing_profile(selected_backend_keys: list[str]) -> None:
         toml_doc = load_toml_with_tomlkit(routing_profiles_toml_path)
 
         # Get backend options for display names
-        template_backends_path = os.path.join(str(get_kit_configs_dir()), "inference", "backends.toml")
+        template_backends_path = str(get_kit_configs_dir() / "inference" / "backends.toml")
         backend_options = get_backend_options_from_toml(template_backends_path, backends_toml_path)
 
         # Case 1: pipelex_gateway is enabled - use all_pipelex_gateway

--- a/pipelex/cli/commands/show_cmd.py
+++ b/pipelex/cli/commands/show_cmd.py
@@ -76,8 +76,8 @@ def do_show_backends(show_all: bool = False) -> None:
             backend_library = InferenceBackendLibrary()
             backend_library.load(
                 secrets_provider=secrets_provider,
-                backends_library_path=config_manager.backends_file_path,
-                backends_dir_path=config_manager.backends_dir_path,
+                backends_library_path=str(config_manager.backends_file_path),
+                backends_dir_path=str(config_manager.backends_dir_path),
                 include_disabled=True,
                 lenient=True,
             )

--- a/pipelex/cli/dev_cli/commands/preprocess_test_models_cmd.py
+++ b/pipelex/cli/dev_cli/commands/preprocess_test_models_cmd.py
@@ -161,7 +161,7 @@ def _collect_all_model_availability() -> dict[str, Any]:
         "search": {},
     }
 
-    backends_dir = Path(config_manager.backends_dir_path)
+    backends_dir = config_manager.backends_dir_path
 
     # Process each backend TOML file
     for backend_file in sorted(backends_dir.glob("*.toml")):
@@ -621,7 +621,7 @@ def preprocess_test_models_cmd(
         console.print()
 
     # Collect model availability
-    backends_dir = Path(config_manager.backends_dir_path)
+    backends_dir = config_manager.backends_dir_path
     if not backends_dir.exists():
         if quiet:
             console.print(f"[red]✗ Preprocessing failed:[/red] Backends directory not found: {backends_dir}")

--- a/pipelex/cogt/models/model_manager.py
+++ b/pipelex/cogt/models/model_manager.py
@@ -60,18 +60,18 @@ class ModelManager(ModelManagerAbstract):
     ) -> None:
         self.inference_backend_library.load(
             secrets_provider=secrets_provider,
-            backends_library_path=config_manager.backends_file_path,
-            backends_dir_path=config_manager.backends_dir_path,
+            backends_library_path=str(config_manager.backends_file_path),
+            backends_dir_path=str(config_manager.backends_dir_path),
             gateway_model_specs=gateway_model_specs,
             lenient=not needs_inference,
         )
         enabled_backends = self.inference_backend_library.all_enabled_backends()
         self._routing_profile = load_active_routing_profile(
-            routing_profile_library_path=config_manager.routing_profiles_file_path,
+            routing_profile_library_path=str(config_manager.routing_profiles_file_path),
             enabled_backends=enabled_backends,
             lenient=not needs_inference,
         )
-        model_deck_paths = ModelManager.get_model_deck_paths(deck_dir_path=config_manager.model_decks_dir_path)
+        model_deck_paths = ModelManager.get_model_deck_paths(deck_dir_path=str(config_manager.model_decks_dir_path))
         deck_blueprint = load_model_deck_blueprint(model_deck_paths=model_deck_paths)
         self.model_deck = self.build_deck(enabled_backends=enabled_backends, model_deck_blueprint=deck_blueprint)
 

--- a/pipelex/pipelex.py
+++ b/pipelex/pipelex.py
@@ -92,7 +92,7 @@ PACKAGE_NAME, PACKAGE_VERSION = get_package_info()
 class Pipelex(metaclass=MetaSingleton):
     def __init__(
         self,
-        config_dir_path: str | None = None,
+        config_dir_path: Path | None = None,
         config_cls: type[ConfigRoot] | None = None,
     ) -> None:
         self.is_pipelex_service_enabled = False  # Will be set during setup

--- a/pipelex/system/configuration/config_loader.py
+++ b/pipelex/system/configuration/config_loader.py
@@ -89,15 +89,28 @@ class ConfigLoader:
             return project_dir
         return self.global_config_dir
 
-    def _resolve_inference_file(self, relative_path: str) -> str:
-        """Resolve an inference file path, checking project dir first, then global.
+    def resolve_config_file(self, relative_path: str, config_dir: str | None = None) -> str:
+        """Resolve a config file path with layered resolution.
+
+        When config_dir is provided (e.g. for --global override), the file is
+        resolved directly under that directory.
+
+        Otherwise, the project .pipelex/ directory is checked first; if the file
+        exists there it wins, otherwise the global ~/.pipelex/ is used.
+        This works on all platforms (macOS, Linux, Windows) because Path.home()
+        returns the correct home directory everywhere.
 
         Args:
-            relative_path: Path relative to the .pipelex directory (e.g. "inference/backends.toml").
+            relative_path: Path relative to the .pipelex directory (e.g. "telemetry.toml",
+                "inference/backends.toml").
+            config_dir: Explicit config directory override. When set, skips layered
+                resolution and uses this directory directly.
 
         Returns:
             The resolved absolute path.
         """
+        if config_dir is not None:
+            return os.path.join(config_dir, relative_path)
         project_dir = self.project_config_dir
         if project_dir is not None:
             candidate = os.path.join(project_dir, relative_path)
@@ -108,22 +121,22 @@ class ConfigLoader:
     @property
     def backends_file_path(self) -> str:
         """Resolve backends.toml from project dir or global dir."""
-        return self._resolve_inference_file(os.path.join(INFERENCE_DIR_NAME, BACKENDS_FILE_NAME))
+        return self.resolve_config_file(os.path.join(INFERENCE_DIR_NAME, BACKENDS_FILE_NAME))
 
     @property
     def backends_dir_path(self) -> str:
         """Resolve backends/ directory from project dir or global dir."""
-        return self._resolve_inference_file(os.path.join(INFERENCE_DIR_NAME, BACKENDS_DIR_NAME))
+        return self.resolve_config_file(os.path.join(INFERENCE_DIR_NAME, BACKENDS_DIR_NAME))
 
     @property
     def routing_profiles_file_path(self) -> str:
         """Resolve routing_profiles.toml from project dir or global dir."""
-        return self._resolve_inference_file(os.path.join(INFERENCE_DIR_NAME, ROUTING_PROFILES_FILE_NAME))
+        return self.resolve_config_file(os.path.join(INFERENCE_DIR_NAME, ROUTING_PROFILES_FILE_NAME))
 
     @property
     def model_decks_dir_path(self) -> str:
         """Resolve model decks directory from project dir or global dir."""
-        return self._resolve_inference_file(os.path.join(INFERENCE_DIR_NAME, MODEL_DECKS_DIR_NAME))
+        return self.resolve_config_file(os.path.join(INFERENCE_DIR_NAME, MODEL_DECKS_DIR_NAME))
 
     def ensure_global_config_exists(self) -> None:
         """Create the global ~/.pipelex/ directory with kit template files if it doesn't exist."""

--- a/pipelex/system/configuration/config_loader.py
+++ b/pipelex/system/configuration/config_loader.py
@@ -1,4 +1,3 @@
-import os
 import shutil
 from pathlib import Path
 from typing import Any
@@ -20,13 +19,13 @@ MODEL_DECKS_DIR_NAME = "deck"
 
 class ConfigLoader:
     @property
-    def pipelex_root_dir(self) -> str:
+    def pipelex_root_dir(self) -> Path:
         """Get the root directory of the installed pipelex package.
 
         Uses __file__ to locate the package directory, which works in both
         development and installed modes.
         """
-        return str(Path(__file__).resolve().parent.parent.parent)
+        return Path(__file__).resolve().parent.parent.parent
 
     @staticmethod
     def find_project_root(start_dir: Path) -> Path | None:
@@ -51,20 +50,17 @@ class ConfigLoader:
             current = parent
 
     @property
-    def global_config_dir(self) -> str:
+    def global_config_dir(self) -> Path:
         """Get the global config directory at ~/.pipelex."""
-        return str(Path.home() / CONFIG_DIR_NAME)
+        return Path.home() / CONFIG_DIR_NAME
 
     @property
-    def project_root(self) -> str | None:
+    def project_root(self) -> Path | None:
         """Get the detected project root directory, or None if no project root markers found."""
-        project_root = self.find_project_root(Path.cwd())
-        if project_root is None:
-            return None
-        return str(project_root)
+        return self.find_project_root(Path.cwd())
 
     @property
-    def project_config_dir(self) -> str | None:
+    def project_config_dir(self) -> Path | None:
         """Get the project config directory if it exists on disk.
 
         Returns the path to {project_root}/.pipelex if the project root was found
@@ -75,11 +71,11 @@ class ConfigLoader:
             return None
         project_config = project_root / CONFIG_DIR_NAME
         if project_config.is_dir():
-            return str(project_config)
+            return project_config
         return None
 
     @property
-    def pipelex_config_dir(self) -> str:
+    def pipelex_config_dir(self) -> Path:
         """Get the effective config directory (project if exists, else global).
 
         This preserves backwards compatibility for all current consumers.
@@ -89,7 +85,7 @@ class ConfigLoader:
             return project_dir
         return self.global_config_dir
 
-    def resolve_config_file(self, relative_path: str, config_dir: str | None = None) -> str:
+    def resolve_config_file(self, relative_path: str, config_dir: Path | None = None) -> Path:
         """Resolve a config file path with layered resolution.
 
         When config_dir is provided (e.g. for --global override), the file is
@@ -110,60 +106,58 @@ class ConfigLoader:
             The resolved absolute path.
         """
         if config_dir is not None:
-            return os.path.join(config_dir, relative_path)
+            return config_dir / relative_path
         project_dir = self.project_config_dir
         if project_dir is not None:
-            candidate = os.path.join(project_dir, relative_path)
-            if os.path.exists(candidate):
+            candidate = project_dir / relative_path
+            if candidate.exists():
                 return candidate
-        return os.path.join(self.global_config_dir, relative_path)
+        return self.global_config_dir / relative_path
 
     @property
-    def backends_file_path(self) -> str:
+    def backends_file_path(self) -> Path:
         """Resolve backends.toml from project dir or global dir."""
-        return self.resolve_config_file(os.path.join(INFERENCE_DIR_NAME, BACKENDS_FILE_NAME))
+        return self.resolve_config_file(str(Path(INFERENCE_DIR_NAME) / BACKENDS_FILE_NAME))
 
     @property
-    def backends_dir_path(self) -> str:
+    def backends_dir_path(self) -> Path:
         """Resolve backends/ directory from project dir or global dir."""
-        return self.resolve_config_file(os.path.join(INFERENCE_DIR_NAME, BACKENDS_DIR_NAME))
+        return self.resolve_config_file(str(Path(INFERENCE_DIR_NAME) / BACKENDS_DIR_NAME))
 
     @property
-    def routing_profiles_file_path(self) -> str:
+    def routing_profiles_file_path(self) -> Path:
         """Resolve routing_profiles.toml from project dir or global dir."""
-        return self.resolve_config_file(os.path.join(INFERENCE_DIR_NAME, ROUTING_PROFILES_FILE_NAME))
+        return self.resolve_config_file(str(Path(INFERENCE_DIR_NAME) / ROUTING_PROFILES_FILE_NAME))
 
     @property
-    def model_decks_dir_path(self) -> str:
+    def model_decks_dir_path(self) -> Path:
         """Resolve model decks directory from project dir or global dir."""
-        return self.resolve_config_file(os.path.join(INFERENCE_DIR_NAME, MODEL_DECKS_DIR_NAME))
+        return self.resolve_config_file(str(Path(INFERENCE_DIR_NAME) / MODEL_DECKS_DIR_NAME))
 
     def ensure_global_config_exists(self) -> None:
         """Create the global ~/.pipelex/ directory with kit template files if it doesn't exist."""
-        global_dir = Path(self.global_config_dir)
+        global_dir = self.global_config_dir
         if global_dir.is_dir():
             return
 
         from pipelex.kit.paths import GIT_IGNORED_CONFIG_FILES, get_kit_configs_dir  # noqa: PLC0415
 
-        config_template_dir = str(get_kit_configs_dir())
-        global_dir_str = str(global_dir)
-        os.makedirs(global_dir_str, exist_ok=True)
+        config_template_dir = Path(str(get_kit_configs_dir()))
+        global_dir.mkdir(parents=True, exist_ok=True)
 
-        def copy_directory_structure(src_dir: str, dst_dir: str) -> None:
+        def copy_directory_structure(src_dir: Path, dst_dir: Path) -> None:
             """Recursively copy directory structure from kit templates."""
-            for item in os.listdir(src_dir):
-                if item in GIT_IGNORED_CONFIG_FILES or item == ".DS_Store":
+            for item in src_dir.iterdir():
+                if item.name in GIT_IGNORED_CONFIG_FILES or item.name == ".DS_Store":
                     continue
-                src_item = os.path.join(src_dir, item)
-                dst_item = os.path.join(dst_dir, item)
-                if os.path.isdir(src_item):
-                    os.makedirs(dst_item, exist_ok=True)
-                    copy_directory_structure(src_item, dst_item)
+                dst_item = dst_dir / item.name
+                if item.is_dir():
+                    dst_item.mkdir(parents=True, exist_ok=True)
+                    copy_directory_structure(item, dst_item)
                 else:
-                    shutil.copy2(src_item, dst_item)
+                    shutil.copy2(item, dst_item)
 
-        copy_directory_structure(src_dir=config_template_dir, dst_dir=global_dir_str)
+        copy_directory_structure(src_dir=config_template_dir, dst_dir=global_dir)
 
     def load_config(self) -> dict[str, Any]:
         """Load and merge configurations from pipelex and local config files.
@@ -183,36 +177,36 @@ class ConfigLoader:
         """
         self.ensure_global_config_exists()
 
-        list_of_configs: list[str] = []
+        list_of_configs: list[Path] = []
 
         # 1. Pipelex package defaults
-        list_of_configs.append(os.path.join(self.pipelex_root_dir, CONFIG_NAME))
+        list_of_configs.append(self.pipelex_root_dir / CONFIG_NAME)
 
         # 2. Global config
-        list_of_configs.append(os.path.join(self.global_config_dir, CONFIG_NAME))
+        list_of_configs.append(self.global_config_dir / CONFIG_NAME)
 
         # 3. Project config (if different from global)
         project_dir = self.project_config_dir
         if project_dir is not None and project_dir != self.global_config_dir:
-            list_of_configs.append(os.path.join(project_dir, CONFIG_NAME))
+            list_of_configs.append(project_dir / CONFIG_NAME)
 
         # Effective config dir for overrides
         effective_config_dir = self.pipelex_config_dir
 
         # 4. Override for local execution
-        list_of_configs.append(os.path.join(effective_config_dir, "pipelex_local.toml"))
+        list_of_configs.append(effective_config_dir / "pipelex_local.toml")
 
         # Override for environment
-        list_of_configs.append(os.path.join(effective_config_dir, f"pipelex_{runtime_manager.environment}.toml"))
+        list_of_configs.append(effective_config_dir / f"pipelex_{runtime_manager.environment}.toml")
 
         # Override for run mode
         if runtime_manager.is_unit_testing:
-            list_of_configs.append(os.path.join(os.getcwd(), "tests", f"pipelex_{runtime_manager.run_mode}.toml"))
+            list_of_configs.append(Path.cwd() / "tests" / f"pipelex_{runtime_manager.run_mode}.toml")
         else:
-            list_of_configs.append(os.path.join(effective_config_dir, f"pipelex_{runtime_manager.run_mode}.toml"))
+            list_of_configs.append(effective_config_dir / f"pipelex_{runtime_manager.run_mode}.toml")
 
         # Final override
-        list_of_configs.append(os.path.join(effective_config_dir, "pipelex_override.toml"))
+        list_of_configs.append(effective_config_dir / "pipelex_override.toml")
 
         return load_toml_from_path_and_merge_with_overrides(paths=list_of_configs)
 

--- a/pipelex/system/pipelex_service/pipelex_service_agreement.py
+++ b/pipelex/system/pipelex_service/pipelex_service_agreement.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 
 from pydantic import Field
 
@@ -18,7 +18,7 @@ class PipelexServiceAgreement(ConfigModel):
     )
 
 
-def update_service_terms_acceptance(accepted: bool, config_dir: str | None = None) -> None:
+def update_service_terms_acceptance(accepted: bool, config_dir: Path | None = None) -> None:
     """Update the service terms acceptance in pipelex_service.toml.
 
     Args:
@@ -26,7 +26,7 @@ def update_service_terms_acceptance(accepted: bool, config_dir: str | None = Non
         config_dir: Explicit config directory path. If None, uses config_manager.pipelex_config_dir.
     """
     resolved_config_dir = config_dir or config_manager.pipelex_config_dir
-    service_config_path = os.path.join(resolved_config_dir, PIPELEX_SERVICE_CONFIG_FILE_NAME)
+    service_config_path = resolved_config_dir / PIPELEX_SERVICE_CONFIG_FILE_NAME
 
     if path_exists(service_config_path):
         toml_doc = load_toml_with_tomlkit(service_config_path)

--- a/pipelex/system/pipelex_service/pipelex_service_config.py
+++ b/pipelex/system/pipelex_service/pipelex_service_config.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 from typing import Any, cast
 
 from pydantic import ValidationError
@@ -19,7 +19,7 @@ class PipelexServiceConfig(ConfigModel):
     agreement: PipelexServiceAgreement
 
 
-def load_pipelex_service_config_if_exists(config_dir: str) -> PipelexServiceConfig | None:
+def load_pipelex_service_config_if_exists(config_dir: Path) -> PipelexServiceConfig | None:
     """Load Pipelex service configuration if the file exists.
 
     Args:
@@ -28,7 +28,7 @@ def load_pipelex_service_config_if_exists(config_dir: str) -> PipelexServiceConf
     Returns:
         PipelexServiceConfig instance or None if file doesn't exist.
     """
-    config_path = os.path.join(config_dir, PIPELEX_SERVICE_CONFIG_FILE_NAME)
+    config_path = config_dir / PIPELEX_SERVICE_CONFIG_FILE_NAME
     try:
         config_toml = load_toml_from_path(path=config_path)
         return PipelexServiceConfig.model_validate(config_toml)

--- a/pipelex/system/telemetry/telemetry_config.py
+++ b/pipelex/system/telemetry/telemetry_config.py
@@ -1,4 +1,3 @@
-import os
 from functools import partial
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
@@ -240,9 +239,10 @@ def load_telemetry_config(secrets_provider: SecretsProviderAbstract) -> Telemetr
     Raises:
         TelemetryConfigValidationError: If configuration is invalid or variable substitution fails.
     """
-    telemetry_config_paths: list[str] = []
-    telemetry_config_paths.append(os.path.join(config_manager.pipelex_config_dir, TELEMETRY_CONFIG_FILE_NAME))
-    telemetry_config_paths.append(os.path.join(config_manager.pipelex_config_dir, TELEMETRY_CONFIG_OVERRIDE_FILE_NAME))
+    telemetry_config_paths = [
+        config_manager.pipelex_config_dir / TELEMETRY_CONFIG_FILE_NAME,
+        config_manager.pipelex_config_dir / TELEMETRY_CONFIG_OVERRIDE_FILE_NAME,
+    ]
     telemetry_config_toml_raw = load_toml_from_path_and_merge_with_overrides(paths=telemetry_config_paths)
 
     # Apply variable substitution to all string values (keep placeholders for missing vars)
@@ -250,7 +250,7 @@ def load_telemetry_config(secrets_provider: SecretsProviderAbstract) -> Telemetr
     try:
         telemetry_config_toml = apply_to_strings_recursive(telemetry_config_toml_raw, substitute_vars_with_provider)
     except UnknownVarPrefixError as exc:
-        paths_str = "\n".join(telemetry_config_paths)
+        paths_str = "\n".join(str(path) for path in telemetry_config_paths)
         msg = f"Variable substitution failed in telemetry configuration based on '{paths_str}': {exc}"
         raise TelemetryConfigValidationError(msg) from exc
 
@@ -258,7 +258,7 @@ def load_telemetry_config(secrets_provider: SecretsProviderAbstract) -> Telemetr
         telemetry_config = TelemetryConfig.model_validate(telemetry_config_toml)
     except ValidationError as exc:
         validation_error_msg = format_pydantic_validation_error(exc)
-        paths_str = "\n".join(telemetry_config_paths)
+        paths_str = "\n".join(str(path) for path in telemetry_config_paths)
         msg = f"Invalid telemetry configuration in '{paths_str}':\n{validation_error_msg}"
         raise TelemetryConfigValidationError(msg) from exc
     return telemetry_config

--- a/pipelex/tools/misc/file_utils.py
+++ b/pipelex/tools/misc/file_utils.py
@@ -272,7 +272,7 @@ def ensure_directory_for_file_path(file_path: str) -> None:
     ensure_directory_exists(os.path.dirname(file_path))
 
 
-def path_exists(path_str: str) -> bool:
+def path_exists(path_str: str | Path) -> bool:
     """Checks if a file or directory exists at the specified path.
 
     This function converts the input string path to a Path object and checks

--- a/pipelex/tools/misc/toml_utils.py
+++ b/pipelex/tools/misc/toml_utils.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from pathlib import Path
 
 import tomli
 import tomlkit
@@ -31,7 +35,7 @@ def load_toml_from_content(content: str) -> dict[str, Any]:
         raise TomlError.from_tomli_error(exc) from exc
 
 
-def load_toml_from_path(path: str) -> dict[str, Any]:
+def load_toml_from_path(path: str | Path) -> dict[str, Any]:
     """Load TOML from path.
 
     Args:
@@ -52,14 +56,14 @@ def load_toml_from_path(path: str) -> dict[str, Any]:
         raise TomlError(message=msg, doc=exc.doc, pos=exc.pos, lineno=exc.lineno, colno=exc.colno) from exc
 
 
-def load_toml_from_path_if_exists(path: str) -> dict[str, Any] | None:
+def load_toml_from_path_if_exists(path: str | Path) -> dict[str, Any] | None:
     """Load TOML from path if it exists."""
     if not path_exists(path):
         return None
     return load_toml_from_path(path)
 
 
-def load_toml_with_tomlkit(path: str) -> tomlkit.TOMLDocument:
+def load_toml_with_tomlkit(path: str | Path) -> tomlkit.TOMLDocument:
     """Load TOML using tomlkit to preserve formatting and comments.
 
     Args:
@@ -73,7 +77,7 @@ def load_toml_with_tomlkit(path: str) -> tomlkit.TOMLDocument:
         return tomlkit.load(file)
 
 
-def save_toml_to_path(data: dict[str, Any] | tomlkit.TOMLDocument, path: str) -> None:
+def save_toml_to_path(data: dict[str, Any] | tomlkit.TOMLDocument, path: str | Path) -> None:
     """Save dictionary as TOML to path, preserving formatting and comments.
 
     Args:
@@ -85,7 +89,7 @@ def save_toml_to_path(data: dict[str, Any] | tomlkit.TOMLDocument, path: str) ->
         tomlkit.dump(data, file)  # type: ignore[arg-type]
 
 
-def load_toml_from_path_and_merge_with_overrides(paths: list[str]) -> dict[str, Any]:
+def load_toml_from_path_and_merge_with_overrides(paths: Sequence[str | Path]) -> dict[str, Any]:
     """Load and merge toml files from paths if they exist, merged in sequence.
 
     Returns:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,10 +40,10 @@ def _cached_fetch_remote_config() -> RemoteConfig:
 
 
 # Session-level cache for pipelex service config to avoid flaky tests from concurrent file reads
-_pipelex_service_config_cache: dict[str, PipelexServiceConfig | None] = {}
+_pipelex_service_config_cache: dict[Path, PipelexServiceConfig | None] = {}
 
 
-def _cached_load_pipelex_service_config(config_dir: str) -> PipelexServiceConfig | None:
+def _cached_load_pipelex_service_config(config_dir: Path) -> PipelexServiceConfig | None:
     """Wrapper that caches the pipelex service config for the entire test session.
 
     This prevents flaky tests caused by concurrent file reads during parallel pytest-xdist execution.

--- a/tests/helpers/init_cmd_helpers.py
+++ b/tests/helpers/init_cmd_helpers.py
@@ -180,14 +180,14 @@ class MockedInitEnvironment:
     def mock_config_manager_paths(self) -> None:
         """Mock config_manager to use tmp_path."""
         self.mock_config_manager = self.mocker.MagicMock()
-        self.mock_config_manager.pipelex_config_dir = str(self.pipelex_dir)
-        self.mock_config_manager.global_config_dir = str(self.pipelex_dir)
-        self.mock_config_manager.project_config_dir = str(self.pipelex_dir)
-        self.mock_config_manager.project_root = str(self.tmp_path)
-        self.mock_config_manager.backends_file_path = str(self.inference_dir / "backends.toml")
-        self.mock_config_manager.backends_dir_path = str(self.inference_dir / "backends")
-        self.mock_config_manager.routing_profiles_file_path = str(self.inference_dir / "routing_profiles.toml")
-        self.mock_config_manager.model_decks_dir_path = str(self.inference_dir / "deck")
+        self.mock_config_manager.pipelex_config_dir = self.pipelex_dir
+        self.mock_config_manager.global_config_dir = self.pipelex_dir
+        self.mock_config_manager.project_config_dir = self.pipelex_dir
+        self.mock_config_manager.project_root = self.tmp_path
+        self.mock_config_manager.backends_file_path = self.inference_dir / "backends.toml"
+        self.mock_config_manager.backends_dir_path = self.inference_dir / "backends"
+        self.mock_config_manager.routing_profiles_file_path = self.inference_dir / "routing_profiles.toml"
+        self.mock_config_manager.model_decks_dir_path = self.inference_dir / "deck"
 
         # Patch all locations where config_manager is used
         self.mocker.patch("pipelex.cli.commands.init.command.config_manager", self.mock_config_manager)

--- a/tests/integration/pipelex/cli/test_init_cmd_backend_customization.py
+++ b/tests/integration/pipelex/cli/test_init_cmd_backend_customization.py
@@ -29,7 +29,8 @@ class TestBackendCustomization:
 
         # Mock config_manager
         mock_config_manager = mocker.MagicMock()
-        mock_config_manager.pipelex_config_dir = str(tmp_path / ".pipelex")
+        mock_config_manager.pipelex_config_dir = tmp_path / ".pipelex"
+        mock_config_manager.global_config_dir = tmp_path / ".pipelex"
         mocker.patch("pipelex.cli.commands.init.backends.config_manager", mock_config_manager)
 
         # Mock console provider
@@ -91,7 +92,7 @@ class TestBackendCustomization:
 
         # Mock config_manager
         mock_config_manager = mocker.MagicMock()
-        mock_config_manager.pipelex_config_dir = str(tmp_path / ".pipelex")
+        mock_config_manager.pipelex_config_dir = tmp_path / ".pipelex"
         mocker.patch("pipelex.cli.commands.init.backends.config_manager", mock_config_manager)
 
         # Mock console provider
@@ -145,7 +146,8 @@ class TestBackendCustomization:
 
         # Mock config_manager
         mock_config_manager = mocker.MagicMock()
-        mock_config_manager.pipelex_config_dir = str(tmp_path / ".pipelex")
+        mock_config_manager.pipelex_config_dir = tmp_path / ".pipelex"
+        mock_config_manager.global_config_dir = tmp_path / ".pipelex"
         mocker.patch("pipelex.cli.commands.init.backends.config_manager", mock_config_manager)
 
         # Mock console provider
@@ -207,7 +209,7 @@ class TestBackendCustomization:
         # Mock config_manager
         mocker.patch("pipelex.cli.commands.init.config_files.get_kit_configs_dir", return_value=str(kit_configs_dir))
         mock_config_manager = mocker.MagicMock()
-        mock_config_manager.pipelex_config_dir = str(target_dir)
+        mock_config_manager.pipelex_config_dir = target_dir
         mocker.patch("pipelex.cli.commands.init.config_files.config_manager", mock_config_manager)
         mocker.patch("typer.echo")
 
@@ -228,7 +230,7 @@ class TestBackendCustomization:
         config_dir.mkdir()
 
         mock_config_manager = mocker.MagicMock()
-        mock_config_manager.pipelex_config_dir = str(config_dir)
+        mock_config_manager.pipelex_config_dir = config_dir
         mocker.patch("pipelex.cli.commands.init.backends.config_manager", mock_config_manager)
 
         mock_console = mocker.MagicMock()

--- a/tests/unit/pipelex/cli/test_doctor_cmd.py
+++ b/tests/unit/pipelex/cli/test_doctor_cmd.py
@@ -1,0 +1,127 @@
+"""Unit tests for the doctor command — layered config resolution."""
+
+from __future__ import annotations
+
+import os
+import pathlib
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+from pipelex.cli.commands.doctor_cmd import (
+    check_backend_credentials,
+    check_telemetry_config,
+    do_doctor_cmd,
+)
+from pipelex.system.configuration.config_loader import ConfigLoader
+from pipelex.system.telemetry.telemetry_config import TELEMETRY_CONFIG_FILE_NAME
+
+# Minimal valid telemetry TOML — only [custom_posthog].mode is needed, rest defaults
+TELEMETRY_OFF = '[custom_posthog]\nmode = "off"\n'
+TELEMETRY_ANONYMOUS = '[custom_posthog]\nmode = "anonymous"\n'
+
+
+class TestDoctorLayeredResolution:
+    """Verify that doctor checks use layered config resolution:
+    project .pipelex/ first, fall back to global ~/.pipelex/.
+
+    This covers the scenario where pipelex is installed globally and run
+    from a project that may or may not have its own .pipelex/ directory.
+    """
+
+    def test_do_doctor_cmd_delegates_layered_resolution_to_checks(self, mocker: MockerFixture) -> None:
+        """do_doctor_cmd should call check functions with no config_dir so they use layered resolution."""
+        mock_check_config = mocker.patch(
+            "pipelex.cli.commands.doctor_cmd.check_config_files",
+            return_value=(True, 0, "OK"),
+        )
+        mock_check_telemetry = mocker.patch(
+            "pipelex.cli.commands.doctor_cmd.check_telemetry_config",
+            return_value=(True, "OK"),
+        )
+        mock_check_backends = mocker.patch(
+            "pipelex.cli.commands.doctor_cmd.check_backend_credentials",
+            return_value=(True, {}, "OK"),
+        )
+        mock_check_models = mocker.patch(
+            "pipelex.cli.commands.doctor_cmd.check_models",
+            return_value=(True, "OK", {}),
+        )
+        mocker.patch("pipelex.cli.commands.doctor_cmd.display_health_report")
+
+        with pytest.raises(SystemExit) as exc_info:
+            do_doctor_cmd(fix=False)
+        assert exc_info.value.code == 0
+
+        # All checks must be called without config_dir (layered resolution)
+        mock_check_config.assert_called_once_with()
+        mock_check_telemetry.assert_called_once_with()
+        mock_check_backends.assert_called_once_with()
+        mock_check_models.assert_called_once_with()
+
+    def test_telemetry_check_falls_back_to_global(self, mocker: MockerFixture, tmp_path: pytest.TempPathFactory) -> None:
+        """When project .pipelex/ exists but has no telemetry.toml, fall back to global ~/.pipelex/."""
+        global_dir = str(tmp_path / "global_pipelex")  # type: ignore[operator]
+        project_dir = str(tmp_path / "project_pipelex")  # type: ignore[operator]
+
+        # Create both dirs but only put telemetry.toml in global
+        os.makedirs(global_dir)
+        os.makedirs(project_dir)
+        pathlib.Path(os.path.join(global_dir, TELEMETRY_CONFIG_FILE_NAME)).write_text(TELEMETRY_OFF, encoding="utf-8")
+
+        mocker.patch.object(ConfigLoader, "project_config_dir", new_callable=mocker.PropertyMock, return_value=project_dir)
+        mocker.patch.object(ConfigLoader, "global_config_dir", new_callable=mocker.PropertyMock, return_value=global_dir)
+
+        # No config_dir override → layered resolution should find it in global
+        healthy, message = check_telemetry_config()
+        assert healthy is True
+        assert "off" in message
+
+    def test_telemetry_check_uses_project_override(self, mocker: MockerFixture, tmp_path: pytest.TempPathFactory) -> None:
+        """When project .pipelex/ has telemetry.toml, it should be used instead of global."""
+        global_dir = str(tmp_path / "global_pipelex")  # type: ignore[operator]
+        project_dir = str(tmp_path / "project_pipelex")  # type: ignore[operator]
+
+        os.makedirs(global_dir)
+        os.makedirs(project_dir)
+        pathlib.Path(os.path.join(global_dir, TELEMETRY_CONFIG_FILE_NAME)).write_text(TELEMETRY_OFF, encoding="utf-8")
+        pathlib.Path(os.path.join(project_dir, TELEMETRY_CONFIG_FILE_NAME)).write_text(TELEMETRY_ANONYMOUS, encoding="utf-8")
+
+        mocker.patch.object(ConfigLoader, "project_config_dir", new_callable=mocker.PropertyMock, return_value=project_dir)
+        mocker.patch.object(ConfigLoader, "global_config_dir", new_callable=mocker.PropertyMock, return_value=global_dir)
+
+        healthy, message = check_telemetry_config()
+        assert healthy is True
+        assert "anonymous" in message
+
+    def test_telemetry_check_with_explicit_config_dir_skips_layering(self, tmp_path: pytest.TempPathFactory) -> None:
+        """When config_dir is explicitly provided (e.g. --global), use it directly without layering."""
+        explicit_dir = str(tmp_path / "explicit_pipelex")  # type: ignore[operator]
+        os.makedirs(explicit_dir)
+        pathlib.Path(os.path.join(explicit_dir, TELEMETRY_CONFIG_FILE_NAME)).write_text(TELEMETRY_OFF, encoding="utf-8")
+
+        healthy, _message = check_telemetry_config(config_dir=explicit_dir)
+        assert healthy is True
+
+    def test_backend_credentials_falls_back_to_global(self, mocker: MockerFixture, tmp_path: pytest.TempPathFactory) -> None:
+        """When project .pipelex/ exists but has no backends.toml, fall back to global."""
+        global_dir = str(tmp_path / "global_pipelex")  # type: ignore[operator]
+        project_dir = str(tmp_path / "project_pipelex")  # type: ignore[operator]
+
+        os.makedirs(project_dir)
+        global_inference_dir = os.path.join(global_dir, "inference")
+        os.makedirs(global_inference_dir)
+
+        # Only global has backends.toml — with only the internal backend
+        backends_content = "[internal]\nenabled = true\n"
+        pathlib.Path(os.path.join(global_inference_dir, "backends.toml")).write_text(backends_content, encoding="utf-8")
+
+        mocker.patch.object(ConfigLoader, "project_config_dir", new_callable=mocker.PropertyMock, return_value=project_dir)
+        mocker.patch.object(ConfigLoader, "global_config_dir", new_callable=mocker.PropertyMock, return_value=global_dir)
+
+        _healthy, _, message = check_backend_credentials()
+        # Should find backends.toml in global, not report "not found"
+        assert "not found" not in message.lower()

--- a/tests/unit/pipelex/cli/test_doctor_cmd.py
+++ b/tests/unit/pipelex/cli/test_doctor_cmd.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
-import os
-import pathlib
 from typing import TYPE_CHECKING
 
 import pytest
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from pytest_mock import MockerFixture
 
 from pipelex.cli.commands.doctor_cmd import (
@@ -62,15 +62,14 @@ class TestDoctorLayeredResolution:
         mock_check_backends.assert_called_once_with()
         mock_check_models.assert_called_once_with()
 
-    def test_telemetry_check_falls_back_to_global(self, mocker: MockerFixture, tmp_path: pytest.TempPathFactory) -> None:
+    def test_telemetry_check_falls_back_to_global(self, mocker: MockerFixture, tmp_path: Path) -> None:
         """When project .pipelex/ exists but has no telemetry.toml, fall back to global ~/.pipelex/."""
-        global_dir = str(tmp_path / "global_pipelex")  # type: ignore[operator]
-        project_dir = str(tmp_path / "project_pipelex")  # type: ignore[operator]
-
+        global_dir = tmp_path / "global_pipelex"
+        project_dir = tmp_path / "project_pipelex"
         # Create both dirs but only put telemetry.toml in global
-        os.makedirs(global_dir)
-        os.makedirs(project_dir)
-        pathlib.Path(os.path.join(global_dir, TELEMETRY_CONFIG_FILE_NAME)).write_text(TELEMETRY_OFF, encoding="utf-8")
+        global_dir.mkdir()
+        project_dir.mkdir()
+        (global_dir / TELEMETRY_CONFIG_FILE_NAME).write_text(TELEMETRY_OFF, encoding="utf-8")
 
         mocker.patch.object(ConfigLoader, "project_config_dir", new_callable=mocker.PropertyMock, return_value=project_dir)
         mocker.patch.object(ConfigLoader, "global_config_dir", new_callable=mocker.PropertyMock, return_value=global_dir)
@@ -80,15 +79,14 @@ class TestDoctorLayeredResolution:
         assert healthy is True
         assert "off" in message
 
-    def test_telemetry_check_uses_project_override(self, mocker: MockerFixture, tmp_path: pytest.TempPathFactory) -> None:
+    def test_telemetry_check_uses_project_override(self, mocker: MockerFixture, tmp_path: Path) -> None:
         """When project .pipelex/ has telemetry.toml, it should be used instead of global."""
-        global_dir = str(tmp_path / "global_pipelex")  # type: ignore[operator]
-        project_dir = str(tmp_path / "project_pipelex")  # type: ignore[operator]
-
-        os.makedirs(global_dir)
-        os.makedirs(project_dir)
-        pathlib.Path(os.path.join(global_dir, TELEMETRY_CONFIG_FILE_NAME)).write_text(TELEMETRY_OFF, encoding="utf-8")
-        pathlib.Path(os.path.join(project_dir, TELEMETRY_CONFIG_FILE_NAME)).write_text(TELEMETRY_ANONYMOUS, encoding="utf-8")
+        global_dir = tmp_path / "global_pipelex"
+        project_dir = tmp_path / "project_pipelex"
+        global_dir.mkdir()
+        project_dir.mkdir()
+        (global_dir / TELEMETRY_CONFIG_FILE_NAME).write_text(TELEMETRY_OFF, encoding="utf-8")
+        (project_dir / TELEMETRY_CONFIG_FILE_NAME).write_text(TELEMETRY_ANONYMOUS, encoding="utf-8")
 
         mocker.patch.object(ConfigLoader, "project_config_dir", new_callable=mocker.PropertyMock, return_value=project_dir)
         mocker.patch.object(ConfigLoader, "global_config_dir", new_callable=mocker.PropertyMock, return_value=global_dir)
@@ -97,27 +95,26 @@ class TestDoctorLayeredResolution:
         assert healthy is True
         assert "anonymous" in message
 
-    def test_telemetry_check_with_explicit_config_dir_skips_layering(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_telemetry_check_with_explicit_config_dir_skips_layering(self, tmp_path: Path) -> None:
         """When config_dir is explicitly provided (e.g. --global), use it directly without layering."""
-        explicit_dir = str(tmp_path / "explicit_pipelex")  # type: ignore[operator]
-        os.makedirs(explicit_dir)
-        pathlib.Path(os.path.join(explicit_dir, TELEMETRY_CONFIG_FILE_NAME)).write_text(TELEMETRY_OFF, encoding="utf-8")
+        explicit_dir = tmp_path / "explicit_pipelex"
+        explicit_dir.mkdir()
+        (explicit_dir / TELEMETRY_CONFIG_FILE_NAME).write_text(TELEMETRY_OFF, encoding="utf-8")
 
         healthy, _message = check_telemetry_config(config_dir=explicit_dir)
         assert healthy is True
 
-    def test_backend_credentials_falls_back_to_global(self, mocker: MockerFixture, tmp_path: pytest.TempPathFactory) -> None:
+    def test_backend_credentials_falls_back_to_global(self, mocker: MockerFixture, tmp_path: Path) -> None:
         """When project .pipelex/ exists but has no backends.toml, fall back to global."""
-        global_dir = str(tmp_path / "global_pipelex")  # type: ignore[operator]
-        project_dir = str(tmp_path / "project_pipelex")  # type: ignore[operator]
-
-        os.makedirs(project_dir)
-        global_inference_dir = os.path.join(global_dir, "inference")
-        os.makedirs(global_inference_dir)
+        global_dir = tmp_path / "global_pipelex"
+        project_dir = tmp_path / "project_pipelex"
+        project_dir.mkdir()
+        global_inference_dir = global_dir / "inference"
+        global_inference_dir.mkdir(parents=True)
 
         # Only global has backends.toml — with only the internal backend
         backends_content = "[internal]\nenabled = true\n"
-        pathlib.Path(os.path.join(global_inference_dir, "backends.toml")).write_text(backends_content, encoding="utf-8")
+        (global_inference_dir / "backends.toml").write_text(backends_content, encoding="utf-8")
 
         mocker.patch.object(ConfigLoader, "project_config_dir", new_callable=mocker.PropertyMock, return_value=project_dir)
         mocker.patch.object(ConfigLoader, "global_config_dir", new_callable=mocker.PropertyMock, return_value=global_dir)

--- a/tests/unit/pipelex/cli/test_init_cmd.py
+++ b/tests/unit/pipelex/cli/test_init_cmd.py
@@ -27,7 +27,7 @@ class TestInitCmd:
         # Mock get_configs_dir and config manager
         mocker.patch("pipelex.cli.commands.init.config_files.get_kit_configs_dir", return_value=kit_configs_dir)
         mock_config_manager = mocker.MagicMock()
-        mock_config_manager.pipelex_config_dir = str(target_dir)
+        mock_config_manager.pipelex_config_dir = target_dir
         mocker.patch("pipelex.cli.commands.init.config_files.config_manager", mock_config_manager)
 
         # Execute
@@ -51,7 +51,7 @@ class TestInitCmd:
         # Mock get_configs_dir and config manager
         mocker.patch("pipelex.cli.commands.init.config_files.get_kit_configs_dir", return_value=kit_configs_dir)
         mock_config_manager = mocker.MagicMock()
-        mock_config_manager.pipelex_config_dir = str(target_dir)
+        mock_config_manager.pipelex_config_dir = target_dir
         mocker.patch("pipelex.cli.commands.init.config_files.config_manager", mock_config_manager)
 
         # Execute
@@ -78,7 +78,7 @@ class TestInitCmd:
         # Mock get_configs_dir and config manager
         mocker.patch("pipelex.cli.commands.init.config_files.get_kit_configs_dir", return_value=kit_configs_dir)
         mock_config_manager = mocker.MagicMock()
-        mock_config_manager.pipelex_config_dir = str(target_dir)
+        mock_config_manager.pipelex_config_dir = target_dir
         mocker.patch("pipelex.cli.commands.init.config_files.config_manager", mock_config_manager)
 
         # Execute
@@ -110,7 +110,7 @@ class TestInitCmd:
         # Mock get_configs_dir and config manager
         mocker.patch("pipelex.cli.commands.init.config_files.get_kit_configs_dir", return_value=kit_configs_dir)
         mock_config_manager = mocker.MagicMock()
-        mock_config_manager.pipelex_config_dir = str(target_dir)
+        mock_config_manager.pipelex_config_dir = target_dir
         mocker.patch("pipelex.cli.commands.init.config_files.config_manager", mock_config_manager)
 
         # Execute
@@ -137,7 +137,7 @@ class TestInitCmd:
         # Mock get_configs_dir and config manager
         mocker.patch("pipelex.cli.commands.init.config_files.get_kit_configs_dir", return_value=kit_configs_dir)
         mock_config_manager = mocker.MagicMock()
-        mock_config_manager.pipelex_config_dir = str(target_dir)
+        mock_config_manager.pipelex_config_dir = target_dir
         mocker.patch("pipelex.cli.commands.init.config_files.config_manager", mock_config_manager)
         mocker.patch("shutil.copy2", side_effect=PermissionError("Permission denied"))
 
@@ -158,7 +158,7 @@ class TestInitCmd:
         # Mock get_configs_dir and config manager
         mocker.patch("pipelex.cli.commands.init.config_files.get_kit_configs_dir", return_value=kit_configs_dir)
         mock_config_manager = mocker.MagicMock()
-        mock_config_manager.pipelex_config_dir = str(target_dir)
+        mock_config_manager.pipelex_config_dir = target_dir
         mocker.patch("pipelex.cli.commands.init.config_files.config_manager", mock_config_manager)
 
         # Execute
@@ -188,7 +188,7 @@ class TestInitCmd:
         # Mock config_manager
         mocker.patch("pipelex.cli.commands.init.config_files.get_kit_configs_dir", return_value=kit_configs_dir)
         mock_config_manager = mocker.MagicMock()
-        mock_config_manager.pipelex_config_dir = str(target_dir)
+        mock_config_manager.pipelex_config_dir = target_dir
         mocker.patch("pipelex.cli.commands.init.config_files.config_manager", mock_config_manager)
 
         # Execute dry-run
@@ -216,7 +216,7 @@ class TestInitCmd:
         # Mock config_manager and customize function
         mocker.patch("pipelex.cli.commands.init.config_files.get_kit_configs_dir", return_value=kit_configs_dir)
         mock_config_manager = mocker.MagicMock()
-        mock_config_manager.pipelex_config_dir = str(target_dir)
+        mock_config_manager.pipelex_config_dir = target_dir
         mocker.patch("pipelex.cli.commands.init.config_files.config_manager", mock_config_manager)
 
         mock_customize = mocker.patch("pipelex.cli.commands.init.backends.customize_backends_config")
@@ -240,7 +240,7 @@ class TestInitCmd:
         # Mock config_manager and customize function
         mocker.patch("pipelex.cli.commands.init.config_files.get_kit_configs_dir", return_value=kit_configs_dir)
         mock_config_manager = mocker.MagicMock()
-        mock_config_manager.pipelex_config_dir = str(target_dir)
+        mock_config_manager.pipelex_config_dir = target_dir
         mocker.patch("pipelex.cli.commands.init.config_files.config_manager", mock_config_manager)
 
         mock_customize = mocker.patch("pipelex.cli.commands.init.backends.customize_backends_config")

--- a/tests/unit/pipelex/cli/test_init_credentials.py
+++ b/tests/unit/pipelex/cli/test_init_credentials.py
@@ -126,7 +126,7 @@ class TestInitCredentials:
         mocker.patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test"})
         mocker.patch(
             "pipelex.cli.commands.init.credentials.config_manager",
-            global_config_dir=str(tmp_path),
+            global_config_dir=tmp_path,
         )
         mock_prompt = mocker.patch("pipelex.cli.commands.init.credentials.Prompt.ask")
         mock_console: MagicMock = mocker.MagicMock()
@@ -145,7 +145,7 @@ class TestInitCredentials:
 
         mocker.patch(
             "pipelex.cli.commands.init.credentials.config_manager",
-            global_config_dir=str(tmp_path),
+            global_config_dir=tmp_path,
         )
         mocker.patch(
             "pipelex.cli.commands.init.credentials.Prompt.ask",
@@ -175,7 +175,7 @@ class TestInitCredentials:
 
         mocker.patch(
             "pipelex.cli.commands.init.credentials.config_manager",
-            global_config_dir=str(tmp_path),
+            global_config_dir=tmp_path,
         )
         mocker.patch(
             "pipelex.cli.commands.init.credentials.Prompt.ask",
@@ -200,7 +200,7 @@ class TestInitCredentials:
 
         mocker.patch(
             "pipelex.cli.commands.init.credentials.config_manager",
-            global_config_dir=str(tmp_path),
+            global_config_dir=tmp_path,
         )
         mocker.patch(
             "pipelex.cli.commands.init.credentials.Prompt.ask",
@@ -222,7 +222,7 @@ class TestInitCredentials:
         backends_toml.write_text('[openai]\nenabled = false\napi_key = "${OPENAI_API_KEY}"\n\n[internal]\nenabled = true\n')
         mocker.patch(
             "pipelex.cli.commands.init.credentials.config_manager",
-            global_config_dir=str(tmp_path),
+            global_config_dir=tmp_path,
         )
         mock_prompt = mocker.patch("pipelex.cli.commands.init.credentials.Prompt.ask")
         mock_console: MagicMock = mocker.MagicMock()

--- a/tests/unit/pipelex/cogt/models/test_model_deck_references.py
+++ b/tests/unit/pipelex/cogt/models/test_model_deck_references.py
@@ -36,7 +36,7 @@ class TestModelDeckReferences:
     @pytest.fixture(scope="class")
     def model_deck_blueprint(self) -> ModelDeckBlueprint:
         """Load actual model deck blueprint from TOML files."""
-        model_deck_paths = ModelManager.get_model_deck_paths(deck_dir_path=config_manager.model_decks_dir_path)
+        model_deck_paths = ModelManager.get_model_deck_paths(deck_dir_path=str(config_manager.model_decks_dir_path))
         return load_model_deck_blueprint(model_deck_paths=model_deck_paths)
 
     @pytest.fixture(scope="class")
@@ -94,7 +94,7 @@ class TestModelDeckReferences:
         known_handles: dict[str, ModelType] = {}
         backends_dir = config_manager.backends_dir_path
 
-        toml_files = find_files_in_dir(backends_dir, pattern="*.toml", is_recursive=False)
+        toml_files = find_files_in_dir(str(backends_dir), pattern="*.toml", is_recursive=False)
         for toml_path in toml_files:
             backend_data = load_toml_from_path_if_exists(str(toml_path))
             if backend_data:

--- a/tests/unit/pipelex/system/pipelex_service/test_pipelex_service_config.py
+++ b/tests/unit/pipelex/system/pipelex_service/test_pipelex_service_config.py
@@ -33,7 +33,7 @@ class TestPipelexServiceConfig:
     def test_load_pipelex_service_config_if_exists_returns_none(self) -> None:
         """Test load_pipelex_service_config_if_exists returns None when file doesn't exist."""
         with tempfile.TemporaryDirectory() as temp_dir:
-            config = load_pipelex_service_config_if_exists(config_dir=temp_dir)
+            config = load_pipelex_service_config_if_exists(config_dir=pathlib.Path(temp_dir))
             assert config is None
 
     def test_load_pipelex_service_config_if_exists_returns_config(self) -> None:
@@ -45,6 +45,6 @@ terms_accepted = false
             config_path = os.path.join(temp_dir, PIPELEX_SERVICE_CONFIG_FILE_NAME)
             pathlib.Path(config_path).write_text(config_content, encoding="utf-8")
 
-            config = load_pipelex_service_config_if_exists(config_dir=temp_dir)
+            config = load_pipelex_service_config_if_exists(config_dir=pathlib.Path(temp_dir))
             assert config is not None
             assert config.agreement.terms_accepted is False

--- a/tests/unit/pipelex/system/test_config_resolution.py
+++ b/tests/unit/pipelex/system/test_config_resolution.py
@@ -96,7 +96,7 @@ class TestConfigResolution:
 
         loader = ConfigLoader()
 
-        assert loader.global_config_dir == str(fake_home / ".pipelex")
+        assert loader.global_config_dir == fake_home / ".pipelex"
 
     def test_project_config_dir_when_exists(self, tmp_path: Path, mocker: MockerFixture) -> None:
         """project_config_dir returns the path when .pipelex exists at the project root."""
@@ -108,7 +108,7 @@ class TestConfigResolution:
 
         loader = ConfigLoader()
 
-        assert loader.project_config_dir == str((project_dir / ".pipelex").resolve())
+        assert loader.project_config_dir == (project_dir / ".pipelex").resolve()
 
     def test_project_config_dir_none_when_no_pipelex_dir(self, tmp_path: Path, mocker: MockerFixture) -> None:
         """project_config_dir returns None when project root has no .pipelex directory."""
@@ -132,7 +132,7 @@ class TestConfigResolution:
 
         loader = ConfigLoader()
 
-        assert loader.pipelex_config_dir == str((project_dir / ".pipelex").resolve())
+        assert loader.pipelex_config_dir == (project_dir / ".pipelex").resolve()
 
     def test_effective_config_dir_falls_back_to_global(self, tmp_path: Path, mocker: MockerFixture) -> None:
         """pipelex_config_dir returns global path when no project .pipelex exists."""
@@ -148,7 +148,7 @@ class TestConfigResolution:
 
         loader = ConfigLoader()
 
-        assert loader.pipelex_config_dir == str(fake_home / ".pipelex")
+        assert loader.pipelex_config_dir == fake_home / ".pipelex"
 
     def test_project_root_returns_str_when_found(self, tmp_path: Path, mocker: MockerFixture) -> None:
         """project_root returns the project root as a string."""
@@ -161,7 +161,7 @@ class TestConfigResolution:
 
         loader = ConfigLoader()
 
-        assert loader.project_root == str(project_dir.resolve())
+        assert loader.project_root == project_dir.resolve()
 
     def test_project_root_returns_none_without_markers(self, mocker: MockerFixture) -> None:
         """project_root returns None when no project root markers are found.
@@ -193,10 +193,10 @@ class TestConfigResolution:
 
         loader = ConfigLoader()
 
-        assert loader.backends_file_path == str(inference_dir / "backends.toml")
-        assert loader.backends_dir_path == str(backends_dir)
-        assert loader.routing_profiles_file_path == str(inference_dir / "routing_profiles.toml")
-        assert loader.model_decks_dir_path == str(deck_dir)
+        assert loader.backends_file_path == inference_dir / "backends.toml"
+        assert loader.backends_dir_path == backends_dir
+        assert loader.routing_profiles_file_path == inference_dir / "routing_profiles.toml"
+        assert loader.model_decks_dir_path == deck_dir
 
     def test_inference_files_fallback_to_global(self, tmp_path: Path, mocker: MockerFixture) -> None:
         """Inference file paths fall back to global dir when project dir has no files."""
@@ -216,7 +216,7 @@ class TestConfigResolution:
         loader = ConfigLoader()
 
         # backends.toml exists in global, so it should resolve there
-        assert loader.backends_file_path == str(global_config / "backends.toml")
+        assert loader.backends_file_path == global_config / "backends.toml"
 
     def test_ensure_global_config_created_on_first_run(self, tmp_path: Path, mocker: MockerFixture) -> None:
         """ensure_global_config_exists creates ~/.pipelex/ with template files when it doesn't exist."""
@@ -285,5 +285,5 @@ class TestConfigResolution:
         global_dir = loader.global_config_dir
 
         # Verify the path is valid and uses the correct separator for the platform
-        assert Path(global_dir).name == ".pipelex"
-        assert Path(global_dir).parent == fake_home
+        assert global_dir.name == ".pipelex"
+        assert global_dir.parent == fake_home


### PR DESCRIPTION
### Changed

- **Config paths use `pathlib.Path`**: All `ConfigLoader` properties and methods now return `Path` instead of `str`. Consumer code across the config system (doctor, init, backends, routing, credentials, telemetry, agent CLI) updated accordingly.
- **Layered config resolution for `pipelex doctor` and `pipelex init`**: Config files are now resolved with project-first, global-fallback layering per file. Fixed `replace_backend_file` using CWD-relative path that broke when run from another directory.
- **Gateway terms are explicitly global**: `update_service_terms_acceptance` now targets `~/.pipelex/` by default, since gateway terms are a user-level agreement, not project-level.