### PR TITLE
Release v0.20.8

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -16,7 +16,7 @@ This skill handles the full release cycle for the `pipelex` Python package.
 ## Files touched
 
 - **`pyproject.toml`** — the `version` field (line 3)
-- **`CHANGELOG.md`** — promote `[Unreleased]` to `[vX.Y.Z] - YYYY-MM-DD`
+- **`CHANGELOG.md`** — add `[vX.Y.Z] - YYYY-MM-DD` entry (remove `[Unreleased]` if present)
 - **`uv.lock`** — regenerated via `make li` (lock + install)
 - **`.badges/tests.json`** — test count updated to match actual count
 
@@ -46,28 +46,29 @@ failure.
 
 ### 4. Finalize the changelog
 
-The `CHANGELOG.md` has an `## [Unreleased]` section at the top with pending
-changes.
+Add a new version entry at the top of the changelog for the release.
 
-1. If the `[Unreleased]` section is **empty** (no bullet points), warn the user
-   and ask whether to proceed with an empty changelog entry or abort so they can
-   add notes first.
-2. If the `[Unreleased]` section has content:
-   - Rename `## [Unreleased]` to `## [vX.Y.Z] - YYYY-MM-DD` (using today's
-     date).
-   - Insert a fresh empty `## [Unreleased]` section above the new version
-     heading, with a blank line separating them.
-3. The result should look like:
+1. If there is an `## [Unreleased]` section, **remove it** (including any blank
+   lines that follow it) and replace it with the new version heading. Any
+   content that was under `[Unreleased]` becomes the content of the new version.
+2. If there is no `[Unreleased]` section, insert the new version heading
+   directly after the `# Changelog` title.
+3. **Never add an `[Unreleased]` heading.** The changelog should only contain
+   concrete version entries.
+4. If the release has no changelog content yet, ask the user what to include
+   before proceeding.
+5. The result should look like:
 
 ```markdown
 # Changelog
-
-## [Unreleased]
 
 ## [vX.Y.Z] - YYYY-MM-DD
 
 ### Changed
 - ...
+
+## [vPREVIOUS] - PREVIOUS-DATE
+...
 ```
 
 ### 5. Bump the version in pyproject.toml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [v0.20.8] - 2026-03-13
+
+- Add `needs_model_specs=True` to agent CLI run and models commands.
+
 ## [v0.20.7] - 2026-03-12
 
 - Bump `mthds` dependency to `>=0.1.1`.

