### PR TITLE
fix/init-local-backends

### DIFF
--- a/pipelex/cli/commands/init/backends.py
+++ b/pipelex/cli/commands/init/backends.py
@@ -167,11 +167,18 @@ def customize_backends_config(is_first_time_setup: bool = False, target_config_d
                 update_service_terms_acceptance(accepted=gateway_terms_accepted, config_dir=global_config_dir)
             except Exception as terms_exc:
                 log.warning(f"Could not save gateway terms acceptance to global config: {terms_exc}")
-                console.print("[yellow]⚠ Could not save gateway terms acceptance. You can run 'pipelex init agreement' later.[/yellow]")
-                # If terms were accepted but persistence failed, disable gateway in backends.toml
-                # to prevent an inconsistent state where gateway is enabled but terms aren't recorded
                 if gateway_terms_accepted:
-                    disable_gateway_backend(backends_toml_path)
+                    # Gateway enabled in backends.toml but terms not recorded — runtime will fail.
+                    # Disable gateway as a safety measure.
+                    try:
+                        disable_gateway_backend(backends_toml_path)
+                        console.print("[yellow]⚠ Could not save gateway terms. Gateway has been disabled to prevent errors.[/yellow]")
+                    except Exception as disable_exc:
+                        log.warning(f"Could not disable gateway backend: {disable_exc}")
+                        console.print(
+                            "[red]⚠ Could not save gateway terms or disable gateway. Please manually disable pipelex_gateway in backends.toml.[/red]"
+                        )
+                    console.print("[dim]Re-run 'pipelex init' to set up gateway again.[/dim]")
 
     except Exception as exc:
         console.print(f"[yellow]⚠ Warning: Failed to customize backends: {escape(str(exc))}[/yellow]")

--- a/pipelex/cli/commands/init/backends.py
+++ b/pipelex/cli/commands/init/backends.py
@@ -137,26 +137,37 @@ def customize_backends_config(is_first_time_setup: bool = False, target_config_d
         except Exception as exc:
             log.debug(f"IDE extension suggestion failed: {exc}")
 
-        # Check if pipelex_gateway is selected and handle terms acceptance
+        # Check if pipelex_gateway is selected and handle terms acceptance prompt
+        gateway_terms_accepted: bool | None = None
         if PipelexBackend.GATEWAY in selected_backends:
             gateway_accepted = prompt_gateway_acceptance(console)
 
             if gateway_accepted:
                 display_gateway_accepted_message(console)
-                update_service_terms_acceptance(accepted=True, config_dir=config_manager.global_config_dir)
+                gateway_terms_accepted = True
             else:
                 display_gateway_declined_message(console)
-                update_service_terms_acceptance(accepted=False, config_dir=config_manager.global_config_dir)
+                gateway_terms_accepted = False
 
                 # Remove pipelex_gateway from selected indices
                 selected_indices = [idx for idx in selected_indices if backend_options[idx][0] != PipelexBackend.GATEWAY]
 
-        # Business logic: Update TOML
+        # Business logic: Update and save backends.toml first (local operation)
         update_backends_in_toml(toml_doc, selected_indices, backend_options)
         save_toml_to_path(toml_doc, backends_toml_path)
 
         # UI: Display confirmation
         display_selected_backends(console, selected_indices, backend_options)
+
+        # Save gateway terms acceptance to global config (separate from backends save)
+        if gateway_terms_accepted is not None:
+            try:
+                global_config_dir = config_manager.global_config_dir
+                global_config_dir.mkdir(parents=True, exist_ok=True)
+                update_service_terms_acceptance(accepted=gateway_terms_accepted, config_dir=global_config_dir)
+            except Exception as terms_exc:
+                log.warning(f"Could not save gateway terms acceptance to global config: {terms_exc}")
+                console.print("[yellow]⚠ Could not save gateway terms acceptance. You can run 'pipelex init agreement' later.[/yellow]")
 
     except Exception as exc:
         console.print(f"[yellow]⚠ Warning: Failed to customize backends: {escape(str(exc))}[/yellow]")

--- a/pipelex/cli/commands/init/backends.py
+++ b/pipelex/cli/commands/init/backends.py
@@ -168,6 +168,10 @@ def customize_backends_config(is_first_time_setup: bool = False, target_config_d
             except Exception as terms_exc:
                 log.warning(f"Could not save gateway terms acceptance to global config: {terms_exc}")
                 console.print("[yellow]⚠ Could not save gateway terms acceptance. You can run 'pipelex init agreement' later.[/yellow]")
+                # If terms were accepted but persistence failed, disable gateway in backends.toml
+                # to prevent an inconsistent state where gateway is enabled but terms aren't recorded
+                if gateway_terms_accepted:
+                    disable_gateway_backend(backends_toml_path)
 
     except Exception as exc:
         console.print(f"[yellow]⚠ Warning: Failed to customize backends: {escape(str(exc))}[/yellow]")


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes init-time backend/terms persistence order and adds fallback behavior that can auto-disable `pipelex_gateway` if global terms acceptance can’t be written, which may affect onboarding flows and gateway availability.
> 
> **Overview**
> Backend selection during `pipelex init` now **saves `backends.toml` first** and records `pipelex_gateway` terms acceptance as a separate best-effort write to the *global* config.
> 
> If saving the gateway terms fails, the CLI warns and, when gateway was enabled, **automatically disables `pipelex_gateway`** in `backends.toml` to avoid a broken runtime state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0722d3f3c63731bff219d4cd02e96edf6ec0c0e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->