### PR TITLE
Add dotted-path batch_over support with e2e and integration tests

### DIFF
--- a/pipelex/pipe_controllers/parallel/pipe_parallel.py
+++ b/pipelex/pipe_controllers/parallel/pipe_parallel.py
@@ -22,6 +22,7 @@ from pipelex.pipe_controllers.sub_pipe import SubPipe
 from pipelex.pipe_run.exceptions import PipeRunError
 from pipelex.pipe_run.pipe_run_params import PipeRunParams
 from pipelex.pipeline.job_metadata import JobMetadata
+from pipelex.tools.misc.string_utils import get_root_from_dotted_path
 from pipelex.types import Self
 
 if TYPE_CHECKING:
@@ -86,8 +87,9 @@ class PipeParallel(PipeController):
                         f"in this Parallel Pipe '{self.code}' input requirements: {pipe_needed_inputs}"
                     )
                     raise PipeValidationError(message=msg) from exc
+                input_list_root = get_root_from_dotted_path(sub_pipe.batch_params.input_list_stuff_name)
                 needed_inputs.add_stuff_spec(
-                    variable_name=sub_pipe.batch_params.input_list_stuff_name,
+                    variable_name=input_list_root,
                     concept=stuff_spec.concept,
                     multiplicity=True,
                 )

--- a/pipelex/pipe_controllers/sequence/pipe_sequence.py
+++ b/pipelex/pipe_controllers/sequence/pipe_sequence.py
@@ -147,10 +147,11 @@ class PipeSequence(PipeController):
                             f"in this PipeSequence '{self.code}' input requirements: {sub_pipe_needed_inputs.format_for_display()}"
                         )
                         raise PipeSequenceValueError(msg) from exc
+                    is_dotted_path = "." in sequential_sub_pipe.batch_params.input_list_stuff_name
                     needed_inputs.add_stuff_spec(
                         variable_name=input_list_root,
                         concept=stuff_spec.concept,
-                        multiplicity=True,
+                        multiplicity=True if not is_dotted_path else None,
                     )
                     for input_name, stuff_spec in sub_pipe_needed_inputs.items:
                         if input_name != sequential_sub_pipe.batch_params.input_item_stuff_name and input_name not in generated_outputs:

--- a/pipelex/pipe_controllers/sequence/pipe_sequence.py
+++ b/pipelex/pipe_controllers/sequence/pipe_sequence.py
@@ -18,6 +18,7 @@ from pipelex.pipe_controllers.sequence.exceptions import PipeSequenceValueError
 from pipelex.pipe_controllers.sub_pipe import SubPipe
 from pipelex.pipe_run.pipe_run_params import PipeRunParams
 from pipelex.pipeline.job_metadata import JobMetadata
+from pipelex.tools.misc.string_utils import get_root_from_dotted_path
 
 
 class PipeSequence(PipeController):
@@ -134,7 +135,8 @@ class PipeSequence(PipeController):
                         generated_outputs.add(sub_parallel_pipe.output_name)
 
             if sequential_sub_pipe.batch_params:
-                if sequential_sub_pipe.batch_params.input_list_stuff_name not in generated_outputs:
+                input_list_root = get_root_from_dotted_path(sequential_sub_pipe.batch_params.input_list_stuff_name)
+                if input_list_root not in generated_outputs:
                     try:
                         stuff_spec = sub_pipe_needed_inputs.get_required_stuff_spec(
                             variable_name=sequential_sub_pipe.batch_params.input_item_stuff_name
@@ -146,7 +148,7 @@ class PipeSequence(PipeController):
                         )
                         raise PipeSequenceValueError(msg) from exc
                     needed_inputs.add_stuff_spec(
-                        variable_name=sequential_sub_pipe.batch_params.input_list_stuff_name,
+                        variable_name=input_list_root,
                         concept=stuff_spec.concept,
                         multiplicity=True,
                     )

--- a/pipelex/pipe_controllers/sub_pipe.py
+++ b/pipelex/pipe_controllers/sub_pipe.py
@@ -1,3 +1,5 @@
+from typing import cast
+
 from pydantic import BaseModel
 
 from pipelex import log
