### PR TITLE
Add graph_name param and improve agent CLI tolerance

### DIFF
--- a/.pipelex/inference/backends/pipelex_gateway_models.md
+++ b/.pipelex/inference/backends/pipelex_gateway_models.md
@@ -515,6 +515,6 @@ For configuration details, see the [documentation](https://docs.pipelex.com/late
 
 
 > **AUTO-GENERATED FILE** - Do not edit manually.
-> Last updated: 2026-03-04T07:00:39Z
+> Last updated: 2026-03-10T06:49:52Z
 >
 > Run `pipelex-dev update-gateway-models` or `make ugm` to regenerate.

--- a/.pipelex/inference/backends/pipelex_gateway_models_plain.md
+++ b/.pipelex/inference/backends/pipelex_gateway_models_plain.md
@@ -193,6 +193,6 @@ For configuration details, see the [documentation](https://docs.pipelex.com/late
 
 
 > **AUTO-GENERATED FILE** - Do not edit manually.
-> Last updated: 2026-03-04T07:00:39Z
+> Last updated: 2026-03-10T06:49:52Z
 >
 > Run `pipelex-dev update-gateway-models` or `make ugm` to regenerate.

--- a/pipelex/builder/pipe/pipe_compose_spec.py
+++ b/pipelex/builder/pipe/pipe_compose_spec.py
@@ -1,6 +1,6 @@
 from typing import Any, Literal
 
-from pydantic import Field, field_validator, model_validator
+from pydantic import ConfigDict, Field, field_validator, model_validator
 from pydantic.json_schema import SkipJsonSchema
 from rich.console import Group
 from rich.panel import Panel
@@ -90,6 +90,8 @@ class PipeComposeSpec(PipeSpec):
     - Use `{ template = "..." }` ONLY for string composition (e.g., "INV-$order.id")
     - NEVER use templates to manually replicate object attributes
     """
+
+    model_config = ConfigDict(populate_by_name=True)
 
     type: SkipJsonSchema[Literal["PipeCompose"]] = "PipeCompose"
     pipe_category: SkipJsonSchema[Literal["PipeOperator"]] = "PipeOperator"

--- a/pipelex/builder/pipe/pipe_spec.py
+++ b/pipelex/builder/pipe/pipe_spec.py
@@ -1,7 +1,7 @@
 import re
 from typing import Any
 
-from pydantic import Field, field_validator
+from pydantic import ConfigDict, Field, field_validator
 from rich.console import Group
 from rich.table import Table
 from rich.text import Text
@@ -35,6 +35,8 @@ class PipeSpec(StructuredContent):
         output = "Article[]"  # produces a list of articles
         output = "Image[5]"  # produces exactly 5 images
     """
+
+    model_config = ConfigDict(extra="forbid")
 
     pipe_code: str = Field(description="Unique pipe identifier. Must be snake_case.", json_schema_extra={"mock_format": MockFormat.SNAKE_CASE})
     type: Any = Field(

--- a/pipelex/cli/agent_cli/commands/concept_cmd.py
+++ b/pipelex/cli/agent_cli/commands/concept_cmd.py
@@ -103,9 +103,11 @@ def _parse_concept_spec_from_json(spec_data: dict[str, Any]) -> ConceptSpec:
     """
     # Accept common aliases for "the_concept_code"
     for alias in ("concept_code", "code", "name", "concept_name"):
-        if alias in spec_data and "the_concept_code" not in spec_data:
-            spec_data["the_concept_code"] = spec_data.pop(alias)
-            break
+        if alias in spec_data:
+            if "the_concept_code" not in spec_data:
+                spec_data["the_concept_code"] = spec_data.pop(alias)
+            else:
+                spec_data.pop(alias)
 
     # Convert structure if present - need to add field names
     if spec_data.get("structure"):

--- a/pipelex/cli/agent_cli/commands/concept_cmd.py
+++ b/pipelex/cli/agent_cli/commands/concept_cmd.py
@@ -101,6 +101,12 @@ def _parse_concept_spec_from_json(spec_data: dict[str, Any]) -> ConceptSpec:
     Raises:
         ValidationError: If validation fails.
     """
+    # Accept common aliases for "the_concept_code"
+    for alias in ("concept_code", "code", "name", "concept_name"):
+        if alias in spec_data and "the_concept_code" not in spec_data:
+            spec_data["the_concept_code"] = spec_data.pop(alias)
+            break
+
     # Convert structure if present - need to add field names
     if spec_data.get("structure"):
         structure_data = spec_data["structure"]

--- a/pipelex/cli/agent_cli/commands/doctor_cmd.py
+++ b/pipelex/cli/agent_cli/commands/doctor_cmd.py
@@ -57,7 +57,7 @@ def agent_doctor_cmd(
         models_healthy, models_message, backend_file_reports = check_models(config_dir=config_dir)
     except Exception as exc:
         agent_error(f"Health check failed unexpectedly: {exc}", type(exc).__name__, cause=exc)
-        return
+        # agent_error has NoReturn
 
     all_healthy = config_healthy and telemetry_healthy and backends_healthy and models_healthy
 

--- a/pipelex/cli/agent_cli/commands/pipe_cmd.py
+++ b/pipelex/cli/agent_cli/commands/pipe_cmd.py
@@ -388,6 +388,8 @@ def pipe_cmd(
     # Accept "pipe_type" as an alias for "type" in the JSON spec
     if "pipe_type" in spec_data and "type" not in spec_data:
         spec_data["type"] = spec_data.pop("pipe_type")
+    elif "pipe_type" in spec_data:
+        spec_data.pop("pipe_type")
 
     # Resolve pipe type: CLI option takes precedence, then extract from spec JSON
     resolved_pipe_type: str

--- a/pipelex/cli/agent_cli/commands/pipe_cmd.py
+++ b/pipelex/cli/agent_cli/commands/pipe_cmd.py
@@ -56,6 +56,22 @@ EXTRACT_TALENT_TO_MODEL: dict[str, str] = {
     "full-document-extractor": "@default-extract-document",
 }
 
+# Reverse mappings: preset name → talent name (for fuzzy resolution)
+_MODEL_TO_LLM_TALENT: dict[str, str] = {}
+for _talent, _preset in LLM_TALENT_TO_MODEL.items():
+    _MODEL_TO_LLM_TALENT[_preset] = _talent
+    _MODEL_TO_LLM_TALENT[_preset.lstrip("$@")] = _talent
+
+_MODEL_TO_IMG_GEN_TALENT: dict[str, str] = {}
+for _talent, _preset in IMG_GEN_TALENT_TO_MODEL.items():
+    _MODEL_TO_IMG_GEN_TALENT[_preset] = _talent
+    _MODEL_TO_IMG_GEN_TALENT[_preset.lstrip("$@")] = _talent
+
+_MODEL_TO_EXTRACT_TALENT: dict[str, str] = {}
+for _talent, _preset in EXTRACT_TALENT_TO_MODEL.items():
+    _MODEL_TO_EXTRACT_TALENT[_preset] = _talent
+    _MODEL_TO_EXTRACT_TALENT[_preset.lstrip("$@")] = _talent
+
 # Maps pipe types to their talent field names and valid values.
 # Used to enrich validation errors with field_hints so the agent knows
 # what values are valid when a talent field is missing or wrong.
@@ -194,6 +210,24 @@ def _add_type_specific_fields(pipe_spec: PipeSpec, pipe_table: tomlkit.TOMLDocum
         pipe_table.add("function_name", pipe_spec.function_name)
 
 
+def _resolve_talent_value(pipe_type: str, raw_value: str) -> str:
+    """Attempt to resolve a talent value, accepting preset names as aliases."""
+    reverse_maps: dict[str, dict[str, str]] = {
+        "PipeLLM": _MODEL_TO_LLM_TALENT,
+        "PipeImgGen": _MODEL_TO_IMG_GEN_TALENT,
+        "PipeExtract": _MODEL_TO_EXTRACT_TALENT,
+    }
+    reverse_map = reverse_maps.get(pipe_type)
+    if not reverse_map:
+        return raw_value
+    # If it's already a valid talent, return as-is
+    # Otherwise try reverse-mapping from preset
+    resolved = reverse_map.get(raw_value)
+    if resolved:
+        return resolved
+    return raw_value  # Let Pydantic validation handle the error
+
+
 def _parse_pipe_spec_from_json(pipe_type: str, spec_data: dict[str, Any]) -> PipeSpec:
     """Parse and validate a PipeSpec from JSON data.
 
@@ -218,9 +252,26 @@ def _parse_pipe_spec_from_json(pipe_type: str, spec_data: dict[str, Any]) -> Pip
     # Add type to spec_data if not present
     spec_data["type"] = pipe_type
 
-    # Accept "code" as an alias for "pipe_code"
-    if "code" in spec_data and "pipe_code" not in spec_data:
-        spec_data["pipe_code"] = spec_data.pop("code")
+    # Accept common aliases for "pipe_code"
+    for alias in ("code", "the_pipe_code", "name"):
+        if alias in spec_data and "pipe_code" not in spec_data:
+            spec_data["pipe_code"] = spec_data.pop(alias)
+            break
+
+    # Accept generic talent aliases and map to the type-specific field
+    talent_aliases = ("talent_name", "talent")
+    pipe_type_to_talent_field: dict[str, str] = {
+        "PipeLLM": "llm_talent",
+        "PipeExtract": "extract_talent",
+        "PipeImgGen": "img_gen_talent",
+        "PipeSearch": "search_talent",
+    }
+    talent_field = pipe_type_to_talent_field.get(pipe_type)
+    if talent_field:
+        for alias in talent_aliases:
+            if alias in spec_data and talent_field not in spec_data:
+                spec_data[talent_field] = spec_data.pop(alias)
+                break
 
     # Handle steps/branches conversion - need to convert pipe to pipe_code
     if "steps" in spec_data:
@@ -244,13 +295,23 @@ def _parse_pipe_spec_from_json(pipe_type: str, spec_data: dict[str, Any]) -> Pip
         if "jinja2_expression_template" not in spec_data:
             spec_data["jinja2_expression_template"] = spec_data.pop("expression")
 
+    # Resolve preset names to talent names (tolerance for agent mistakes)
+    talent_field = pipe_type_to_talent_field.get(pipe_type)
+    if talent_field and talent_field in spec_data:
+        spec_data[talent_field] = _resolve_talent_value(pipe_type, spec_data[talent_field])
+
+    # Accept output as dict with "type" key → extract the type string
+    if "output" in spec_data and isinstance(spec_data["output"], dict):
+        if "type" in spec_data["output"]:
+            spec_data["output"] = spec_data["output"]["type"]
+
     return spec_class.model_validate(spec_data)
 
 
 def pipe_cmd(
     pipe_type: Annotated[
         str | None,
-        typer.Option("--type", "-t", help=f"Pipe type. Must be one of: {PipeType.value_list()}"),
+        typer.Option("--type", "--pipe-type", "--pipe_type", "-t", help=f"Pipe type. Must be one of: {PipeType.value_list()}"),
     ] = None,
     spec: Annotated[
         str | None,
@@ -315,6 +376,10 @@ def pipe_cmd(
         agent_error(f"Spec file not found: {spec_file}", "FileNotFoundError", cause=exc)
     except json.JSONDecodeError as exc:
         agent_error(f"Invalid JSON: {exc.msg}", "JSONDecodeError", cause=exc)
+
+    # Accept "pipe_type" as an alias for "type" in the JSON spec
+    if "pipe_type" in spec_data and "type" not in spec_data:
+        spec_data["type"] = spec_data.pop("pipe_type")
 
     # Resolve pipe type: CLI option takes precedence, then extract from spec JSON
     resolved_pipe_type: str

--- a/pipelex/cli/agent_cli/commands/pipe_cmd.py
+++ b/pipelex/cli/agent_cli/commands/pipe_cmd.py
@@ -210,8 +210,10 @@ def _add_type_specific_fields(pipe_spec: PipeSpec, pipe_table: tomlkit.TOMLDocum
         pipe_table.add("function_name", pipe_spec.function_name)
 
 
-def _resolve_talent_value(pipe_type: str, raw_value: str) -> str:
+def _resolve_talent_value(pipe_type: str, raw_value: Any) -> Any:
     """Attempt to resolve a talent value, accepting preset names as aliases."""
+    if not isinstance(raw_value, str):
+        return raw_value
     reverse_maps: dict[str, dict[str, str]] = {
         "PipeLLM": _MODEL_TO_LLM_TALENT,
         "PipeImgGen": _MODEL_TO_IMG_GEN_TALENT,
@@ -254,9 +256,11 @@ def _parse_pipe_spec_from_json(pipe_type: str, spec_data: dict[str, Any]) -> Pip
 
     # Accept common aliases for "pipe_code"
     for alias in ("code", "the_pipe_code", "name"):
-        if alias in spec_data and "pipe_code" not in spec_data:
-            spec_data["pipe_code"] = spec_data.pop(alias)
-            break
+        if alias in spec_data:
+            if "pipe_code" not in spec_data:
+                spec_data["pipe_code"] = spec_data.pop(alias)
+            else:
+                spec_data.pop(alias)
 
     # Accept generic talent aliases and map to the type-specific field
     talent_aliases = ("talent_name", "talent")
@@ -269,9 +273,11 @@ def _parse_pipe_spec_from_json(pipe_type: str, spec_data: dict[str, Any]) -> Pip
     talent_field = pipe_type_to_talent_field.get(pipe_type)
     if talent_field:
         for alias in talent_aliases:
-            if alias in spec_data and talent_field not in spec_data:
-                spec_data[talent_field] = spec_data.pop(alias)
-                break
+            if alias in spec_data:
+                if talent_field not in spec_data:
+                    spec_data[talent_field] = spec_data.pop(alias)
+                else:
+                    spec_data.pop(alias)
 
     # Handle steps/branches conversion - need to convert pipe to pipe_code
     if "steps" in spec_data:

--- a/pipelex/cli/agent_cli/commands/pipe_cmd.py
+++ b/pipelex/cli/agent_cli/commands/pipe_cmd.py
@@ -300,6 +300,8 @@ def _parse_pipe_spec_from_json(pipe_type: str, spec_data: dict[str, Any]) -> Pip
     if pipe_type == "PipeCondition" and "expression" in spec_data:
         if "jinja2_expression_template" not in spec_data:
             spec_data["jinja2_expression_template"] = spec_data.pop("expression")
+        else:
+            spec_data.pop("expression")
 
     # Resolve preset names to talent names (tolerance for agent mistakes)
     talent_field = pipe_type_to_talent_field.get(pipe_type)

--- a/pipelex/graph/graph_rendering.py
+++ b/pipelex/graph/graph_rendering.py
@@ -164,6 +164,7 @@ async def generate_graph_for_bundle(
     graph_format: GraphFormat,
     library_dirs: list[str] | None = None,
     direction: FlowchartDirection | None = None,
+    graph_name: str = "dry_run.html",
 ) -> dict[str, Any]:
     """Generate graph visualization for a bundle via dry-run pipeline execution.
 
@@ -175,6 +176,7 @@ async def generate_graph_for_bundle(
         graph_format: Which graph format(s) to generate.
         library_dirs: Optional library directories for pipe resolution.
         direction: Flowchart layout direction (default: None, uses TB).
+        graph_name: Filename for the generated HTML graph (default: "dry_run.html").
 
     Returns:
         Dictionary with graph_files, graph_output_dir, and direction.
@@ -214,6 +216,13 @@ async def generate_graph_for_bundle(
         pipe_code=pipe_code,
         direction=direction,
     )
+
+    # Rename reactflow.html to the requested filename
+    reactflow_path = saved_files.get("reactflow_html")
+    if reactflow_path and graph_name:
+        final_path = reactflow_path.parent / graph_name
+        reactflow_path.rename(final_path)
+        saved_files["reactflow_html"] = final_path
 
     return {
         "graph_files": {key: str(path) for key, path in saved_files.items()},

--- a/pipelex/graph/graph_rendering.py
+++ b/pipelex/graph/graph_rendering.py
@@ -23,6 +23,19 @@ from pipelex.tools.misc.chart_utils import FlowchartDirection
 from pipelex.types import StrEnum
 
 
+def _sanitize_graph_name(graph_name: str) -> str:
+    """Sanitize graph_name to prevent path traversal.
+
+    Args:
+        graph_name: The requested filename for the graph output.
+
+    Returns:
+        A safe filename with no directory components.
+    """
+    sanitized = Path(graph_name).name
+    return sanitized or "graph.html"
+
+
 class GraphFormat(StrEnum):
     """Selectable graph output formats."""
 
@@ -219,8 +232,9 @@ async def generate_graph_for_bundle(
 
     # Rename reactflow.html to the requested filename
     reactflow_path = saved_files.get("reactflow_html")
-    if reactflow_path and graph_name:
-        final_path = reactflow_path.parent / graph_name
+    safe_name = _sanitize_graph_name(graph_name)
+    if reactflow_path and safe_name:
+        final_path = reactflow_path.parent / safe_name
         reactflow_path.rename(final_path)
         saved_files["reactflow_html"] = final_path
 

--- a/tests/unit/pipelex/cli/test_concept_cmd.py
+++ b/tests/unit/pipelex/cli/test_concept_cmd.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import json
-from typing import Any
+from typing import Any, ClassVar
+
+import pytest
+from pydantic import ValidationError as PydanticValidationError
 
 from pipelex.builder.concept.concept_spec import ConceptStructureSpec, ConceptStructureSpecFieldType
 from pipelex.cli.agent_cli.commands.concept_cmd import (
@@ -124,6 +127,77 @@ class TestStructureFieldToDict:
 
         assert result["choices"] == ["active", "inactive", "pending"]
         assert result["default"] == "pending"
+
+
+class TestConceptCodeAliases:
+    """Tests for concept_code alias handling in _parse_concept_spec_from_json."""
+
+    _BASE: ClassVar[dict[str, Any]] = {
+        "description": "A test concept",
+        "refines": "Text",
+    }
+
+    def test_canonical_the_concept_code(self) -> None:
+        spec = {**self._BASE, "the_concept_code": "Invoice"}
+        result = _parse_concept_spec_from_json(spec)
+        assert result.the_concept_code == "Invoice"
+
+    def test_alias_concept_code(self) -> None:
+        spec = {**self._BASE, "concept_code": "Invoice"}
+        result = _parse_concept_spec_from_json(spec)
+        assert result.the_concept_code == "Invoice"
+
+    def test_alias_code(self) -> None:
+        spec = {**self._BASE, "code": "Invoice"}
+        result = _parse_concept_spec_from_json(spec)
+        assert result.the_concept_code == "Invoice"
+
+    def test_alias_name(self) -> None:
+        spec = {**self._BASE, "name": "Invoice"}
+        result = _parse_concept_spec_from_json(spec)
+        assert result.the_concept_code == "Invoice"
+
+    def test_alias_concept_name(self) -> None:
+        spec = {**self._BASE, "concept_name": "Invoice"}
+        result = _parse_concept_spec_from_json(spec)
+        assert result.the_concept_code == "Invoice"
+
+    def test_canonical_ignores_alias(self) -> None:
+        """When the_concept_code is present, alias keys are left untouched (Pydantic rejects extra fields)."""
+        spec = {**self._BASE, "the_concept_code": "Canonical", "name": "Alias"}
+        with pytest.raises(PydanticValidationError, match="name"):
+            _parse_concept_spec_from_json(spec)
+
+
+class TestStructureFieldStringShorthand:
+    """A bare string in structure should be treated as a text field with that description."""
+
+    def test_string_field_becomes_text(self) -> None:
+        spec: dict[str, Any] = {
+            "the_concept_code": "Simple",
+            "description": "A simple concept",
+            "structure": {
+                "title": "The title of the item",
+            },
+        }
+        result = _parse_concept_spec_from_json(spec)
+        assert result.structure is not None
+        assert result.structure["title"].type == ConceptStructureSpecFieldType.TEXT
+        assert result.structure["title"].description == "The title of the item"
+
+    def test_mixed_string_and_dict_fields(self) -> None:
+        spec: dict[str, Any] = {
+            "the_concept_code": "Mixed",
+            "description": "A mixed concept",
+            "structure": {
+                "name": "The person's name",
+                "age": {"type": "integer", "description": "Age in years"},
+            },
+        }
+        result = _parse_concept_spec_from_json(spec)
+        assert result.structure is not None
+        assert result.structure["name"].type == ConceptStructureSpecFieldType.TEXT
+        assert result.structure["age"].type == ConceptStructureSpecFieldType.INTEGER
 
 
 class TestParseConceptSpecFromJson:

--- a/tests/unit/pipelex/cli/test_concept_cmd.py
+++ b/tests/unit/pipelex/cli/test_concept_cmd.py
@@ -5,9 +5,6 @@ from __future__ import annotations
 import json
 from typing import Any, ClassVar
 
-import pytest
-from pydantic import ValidationError as PydanticValidationError
-
 from pipelex.builder.concept.concept_spec import ConceptStructureSpec, ConceptStructureSpecFieldType
 from pipelex.cli.agent_cli.commands.concept_cmd import (
     _concept_spec_to_toml,  # noqa: PLC2701 # pyright: ignore[reportPrivateUsage]
@@ -163,10 +160,16 @@ class TestConceptCodeAliases:
         assert result.the_concept_code == "Invoice"
 
     def test_canonical_ignores_alias(self) -> None:
-        """When the_concept_code is present, alias keys are left untouched (Pydantic rejects extra fields)."""
+        """When the_concept_code is present, alias keys are removed so Pydantic doesn't reject them."""
         spec = {**self._BASE, "the_concept_code": "Canonical", "name": "Alias"}
-        with pytest.raises(PydanticValidationError, match="name"):
-            _parse_concept_spec_from_json(spec)
+        result = _parse_concept_spec_from_json(spec)
+        assert result.the_concept_code == "Canonical"
+
+    def test_multiple_aliases_all_cleaned_up(self) -> None:
+        """When the_concept_code and multiple aliases are present, all aliases are removed."""
+        spec = {**self._BASE, "concept_code": "Invoice", "name": "Alt", "code": "Alt2"}
+        result = _parse_concept_spec_from_json(spec)
+        assert result.the_concept_code == "Invoice"
 
 
 class TestStructureFieldStringShorthand:

--- a/tests/unit/pipelex/cli/test_pipe_cmd.py
+++ b/tests/unit/pipelex/cli/test_pipe_cmd.py
@@ -103,6 +103,21 @@ class TestResolveTalentValue:
         """PipeSearch has no reverse mapping; values pass through."""
         assert _resolve_talent_value("PipeSearch", "web-search") == "web-search"
 
+    def test_dict_value_passes_through(self) -> None:
+        """Non-string values (dict) should pass through without crashing."""
+        result = _resolve_talent_value("PipeLLM", {"name": "creative-writer"})
+        assert result == {"name": "creative-writer"}
+
+    def test_list_value_passes_through(self) -> None:
+        """Non-string values (list) should pass through without crashing."""
+        result = _resolve_talent_value("PipeLLM", ["creative-writer"])
+        assert result == ["creative-writer"]
+
+    def test_int_value_passes_through(self) -> None:
+        """Non-string values (int) should pass through without crashing."""
+        result = _resolve_talent_value("PipeLLM", 42)
+        assert result == 42
+
 
 # ---------------------------------------------------------------------------
 # _parse_pipe_spec_from_json — pipe_code aliases
@@ -141,10 +156,22 @@ class TestPipeCodeAliases:
         assert result.pipe_code == "my_pipe"
 
     def test_canonical_ignores_alias(self) -> None:
-        """When pipe_code is present, alias keys are left untouched (Pydantic rejects extra fields)."""
+        """When pipe_code is present, alias keys are removed so Pydantic doesn't reject them."""
         spec = {**self._BASE_LLM, "pipe_code": "canonical", "code": "alias"}
-        with pytest.raises(ValidationError, match="code"):
-            _parse_pipe_spec_from_json("PipeLLM", spec)
+        result = _parse_pipe_spec_from_json("PipeLLM", spec)
+        assert result.pipe_code == "canonical"
+
+    def test_multiple_aliases_all_cleaned_up(self) -> None:
+        """When pipe_code and multiple aliases are present, all aliases are removed."""
+        spec = {**self._BASE_LLM, "code": "my_pipe", "name": "alt"}
+        result = _parse_pipe_spec_from_json("PipeLLM", spec)
+        assert result.pipe_code == "my_pipe"
+
+    def test_three_aliases_all_cleaned_up(self) -> None:
+        """When pipe_code and all aliases are present, all aliases are removed."""
+        spec = {**self._BASE_LLM, "code": "my_pipe", "the_pipe_code": "alt", "name": "alt2"}
+        result = _parse_pipe_spec_from_json("PipeLLM", spec)
+        assert result.pipe_code == "my_pipe"
 
 
 # ---------------------------------------------------------------------------
@@ -174,10 +201,10 @@ class TestTalentFieldAliases:
         assert result.llm_talent == "engineer"  # type: ignore[attr-defined]
 
     def test_canonical_talent_field_ignores_alias(self) -> None:
-        """When llm_talent is present, generic alias is left untouched (Pydantic rejects extra fields)."""
+        """When llm_talent is present, generic alias is removed so Pydantic doesn't reject it."""
         spec = {**self._BASE, "llm_talent": "coder", "talent_name": "engineer"}
-        with pytest.raises(ValidationError, match="talent_name"):
-            _parse_pipe_spec_from_json("PipeLLM", spec)
+        result = _parse_pipe_spec_from_json("PipeLLM", spec)
+        assert result.llm_talent == "coder"  # type: ignore[attr-defined]
 
     def test_talent_alias_for_extract(self) -> None:
         spec = {

--- a/tests/unit/pipelex/cli/test_pipe_cmd.py
+++ b/tests/unit/pipelex/cli/test_pipe_cmd.py
@@ -1,0 +1,553 @@
+"""Unit tests for the agent CLI pipe command — non-nominal / tolerance cases."""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar
+
+import pytest
+from pydantic import ValidationError
+
+from pipelex.cli.agent_cli.commands.pipe_cmd import (
+    _MODEL_TO_EXTRACT_TALENT,  # noqa: PLC2701 # pyright: ignore[reportPrivateUsage]
+    _MODEL_TO_IMG_GEN_TALENT,  # noqa: PLC2701 # pyright: ignore[reportPrivateUsage]
+    _MODEL_TO_LLM_TALENT,  # noqa: PLC2701 # pyright: ignore[reportPrivateUsage]
+    LLM_TALENT_TO_MODEL,
+    _parse_pipe_spec_from_json,  # noqa: PLC2701 # pyright: ignore[reportPrivateUsage]
+    _pipe_spec_to_toml,  # noqa: PLC2701 # pyright: ignore[reportPrivateUsage]
+    _resolve_talent_value,  # noqa: PLC2701 # pyright: ignore[reportPrivateUsage]
+)
+
+# ---------------------------------------------------------------------------
+# Reverse talent mappings
+# ---------------------------------------------------------------------------
+
+
+class TestReverseTalentMappings:
+    """Verify the module-level reverse mappings are built correctly."""
+
+    def test_llm_preset_with_prefix(self) -> None:
+        assert _MODEL_TO_LLM_TALENT["$writing-creative"] == "creative-writer"
+
+    def test_llm_preset_without_prefix(self) -> None:
+        assert _MODEL_TO_LLM_TALENT["writing-creative"] == "creative-writer"
+
+    def test_llm_all_presets_have_reverse_entries(self) -> None:
+        for talent, preset in LLM_TALENT_TO_MODEL.items():
+            assert _MODEL_TO_LLM_TALENT[preset] == talent or _MODEL_TO_LLM_TALENT[preset] in LLM_TALENT_TO_MODEL
+            assert _MODEL_TO_LLM_TALENT[preset.lstrip("$@")] == talent or _MODEL_TO_LLM_TALENT[preset.lstrip("$@")] in LLM_TALENT_TO_MODEL
+
+    def test_img_gen_preset_with_prefix(self) -> None:
+        assert _MODEL_TO_IMG_GEN_TALENT["$gen-image"] == "gen-image"
+
+    def test_img_gen_preset_without_prefix(self) -> None:
+        assert _MODEL_TO_IMG_GEN_TALENT["gen-image"] == "gen-image"
+
+    def test_extract_preset_with_prefix(self) -> None:
+        assert _MODEL_TO_EXTRACT_TALENT["@default-text-from-pdf"] == "pdf-basic-text-extractor"
+
+    def test_extract_preset_without_prefix(self) -> None:
+        assert _MODEL_TO_EXTRACT_TALENT["default-text-from-pdf"] == "pdf-basic-text-extractor"
+
+
+# ---------------------------------------------------------------------------
+# _resolve_talent_value
+# ---------------------------------------------------------------------------
+
+
+class TestResolveTalentValue:
+    """Tests for the preset-to-talent resolution helper."""
+
+    # --- PipeLLM ---
+
+    def test_valid_talent_passes_through(self) -> None:
+        assert _resolve_talent_value("PipeLLM", "creative-writer") == "creative-writer"
+
+    def test_preset_without_prefix_resolves(self) -> None:
+        assert _resolve_talent_value("PipeLLM", "writing-creative") == "creative-writer"
+
+    def test_preset_with_dollar_prefix_resolves(self) -> None:
+        assert _resolve_talent_value("PipeLLM", "$writing-creative") == "creative-writer"
+
+    def test_invalid_talent_passes_through(self) -> None:
+        """Unknown values pass through so Pydantic can produce a clear error."""
+        assert _resolve_talent_value("PipeLLM", "totally-wrong") == "totally-wrong"
+
+    def test_engineering_code_resolves(self) -> None:
+        assert _resolve_talent_value("PipeLLM", "engineering-code") == "coder"
+
+    def test_retrieval_resolves(self) -> None:
+        assert _resolve_talent_value("PipeLLM", "retrieval") == "data-retrieval"
+
+    # --- PipeImgGen ---
+
+    def test_img_gen_preset_resolves(self) -> None:
+        assert _resolve_talent_value("PipeImgGen", "$gen-image-fast") == "gen-image-fast"
+
+    def test_img_gen_valid_talent_passes_through(self) -> None:
+        assert _resolve_talent_value("PipeImgGen", "gen-image-high-quality") == "gen-image-high-quality"
+
+    # --- PipeExtract ---
+
+    def test_extract_preset_resolves(self) -> None:
+        assert _resolve_talent_value("PipeExtract", "default-extract-document") == "full-document-extractor"
+
+    def test_extract_preset_with_at_resolves(self) -> None:
+        assert _resolve_talent_value("PipeExtract", "@default-extract-image") == "image-text-extractor"
+
+    # --- Unknown pipe types ---
+
+    def test_unknown_pipe_type_passes_through(self) -> None:
+        assert _resolve_talent_value("PipeCompose", "anything") == "anything"
+
+    def test_pipe_search_passes_through(self) -> None:
+        """PipeSearch has no reverse mapping; values pass through."""
+        assert _resolve_talent_value("PipeSearch", "web-search") == "web-search"
+
+
+# ---------------------------------------------------------------------------
+# _parse_pipe_spec_from_json — pipe_code aliases
+# ---------------------------------------------------------------------------
+
+
+class TestPipeCodeAliases:
+    """The parser should accept 'code', 'the_pipe_code', and 'name' as aliases for 'pipe_code'."""
+
+    _BASE_LLM: ClassVar[dict[str, Any]] = {
+        "description": "Test pipe",
+        "llm_talent": "creative-writer",
+        "inputs": {"text": "Text"},
+        "output": "Text",
+        "prompt": "Write something about @text",
+    }
+
+    def test_canonical_pipe_code(self) -> None:
+        spec = {**self._BASE_LLM, "pipe_code": "my_pipe"}
+        result = _parse_pipe_spec_from_json("PipeLLM", spec)
+        assert result.pipe_code == "my_pipe"
+
+    def test_alias_code(self) -> None:
+        spec = {**self._BASE_LLM, "code": "my_pipe"}
+        result = _parse_pipe_spec_from_json("PipeLLM", spec)
+        assert result.pipe_code == "my_pipe"
+
+    def test_alias_the_pipe_code(self) -> None:
+        spec = {**self._BASE_LLM, "the_pipe_code": "my_pipe"}
+        result = _parse_pipe_spec_from_json("PipeLLM", spec)
+        assert result.pipe_code == "my_pipe"
+
+    def test_alias_name(self) -> None:
+        spec = {**self._BASE_LLM, "name": "my_pipe"}
+        result = _parse_pipe_spec_from_json("PipeLLM", spec)
+        assert result.pipe_code == "my_pipe"
+
+    def test_canonical_ignores_alias(self) -> None:
+        """When pipe_code is present, alias keys are left untouched (Pydantic rejects extra fields)."""
+        spec = {**self._BASE_LLM, "pipe_code": "canonical", "code": "alias"}
+        with pytest.raises(ValidationError, match="code"):
+            _parse_pipe_spec_from_json("PipeLLM", spec)
+
+
+# ---------------------------------------------------------------------------
+# _parse_pipe_spec_from_json — talent field aliases
+# ---------------------------------------------------------------------------
+
+
+class TestTalentFieldAliases:
+    """The parser should accept 'talent_name' and 'talent' as generic talent aliases."""
+
+    _BASE: ClassVar[dict[str, Any]] = {
+        "pipe_code": "test_pipe",
+        "description": "Test pipe",
+        "inputs": {"text": "Text"},
+        "output": "Text",
+        "prompt": "Write about @text",
+    }
+
+    def test_talent_name_alias_for_llm(self) -> None:
+        spec = {**self._BASE, "talent_name": "creative-writer"}
+        result = _parse_pipe_spec_from_json("PipeLLM", spec)
+        assert result.llm_talent == "creative-writer"  # type: ignore[attr-defined]
+
+    def test_talent_alias_for_llm(self) -> None:
+        spec = {**self._BASE, "talent": "engineer"}
+        result = _parse_pipe_spec_from_json("PipeLLM", spec)
+        assert result.llm_talent == "engineer"  # type: ignore[attr-defined]
+
+    def test_canonical_talent_field_ignores_alias(self) -> None:
+        """When llm_talent is present, generic alias is left untouched (Pydantic rejects extra fields)."""
+        spec = {**self._BASE, "llm_talent": "coder", "talent_name": "engineer"}
+        with pytest.raises(ValidationError, match="talent_name"):
+            _parse_pipe_spec_from_json("PipeLLM", spec)
+
+    def test_talent_alias_for_extract(self) -> None:
+        spec = {
+            "pipe_code": "test_extract",
+            "description": "Extract pipe",
+            "inputs": {"doc": "Document"},
+            "output": "Page[]",
+            "talent_name": "full-document-extractor",
+        }
+        result = _parse_pipe_spec_from_json("PipeExtract", spec)
+        assert result.extract_talent == "full-document-extractor"  # type: ignore[attr-defined]
+
+    def test_talent_alias_for_img_gen(self) -> None:
+        spec = {
+            "pipe_code": "test_img_gen",
+            "description": "Image gen pipe",
+            "inputs": {"prompt_text": "ImgGenPrompt"},
+            "output": "Image",
+            "talent": "gen-image",
+            "prompt": "Generate: $prompt_text",
+        }
+        result = _parse_pipe_spec_from_json("PipeImgGen", spec)
+        assert result.img_gen_talent == "gen-image"  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# _parse_pipe_spec_from_json — preset-to-talent resolution
+# ---------------------------------------------------------------------------
+
+
+class TestPresetToTalentResolution:
+    """Preset names used where talent names are expected should be auto-resolved."""
+
+    _BASE_LLM: ClassVar[dict[str, Any]] = {
+        "pipe_code": "test_pipe",
+        "description": "Test pipe",
+        "inputs": {"text": "Text"},
+        "output": "Text",
+        "prompt": "Write about @text",
+    }
+
+    def test_preset_name_resolved_to_talent_for_llm(self) -> None:
+        spec = {**self._BASE_LLM, "llm_talent": "writing-creative"}
+        result = _parse_pipe_spec_from_json("PipeLLM", spec)
+        assert result.llm_talent == "creative-writer"  # type: ignore[attr-defined]
+
+    def test_preset_with_dollar_resolved_for_llm(self) -> None:
+        spec = {**self._BASE_LLM, "llm_talent": "$writing-creative"}
+        result = _parse_pipe_spec_from_json("PipeLLM", spec)
+        assert result.llm_talent == "creative-writer"  # type: ignore[attr-defined]
+
+    def test_valid_talent_unchanged_for_llm(self) -> None:
+        spec = {**self._BASE_LLM, "llm_talent": "creative-writer"}
+        result = _parse_pipe_spec_from_json("PipeLLM", spec)
+        assert result.llm_talent == "creative-writer"  # type: ignore[attr-defined]
+
+    def test_invalid_talent_raises_validation_error(self) -> None:
+        spec = {**self._BASE_LLM, "llm_talent": "totally-invalid"}
+        with pytest.raises(ValidationError):
+            _parse_pipe_spec_from_json("PipeLLM", spec)
+
+    def test_preset_via_generic_alias_also_resolved(self) -> None:
+        """talent_name alias + preset value should both be handled."""
+        spec = {**self._BASE_LLM, "talent_name": "engineering-code"}
+        result = _parse_pipe_spec_from_json("PipeLLM", spec)
+        assert result.llm_talent == "coder"  # type: ignore[attr-defined]
+
+    def test_extract_preset_resolved(self) -> None:
+        spec = {
+            "pipe_code": "test_extract",
+            "description": "Extract pipe",
+            "inputs": {"doc": "Document"},
+            "output": "Page[]",
+            "extract_talent": "default-text-from-pdf",
+        }
+        result = _parse_pipe_spec_from_json("PipeExtract", spec)
+        assert result.extract_talent == "pdf-basic-text-extractor"  # type: ignore[attr-defined]
+
+    def test_img_gen_preset_resolved(self) -> None:
+        spec = {
+            "pipe_code": "test_img_gen",
+            "description": "Image gen pipe",
+            "inputs": {"prompt_text": "ImgGenPrompt"},
+            "output": "Image",
+            "img_gen_talent": "$gen-image-high-quality",
+            "prompt": "Generate: $prompt_text",
+        }
+        result = _parse_pipe_spec_from_json("PipeImgGen", spec)
+        assert result.img_gen_talent == "gen-image-high-quality"  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# _parse_pipe_spec_from_json — output dict tolerance
+# ---------------------------------------------------------------------------
+
+
+class TestOutputDictTolerance:
+    """The parser should accept output as {"type": "ConceptName"} and extract the string."""
+
+    _BASE_LLM: ClassVar[dict[str, Any]] = {
+        "pipe_code": "test_pipe",
+        "description": "Test pipe",
+        "llm_talent": "creative-writer",
+        "inputs": {"text": "Text"},
+        "prompt": "Write about @text",
+    }
+
+    def test_output_as_string(self) -> None:
+        spec = {**self._BASE_LLM, "output": "ImgGenPrompt"}
+        result = _parse_pipe_spec_from_json("PipeLLM", spec)
+        assert result.output == "ImgGenPrompt"
+
+    def test_output_as_dict_with_type_key(self) -> None:
+        spec = {**self._BASE_LLM, "output": {"type": "ImgGenPrompt"}}
+        result = _parse_pipe_spec_from_json("PipeLLM", spec)
+        assert result.output == "ImgGenPrompt"
+
+    def test_output_dict_without_type_key_passes_through(self) -> None:
+        """If the dict has no 'type' key, let Pydantic handle the error."""
+        spec = {**self._BASE_LLM, "output": {"name": "ImgGenPrompt"}}
+        with pytest.raises(ValidationError):
+            _parse_pipe_spec_from_json("PipeLLM", spec)
+
+
+# ---------------------------------------------------------------------------
+# _parse_pipe_spec_from_json — steps/branches 'pipe' → 'pipe_code' alias
+# ---------------------------------------------------------------------------
+
+
+class TestStepsBranchesAlias:
+    """Steps and branches should accept 'pipe' as an alias for 'pipe_code'."""
+
+    def test_sequence_steps_pipe_alias(self) -> None:
+        spec: dict[str, Any] = {
+            "pipe_code": "my_seq",
+            "description": "A sequence",
+            "inputs": {"doc": "Document"},
+            "output": "Text",
+            "steps": [
+                {"pipe": "step_one", "result": "intermediate"},
+                {"pipe": "step_two", "result": "final"},
+            ],
+        }
+        result = _parse_pipe_spec_from_json("PipeSequence", spec)
+        assert result.steps[0].pipe_code == "step_one"  # type: ignore[attr-defined]
+        assert result.steps[1].pipe_code == "step_two"  # type: ignore[attr-defined]
+
+    def test_sequence_steps_pipe_code_canonical(self) -> None:
+        spec: dict[str, Any] = {
+            "pipe_code": "my_seq",
+            "description": "A sequence",
+            "inputs": {"doc": "Document"},
+            "output": "Text",
+            "steps": [
+                {"pipe_code": "step_one", "result": "intermediate"},
+            ],
+        }
+        result = _parse_pipe_spec_from_json("PipeSequence", spec)
+        assert result.steps[0].pipe_code == "step_one"  # type: ignore[attr-defined]
+
+    def test_parallel_branches_pipe_alias(self) -> None:
+        spec: dict[str, Any] = {
+            "pipe_code": "my_parallel",
+            "description": "Parallel branches",
+            "inputs": {"doc": "Document"},
+            "output": "Text",
+            "add_each_output": True,
+            "branches": [
+                {"pipe": "branch_a", "result": "result_a"},
+                {"pipe": "branch_b", "result": "result_b"},
+            ],
+        }
+        result = _parse_pipe_spec_from_json("PipeParallel", spec)
+        assert result.branches[0].pipe_code == "branch_a"  # type: ignore[attr-defined]
+        assert result.branches[1].pipe_code == "branch_b"  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# _parse_pipe_spec_from_json — PipeCondition expression alias
+# ---------------------------------------------------------------------------
+
+
+class TestConditionExpressionAlias:
+    """PipeCondition should accept 'expression' as alias for 'jinja2_expression_template'."""
+
+    def test_expression_alias(self) -> None:
+        spec: dict[str, Any] = {
+            "pipe_code": "my_condition",
+            "description": "Route by status",
+            "inputs": {"status": "Text"},
+            "output": "Text",
+            "expression": "{{ status }}",
+            "outcomes": {"high": "handle_high", "low": "handle_low"},
+            "default_outcome": "handle_default",
+        }
+        result = _parse_pipe_spec_from_json("PipeCondition", spec)
+        assert result.jinja2_expression_template == "{{ status }}"  # type: ignore[attr-defined]
+
+    def test_canonical_expression_field(self) -> None:
+        spec: dict[str, Any] = {
+            "pipe_code": "my_condition",
+            "description": "Route by status",
+            "inputs": {"status": "Text"},
+            "output": "Text",
+            "jinja2_expression_template": "{{ status }}",
+            "outcomes": {"high": "handle_high", "low": "handle_low"},
+            "default_outcome": "handle_default",
+        }
+        result = _parse_pipe_spec_from_json("PipeCondition", spec)
+        assert result.jinja2_expression_template == "{{ status }}"  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# _parse_pipe_spec_from_json — pipe_type alias in JSON
+# ---------------------------------------------------------------------------
+
+
+class TestPipeTypeAlias:
+    """'pipe_type' in spec JSON should be accepted as alias for 'type'."""
+
+    def test_type_extracted_from_spec(self) -> None:
+        """When type is in the spec dict it should be used (and popped)."""
+        spec: dict[str, Any] = {
+            "type": "PipeLLM",
+            "pipe_code": "test",
+            "description": "Test",
+            "llm_talent": "creative-writer",
+            "inputs": {"text": "Text"},
+            "output": "Text",
+            "prompt": "Write about @text",
+        }
+        # Simulate what pipe_cmd does: pop 'type' and pass it as pipe_type
+        pipe_type = spec.pop("type")
+        result = _parse_pipe_spec_from_json(pipe_type, spec)
+        assert result.pipe_code == "test"
+
+
+# ---------------------------------------------------------------------------
+# _parse_pipe_spec_from_json — invalid pipe type
+# ---------------------------------------------------------------------------
+
+
+class TestInvalidPipeType:
+    """Invalid pipe types should raise ValueError."""
+
+    def test_invalid_pipe_type(self) -> None:
+        with pytest.raises(ValueError, match="Invalid pipe type"):
+            _parse_pipe_spec_from_json("PipeNonExistent", {"pipe_code": "x", "description": "x"})
+
+
+# ---------------------------------------------------------------------------
+# _pipe_spec_to_toml — talent-to-model in TOML output
+# ---------------------------------------------------------------------------
+
+
+class TestPipeSpecToToml:
+    """Verify TOML output maps talents to model presets correctly."""
+
+    _BASE_LLM: ClassVar[dict[str, Any]] = {
+        "pipe_code": "my_llm_pipe",
+        "description": "Test LLM pipe",
+        "llm_talent": "creative-writer",
+        "inputs": {"text": "Text"},
+        "output": "Text",
+        "prompt": "Write about @text",
+    }
+
+    def test_llm_talent_becomes_model_preset_in_toml(self) -> None:
+        spec = _parse_pipe_spec_from_json("PipeLLM", {**self._BASE_LLM})
+        toml = _pipe_spec_to_toml(spec)
+        assert 'model = "$writing-creative"' in toml
+
+    def test_llm_preset_input_still_maps_to_correct_model(self) -> None:
+        """If the agent provides a preset name, it should resolve and then map to model."""
+        spec = _parse_pipe_spec_from_json("PipeLLM", {**self._BASE_LLM, "llm_talent": "engineering-structured"})
+        toml = _pipe_spec_to_toml(spec)
+        assert 'model = "$engineering-structured"' in toml
+
+    def test_extract_talent_becomes_model_in_toml(self) -> None:
+        spec = _parse_pipe_spec_from_json(
+            "PipeExtract",
+            {
+                "pipe_code": "my_extract",
+                "description": "Extract pipe",
+                "inputs": {"doc": "Document"},
+                "output": "Page[]",
+                "extract_talent": "full-document-extractor",
+            },
+        )
+        toml = _pipe_spec_to_toml(spec)
+        assert 'model = "@default-extract-document"' in toml
+
+    def test_img_gen_talent_becomes_model_in_toml(self) -> None:
+        spec = _parse_pipe_spec_from_json(
+            "PipeImgGen",
+            {
+                "pipe_code": "my_img_gen",
+                "description": "Image gen pipe",
+                "inputs": {"prompt_text": "ImgGenPrompt"},
+                "output": "Image",
+                "img_gen_talent": "gen-image",
+                "prompt": "Generate: $prompt_text",
+            },
+        )
+        toml = _pipe_spec_to_toml(spec)
+        assert 'model = "$gen-image"' in toml
+
+    def test_toml_contains_pipe_section(self) -> None:
+        spec = _parse_pipe_spec_from_json("PipeLLM", {**self._BASE_LLM})
+        toml = _pipe_spec_to_toml(spec)
+        assert "[pipe.my_llm_pipe]" in toml
+        assert 'type = "PipeLLM"' in toml
+
+    def test_toml_contains_prompt(self) -> None:
+        spec = _parse_pipe_spec_from_json("PipeLLM", {**self._BASE_LLM})
+        toml = _pipe_spec_to_toml(spec)
+        assert 'prompt = "Write about @text"' in toml
+
+    def test_sequence_toml_has_steps(self) -> None:
+        spec = _parse_pipe_spec_from_json(
+            "PipeSequence",
+            {
+                "pipe_code": "my_seq",
+                "description": "A sequence",
+                "inputs": {"doc": "Document"},
+                "output": "Text",
+                "steps": [
+                    {"pipe": "step_one", "result": "intermediate"},
+                    {"pipe": "step_two", "result": "final"},
+                ],
+            },
+        )
+        toml = _pipe_spec_to_toml(spec)
+        assert "step_one" in toml
+        assert "step_two" in toml
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: combined tolerance scenarios (the original bug)
+# ---------------------------------------------------------------------------
+
+
+class TestEndToEndTolerance:
+    """Reproduce the exact bug scenario that motivated these changes."""
+
+    def test_original_bug_preset_as_talent_with_dict_output(self) -> None:
+        """The agent sent 'writing-creative' (preset) and output as dict — both should be tolerated."""
+        spec: dict[str, Any] = {
+            "pipe_code": "generate_prompt",
+            "description": "Generate an image prompt from an idea",
+            "llm_talent": "writing-creative",
+            "inputs": {"idea": "Text"},
+            "output": {"type": "ImgGenPrompt"},
+            "prompt": "Generate a creative image prompt based on @idea",
+        }
+        result = _parse_pipe_spec_from_json("PipeLLM", spec)
+        assert result.llm_talent == "creative-writer"  # type: ignore[attr-defined]
+        assert result.output == "ImgGenPrompt"
+
+    def test_original_bug_toml_output_has_correct_model(self) -> None:
+        """After resolution, the TOML should contain the correct model preset."""
+        spec: dict[str, Any] = {
+            "pipe_code": "generate_prompt",
+            "description": "Generate an image prompt from an idea",
+            "llm_talent": "writing-creative",
+            "inputs": {"idea": "Text"},
+            "output": {"type": "ImgGenPrompt"},
+            "prompt": "Generate a creative image prompt based on @idea",
+        }
+        result = _parse_pipe_spec_from_json("PipeLLM", spec)
+        toml = _pipe_spec_to_toml(result)
+        assert 'model = "$writing-creative"' in toml
+        assert 'output = "ImgGenPrompt"' in toml

--- a/tests/unit/pipelex/graph/test_graph_rendering.py
+++ b/tests/unit/pipelex/graph/test_graph_rendering.py
@@ -1,0 +1,31 @@
+"""Unit tests for graph rendering helpers."""
+
+from __future__ import annotations
+
+from pipelex.graph.graph_rendering import (
+    _sanitize_graph_name,  # noqa: PLC2701 # pyright: ignore[reportPrivateUsage]
+)
+
+
+class TestSanitizeGraphName:
+    """Tests for the _sanitize_graph_name helper that prevents path traversal."""
+
+    def test_plain_filename(self) -> None:
+        """A plain filename should pass through unchanged."""
+        assert _sanitize_graph_name("dry_run.html") == "dry_run.html"
+
+    def test_traversal_stripped(self) -> None:
+        """Directory traversal components should be stripped."""
+        assert _sanitize_graph_name("../../etc/passwd") == "passwd"
+
+    def test_absolute_path_stripped(self) -> None:
+        """Absolute paths should be reduced to just the filename."""
+        assert _sanitize_graph_name("/var/data/evil.html") == "evil.html"
+
+    def test_subdirectory_stripped(self) -> None:
+        """Subdirectory paths should be reduced to just the filename."""
+        assert _sanitize_graph_name("subdir/graph.html") == "graph.html"
+
+    def test_empty_string_returns_default(self) -> None:
+        """An empty string should return the default filename."""
+        assert _sanitize_graph_name("") == "graph.html"


### PR DESCRIPTION
## Summary
- Add `graph_name` parameter to `generate_graph_for_bundle` for custom HTML graph filenames
- Improve agent CLI tolerance: accept common aliases for pipe_code, concept_code, talent fields, and output format
- Auto-resolve preset names to talent names (e.g. `writing-creative` → `creative-writer`) to handle common agent mistakes
- Add `populate_by_name` to `PipeComposeSpec` and `extra="forbid"` to `PipeSpec`
- Add comprehensive unit tests for all pipe_cmd tolerance cases

## Test plan
- [x] Unit tests added for reverse talent mappings, talent resolution, pipe_code aliases, talent field aliases, preset-to-talent resolution, output dict tolerance, steps/branches aliases, condition expression alias, pipe_type alias, TOML output, and end-to-end tolerance scenarios
- [x] Existing concept_cmd tests extended with alias and string shorthand tests
- [ ] Run `make agent-check` and `make agent-test` to verify all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it tightens Pydantic validation (`extra="forbid"`) on `PipeSpec` and changes agent-side spec parsing/normalization, which could reject previously-accepted inputs or subtly alter generated TOML. Graph output renaming also changes filesystem behavior (potential overwrites) but is mitigated by path sanitization.
> 
> **Overview**
> **Graph generation:** `generate_graph_for_bundle` now accepts `graph_name` and renames the produced ReactFlow HTML to that (sanitized) filename via a new `_sanitize_graph_name` helper to prevent path traversal.
> 
> **Agent CLI tolerance:** The `pipe` and `concept` agent commands now accept multiple common aliases for codes and talent fields, tolerate `output` being provided as `{ "type": ... }`, and auto-resolve model preset names back to canonical talent names before Pydantic validation.
> 
> **Validation/config hardening:** `PipeSpec` now forbids unknown fields (`extra="forbid"`), and `PipeComposeSpec` enables `populate_by_name=True`. Comprehensive unit tests were added/extended to cover the new tolerance and sanitization behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 376e4b5f6d2f903c50ab49f00e6bafbd12004d0f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->