### PR TITLE
Release v0.20.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v0.20.11] - 2026-03-16
+
+### Fixed
+
+- Fix `docs-deploy-root` silently failing due to shell comments breaking the `\` continuation chain in the Makefile recipe — root `sitemap.xml` and updated `robots.txt` were never deployed in v0.20.10.
+
 ## [v0.20.10] - 2026-03-16
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -878,6 +878,15 @@ docs-deploy-specific-version-pre-release: env
 	$(VENV_MIKE) deploy --push --update-aliases $(DOCS_VERSION) pre-release
 	$(MAKE) docs-deploy-root
 
+# Deploy root assets (404.html, robots.txt, index.html, sitemap.xml) to gh-pages.
+# The root sitemap is generated from latest/sitemap.xml (not $(DOCS_VERSION)/) so
+# that pre-release deploys don't overwrite it with pages not served at /latest/.
+# Mike does NOT rewrite sitemap URLs for aliases — latest/sitemap.xml contains
+# versioned URLs like /0.20.9/page/, identical to the version directory. The sed
+# rewrites any semver path segment (including pre-release suffixes like -rc1) to /latest/.
+# WARNING: Do NOT insert comments inside the shell continuation chain below.
+# Lines starting with # after a \ continuation become shell comments that silently
+# truncate the command.
 docs-deploy-root:
 ifeq ($(SITE_DOMAIN),)
 	$(error SITE_DOMAIN is empty — docs/CNAME is missing or blank. Cannot generate root assets with valid URLs)
@@ -890,12 +899,6 @@ endif
 	cp docs/404.html "$$TMPDIR/404.html" && \
 	echo "$$ROOT_ROBOTS_TXT" > "$$TMPDIR/robots.txt" && \
 	echo "$$ROOT_INDEX_HTML" > "$$TMPDIR/index.html" && \
-# Generate root sitemap with /latest/ URLs.
-# Source from latest/ (not $(DOCS_VERSION)/) so that pre-release deploys don't
-# overwrite the root sitemap with pages that aren't served at /latest/.
-# Mike does NOT rewrite sitemap URLs for aliases — latest/sitemap.xml contains
-# versioned URLs like /0.20.9/page/, identical to the version directory. The sed
-# rewrites any semver path segment (including pre-release suffixes like -rc1) to /latest/.
 	sed 's|/[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*[^/]*/|/latest/|g' "$$TMPDIR/latest/sitemap.xml" > "$$TMPDIR/sitemap.xml" && \
 	cd "$$TMPDIR" && \
 	git add 404.html robots.txt index.html sitemap.xml && \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pipelex"
-version = "0.20.10"
+version = "0.20.11"
 description = "Execute composable AI methods declared in the MTHDS open standard"
 authors = [{ name = "Evotis S.A.S.", email = "oss@pipelex.com" }]
 maintainers = [{ name = "Pipelex staff", email = "oss@pipelex.com" }]

--- a/uv.lock
+++ b/uv.lock
@@ -3420,7 +3420,7 @@ wheels = [
 
 [[package]]
 name = "pipelex"
-version = "0.20.10"
+version = "0.20.11"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Release v0.20.11

Bumps version from `0.20.10` to `0.20.11`.

### Changelog

### Fixed

- Fix `docs-deploy-root` silently failing due to shell comments breaking the `\` continuation chain in the Makefile recipe — root `sitemap.xml` and updated `robots.txt` were never deployed in v0.20.10.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Patch release v0.20.11 fixes `docs-deploy-root` in the Makefile so root assets deploy to `gh-pages` again; shell comments no longer break the backslash continuation, so `sitemap.xml` and `robots.txt` publish correctly. Bumps `pipelex` to 0.20.11.

<sup>Written for commit d29cc5470105d59cc918063fce28de4f0759e95a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