@@ -8,6 +10,8 @@ from pipelex.core.pipes.pipe_factory import PipeFactory
 from pipelex.core.pipes.pipe_output import PipeOutput
 from pipelex.core.pipes.variable_multiplicity import VariableMultiplicity
 from pipelex.core.stuffs.list_content import ListContent
+from pipelex.core.stuffs.stuff_content import StuffContent
+from pipelex.core.stuffs.stuff_factory import StuffFactory
 from pipelex.hub import get_required_pipe
 from pipelex.pipe_controllers.batch.pipe_batch import PipeBatch
 from pipelex.pipe_controllers.batch.pipe_batch_blueprint import PipeBatchBlueprint
@@ -38,6 +42,61 @@ class SubPipe(BaseModel):
         # Case 1: Batch processing
         if batch_params := self.batch_params:
             sub_pipe_run_params.batch_params = batch_params
+
+            # Pre-resolve dotted paths (e.g. "search_result.sources") before PipeBatch
+            synthetic_flat_name: str | None = None
+            input_list_stuff_name = batch_params.input_list_stuff_name
+            if "." in input_list_stuff_name:
+                try:
+                    # wanted_type=None: the nested attribute may be a plain list (not ListContent), so skip type checking here
+                    resolved = working_memory.get_typed_object_or_attribute(name=input_list_stuff_name, wanted_type=None)
+                except WorkingMemoryStuffNotFoundError as exc:
+                    msg = (
+                        f"Input list stuff named '{input_list_stuff_name}' required by sub_pipe '{self.pipe_code}' "
+                        f"of pipe '{calling_pipe_code}' not found in working memory: {exc}"
+                    )
+                    raise PipeRunInputsError(
+                        message=msg,
+                        run_mode=sub_pipe_run_params.run_mode,
+                        pipe_code=self.pipe_code,
+                        variable_name=input_list_stuff_name,
+                        concept_code=None,
+                    ) from exc
+
+                list_content: ListContent[StuffContent]
+                if isinstance(resolved, ListContent):
+                    list_content = cast("ListContent[StuffContent]", resolved)
+                elif isinstance(resolved, list):
+                    list_content = ListContent[StuffContent](items=cast("list[StuffContent]", resolved))
+                else:
+                    msg = (
+                        f"Dotted path '{input_list_stuff_name}' resolved to {type(resolved).__name__}, "
+                        f"expected ListContent or list for batch_over in sub_pipe '{self.pipe_code}' "
+                        f"of pipe '{calling_pipe_code}'"
+                    )
+                    raise PipeRunInputsError(
+                        message=msg,
+                        run_mode=sub_pipe_run_params.run_mode,
+                        pipe_code=self.pipe_code,
+                        variable_name=input_list_stuff_name,
+                        concept_code=None,
+                    )
+
+                # Inject resolved list under a synthetic flat name and update batch_params
+                synthetic_flat_name = input_list_stuff_name.replace(".", "__")
+                item_stuff_spec = sub_pipe.inputs.get_required_stuff_spec(variable_name=batch_params.input_item_stuff_name)
+                synthetic_stuff = StuffFactory.make_stuff(
+                    concept=item_stuff_spec.concept,
+                    content=list_content,
+                    name=synthetic_flat_name,
+                )
+                working_memory.add_new_stuff(name=synthetic_flat_name, stuff=synthetic_stuff)
+                batch_params = BatchParams(
+                    input_list_stuff_name=synthetic_flat_name,
+                    input_item_stuff_name=batch_params.input_item_stuff_name,
+                )
+                sub_pipe_run_params.batch_params = batch_params
+
             try:
                 working_memory.get_typed_object_or_attribute(name=batch_params.input_list_stuff_name, wanted_type=ListContent)
             except WorkingMemoryStuffNotFoundError as exc:
@@ -85,12 +144,17 @@ class SubPipe(BaseModel):
                 blueprint=pipe_batch_blueprint,
                 concept_codes_from_the_same_domain=[concept.code for concept in sub_pipe.concept_dependencies],
             )
