### PR TITLE
Add needs_model_specs=True to agent CLI run and models commands

### DIFF
--- a/pipelex/cli/agent_cli/commands/models_cmd.py
+++ b/pipelex/cli/agent_cli/commands/models_cmd.py
@@ -240,7 +240,7 @@ def agent_models_cmd(
     that an agent needs to reference when building pipelines.
     """
     try:
-        make_pipelex_for_agent_cli(log_level=ctx.obj["log_level"], needs_inference=False)
+        make_pipelex_for_agent_cli(log_level=ctx.obj["log_level"], needs_inference=False, needs_model_specs=True)
 
         model_deck = get_model_deck()
         builder_config = get_config().pipelex.builder_config

--- a/pipelex/cli/agent_cli/commands/run/bundle_cmd.py
+++ b/pipelex/cli/agent_cli/commands/run/bundle_cmd.py
@@ -173,7 +173,7 @@ def run_bundle_cmd(
                 agent_error(str(exc), type(exc).__name__, cause=exc)
 
         case RunnerType.PIPELEX:
-            make_pipelex_for_agent_cli(log_level=ctx.obj["log_level"], needs_inference=not dry_run)
+            make_pipelex_for_agent_cli(log_level=ctx.obj["log_level"], needs_inference=not dry_run, needs_model_specs=True)
 
             try:
                 result = asyncio.run(

--- a/pipelex/cli/agent_cli/commands/run/method_cmd.py
+++ b/pipelex/cli/agent_cli/commands/run/method_cmd.py
@@ -130,7 +130,7 @@ def run_method_cmd(
                 agent_error(str(exc), type(exc).__name__, cause=exc)
 
         case RunnerType.PIPELEX:
-            make_pipelex_for_agent_cli(log_level=ctx.obj["log_level"], needs_inference=not dry_run)
+            make_pipelex_for_agent_cli(log_level=ctx.obj["log_level"], needs_inference=not dry_run, needs_model_specs=True)
 
             try:
                 result = asyncio.run(

--- a/pipelex/cli/agent_cli/commands/run/pipe_cmd.py
+++ b/pipelex/cli/agent_cli/commands/run/pipe_cmd.py
@@ -128,7 +128,7 @@ def run_pipe_cmd(
                 agent_error(str(exc), type(exc).__name__, cause=exc)
 
         case RunnerType.PIPELEX:
-            make_pipelex_for_agent_cli(log_level=ctx.obj["log_level"], needs_inference=not dry_run)
+            make_pipelex_for_agent_cli(log_level=ctx.obj["log_level"], needs_inference=not dry_run, needs_model_specs=True)
 
             try:
                 result = asyncio.run(


### PR DESCRIPTION
## Summary
- Adds `needs_model_specs=True` to `make_pipelex_for_agent_cli()` calls in the agent CLI `models`, `bundle`, `method`, and `pipe` commands
- Ensures model specification data is properly loaded for these commands which require it

## Test plan
- [ ] Run `pipelex-agent models` and verify model specs are loaded
- [ ] Run `pipelex-agent run pipe`, `run method`, `run bundle` commands and verify they work correctly with model specs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts agent CLI initialization flags to ensure model specs are loaded; behavior change is limited to startup/config loading for these commands.
> 
> **Overview**
> Ensures the agent CLI loads real model specification data by passing `needs_model_specs=True` into `make_pipelex_for_agent_cli()` for `models` and the Pipelex runner paths of `run pipe`, `run method`, and `run bundle`.
> 
> This makes model-backed filtering/validation consistent even when running with `--dry-run` or when inference setup is otherwise skipped.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2be0a6fd1229b1247a6cd77a9d6da2f160650937. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->