--- a/pipelex/cli/agent_cli/commands/models_cmd.py
+++ b/pipelex/cli/agent_cli/commands/models_cmd.py
@@ -240,7 +240,7 @@ def agent_models_cmd(
     that an agent needs to reference when building pipelines.
     """
     try:
-        make_pipelex_for_agent_cli(log_level=ctx.obj["log_level"], needs_inference=False, needs_model_specs=True)
+        make_pipelex_for_agent_cli(log_level=ctx.obj["log_level"], needs_inference=False, needs_model_specs=backend is not None)
 
         model_deck = get_model_deck()
         builder_config = get_config().pipelex.builder_config

--- a/pipelex/cli/agent_cli/commands/models_cmd.py
+++ b/pipelex/cli/agent_cli/commands/models_cmd.py
@@ -240,7 +240,7 @@ def agent_models_cmd(
     that an agent needs to reference when building pipelines.
     """
     try:
-        make_pipelex_for_agent_cli(log_level=ctx.obj["log_level"], needs_inference=False)
+        make_pipelex_for_agent_cli(log_level=ctx.obj["log_level"], needs_inference=False, needs_model_specs=True)
 
         model_deck = get_model_deck()
         builder_config = get_config().pipelex.builder_config

--- a/pipelex/cli/agent_cli/commands/run/bundle_cmd.py
+++ b/pipelex/cli/agent_cli/commands/run/bundle_cmd.py
@@ -173,7 +173,7 @@ def run_bundle_cmd(
                 agent_error(str(exc), type(exc).__name__, cause=exc)
 
         case RunnerType.PIPELEX:
-            make_pipelex_for_agent_cli(log_level=ctx.obj["log_level"], needs_inference=not dry_run)
+            make_pipelex_for_agent_cli(log_level=ctx.obj["log_level"], needs_inference=not dry_run, needs_model_specs=True)
 
             try:
                 result = asyncio.run(

--- a/pipelex/cli/agent_cli/commands/run/method_cmd.py
+++ b/pipelex/cli/agent_cli/commands/run/method_cmd.py
@@ -130,7 +130,7 @@ def run_method_cmd(
                 agent_error(str(exc), type(exc).__name__, cause=exc)
 
         case RunnerType.PIPELEX:
-            make_pipelex_for_agent_cli(log_level=ctx.obj["log_level"], needs_inference=not dry_run)
+            make_pipelex_for_agent_cli(log_level=ctx.obj["log_level"], needs_inference=not dry_run, needs_model_specs=True)
 
             try:
                 result = asyncio.run(

--- a/pipelex/cli/agent_cli/commands/run/pipe_cmd.py
+++ b/pipelex/cli/agent_cli/commands/run/pipe_cmd.py
@@ -128,7 +128,7 @@ def run_pipe_cmd(
                 agent_error(str(exc), type(exc).__name__, cause=exc)
 
         case RunnerType.PIPELEX:
-            make_pipelex_for_agent_cli(log_level=ctx.obj["log_level"], needs_inference=not dry_run)
+            make_pipelex_for_agent_cli(log_level=ctx.obj["log_level"], needs_inference=not dry_run, needs_model_specs=True)
 
             try:
                 result = asyncio.run(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pipelex"
-version = "0.20.7"
+version = "0.20.8"
 description = "Execute composable AI methods declared in the MTHDS open standard"
 authors = [{ name = "Evotis S.A.S.", email = "oss@pipelex.com" }]
 maintainers = [{ name = "Pipelex staff", email = "oss@pipelex.com" }]

--- a/uv.lock
+++ b/uv.lock
@@ -2989,9 +2989,9 @@ name = "ocrmac"
 version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
-    { name = "pillow" },
-    { name = "pyobjc-framework-vision" },
+    { name = "click", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "pillow", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "pyobjc-framework-vision", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5e/07/3e15ab404f75875c5e48c47163300eb90b7409044d8711fc3aaf52503f2e/ocrmac-1.0.1.tar.gz", hash = "sha256:507fe5e4cbd67b2d03f6729a52bbc11f9d0b58241134eb958a5daafd4b9d93d9", size = 1454317, upload-time = "2026-01-08T16:44:26.412Z" }
 wheels = [
@@ -3408,7 +3408,7 @@ wheels = [
 
 [[package]]
 name = "pipelex"
-version = "0.20.7"
+version = "0.20.8"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },
@@ -4134,7 +4134,7 @@ name = "pyobjc-framework-cocoa"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
+    { name = "pyobjc-core", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/02/a3/16ca9a15e77c061a9250afbae2eae26f2e1579eb8ca9462ae2d2c71e1169/pyobjc_framework_cocoa-12.1.tar.gz", hash = "sha256:5556c87db95711b985d5efdaaf01c917ddd41d148b1e52a0c66b1a2e2c5c1640", size = 2772191, upload-time = "2025-11-14T10:13:02.069Z" }
 wheels = [
@@ -4152,8 +4152,8 @@ name = "pyobjc-framework-coreml"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
-    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-core", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "pyobjc-framework-cocoa", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/30/2d/baa9ea02cbb1c200683cb7273b69b4bee5070e86f2060b77e6a27c2a9d7e/pyobjc_framework_coreml-12.1.tar.gz", hash = "sha256:0d1a4216891a18775c9e0170d908714c18e4f53f9dc79fb0f5263b2aa81609ba", size = 40465, upload-time = "2025-11-14T10:14:02.265Z" }
 wheels = [
@@ -4171,8 +4171,8 @@ name = "pyobjc-framework-quartz"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
-    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-core", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "pyobjc-framework-cocoa", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/94/18/cc59f3d4355c9456fc945eae7fe8797003c4da99212dd531ad1b0de8a0c6/pyobjc_framework_quartz-12.1.tar.gz", hash = "sha256:27f782f3513ac88ec9b6c82d9767eef95a5cf4175ce88a1e5a65875fee799608", size = 3159099, upload-time = "2025-11-14T10:21:24.31Z" }
 wheels = [
@@ -4190,10 +4190,10 @@ name = "pyobjc-framework-vision"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
-    { name = "pyobjc-framework-cocoa" },
-    { name = "pyobjc-framework-coreml" },
-    { name = "pyobjc-framework-quartz" },
+    { name = "pyobjc-core", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "pyobjc-framework-cocoa", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "pyobjc-framework-coreml", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "pyobjc-framework-quartz", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c2/5a/08bb3e278f870443d226c141af14205ff41c0274da1e053b72b11dfc9fb2/pyobjc_framework_vision-12.1.tar.gz", hash = "sha256:a30959100e85dcede3a786c544e621ad6eb65ff6abf85721f805822b8c5fe9b0", size = 59538, upload-time = "2025-11-14T10:23:21.979Z" }
 wheels = [


### PR DESCRIPTION
## Release v0.20.8

Bumps version from `0.20.7` to `0.20.8`.

### Changelog

- Add `needs_model_specs=True` to agent CLI run and models commands.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: tweaks agent CLI initialization flags to force or conditionally fetch model specs, which could change runtime behavior and trigger additional remote config/model lookups during `pipelex-agent` commands.
> 
> **Overview**
> **Cuts release `v0.20.8`** by bumping `pyproject.toml`/`uv.lock` versions and adding a `v0.20.8` entry to `CHANGELOG.md`.
> 
> **Agent CLI behavior change:** `pipelex-agent` `run` commands now initialize Pipelex with `needs_model_specs=True`, and `models --backend` conditionally enables `needs_model_specs` so backend-filtering can resolve real model specs even when `needs_inference=False`.
> 
> Updates the internal release skill doc to remove the `[Unreleased]` changelog workflow (version entries only), and regenerates `uv.lock` (notably adding platform markers to some deps).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2bd34cc2fcd39a749668a161b33870f4278fc7c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->