-            pipe_output = await pipe_batch.run_pipe(
-                job_metadata=job_metadata,
-                working_memory=working_memory,
-                pipe_run_params=sub_pipe_run_params,
-                output_name=self.output_name,
-            )
+            try:
+                pipe_output = await pipe_batch.run_pipe(
+                    job_metadata=job_metadata,
+                    working_memory=working_memory,
+                    pipe_run_params=sub_pipe_run_params,
+                    output_name=self.output_name,
+                )
+            finally:
+                # Clean up synthetic stuff injected for dotted-path resolution
+                if synthetic_flat_name:
+                    working_memory.remove_stuff(name=synthetic_flat_name)
         # Case 2: Condition processing
         elif isinstance(sub_pipe, PipeCondition):
             pipe_output = await sub_pipe.run_pipe(

--- a/pipelex/pipe_controllers/sub_pipe.py
+++ b/pipelex/pipe_controllers/sub_pipe.py
@@ -84,7 +84,33 @@ class SubPipe(BaseModel):
 
                 # Inject resolved list under a synthetic flat name and update batch_params
                 synthetic_flat_name = input_list_stuff_name.replace(".", "__")
-                item_stuff_spec = sub_pipe.inputs.get_required_stuff_spec(variable_name=batch_params.input_item_stuff_name)
+                if working_memory.is_stuff_exists(name=synthetic_flat_name):
+                    msg = (
+                        f"Cannot use synthetic name '{synthetic_flat_name}' for dotted-path batch resolution "
+                        f"in sub_pipe '{self.pipe_code}' of pipe '{calling_pipe_code}': "
+                        f"a stuff with that name already exists in working memory"
+                    )
+                    raise PipeRunInputsError(
+                        message=msg,
+                        run_mode=sub_pipe_run_params.run_mode,
+                        pipe_code=self.pipe_code,
+                        variable_name=synthetic_flat_name,
+                        concept_code=None,
+                    )
+                try:
+                    item_stuff_spec = sub_pipe.inputs.get_required_stuff_spec(variable_name=batch_params.input_item_stuff_name)
+                except InputStuffSpecNotFoundError as exc:
+                    msg = (
+                        f"Batch input item named '{batch_params.input_item_stuff_name}' from '{calling_pipe_code}' is not "
+                        f"in SubPipe '{self.pipe_code}' input stuff specs: {sub_pipe.inputs}"
+                    )
+                    raise PipeRunInputsError(
+                        message=msg,
+                        run_mode=sub_pipe_run_params.run_mode,
+                        pipe_code=self.pipe_code,
+                        variable_name=batch_params.input_item_stuff_name,
+                        concept_code=None,
+                    ) from exc
                 synthetic_stuff = StuffFactory.make_stuff(
                     concept=item_stuff_spec.concept,
                     content=list_content,

--- a/pipelex/pipe_operators/search/pipe_search.py
+++ b/pipelex/pipe_operators/search/pipe_search.py
@@ -15,6 +15,7 @@ from pipelex.cogt.templating.template_rendering import render_template
 from pipelex.core.memory.working_memory import WorkingMemory
 from pipelex.core.pipes.inputs.input_stuff_specs import InputStuffSpecs
 from pipelex.core.pipes.pipe_output import PipeOutput
+from pipelex.core.stuffs.document_content import DocumentContent
 from pipelex.core.stuffs.search_result_content import SearchResultContent
 from pipelex.core.stuffs.stuff_factory import StuffFactory
 from pipelex.hub import get_model_deck
@@ -157,14 +158,14 @@ class PipeSearch(PipeOperator[PipeSearchOutput]):
     ) -> PipeSearchOutput:
         content: StuffContent
         if not self.is_structured_output:
-            content = SearchResultContent(
-                answer="[DRY RUN] Mock search result",
-                sources=[],
-            )
+            doc_factory = DryRunFactory.make_dry_run_factory(DocumentContent)
+            mock_sources = [doc_factory.build() for _ in range(3)]
+            search_result_factory = DryRunFactory.make_dry_run_factory(SearchResultContent)
+            content = search_result_factory.build(sources=mock_sources)
         else:
             output_structure_class = self.output.concept.get_structure_class()
-            object_factory = DryRunFactory.make_dry_run_factory(output_structure_class)
-            content = object_factory.build()
+            structured_factory = DryRunFactory.make_dry_run_factory(output_structure_class)
+            content = structured_factory.build()
 
         output_stuff = StuffFactory.make_stuff(
             name=output_name,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
   "opentelemetry-semantic-conventions",
   "opentelemetry-sdk",
   "pillow>=11.2.1",
-  "pipelex-tools>=0.3.1",                               # plxt CLI for MTHDS/TOML/PLX formatting & linting, needed by client projects too
+  "pipelex-tools>=0.3.2",                               # plxt CLI for MTHDS/TOML/PLX formatting & linting, needed by client projects too
   "polyfactory>=2.21.0",
   "portkey-ai>=2.1.0",
   "posthog>=6.7.0",

--- a/tests/e2e/pipelex/pipes/pipe_controller/pipe_batch/article_briefing.mthds
+++ b/tests/e2e/pipelex/pipes/pipe_controller/pipe_batch/article_briefing.mthds
@@ -1,0 +1,62 @@
+domain      = "article_briefing"
+description = "Search for articles on a topic, fetch and review each one with a comment and interest rating, then write a concise synthesis"
+main_pipe   = "article_briefing"
+
+[concept.ArticleReview]
+description = "A review of a single article with a short comment and interest rating"
+
+[concept.ArticleReview.structure]
+title = { type = "text", description = "Title of the article", required = true }
+url = { type = "text", description = "URL of the article", required = true }
+comment = { type = "text", description = "A short comment about the article content and value", required = true }
+rating = { type = "integer", description = "Interest rating from 1 (low) to 5 (high)", required = true, choices = [
+  "1",
+  "2",
+  "3",
+  "4",
+  "5",
+] }
+
+[pipe.article_briefing]
+type = "PipeSequence"
+description = "Search for articles on a topic, fetch and review each one, then synthesize"
+inputs = { topic = "Text" }
+output = "Text"
+steps = [
+  { pipe = "search_articles", result = "search_result" },
+  { pipe = "fetch_article", result = "fetched_pages", batch_over = "search_result.sources", batch_as = "document" },
+  { pipe = "review_article", result = "reviews", batch_over = "fetched_pages", batch_as = "pages" },
+  { pipe = "synthesize_reviews", result = "synthesis" },
+]
+
+[pipe.search_articles]
+type        = "PipeSearch"
+description = "Search the web for articles on the given topic"
+inputs      = { topic = "Text" }
+output      = "SearchResult"
+model       = "$standard"
+prompt      = "Find articles about $topic"
+max_results = 5
+
+[pipe.fetch_article]
+type        = "PipeExtract"
+description = "Fetch full page content from a source URL"
+inputs      = { document = "Document" }
+output      = "Page[]"
+model       = "@default-extract-web-page"
+
+[pipe.review_article]
+type        = "PipeLLM"
+description = "Write a short comment and rate an article from 1 to 5 in terms of interest"
+inputs      = { pages = "Page[]" }
+output      = "ArticleReview"
+model       = "$testing-text"
+prompt      = "You are reviewing an article that was fetched from the web.\n\nHere is the article content:\n\n@pages\n\nWrite a short comment about this article (2-3 sentences covering what it is about and its value), and rate it from 1 to 5 in terms of interest (1 = not interesting, 5 = very interesting).\n\nAlso extract the article title and URL from the content."
+
+[pipe.synthesize_reviews]
+type        = "PipeLLM"
+description = "Write a concise synthesis of all reviewed articles"
+inputs      = { reviews = "ArticleReview[]" }
+output      = "Text"
+model       = "$testing-text"
+prompt      = "You have reviewed a selection of articles on a given topic. Here are the reviews:\n\n@reviews\n\nWrite a concise synthesis (1-2 paragraphs) of this selection of articles. Highlight the key themes, most interesting findings, and overall quality of the selection."

--- a/tests/e2e/pipelex/pipes/pipe_controller/pipe_batch/test_pipe_batch_graph.py
+++ b/tests/e2e/pipelex/pipes/pipe_controller/pipe_batch/test_pipe_batch_graph.py
@@ -26,6 +26,7 @@ def _get_next_output_folder() -> Path:
 
 @pytest.mark.dry_runnable
 @pytest.mark.llm
+@pytest.mark.search
 @pytest.mark.extract
 @pytest.mark.inference
 @pytest.mark.asyncio(loop_scope="class")
@@ -300,3 +301,36 @@ class TestPipeBatchGraph:
         )
 
         log.info("Structural validation passed: BATCH_AGGREGATE edges correctly target PipeBatch")
+
+    async def test_article_briefing_dotted_batch_over(self, pipe_run_mode: PipeRunMode):
+        """Test that the article_briefing pipeline with dotted-path batch_over runs end-to-end.
+
+        This exercises batch_over="search_result.sources" where sources is a nested
+        attribute of the SearchResult stuff, validating the dotted-path resolution
+        implemented in SubPipe.run_pipe().
+        """
+        runner = PipelexRunner(
+            library_dirs=["tests/e2e/pipelex/pipes/pipe_controller/pipe_batch"],
+            pipe_run_mode=pipe_run_mode,
+        )
+        response = await runner.execute_pipeline(
+            pipe_code="article_briefing",
+            inputs={"topic": "artificial intelligence"},
+        )
+        pipe_output = response.pipe_output
+
+        assert pipe_output is not None
+        assert pipe_output.working_memory is not None
+        assert pipe_output.main_stuff is not None
+
+        # Verify the synthetic flat name was cleaned up after dotted-path batch processing
+        final_memory = pipe_output.working_memory
+        assert final_memory.get_optional_stuff("search_result__sources") is None, (
+            "Synthetic flat name 'search_result__sources' should be cleaned up after batch processing"
+        )
+
+        # Verify the original search_result remains in working memory
+        search_result = final_memory.get_optional_stuff("search_result")
+        assert search_result is not None, "search_result should remain in working memory after batch processing"
+
+        log.info(f"article_briefing pipeline completed, main_stuff concept: {pipe_output.main_stuff.concept.code}")

--- a/tests/integration/pipelex/pipes/controller/pipe_batch_dotted_path/dotted_batch.mthds
+++ b/tests/integration/pipelex/pipes/controller/pipe_batch_dotted_path/dotted_batch.mthds
@@ -1,0 +1,11 @@
+domain      = "dotted_batch_test"
+description = "Branch pipe for dotted-path batch_over integration test"
+main_pipe   = "process_document"
+
+[pipe.process_document]
+type        = "PipeLLM"
+description = "Summarize a single document"
+inputs      = { document = "Document" }
+output      = "Text"
+model       = "$testing-text"
+prompt      = "Summarize this document: $document"

--- a/tests/integration/pipelex/pipes/controller/pipe_batch_dotted_path/test_dotted_batch.py
+++ b/tests/integration/pipelex/pipes/controller/pipe_batch_dotted_path/test_dotted_batch.py
@@ -1,0 +1,105 @@
+"""Integration test for dotted-path batch_over resolution in SubPipe.run_pipe()."""
+
+from pathlib import Path
+from typing import Callable
+
+import pytest
+
+from pipelex import log, pretty_print
+from pipelex.core.concepts.concept_factory import ConceptFactory
+from pipelex.core.concepts.native.concept_native import NativeConceptCode
+from pipelex.core.memory.working_memory_factory import WorkingMemoryFactory
+from pipelex.core.stuffs.document_content import DocumentContent
+from pipelex.core.stuffs.search_result_content import SearchResultContent
+from pipelex.core.stuffs.stuff_factory import StuffFactory
+from pipelex.core.stuffs.text_content import TextContent
+from pipelex.hub import get_required_pipe
+from pipelex.pipe_controllers.sub_pipe import SubPipe
+from pipelex.pipe_run.pipe_run_params import BatchParams, PipeRunMode
+from pipelex.pipe_run.pipe_run_params_factory import PipeRunParamsFactory
+from pipelex.pipeline.job_metadata import JobMetadata
+
+
+@pytest.mark.dry_runnable
+@pytest.mark.llm
+@pytest.mark.inference
+@pytest.mark.asyncio(loop_scope="class")
+class TestDottedBatchOver:
+    async def test_dotted_batch_resolves_nested_list(
+        self,
+        job_metadata: JobMetadata,
+        pipe_run_mode: PipeRunMode,
+        load_test_library: Callable[[list[Path]], None],
+    ):
+        """Test that SubPipe.run_pipe() resolves a dotted-path batch_over and iterates over the nested list.
+
+        Hand-crafts working memory with a SearchResultContent containing DocumentContent sources,
+        then runs SubPipe with batch_params pointing to "search_result.sources". Verifies:
+        - The dotted path is resolved to the nested list
+        - PipeBatch executes one branch per list item
+        - The synthetic flat name is cleaned up afterward
+        """
+        load_test_library([Path("tests/integration/pipelex/pipes/controller/pipe_batch_dotted_path")])
+
+        # Build a SearchResultContent with 3 DocumentContent sources
+        search_content = SearchResultContent(
+            answer="Mock search answer about testing",
+            sources=[
+                DocumentContent(url="https://example.com/doc1", title="Document 1"),
+                DocumentContent(url="https://example.com/doc2", title="Document 2"),
+                DocumentContent(url="https://example.com/doc3", title="Document 3"),
+            ],
+        )
+
+        # Create Stuff wrapping the SearchResultContent
+        search_result_stuff = StuffFactory.make_stuff(
+            concept=ConceptFactory.make_native_concept(native_concept_code=NativeConceptCode.SEARCH_RESULT),
+            content=search_content,
+            name="search_result",
+        )
+        working_memory = WorkingMemoryFactory.make_from_single_stuff(stuff=search_result_stuff)
+
+        # Build SubPipe with dotted-path batch_params
+        sub_pipe = SubPipe(
+            pipe_code="process_document",
+            output_name="processed_docs",
+            batch_params=BatchParams(
+                input_list_stuff_name="search_result.sources",
+                input_item_stuff_name="document",
+            ),
+        )
+
+        # Get the branch pipe to verify it exists
+        branch_pipe = get_required_pipe(pipe_code="process_document")
+        log.info(f"Branch pipe: {branch_pipe.code}, inputs: {branch_pipe.inputs}")
+
+        # Run SubPipe
+        pipe_output = await sub_pipe.run_pipe(
+            calling_pipe_code="test_sequence",
+            working_memory=working_memory,
+            job_metadata=job_metadata,
+            sub_pipe_run_params=PipeRunParamsFactory.make_run_params(pipe_run_mode=pipe_run_mode),
+        )
+
+        # Verify output
+        assert pipe_output is not None
+        assert pipe_output.working_memory is not None
+        assert pipe_output.main_stuff is not None
+
+        pretty_print(pipe_output, title="SubPipe dotted batch output")
+
+        # Verify synthetic flat name was cleaned up
+        final_memory = pipe_output.working_memory
+        assert final_memory.get_optional_stuff("search_result__sources") is None, (
+            "Synthetic flat name 'search_result__sources' should be cleaned up after batch processing"
+        )
+
+        # Original search_result should still be in working memory
+        original = final_memory.get_optional_stuff("search_result")
+        assert original is not None, "search_result should remain in working memory"
+
+        # Output should be a list with one processed item per source document
+        output_list = pipe_output.main_stuff_as_list(item_type=TextContent)
+        assert len(output_list.items) == 3, f"Expected 3 processed items (one per source), got {len(output_list.items)}"
+
+        log.info(f"Dotted-path batch resolved and processed {len(output_list.items)} items successfully")

--- a/tests/unit/pipelex/pipe_controllers/sequence/data.py
+++ b/tests/unit/pipelex/pipe_controllers/sequence/data.py
@@ -79,12 +79,32 @@ class PipeSequenceInputTestCases:
         ),
     )
 
+    VALID_WITH_BATCH_DOTTED_PATH: ClassVar[tuple[str, PipeSequenceBlueprint]] = (
+        "valid_with_batch_dotted_path",
+        PipeSequenceBlueprint(
+            description="Test case: valid_with_batch_dotted_path",
+            inputs={"query": "native.Text"},
+            output="native.Text",
+            steps=[
+                SubPipeBlueprint(pipe="search_step", result="search_result"),
+                SubPipeBlueprint(
+                    pipe="process_source",
+                    batch_over="search_result.sources",
+                    batch_as="source",
+                    result="processed_sources",
+                ),
+                SubPipeBlueprint(pipe="summarize_results", result="summary"),
+            ],
+        ),
+    )
+
     VALID_CASES: ClassVar[list[tuple[str, PipeSequenceBlueprint]]] = [
         VALID_SIMPLE_SEQUENCE,
         VALID_THREE_STEPS,
         VALID_SINGLE_STEP,
         VALID_MULTIPLE_INPUTS,
         VALID_WITH_BATCH,
+        VALID_WITH_BATCH_DOTTED_PATH,
     ]
 
     # Error test cases: (test_id, blueprint_dict, expected_error_message_fragment)

--- a/uv.lock
+++ b/uv.lock
@@ -3597,7 +3597,7 @@ requires-dist = [
     { name = "opentelemetry-sdk" },
     { name = "opentelemetry-semantic-conventions" },
     { name = "pillow", specifier = ">=11.2.1" },
-    { name = "pipelex-tools", specifier = ">=0.3.1" },
+    { name = "pipelex-tools", specifier = ">=0.3.2" },
     { name = "polyfactory", specifier = ">=2.21.0" },
     { name = "portkey-ai", specifier = ">=2.1.0" },
     { name = "posthog", specifier = ">=6.7.0" },
@@ -3632,17 +3632,17 @@ provides-extras = ["anthropic", "bedrock", "docling", "fal", "gcp-storage", "goo
 
 [[package]]
 name = "pipelex-tools"
-version = "0.3.1"
+version = "0.3.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/19/3a/1e871a5b1746e1e2e7d93cb95b737b01b43979132ef6e2b1f493ff0faa55/pipelex_tools-0.3.1.tar.gz", hash = "sha256:72aef8a1800ae7a1c866c34c1657c72ccb823648d1f03f95c6775e1b83473cae", size = 165394, upload-time = "2026-03-09T14:26:51.02Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/aa/99faab239abbb94f34de7fa2c5b915f2493cfc41d496dbf3fb6717f4d1db/pipelex_tools-0.3.2.tar.gz", hash = "sha256:a0f50c039a66e9bd889ec6f27dc6c9d139289e08fc48164588333906d6252535", size = 166104, upload-time = "2026-03-19T12:15:24.726Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/a3/a2511f228da30fc497d2fc557b5c4b497624cbb650a4e93d83d6caf59883/pipelex_tools-0.3.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:23d1b2333dec2d9a6f0258a32f7f9ad6aa9a9f0e8831e3b67bddb2d13e32587c", size = 5148025, upload-time = "2026-03-09T14:26:36.166Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/23/e46c6b91442dda5893985ea986b7059fcfd8e6fff4522b4a0178eb835350/pipelex_tools-0.3.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:9fb2aca00e4ff7b05111e73b73a6bc812f8c4bb363685861e136f8671454cfbf", size = 4891057, upload-time = "2026-03-09T14:26:38.746Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/95/3d5f8486e3723e2995a5d5f39ad6231b28ae94f99ac0047b7fd9a8614b00/pipelex_tools-0.3.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:371cdb2877feee5527a02b87dc2d12606b3baa90ee4be31caa9389aa55844fe7", size = 5024827, upload-time = "2026-03-09T14:26:40.577Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/bc/a55b906e45f440a995c92c9a421e5c602b9fb885d9d3b4ea10f46d339465/pipelex_tools-0.3.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f4d77f28ad8504ab4df977d36c34eaedff95d4a998a4f7bd4b4cfb80045e8edb", size = 5278822, upload-time = "2026-03-09T14:26:43.344Z" },
-    { url = "https://files.pythonhosted.org/packages/69/7b/a6e1bccbaeeb6b5c77cb804571650272c8161af39c1f486997a3a0607a9b/pipelex_tools-0.3.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:50a50131cbdbc4d75a8088f255fccd87def35fcbc98f5a038e76db10f1ebfe02", size = 5287864, upload-time = "2026-03-09T14:26:45.474Z" },
-    { url = "https://files.pythonhosted.org/packages/64/8a/d16b495f3706c9e3a3565b484396c206fa32596d3aec7262e3f47d3ba796/pipelex_tools-0.3.1-py3-none-win32.whl", hash = "sha256:782f735530eec884e1389d1707d19370bcb87390e6ff90c9e499b5a1142a9718", size = 4659317, upload-time = "2026-03-09T14:26:47.208Z" },
-    { url = "https://files.pythonhosted.org/packages/09/c1/5a5049ead77a3b4126c99b70905cb5ac36d8ec4955a53b8023bbe8c08d97/pipelex_tools-0.3.1-py3-none-win_amd64.whl", hash = "sha256:f569e3d5a2e80bc450f7a632a1b78d6be493cda3d19f5f0bf08460afa9471345", size = 5469911, upload-time = "2026-03-09T14:26:49.055Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/65/725fb73c6674b132efed88cf2aff63af206f49b9da1199b2c5e7d49fe77e/pipelex_tools-0.3.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:8306ae964f55b335efa1e3ba69f0e7ad11bc7c4c24b0cc36e83a154a24086439", size = 5147969, upload-time = "2026-03-19T12:15:08.996Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/4c/79c57a1406d2f1b0d9eea80d60556dcfb52a8c41a7d0e6ec719e28103af4/pipelex_tools-0.3.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:97b2749a5c633d3023b93d5b348c440b45563cb72698438e459fe767402225a8", size = 4893870, upload-time = "2026-03-19T12:15:11.828Z" },
+    { url = "https://files.pythonhosted.org/packages/53/46/7ca720d104f4660ffdb95ec30237ab88c4691716e4e67174145ea7d31699/pipelex_tools-0.3.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e9fe437d39ed316ef784fa9ca7507984fc9c7490d110f320ad322601c6bb3dc0", size = 5026135, upload-time = "2026-03-19T12:15:13.866Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/25/cd52544f54905b09e9d53745e6297bd096d3a88bc281d5b46d18f68e4d93/pipelex_tools-0.3.2-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1d38c335e1b3b861843ca02c0eb90a4c6d9ca04291d8d489678e4003c4c0e844", size = 5295755, upload-time = "2026-03-19T12:15:16.02Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/98/007bc52cf7e907403d5a0f80ece8cede3103243e737fab1e64bf98ac73ca/pipelex_tools-0.3.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:160b65cfcfece6912cb6cd6a8ca331e5b7ba4516d6f95de5b28042aa68ed750a", size = 5287854, upload-time = "2026-03-19T12:15:18.605Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/20/7f5f4bc156d30b9da75aaca5f6f525b00a8b7cf6e8d3c453a64512b7e6e7/pipelex_tools-0.3.2-py3-none-win32.whl", hash = "sha256:d001358c45caa83a7d2274a32d0551be97a433dd44576d2e427537a072ad5b79", size = 4672199, upload-time = "2026-03-19T12:15:20.694Z" },
+    { url = "https://files.pythonhosted.org/packages/de/ca/11725dbb93722be2e6970f2cedcbc52e0a441f1eba9f6ef3fcfaf884dea9/pipelex_tools-0.3.2-py3-none-win_amd64.whl", hash = "sha256:18830a579858c81c345959a9fa336a14e7b4589857d6f8c8a9b579d3b98120f2", size = 5468483, upload-time = "2026-03-19T12:15:23.124Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Support batch_over with dotted paths (e.g. "search_result.sources") by resolving nested attributes in SubPipe.run_pipe(), injecting the resolved list under a synthetic flat name, and cleaning it up via try/finally. Fix PipeSearch dry run to use DryRunFactory with 3 mock DocumentContent sources instead of hardcoded empty list. Add e2e test for article_briefing pipeline and integration test exercising SubPipe directly with hand-crafted SearchResultContent working memory.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds dotted-path `batch_over` (e.g., `search_result.sources`) to sub-pipes with safe resolution, naming collision guards, and cleanup. Also improves input discovery and `PipeSearch` dry runs, adds e2e/integration coverage, and bumps `pipelex-tools` to `>=0.3.2`.

- **New Features**
  - `SubPipe.run_pipe()` accepts dotted-path `batch_over`, resolves the nested list, injects it under a synthetic flat name (e.g., `search_result__sources`) with a collision guard, and removes it after execution.
  - `PipeSequence.needed_inputs()` and `PipeParallel.needed_inputs()` use `get_root_from_dotted_path` so required inputs reference the root; added an e2e “article_briefing” pipeline and an integration test validating dotted-path batching and cleanup.

- **Bug Fixes**
  - For dotted-path `batch_over`, the root input is treated as singular (`multiplicity=None`); missing input specs now raise `PipeRunInputsError` with clear context.
  - `PipeSearch` dry run returns 3 mock `DocumentContent` sources and structured outputs via `DryRunFactory`, replacing the previous empty sources.

<sup>Written for commit d2bce93a8d7974cd8a620d52cffd5a8dfa01ef7c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

