### PR TITLE
Pipe namespace fix (pipe_ref) and concept duplicate detection

### DIFF
--- a/pipelex/cli/agent_cli/commands/concept_cmd.py
+++ b/pipelex/cli/agent_cli/commands/concept_cmd.py
@@ -11,6 +11,7 @@ from pydantic import ValidationError
 
 from pipelex.builder.concept.concept_spec import ConceptSpec, ConceptStructureSpec
 from pipelex.cli.agent_cli.commands.agent_output import agent_error, agent_success
+from pipelex.language.toml_string_utils import format_toml_string
 from pipelex.tools.typing.pydantic_utils import format_pydantic_validation_error_for_agent
 
 
@@ -30,7 +31,7 @@ def _concept_spec_to_toml(concept_spec: ConceptSpec) -> str:
     concept_item_table = tomlkit.table()
 
     # Add description
-    concept_item_table.add("description", concept_spec.description)
+    concept_item_table.add("description", format_toml_string(concept_spec.description))
 
     # Add refines if present
     if concept_spec.refines:
@@ -43,7 +44,7 @@ def _concept_spec_to_toml(concept_spec: ConceptSpec) -> str:
             field_dict = _structure_field_to_dict(field_spec)
             # If only description is present, use simple string format
             if len(field_dict) == 1 and "description" in field_dict:
-                structure_table.add(field_name, field_dict["description"])
+                structure_table.add(field_name, format_toml_string(field_dict["description"]))
             else:
                 inline_table = tomlkit.inline_table()
                 for key, value in field_dict.items():

--- a/pipelex/cli/agent_cli/commands/pipe_cmd.py
+++ b/pipelex/cli/agent_cli/commands/pipe_cmd.py
@@ -29,6 +29,7 @@ from pipelex.builder.talents.img_gen_talent import ImgGenTalent
 from pipelex.builder.talents.llm_talent import LLMTalent
 from pipelex.cli.agent_cli.commands.agent_output import agent_error, agent_success
 from pipelex.core.pipes.pipe_blueprint import PipeType
+from pipelex.language.toml_string_utils import format_toml_string
 from pipelex.tools.typing.pydantic_utils import format_pydantic_validation_error_for_agent
 
 # Static talent-to-model preset mappings (from pipelex.toml defaults)
@@ -99,7 +100,7 @@ def _pipe_spec_to_toml(pipe_spec: PipeSpec) -> str:
     pipe_item_table.add("type", pipe_spec.type)
 
     # Add description
-    pipe_item_table.add("description", pipe_spec.description)
+    pipe_item_table.add("description", format_toml_string(pipe_spec.description))
 
     # Add inputs as inline table
     if pipe_spec.inputs:
@@ -133,9 +134,9 @@ def _add_type_specific_fields(pipe_spec: PipeSpec, pipe_table: tomlkit.TOMLDocum
         model_preset = LLM_TALENT_TO_MODEL.get(pipe_spec.llm_talent, "$writing-creative")
         pipe_table.add("model", model_preset)
         if pipe_spec.system_prompt:
-            pipe_table.add("system_prompt", pipe_spec.system_prompt)
+            pipe_table.add("system_prompt", format_toml_string(pipe_spec.system_prompt))
         if pipe_spec.prompt:
-            pipe_table.add("prompt", pipe_spec.prompt)
+            pipe_table.add("prompt", format_toml_string(pipe_spec.prompt))
 
     elif isinstance(pipe_spec, PipeComposeSpec):
         if pipe_spec.construct_spec is not None:
@@ -156,7 +157,7 @@ def _add_type_specific_fields(pipe_spec: PipeSpec, pipe_table: tomlkit.TOMLDocum
             if pipe_spec.target_format is not None:
                 pipe_table.add("target_format", str(pipe_spec.target_format))
             if pipe_spec.template is not None:
-                pipe_table.add("template", pipe_spec.template)
+                pipe_table.add("template", format_toml_string(pipe_spec.template))
 
     elif isinstance(pipe_spec, PipeSequenceSpec):
         steps_array = tomlkit.array()
@@ -205,7 +206,7 @@ def _add_type_specific_fields(pipe_spec: PipeSpec, pipe_table: tomlkit.TOMLDocum
         # Convert img_gen_talent to model preset using static mappings
         model_preset = IMG_GEN_TALENT_TO_MODEL.get(pipe_spec.img_gen_talent, "$gen-image")
         pipe_table.add("model", model_preset)
-        pipe_table.add("prompt", pipe_spec.prompt)
+        pipe_table.add("prompt", format_toml_string(pipe_spec.prompt))
 
     elif isinstance(pipe_spec, PipeFuncSpec):
         pipe_table.add("function_name", pipe_spec.function_name)

--- a/pipelex/cli/agent_cli/commands/validate/_validate_core.py
+++ b/pipelex/cli/agent_cli/commands/validate/_validate_core.py
@@ -47,9 +47,9 @@ async def validate_all_core(
 
     validated_pipes: list[dict[str, str]] = []
     for the_pipe in pipes:
-        dry_run_output = dry_run_results.get(the_pipe.code)
+        dry_run_output = dry_run_results.get(the_pipe.pipe_ref)
         status: str = dry_run_output.status if dry_run_output else DryRunStatus.SUCCESS
-        validated_pipes.append({"pipe_code": the_pipe.code, "status": status})
+        validated_pipes.append({"pipe_code": the_pipe.pipe_ref, "status": status})
 
     return {
         "success": True,
@@ -76,7 +76,7 @@ async def validate_bundle_core(
     """
     result = await validate_bundle(mthds_file_path=bundle_path, library_dirs=library_dirs)
 
-    validated_pipes = [{"pipe_code": the_pipe.code, "status": "SUCCESS"} for the_pipe in result.pipes]
+    validated_pipes = [{"pipe_code": the_pipe.pipe_ref, "status": "SUCCESS"} for the_pipe in result.pipes]
 
     return {
         "success": True,

--- a/pipelex/core/pipes/pipe_abstract.py
+++ b/pipelex/core/pipes/pipe_abstract.py
@@ -54,6 +54,11 @@ class PipeAbstract(ABC, BaseModel):
     output: StuffSpec
 
     @property
+    def pipe_ref(self) -> str:
+        """Domain-qualified pipe reference, e.g. 'scoring.compute_score'."""
+        return f"{self.domain_code}.{self.code}"
+
+    @property
     def pipe_type(self) -> str:
         return self.__class__.__name__
 

--- a/pipelex/language/mthds_factory.py
+++ b/pipelex/language/mthds_factory.py
@@ -4,10 +4,10 @@ from typing import TYPE_CHECKING, Any, Mapping, cast
 
 import tomlkit
 from tomlkit import array, document, inline_table, table
-from tomlkit import string as tomlkit_string
 
 from pipelex import log
 from pipelex.config import get_config
+from pipelex.language.toml_string_utils import format_toml_string
 from pipelex.tools.misc.json_utils import remove_none_values_from_dict
 from pipelex.types import StrEnum
 
@@ -35,23 +35,18 @@ class MthdsFactory:
     @classmethod
     def format_tomlkit_string(cls, text: str) -> Any:  # Can't type this because of tomlkit
         r"""Build a tomlkit string node.
-        - If `force_multiline` or the text contains '\\n', we emit a triple-quoted multiline string.
-        - When multiline, `ensure_trailing_newline` puts the closing quotes on their own line.
-        - When multiline, `ensure_leading_blank_line` inserts a real blank line at the start of the string.
+
+        Delegates to the shared `format_toml_string` utility, passing config values.
         """
         strings_config = cls._mthds_config().strings
-
-        needs_multiline = strings_config.force_multiline or ("\n" in text) or len(text) > strings_config.length_limit_to_multiline
-        normalized = text
-
-        if needs_multiline:
-            if strings_config.ensure_leading_blank_line and not normalized.startswith("\n"):
-                normalized = "\n" + normalized
-            if strings_config.ensure_trailing_newline and not normalized.endswith("\n"):
-                normalized += "\n"
-
-        use_literal = strings_config.prefer_literal and ("'''" not in normalized)
-        return tomlkit_string(normalized, multiline=needs_multiline, literal=use_literal)
+        return format_toml_string(
+            text,
+            force_multiline=strings_config.force_multiline,
+            length_limit_to_multiline=strings_config.length_limit_to_multiline,
+            ensure_trailing_newline=strings_config.ensure_trailing_newline,
+            ensure_leading_blank_line=strings_config.ensure_leading_blank_line,
+            prefer_literal=strings_config.prefer_literal,
+        )
 
     @classmethod
     def convert_dicts_to_inline_tables(cls, value: Any, field_ordering: list[str] | None = None) -> Any:  # Can't type this because of tomlkit

--- a/pipelex/language/toml_string_utils.py
+++ b/pipelex/language/toml_string_utils.py
@@ -1,0 +1,43 @@
+"""Shared TOML string formatting utilities.
+
+Provides a pure function for building tomlkit string nodes with multi-line
+support, used by both MthdsFactory (with config) and the agent CLI (with defaults).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from tomlkit import string as tomlkit_string
+
+
+def format_toml_string(
+    text: str,
+    *,
+    force_multiline: bool = False,
+    length_limit_to_multiline: int = 100,
+    ensure_trailing_newline: bool = True,
+    ensure_leading_blank_line: bool = True,
+    prefer_literal: bool = False,
+) -> Any:  # Can't type this because of tomlkit
+    r"""Build a tomlkit string node.
+
+    - If `force_multiline` or the text contains '\n' or exceeds `length_limit_to_multiline`,
+      we emit a triple-quoted multiline string.
+    - When multiline, `ensure_trailing_newline` puts the closing quotes on their own line.
+    - When multiline, `ensure_leading_blank_line` inserts a real blank line at the start of the string.
+
+    Default parameter values match pipelex.toml defaults so callers without
+    config access get consistent behavior.
+    """
+    needs_multiline = force_multiline or ("\n" in text) or len(text) > length_limit_to_multiline
+    normalized = text
+
+    if needs_multiline:
+        if ensure_leading_blank_line and not normalized.startswith("\n"):
+            normalized = "\n" + normalized
+        if ensure_trailing_newline and not normalized.endswith("\n"):
+            normalized += "\n"
+
+    use_literal = prefer_literal and ("'''" not in normalized)
+    return tomlkit_string(normalized, multiline=needs_multiline, literal=use_literal)

--- a/pipelex/libraries/domain/domain_library.py
+++ b/pipelex/libraries/domain/domain_library.py
@@ -32,8 +32,7 @@ class DomainLibrary(RootModel[DomainLibraryRoot], DomainLibraryAbstract):
     def add_domain(self, domain: Domain):
         domain_code = domain.code
         if domain_code in self.root:
-            msg = f"Trying to add domain '{domain_code}' to domain library but it already exists"
-            raise DomainLibraryError(msg)
+            return  # Idempotent: same domain from another bundle
         self.root[domain_code] = domain
 
     def add_domains(self, domains: list[Domain]):

--- a/pipelex/libraries/domain/domain_library.py
+++ b/pipelex/libraries/domain/domain_library.py
@@ -1,6 +1,7 @@
 from pydantic import RootModel
 from typing_extensions import override
 
+from pipelex import log
 from pipelex.core.domains.domain import Domain
 from pipelex.libraries.domain.domain_library_abstract import DomainLibraryAbstract
 from pipelex.libraries.domain.exceptions import DomainLibraryError
@@ -30,9 +31,22 @@ class DomainLibrary(RootModel[DomainLibraryRoot], DomainLibraryAbstract):
         return self.root.get(domain_code)
 
     def add_domain(self, domain: Domain):
+        # TODO: resolve domain metadata conflicts properly — currently first-write-wins with a warning.
+        # The system_prompt field is used as a PipeLLM fallback; it should be inlined at pipe factory time
+        # before LibraryCrate construction so domain-level system_prompt becomes unnecessary.
         domain_code = domain.code
         if domain_code in self.root:
-            return  # Idempotent: same domain from another bundle
+            existing = self.root[domain_code]
+            if existing.description != domain.description:
+                log.warning(
+                    f"Domain '{domain_code}' declared with different descriptions: "
+                    f"'{existing.description}' vs '{domain.description}'. Keeping the first.",
+                )
+            if existing.system_prompt != domain.system_prompt:
+                log.warning(
+                    f"Domain '{domain_code}' declared with different system_prompts. Keeping the first.",
+                )
+            return
         self.root[domain_code] = domain
 
     def add_domains(self, domains: list[Domain]):

--- a/pipelex/libraries/library_manager.py
+++ b/pipelex/libraries/library_manager.py
@@ -28,6 +28,7 @@ from pipelex.core.qualified_ref import QualifiedRef
 from pipelex.core.stuffs.structured_content import StructuredContent
 from pipelex.core.validation import report_validation_error
 from pipelex.hub import get_current_library
+from pipelex.libraries.concept.exceptions import ConceptLibraryError
 from pipelex.libraries.exceptions import (
     LibraryError,
     LibraryLoadingError,
@@ -91,7 +92,7 @@ class LibraryManager(LibraryManagerAbstract):
     def __init__(self):
         # UNTITLED library is the fallback library for all others
         self._libraries: dict[str, Library] = {}
-        self._pipe_source_map: dict[str, Path] = {}  # pipe_code -> source .mthds file
+        self._pipe_source_map: dict[str, Path] = {}  # pipe_ref (domain.pipe_code) -> source .mthds file
 
     ############################################################
     # Manager lifecycle
@@ -111,8 +112,8 @@ class LibraryManager(LibraryManagerAbstract):
                 raise LibraryError(msg)
             library = self._libraries[library_id]
             # Remove source map entries for pipes in this library
-            for pipe_code in library.pipe_library.root:
-                self._pipe_source_map.pop(pipe_code, None)
+            for pipe_ref in library.pipe_library.root:
+                self._pipe_source_map.pop(pipe_ref, None)
             library.teardown()
             del self._libraries[library_id]
             return
@@ -164,12 +165,22 @@ class LibraryManager(LibraryManagerAbstract):
         """Get the source file path for a pipe.
 
         Args:
-            pipe_code: The pipe code to look up.
+            pipe_code: The pipe code or pipe_ref (domain.code) to look up.
 
         Returns:
             Path to the .mthds file the pipe was loaded from, or None if unknown.
         """
-        return self._pipe_source_map.get(pipe_code)
+        # Direct lookup by pipe_ref
+        result = self._pipe_source_map.get(pipe_code)
+        if result is not None:
+            return result
+        # Bare code fallback: search for a key ending with .pipe_code
+        if "." not in pipe_code:
+            suffix = f".{pipe_code}"
+            matches = [path for key, path in self._pipe_source_map.items() if key.endswith(suffix)]
+            if len(matches) == 1:
+                return matches[0]
+        return None
 
     ############################################################
     # Private methods
@@ -374,22 +385,23 @@ class LibraryManager(LibraryManagerAbstract):
             new_source = Path(blueprint.source) if blueprint.source else None
             if blueprint.pipe is not None:
                 for pipe_code, pipe_blueprint in blueprint.pipe.items():
+                    pipe_ref = f"{blueprint.domain}.{pipe_code}"
                     # Detect duplicate pipe declarations across different bundles in the same library
-                    if pipe_code in pipe_source_in_this_load:
-                        existing_source = pipe_source_in_this_load[pipe_code]
+                    if pipe_ref in pipe_source_in_this_load:
+                        existing_source = pipe_source_in_this_load[pipe_ref]
                         if existing_source == new_source:
                             msg = (
-                                f"Pipe '{pipe_code}' is declared twice in the same bundle file: '{existing_source}'. "
+                                f"Pipe '{pipe_ref}' is declared twice in the same bundle file: '{existing_source}'. "
                                 "Please remove the duplicate declaration."
                             )
                         else:
                             msg = (
-                                f"Pipe '{pipe_code}' is declared in two different bundle files: "
+                                f"Pipe '{pipe_ref}' is declared in two different bundle files: "
                                 f"'{existing_source}' and '{new_source}'. "
                                 "Please remove one of the declarations or rename one of the pipes."
                             )
                         raise PipeLibraryError(msg)
-                    pipe_source_in_this_load[pipe_code] = new_source
+                    pipe_source_in_this_load[pipe_ref] = new_source
                     pipe = PipeFactory[PipeAbstract].make_from_blueprint(
                         domain_code=blueprint.domain,
                         pipe_code=pipe_code,
@@ -399,7 +411,7 @@ class LibraryManager(LibraryManagerAbstract):
                     pipes.append(pipe)
                     # Track source file for this pipe (used by get_pipe_source)
                     if new_source:
-                        self._pipe_source_map[pipe_code] = new_source
+                        self._pipe_source_map[pipe_ref] = new_source
             all_pipes.extend(pipes)
 
         library.pipe_library.add_pipes(pipes=all_pipes)
@@ -474,16 +486,34 @@ class LibraryManager(LibraryManagerAbstract):
         Returns:
             List of loaded concepts
         """
-        # Step 1: Collect all concept entries with metadata
+        # Step 1: Collect all concept entries with metadata, detecting duplicates
+        concept_source_in_this_load: dict[str, Path | None] = {}
         ref_to_entry: dict[str, tuple[str, str, ConceptBlueprint | str]] = {}
 
         for blueprint in blueprints:
             if blueprint.concept is not None:
+                new_source = Path(blueprint.source) if blueprint.source else None
                 for concept_code, concept_blueprint in blueprint.concept.items():
                     concept_ref = ConceptFactory.make_concept_ref_with_domain(
                         domain_code=blueprint.domain,
                         concept_code=concept_code,
                     )
+                    # Detect duplicate concept declarations across different bundles in the same library
+                    if concept_ref in concept_source_in_this_load:
+                        existing_source = concept_source_in_this_load[concept_ref]
+                        if existing_source == new_source:
+                            msg = (
+                                f"Concept '{concept_ref}' is declared twice in the same bundle file: '{existing_source}'. "
+                                "Please remove the duplicate declaration."
+                            )
+                        else:
+                            msg = (
+                                f"Concept '{concept_ref}' is declared in two different bundle files: "
+                                f"'{existing_source}' and '{new_source}'. "
+                                "Please remove one of the declarations or rename one of the concepts."
+                            )
+                        raise ConceptLibraryError(msg)
+                    concept_source_in_this_load[concept_ref] = new_source
                     ref_to_entry[concept_ref] = (
                         blueprint.domain,
                         concept_code,
@@ -967,7 +997,8 @@ class LibraryManager(LibraryManagerAbstract):
     def _remove_pipes_from_blueprint(self, blueprint: PipelexBundleBlueprint) -> None:
         library = self.get_current_library()
         if blueprint.pipe is not None:
-            library.pipe_library.remove_pipes_by_codes(pipe_codes=list(blueprint.pipe.keys()))
+            pipe_refs_to_remove = [f"{blueprint.domain}.{pipe_code}" for pipe_code in blueprint.pipe]
+            library.pipe_library.remove_pipes_by_refs(pipe_refs=pipe_refs_to_remove)
 
     def _remove_concepts_from_blueprint(self, blueprint: PipelexBundleBlueprint) -> None:
         library = self.get_current_library()

--- a/pipelex/libraries/pipe/pipe_library.py
+++ b/pipelex/libraries/pipe/pipe_library.py
@@ -7,7 +7,7 @@ from typing_extensions import override
 
 from pipelex import pretty_print
 from pipelex.core.pipes.pipe_abstract import PipeAbstract
-from pipelex.core.qualified_ref import QualifiedRef, QualifiedRefError
+from pipelex.core.qualified_ref import QualifiedRef
 from pipelex.libraries.pipe.exceptions import PipeLibraryError, PipeNotFoundError
 from pipelex.libraries.pipe.pipe_library_abstract import PipeLibraryAbstract
 from pipelex.types import Self
@@ -37,15 +37,15 @@ class PipeLibrary(RootModel[PipeLibraryRoot], PipeLibraryAbstract):
 
     @override
     def add_new_pipe(self, pipe: PipeAbstract):
-        if pipe.code in self.root:
+        if pipe.pipe_ref in self.root:
             msg = (
-                f"Pipe '{pipe.code}' already exists in the library. "
+                f"Pipe '{pipe.pipe_ref}' already exists in the library. "
                 "It is likely declared in two different bundle files loaded into the same library. "
                 "Check your library configuration: PIPELEXPATH environment variable, "
                 "library_dirs passed to Pipelex.make(), or the --library-dir / -L CLI option."
             )
             raise PipeLibraryError(msg)
-        self.root[pipe.code] = pipe
+        self.root[pipe.pipe_ref] = pipe
 
     @override
     def add_pipes(self, pipes: list[PipeAbstract]):
@@ -54,31 +54,41 @@ class PipeLibrary(RootModel[PipeLibraryRoot], PipeLibraryAbstract):
 
     @override
     def get_optional_pipe(self, pipe_code: str) -> PipeAbstract | None:
-        # Direct lookup first (bare code or exact match)
+        # 1. Direct lookup — handles pipe_ref keys (domain.code) and cross-package keys (alias->domain.code)
         pipe = self.root.get(pipe_code)
         if pipe is not None:
             return pipe
-        # Cross-package: "alias->domain.pipe_code" -> lookup "alias->pipe_code"
+
+        # 2. Cross-package refs
         if QualifiedRef.has_cross_package_prefix(pipe_code):
             alias, remainder = QualifiedRef.split_cross_package_ref(pipe_code)
-            try:
-                ref = QualifiedRef.parse(remainder)
-            except QualifiedRefError:
-                return None
-            pipe = self.root.get(f"{alias}->{ref.local_code}")
-            if pipe is not None and ref.is_qualified and pipe.domain_code != ref.domain_path:
-                return None
-            return pipe
-        # If it's a domain-qualified ref (e.g. "scoring.compute_score"), try the local code
-        if "." in pipe_code:
-            try:
-                ref = QualifiedRef.parse(pipe_code)
-            except QualifiedRefError:
-                return None
-            pipe = self.root.get(ref.local_code)
-            if pipe is not None and ref.is_qualified and pipe.domain_code != ref.domain_path:
-                return None
-            return pipe
+            # Try domain-qualified remainder as direct key
+            aliased_key = f"{alias}->{remainder}"
+            pipe = self.root.get(aliased_key)
+            if pipe is not None:
+                return pipe
+            # Bare code remainder — search aliased entries matching the bare code
+            if "." not in remainder:
+                matches = [val for key, val in self.root.items() if key.startswith(f"{alias}->") and val.code == remainder]
+                if len(matches) == 1:
+                    return matches[0]
+                if len(matches) > 1:
+                    domains = [match.domain_code for match in matches]
+                    msg = f"Ambiguous cross-package pipe code '{pipe_code}' found in domains: {domains}. Use domain-qualified ref."
+                    raise PipeLibraryError(msg)
+            return None
+
+        # 3. Bare code fallback — search across domains (excluding cross-package entries)
+        if "." not in pipe_code:
+            matches = [val for key, val in self.root.items() if not QualifiedRef.has_cross_package_prefix(key) and val.code == pipe_code]
+            if len(matches) == 1:
+                return matches[0]
+            if len(matches) > 1:
+                domains = [match.domain_code for match in matches]
+                msg = f"Ambiguous pipe code '{pipe_code}' found in domains: {domains}. Use domain-qualified ref."
+                raise PipeLibraryError(msg)
+            return None
+
         return None
 
     def add_dependency_pipe(self, alias: str, pipe: PipeAbstract) -> None:
@@ -88,7 +98,7 @@ class PipeLibrary(RootModel[PipeLibraryRoot], PipeLibraryAbstract):
             alias: The dependency alias
             pipe: The pipe to add
         """
-        key = f"{alias}->{pipe.code}"
+        key = f"{alias}->{pipe.pipe_ref}"
         if key in self.root:
             msg = f"Dependency pipe '{key}' already exists in the library"
             raise PipeLibraryError(msg)
@@ -111,13 +121,13 @@ class PipeLibrary(RootModel[PipeLibraryRoot], PipeLibraryAbstract):
         return self.root
 
     @override
-    def remove_pipes_by_codes(self, pipe_codes: list[str]) -> None:
+    def remove_pipes_by_refs(self, pipe_refs: list[str]) -> None:
         # TODO: We should create a separate library, that copies the original one, and then removes the pipes from it
         # Then run the dry run + validation to see if removing those pipe has not broken any other pipe.
         # If validated, it should update the real library.
-        for pipe_code in pipe_codes:
-            if pipe_code in self.root:
-                del self.root[pipe_code]
+        for pipe_ref in pipe_refs:
+            if pipe_ref in self.root:
+                del self.root[pipe_ref]
 
     @override
     def pretty_list_pipes(self) -> None:

--- a/pipelex/libraries/pipe/pipe_library.py
+++ b/pipelex/libraries/pipe/pipe_library.py
@@ -79,6 +79,9 @@ class PipeLibrary(RootModel[PipeLibraryRoot], PipeLibraryAbstract):
             return None
 
         # 3. Bare code fallback — search across domains (excluding cross-package entries)
+        # TODO: add domain_hint parameter so controllers can prefer their own domain when bare code is ambiguous.
+        # Currently, controllers resolve sub-pipes by bare code; if two domains share a pipe code the lookup
+        # raises PipeLibraryError instead of preferring the caller's domain. See PR #779 review.
         if "." not in pipe_code:
             matches = [val for key, val in self.root.items() if not QualifiedRef.has_cross_package_prefix(key) and val.code == pipe_code]
             if len(matches) == 1:

--- a/pipelex/libraries/pipe/pipe_library_abstract.py
+++ b/pipelex/libraries/pipe/pipe_library_abstract.py
@@ -33,7 +33,7 @@ class PipeLibraryAbstract(ABC):
     def get_pipes_dict(self) -> dict[str, PipeAbstract]:
         pass
 
-    def remove_pipes_by_codes(self, pipe_codes: list[str]) -> None:
+    def remove_pipes_by_refs(self, pipe_refs: list[str]) -> None:
         pass
 
     @abstractmethod

--- a/pipelex/pipe_controllers/condition/pipe_condition.py
+++ b/pipelex/pipe_controllers/condition/pipe_condition.py
@@ -62,11 +62,11 @@ class PipeCondition(PipeController):
             visited_pipes = set()
 
         # If we've already visited this pipe, stop recursion
-        if self.code in visited_pipes:
+        if self.pipe_ref in visited_pipes:
             return InputStuffSpecsFactory.make_empty()
 
         # Add this pipe to visited set for recursive calls
-        visited_pipes_with_current = visited_pipes | {self.code}
+        visited_pipes_with_current = visited_pipes | {self.pipe_ref}
 
         needed_inputs = InputStuffSpecsFactory.make_empty()
 

--- a/pipelex/pipe_controllers/parallel/pipe_parallel.py
+++ b/pipelex/pipe_controllers/parallel/pipe_parallel.py
@@ -66,11 +66,11 @@ class PipeParallel(PipeController):
             visited_pipes = set()
 
         # If we've already visited this pipe, stop recursion
-        if self.code in visited_pipes:
+        if self.pipe_ref in visited_pipes:
             return InputStuffSpecsFactory.make_empty()
 
         # Add this pipe to visited set for recursive calls
-        visited_pipes_with_current = visited_pipes | {self.code}
+        visited_pipes_with_current = visited_pipes | {self.pipe_ref}
 
         needed_inputs = InputStuffSpecsFactory.make_empty()
 

--- a/pipelex/pipe_controllers/sequence/pipe_sequence.py
+++ b/pipelex/pipe_controllers/sequence/pipe_sequence.py
@@ -109,11 +109,11 @@ class PipeSequence(PipeController):
             visited_pipes = set()
 
         # If we've already visited this pipe, stop recursion
-        if self.code in visited_pipes:
+        if self.pipe_ref in visited_pipes:
             return InputStuffSpecsFactory.make_empty()
 
         # Add this pipe to visited set for recursive calls
-        visited_pipes_with_current = visited_pipes | {self.code}
+        visited_pipes_with_current = visited_pipes | {self.pipe_ref}
 
         needed_inputs = InputStuffSpecsFactory.make_empty()
         generated_outputs: set[str] = set()

--- a/pipelex/pipe_run/dry_run.py
+++ b/pipelex/pipe_run/dry_run.py
@@ -115,14 +115,14 @@ async def dry_run_pipes(pipes: list[PipeAbstract], raise_on_failure: bool = True
     successful_pipes: list[str] = []
     failed_pipes: list[str] = []
     skipped_pipes: list[str] = []
-    for pipe_code, dry_run_output in results.items():
+    for pipe_ref, dry_run_output in results.items():
         match dry_run_output.status:
             case DryRunStatus.SUCCESS:
-                successful_pipes.append(pipe_code)
+                successful_pipes.append(pipe_ref)
             case DryRunStatus.FAILURE:
-                failed_pipes.append(pipe_code)
+                failed_pipes.append(pipe_ref)
             case DryRunStatus.SKIPPED:
-                skipped_pipes.append(pipe_code)
+                skipped_pipes.append(pipe_ref)
 
     # Compare using bare pipe_code from DryRunOutput since allowed_to_fail_pipes uses bare codes
     unexpected_failures = {pipe_ref: results[pipe_ref] for pipe_ref in failed_pipes if results[pipe_ref].pipe_code not in allowed_to_fail_pipes}
@@ -132,7 +132,7 @@ async def dry_run_pipes(pipes: list[PipeAbstract], raise_on_failure: bool = True
         f"{len(skipped_pipes)} skipped, {len(allowed_to_fail_pipes)} allowed to fail, in {time.time() - start_time:.2f} seconds",
     )
     if unexpected_failures:
-        unexpected_failures_details = "\n".join([f"'{pipe_code}': {results[pipe_code]}" for pipe_code in unexpected_failures])
+        unexpected_failures_details = "\n".join([f"'{pipe_ref}': {results[pipe_ref]}" for pipe_ref in unexpected_failures])
         if raise_on_failure:
             msg = f"Dry run failed with '{len(unexpected_failures)}' unexpected pipe failures:\n{unexpected_failures_details}"
             raise DryRunError(msg)

--- a/pipelex/pipe_run/dry_run.py
+++ b/pipelex/pipe_run/dry_run.py
@@ -110,7 +110,7 @@ async def dry_run_pipes(pipes: list[PipeAbstract], raise_on_failure: bool = True
     allowed_to_fail_pipes = get_config().pipelex.dry_run_config.allowed_to_fail_pipes
 
     for pipe in pipes:
-        results[pipe.code] = await dry_run_pipe(pipe, raise_on_failure=raise_on_failure)
+        results[pipe.pipe_ref] = await dry_run_pipe(pipe, raise_on_failure=raise_on_failure)
 
     successful_pipes: list[str] = []
     failed_pipes: list[str] = []
@@ -124,7 +124,8 @@ async def dry_run_pipes(pipes: list[PipeAbstract], raise_on_failure: bool = True
             case DryRunStatus.SKIPPED:
                 skipped_pipes.append(pipe_code)
 
-    unexpected_failures = {pipe_code: results[pipe_code] for pipe_code in failed_pipes if pipe_code not in allowed_to_fail_pipes}
+    # Compare using bare pipe_code from DryRunOutput since allowed_to_fail_pipes uses bare codes
+    unexpected_failures = {pipe_ref: results[pipe_ref] for pipe_ref in failed_pipes if results[pipe_ref].pipe_code not in allowed_to_fail_pipes}
 
     log.verbose(
         f"Dry run completed: {len(successful_pipes)} successful, {len(failed_pipes)} failed, "

--- a/pipelex/pipe_run/dry_run.py
+++ b/pipelex/pipe_run/dry_run.py
@@ -124,7 +124,8 @@ async def dry_run_pipes(pipes: list[PipeAbstract], raise_on_failure: bool = True
             case DryRunStatus.SKIPPED:
                 skipped_pipes.append(pipe_ref)
 
-    # Compare using bare pipe_code from DryRunOutput since allowed_to_fail_pipes uses bare codes
+    # TODO: allowed_to_fail_pipes uses bare codes, so one allowed code can silently match pipes from multiple domains.
+    #  Consider supporting namespaced pipe_refs (e.g. "domain.pipe_code") in the config to allow precise targeting.
     unexpected_failures = {pipe_ref: results[pipe_ref] for pipe_ref in failed_pipes if results[pipe_ref].pipe_code not in allowed_to_fail_pipes}
 
     log.verbose(

--- a/pipelex/pipeline/pipeline_run_setup.py
+++ b/pipelex/pipeline/pipeline_run_setup.py
@@ -176,7 +176,9 @@ async def pipeline_run_setup(
         if pipe_code:
             pipe = get_required_pipe(pipe_code=pipe_code)
         elif blueprint.main_pipe:
-            pipe = get_required_pipe(pipe_code=blueprint.main_pipe)
+            # Qualify main_pipe with domain to avoid ambiguity when multiple domains define pipes with the same code
+            qualified_main_pipe = f"{blueprint.domain}.{blueprint.main_pipe}"
+            pipe = get_required_pipe(pipe_code=qualified_main_pipe)
         else:
             msg = "No pipe code or main pipe in the MTHDS content provided to the pipeline API."
             raise PipeExecutionError(message=msg)

--- a/tests/integration/pipelex/libraries/test_pipe_namespace.py
+++ b/tests/integration/pipelex/libraries/test_pipe_namespace.py
@@ -1,0 +1,235 @@
+"""Integration tests for pipe namespace (pipe_ref) indexing with real .mthds files."""
+
+import tempfile
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+from pipelex.hub import get_library_manager
+from pipelex.libraries.concept.exceptions import ConceptLibraryError
+from pipelex.libraries.pipe.exceptions import PipeLibraryError, PipeNotFoundError
+
+SCORING_MTHDS = """\
+domain = "scoring"
+description = "Scoring domain"
+
+[concept]
+ScoreResult = "A scoring result"
+
+[pipe.process]
+type = "PipeLLM"
+description = "Process scoring data"
+inputs = { data = "Text" }
+output = "ScoreResult"
+model = "$quick-reasoning"
+prompt = "Process scoring from @data"
+"""
+
+ANALYTICS_MTHDS = """\
+domain = "analytics"
+description = "Analytics domain"
+
+[concept]
+AnalyticsResult = "An analytics result"
+
+[pipe.process]
+type = "PipeLLM"
+description = "Process analytics data"
+inputs = { data = "Text" }
+output = "AnalyticsResult"
+model = "$quick-reasoning"
+prompt = "Process analytics from @data"
+"""
+
+SCORING_CORE_MTHDS = """\
+domain = "scoring"
+description = "Scoring core"
+
+[pipe.compute_score]
+type = "PipeLLM"
+description = "Compute a score"
+inputs = { data = "Text" }
+output = "Text"
+model = "$quick-reasoning"
+prompt = "Compute score from @data"
+"""
+
+SCORING_ADVANCED_MTHDS = """\
+domain = "scoring"
+description = "Scoring advanced"
+
+[pipe.weighted_score]
+type = "PipeLLM"
+description = "Compute a weighted score"
+inputs = { data = "Text" }
+output = "Text"
+model = "$quick-reasoning"
+prompt = "Compute weighted score from @data"
+"""
+
+SCORING_DUPLICATE_MTHDS = """\
+domain = "scoring"
+description = "Scoring duplicate"
+
+[pipe.compute_score]
+type = "PipeLLM"
+description = "Duplicate compute score"
+inputs = { data = "Text" }
+output = "Text"
+model = "$quick-reasoning"
+prompt = "Duplicate compute score from @data"
+"""
+
+SCORING_CONCEPT_A_MTHDS = """\
+domain = "scoring"
+description = "Scoring with concept A"
+
+[concept]
+ScoreResult = "A scoring result"
+
+[pipe.compute_score]
+type = "PipeLLM"
+description = "Compute a score"
+inputs = { data = "Text" }
+output = "ScoreResult"
+model = "$quick-reasoning"
+prompt = "Compute score from @data"
+"""
+
+SCORING_CONCEPT_B_MTHDS = """\
+domain = "scoring"
+description = "Scoring with concept B"
+
+[concept]
+ScoreResult = "A scoring result (duplicate)"
+
+[pipe.weighted_score]
+type = "PipeLLM"
+description = "Compute a weighted score"
+inputs = { data = "Text" }
+output = "ScoreResult"
+model = "$quick-reasoning"
+prompt = "Compute weighted score from @data"
+"""
+
+SINGLE_DOMAIN_MTHDS = """\
+domain = "scoring"
+description = "Scoring domain"
+
+[concept]
+ScoreResult = "A scoring result"
+
+[pipe.compute_score]
+type = "PipeLLM"
+description = "Compute a score"
+inputs = { data = "Text" }
+output = "ScoreResult"
+model = "$quick-reasoning"
+prompt = "Compute score from @data"
+"""
+
+
+class TestPipeNamespace:
+    """Integration tests for pipe_ref-based namespace indexing."""
+
+    def test_same_pipe_code_different_domains(self, load_test_library: Callable[[list[Path]], None]):
+        """Two domains with the same pipe code coexist — would have collided under old bare-code indexing."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            (Path(tmp_dir) / "scoring.mthds").write_text(SCORING_MTHDS, encoding="utf-8")
+            (Path(tmp_dir) / "analytics.mthds").write_text(ANALYTICS_MTHDS, encoding="utf-8")
+
+            load_test_library([Path(tmp_dir)])
+
+            library = get_library_manager().get_current_library()
+
+            # Both pipes retrievable by domain-qualified pipe_ref
+            scoring_pipe = library.pipe_library.get_required_pipe("scoring.process")
+            analytics_pipe = library.pipe_library.get_required_pipe("analytics.process")
+
+            assert scoring_pipe.code == "process"
+            assert scoring_pipe.domain_code == "scoring"
+            assert analytics_pipe.code == "process"
+            assert analytics_pipe.domain_code == "analytics"
+
+            # Bare code is ambiguous
+            with pytest.raises(PipeLibraryError, match="Ambiguous pipe code"):
+                library.pipe_library.get_optional_pipe("process")
+
+    def test_multi_bundle_same_domain(self, load_test_library: Callable[[list[Path]], None]):
+        """Multiple .mthds files contributing to the same domain load successfully."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            (Path(tmp_dir) / "scoring_core.mthds").write_text(SCORING_CORE_MTHDS, encoding="utf-8")
+            (Path(tmp_dir) / "scoring_advanced.mthds").write_text(SCORING_ADVANCED_MTHDS, encoding="utf-8")
+
+            load_test_library([Path(tmp_dir)])
+
+            library = get_library_manager().get_current_library()
+
+            # Both pipes from the same domain exist
+            compute_pipe = library.pipe_library.get_required_pipe("scoring.compute_score")
+            weighted_pipe = library.pipe_library.get_required_pipe("scoring.weighted_score")
+
+            assert compute_pipe.domain_code == "scoring"
+            assert weighted_pipe.domain_code == "scoring"
+
+            # Domain exists once
+            assert library.domain_library.get_domain("scoring") is not None
+
+    def test_duplicate_pipe_same_domain_raises(self, load_empty_library: Callable[[], str]):
+        """Two .mthds files with the same domain and same pipe code raises on load."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            (Path(tmp_dir) / "scoring_core.mthds").write_text(SCORING_CORE_MTHDS, encoding="utf-8")
+            (Path(tmp_dir) / "scoring_duplicate.mthds").write_text(SCORING_DUPLICATE_MTHDS, encoding="utf-8")
+
+            library_id = load_empty_library()
+            library_manager = get_library_manager()
+
+            with pytest.raises(PipeLibraryError):
+                library_manager.load_libraries(
+                    library_id=library_id,
+                    library_dirs=[Path(tmp_dir)],
+                )
+
+    def test_duplicate_concept_same_domain_raises(self, load_empty_library: Callable[[], str]):
+        """Two .mthds files with the same domain and same concept code raises on load."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            (Path(tmp_dir) / "scoring_a.mthds").write_text(SCORING_CONCEPT_A_MTHDS, encoding="utf-8")
+            (Path(tmp_dir) / "scoring_b.mthds").write_text(SCORING_CONCEPT_B_MTHDS, encoding="utf-8")
+
+            library_id = load_empty_library()
+            library_manager = get_library_manager()
+
+            with pytest.raises(ConceptLibraryError, match="declared in two different bundle files"):
+                library_manager.load_libraries(
+                    library_id=library_id,
+                    library_dirs=[Path(tmp_dir)],
+                )
+
+    def test_bare_code_lookup_from_mthds(self, load_test_library: Callable[[list[Path]], None]):
+        """Bare code lookup works when pipe code is unambiguous (single domain)."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            (Path(tmp_dir) / "scoring.mthds").write_text(SINGLE_DOMAIN_MTHDS, encoding="utf-8")
+
+            load_test_library([Path(tmp_dir)])
+
+            library = get_library_manager().get_current_library()
+
+            # Both bare code and pipe_ref lookup work
+            pipe_by_ref = library.pipe_library.get_required_pipe("scoring.compute_score")
+            pipe_by_code = library.pipe_library.get_required_pipe("compute_score")
+
+            assert pipe_by_ref is pipe_by_code
+            assert pipe_by_ref.pipe_ref == "scoring.compute_score"
+
+    def test_wrong_domain_lookup_returns_not_found(self, load_test_library: Callable[[list[Path]], None]):
+        """Looking up a pipe with the wrong domain raises PipeNotFoundError."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            (Path(tmp_dir) / "scoring.mthds").write_text(SINGLE_DOMAIN_MTHDS, encoding="utf-8")
+
+            load_test_library([Path(tmp_dir)])
+
+            library = get_library_manager().get_current_library()
+
+            with pytest.raises(PipeNotFoundError):
+                library.pipe_library.get_required_pipe("analytics.compute_score")

--- a/tests/unit/pipelex/language/test_toml_string_utils.py
+++ b/tests/unit/pipelex/language/test_toml_string_utils.py
@@ -1,0 +1,81 @@
+"""Unit tests for format_toml_string — shared TOML string formatting utility."""
+
+from __future__ import annotations
+
+import pytest
+
+from pipelex.language.toml_string_utils import format_toml_string
+
+
+class TestFormatTomlString:
+    """Verify format_toml_string produces correct tomlkit string nodes."""
+
+    def test_empty_string_stays_basic(self) -> None:
+        """An empty string should remain a single-line basic string."""
+        result = format_toml_string("")
+        rendered = result.as_string()
+        assert rendered == '""'
+
+    def test_short_string_stays_basic(self) -> None:
+        """A short string without newlines should remain a single-line basic string."""
+        result = format_toml_string("hello world")
+        rendered = result.as_string()
+        assert rendered == '"hello world"'
+
+    def test_newline_triggers_multiline(self) -> None:
+        """A string containing newlines should become a multi-line basic string."""
+        result = format_toml_string("line1\nline2")
+        rendered = result.as_string()
+        assert rendered.startswith('"""')
+        assert "line1\nline2" in result.value
+
+    def test_long_string_triggers_multiline(self) -> None:
+        """A string exceeding length_limit_to_multiline should become multi-line."""
+        long_text = "a" * 101
+        result = format_toml_string(long_text)
+        rendered = result.as_string()
+        assert rendered.startswith('"""')
+
+    def test_trailing_newline_added(self) -> None:
+        """By default, a multi-line string gets a trailing newline."""
+        result = format_toml_string("line1\nline2")
+        assert result.value.endswith("\n")
+
+    def test_leading_blank_line_added(self) -> None:
+        """By default, a multi-line string gets a leading blank line."""
+        result = format_toml_string("line1\nline2")
+        assert result.value.startswith("\n")
+
+    def test_no_trailing_newline_when_disabled(self) -> None:
+        result = format_toml_string("line1\nline2", ensure_trailing_newline=False)
+        assert result.value == "\nline1\nline2"
+
+    def test_no_leading_blank_line_when_disabled(self) -> None:
+        result = format_toml_string("line1\nline2", ensure_leading_blank_line=False)
+        assert result.value == "line1\nline2\n"
+
+    def test_force_multiline(self) -> None:
+        """A short string should become multi-line when force_multiline=True."""
+        result = format_toml_string("short", force_multiline=True)
+        rendered = result.as_string()
+        assert rendered.startswith('"""')
+        assert result.value == "\nshort\n"
+
+    def test_prefer_literal(self) -> None:
+        """When prefer_literal=True, should use literal multi-line strings."""
+        result = format_toml_string("line1\nline2", prefer_literal=True)
+        rendered = result.as_string()
+        assert rendered.startswith("'''")
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "text with ''' inside",
+            "'''leading triple quotes",
+        ],
+    )
+    def test_literal_fallback_when_triple_quotes_present(self, text: str) -> None:
+        """Falls back to basic multi-line when text contains triple single-quotes."""
+        result = format_toml_string(text, prefer_literal=True, force_multiline=True)
+        rendered = result.as_string()
+        assert rendered.startswith('"""')

--- a/tests/unit/pipelex/libraries/test_domain_library.py
+++ b/tests/unit/pipelex/libraries/test_domain_library.py
@@ -1,0 +1,26 @@
+from pipelex.core.domains.domain import Domain
+from pipelex.libraries.domain.domain_library import DomainLibrary
+
+
+class TestDomainLibrary:
+    """Tests for DomainLibrary domain management."""
+
+    def test_add_domain_idempotent(self):
+        """Adding the same domain twice does not raise — idempotent for multi-bundle loading."""
+        library = DomainLibrary.make_empty()
+        domain = Domain(code="scoring", description="Scoring domain")
+        library.add_domain(domain=domain)
+        library.add_domain(domain=domain)
+        assert len(library.root) == 1
+        assert library.get_domain("scoring") is domain
+
+    def test_add_different_domains(self):
+        """Adding two different domains stores both."""
+        library = DomainLibrary.make_empty()
+        domain_scoring = Domain(code="scoring", description="Scoring domain")
+        domain_analytics = Domain(code="analytics", description="Analytics domain")
+        library.add_domain(domain=domain_scoring)
+        library.add_domain(domain=domain_analytics)
+        assert len(library.root) == 2
+        assert library.get_domain("scoring") is domain_scoring
+        assert library.get_domain("analytics") is domain_analytics

--- a/tests/unit/pipelex/libraries/test_pipe_library_lookup.py
+++ b/tests/unit/pipelex/libraries/test_pipe_library_lookup.py
@@ -3,47 +3,95 @@ from typing import Any
 import pytest
 from pytest_mock import MockerFixture
 
-from pipelex.libraries.pipe.exceptions import PipeNotFoundError
+from pipelex.libraries.pipe.exceptions import PipeLibraryError, PipeNotFoundError
 from pipelex.libraries.pipe.pipe_library import PipeLibrary
 
 
 def _make_stub_pipe(mocker: MockerFixture, code: str, domain_code: str) -> Any:
-    """Create a minimal mock pipe with code and domain_code."""
+    """Create a minimal mock pipe with code, domain_code, and pipe_ref."""
     mock_pipe = mocker.MagicMock()
     mock_pipe.code = code
     mock_pipe.domain_code = domain_code
+    mock_pipe.pipe_ref = f"{domain_code}.{code}"
     return mock_pipe
 
 
 class TestPipeLibraryLookup:
-    """Tests for PipeLibrary.get_optional_pipe domain enforcement and malformed-ref safety."""
+    """Tests for PipeLibrary lookup with pipe_ref-based indexing."""
 
-    def test_bare_code_lookup(self, mocker: MockerFixture):
-        """Bare code lookup still works."""
+    # ── Direct pipe_ref lookup ──────────────────────────────────────
+
+    def test_pipe_ref_lookup(self, mocker: MockerFixture):
+        """Domain-qualified pipe_ref lookup works as primary path."""
         library = PipeLibrary.make_empty()
         mock_pipe = _make_stub_pipe(mocker, code="compute_score", domain_code="scoring")
-        library.root["compute_score"] = mock_pipe
-        result = library.get_optional_pipe("compute_score")
-        assert result is mock_pipe
-
-    def test_domain_qualified_ref_correct_domain(self, mocker: MockerFixture):
-        """Domain-qualified ref resolves when pipe domain matches."""
-        library = PipeLibrary.make_empty()
-        mock_pipe = _make_stub_pipe(mocker, code="compute_score", domain_code="scoring")
-        library.root["compute_score"] = mock_pipe
+        library.root["scoring.compute_score"] = mock_pipe
         result = library.get_optional_pipe("scoring.compute_score")
         assert result is mock_pipe
 
-    def test_domain_qualified_ref_wrong_domain(self, mocker: MockerFixture):
-        """Domain-qualified ref returns None when pipe domain does not match."""
+    def test_pipe_ref_wrong_domain_returns_none(self, mocker: MockerFixture):
+        """Domain-qualified ref returns None when domain does not exist."""
         library = PipeLibrary.make_empty()
         mock_pipe = _make_stub_pipe(mocker, code="compute_score", domain_code="scoring")
-        library.root["compute_score"] = mock_pipe
+        library.root["scoring.compute_score"] = mock_pipe
         result = library.get_optional_pipe("wrong_domain.compute_score")
         assert result is None
 
-    def test_cross_package_ref_correct_domain(self, mocker: MockerFixture):
-        """Cross-package ref resolves when pipe domain matches."""
+    # ── Bare code fallback ──────────────────────────────────────────
+
+    def test_bare_code_unambiguous(self, mocker: MockerFixture):
+        """Bare code lookup works when only one pipe has that code."""
+        library = PipeLibrary.make_empty()
+        mock_pipe = _make_stub_pipe(mocker, code="compute_score", domain_code="scoring")
+        library.root["scoring.compute_score"] = mock_pipe
+        result = library.get_optional_pipe("compute_score")
+        assert result is mock_pipe
+
+    def test_bare_code_ambiguous_raises(self, mocker: MockerFixture):
+        """Bare code lookup raises PipeLibraryError when multiple domains have the same code."""
+        library = PipeLibrary.make_empty()
+        pipe_scoring = _make_stub_pipe(mocker, code="compute_score", domain_code="scoring")
+        pipe_analytics = _make_stub_pipe(mocker, code="compute_score", domain_code="analytics")
+        library.root["scoring.compute_score"] = pipe_scoring
+        library.root["analytics.compute_score"] = pipe_analytics
+        with pytest.raises(PipeLibraryError, match="Ambiguous pipe code"):
+            library.get_optional_pipe("compute_score")
+
+    def test_bare_code_no_match_returns_none(self):
+        """Bare code lookup returns None when no pipe has that code."""
+        library = PipeLibrary.make_empty()
+        result = library.get_optional_pipe("nonexistent")
+        assert result is None
+
+    # ── Multi-domain coexistence ────────────────────────────────────
+
+    def test_multi_domain_coexistence(self, mocker: MockerFixture):
+        """Two pipes with the same code in different domains coexist and are individually retrievable."""
+        library = PipeLibrary.make_empty()
+        pipe_scoring = _make_stub_pipe(mocker, code="compute_score", domain_code="scoring")
+        pipe_analytics = _make_stub_pipe(mocker, code="compute_score", domain_code="analytics")
+        library.root["scoring.compute_score"] = pipe_scoring
+        library.root["analytics.compute_score"] = pipe_analytics
+
+        assert library.get_optional_pipe("scoring.compute_score") is pipe_scoring
+        assert library.get_optional_pipe("analytics.compute_score") is pipe_analytics
+        assert len(library.root) == 2
+
+    def test_add_new_pipe_multi_domain(self, mocker: MockerFixture):
+        """add_new_pipe stores by pipe_ref so same code in different domains works."""
+        library = PipeLibrary.make_empty()
+        pipe_scoring = _make_stub_pipe(mocker, code="compute_score", domain_code="scoring")
+        pipe_analytics = _make_stub_pipe(mocker, code="compute_score", domain_code="analytics")
+        library.add_new_pipe(pipe=pipe_scoring)
+        library.add_new_pipe(pipe=pipe_analytics)
+
+        assert "scoring.compute_score" in library.root
+        assert "analytics.compute_score" in library.root
+
+    # ── Cross-package refs ──────────────────────────────────────────
+
+    def test_cross_package_ref_with_pipe_ref(self, mocker: MockerFixture):
+        """Cross-package ref with domain-qualified remainder resolves correctly."""
         library = PipeLibrary.make_empty()
         mock_pipe = _make_stub_pipe(mocker, code="compute_score", domain_code="scoring")
         library.add_dependency_pipe(alias="lib", pipe=mock_pipe)
@@ -51,12 +99,22 @@ class TestPipeLibraryLookup:
         assert result is mock_pipe
 
     def test_cross_package_ref_wrong_domain(self, mocker: MockerFixture):
-        """Cross-package ref returns None when pipe domain does not match."""
+        """Cross-package ref with wrong domain returns None."""
         library = PipeLibrary.make_empty()
         mock_pipe = _make_stub_pipe(mocker, code="compute_score", domain_code="scoring")
         library.add_dependency_pipe(alias="lib", pipe=mock_pipe)
         result = library.get_optional_pipe("lib->wrong_domain.compute_score")
         assert result is None
+
+    def test_cross_package_ref_bare_code_unambiguous(self, mocker: MockerFixture):
+        """Cross-package ref with bare code resolves when unambiguous."""
+        library = PipeLibrary.make_empty()
+        mock_pipe = _make_stub_pipe(mocker, code="compute_score", domain_code="scoring")
+        library.add_dependency_pipe(alias="lib", pipe=mock_pipe)
+        result = library.get_optional_pipe("lib->compute_score")
+        assert result is mock_pipe
+
+    # ── Malformed refs ──────────────────────────────────────────────
 
     @pytest.mark.parametrize(
         "malformed_ref",
@@ -86,8 +144,10 @@ class TestPipeLibraryLookup:
         result = library.get_optional_pipe(malformed_ref)
         assert result is None
 
+    # ── get_required_pipe error cases ───────────────────────────────
+
     def test_get_required_pipe_malformed_raises_not_found(self):
-        """Malformed ref through get_required_pipe raises PipeNotFoundError, not QualifiedRefError."""
+        """Malformed ref through get_required_pipe raises PipeNotFoundError."""
         library = PipeLibrary.make_empty()
         with pytest.raises(PipeNotFoundError):
             library.get_required_pipe("foo..bar")
@@ -96,6 +156,42 @@ class TestPipeLibraryLookup:
         """Domain mismatch through get_required_pipe raises PipeNotFoundError."""
         library = PipeLibrary.make_empty()
         mock_pipe = _make_stub_pipe(mocker, code="compute_score", domain_code="scoring")
-        library.root["compute_score"] = mock_pipe
+        library.root["scoring.compute_score"] = mock_pipe
         with pytest.raises(PipeNotFoundError):
             library.get_required_pipe("wrong_domain.compute_score")
+
+    # ── Collision tests ───────────────────────────────────────────────
+
+    def test_same_code_different_domains_no_collision(self, mocker: MockerFixture):
+        """Same bare code in different domains does NOT collide — this would have failed under old bare-code indexing."""
+        library = PipeLibrary.make_empty()
+        pipe_scoring = _make_stub_pipe(mocker, code="process", domain_code="scoring")
+        pipe_analytics = _make_stub_pipe(mocker, code="process", domain_code="analytics")
+
+        # Both add_new_pipe calls succeed — no collision
+        library.add_new_pipe(pipe=pipe_scoring)
+        library.add_new_pipe(pipe=pipe_analytics)
+
+        # Both retrievable by pipe_ref
+        assert library.get_optional_pipe("scoring.process") is pipe_scoring
+        assert library.get_optional_pipe("analytics.process") is pipe_analytics
+
+    def test_same_pipe_ref_collision_raises(self, mocker: MockerFixture):
+        """Same pipe_ref (same domain + same code) from separate add calls raises PipeLibraryError."""
+        library = PipeLibrary.make_empty()
+        pipe_first = _make_stub_pipe(mocker, code="compute_score", domain_code="scoring")
+        pipe_duplicate = _make_stub_pipe(mocker, code="compute_score", domain_code="scoring")
+
+        library.add_new_pipe(pipe=pipe_first)
+        with pytest.raises(PipeLibraryError, match="already exists"):
+            library.add_new_pipe(pipe=pipe_duplicate)
+
+    # ── remove_pipes_by_refs ────────────────────────────────────────
+
+    def test_remove_pipes_by_refs(self, mocker: MockerFixture):
+        """remove_pipes_by_refs removes pipes by their pipe_ref keys."""
+        library = PipeLibrary.make_empty()
+        mock_pipe = _make_stub_pipe(mocker, code="compute_score", domain_code="scoring")
+        library.root["scoring.compute_score"] = mock_pipe
+        library.remove_pipes_by_refs(pipe_refs=["scoring.compute_score"])
+        assert "scoring.compute_score" not in library.root

--- a/tests/unit/pipelex/pipe_run/test_dry_run.py
+++ b/tests/unit/pipelex/pipe_run/test_dry_run.py
@@ -38,12 +38,14 @@ class TestDryRun:
         """Skipped pipes must not inflate the success count in dry_run_pipes."""
         mock_successful_pipe = mocker.MagicMock()
         mock_successful_pipe.code = "successful_pipe"
+        mock_successful_pipe.pipe_ref = "test_domain.successful_pipe"
         mock_successful_pipe.needed_inputs.return_value = mocker.MagicMock(named_stuff_specs=[])
         mock_successful_pipe.validate_with_libraries.return_value = None
         mock_successful_pipe.run_pipe = mocker.AsyncMock(return_value=None)
 
         mock_skipped_pipe = mocker.MagicMock()
         mock_skipped_pipe.code = "skipped_pipe"
+        mock_skipped_pipe.pipe_ref = "test_domain.skipped_pipe"
         mock_skipped_pipe.needed_inputs.side_effect = PipeNotFoundError("dep->domain.pipe not found")
 
         results = await dry_run_pipes(
@@ -51,8 +53,8 @@ class TestDryRun:
             raise_on_failure=False,
         )
 
-        assert results["successful_pipe"].status == DryRunStatus.SUCCESS
-        assert results["skipped_pipe"].status == DryRunStatus.SKIPPED
+        assert results["test_domain.successful_pipe"].status == DryRunStatus.SUCCESS
+        assert results["test_domain.skipped_pipe"].status == DryRunStatus.SKIPPED
 
     @pytest.mark.asyncio
     async def test_dry_run_pipe_skipped_is_not_failure(self, mocker: MockerFixture) -> None:

--- a/wip/B-library-as-execution-context.md
+++ b/wip/B-library-as-execution-context.md
@@ -1,97 +1,199 @@
-# Library as Execution Context: Beyond File-System Bundles
+# The LibraryCrate: From File-System Bundles to Execution Context
 
-> **Status**: Draft — braindump cleanup
+> **Status**: Architecture vision
 > **Date**: 2026-03-23
-> **Related**: [A-temporal-library-fix-proposals-v2.md](A-temporal-library-fix-proposals-v2.md)
+> **Related**: [D-master-plan-distributed-execution-v2.md](D-master-plan-distributed-execution-v2.md), [E-pipe-namespace-fix.md](E-pipe-namespace-fix.md)
 
 ---
 
-## 1. The Library Is Not a Collection of Files
+## 1. The Three-Stage Pipeline
 
-The current mental model treats the library as a set of bundles tied to the file system — `.mthds` files, packages, manifests. But once loaded by the `library_manager`, the library becomes something fundamentally different: a **consistent, namespace-isolated set of concepts and pipes**. The library manager resolves dependencies, enforces naming constraints across domain namespaces, and prevents conflicts.
+Library loading follows a three-stage pipeline. Each stage has a distinct role and a clean boundary with the next.
 
-The bundle is the file-system expression of the library. The loaded library is the runtime truth.
+```
+Bundles (files)  ──►  LibraryCrate (data)  ──►  Library (live)
+```
+
+**Bundles** are file-system and packaging artifacts: `.mthds` files, method packages with manifests, remote dependencies. They are how methods are authored, versioned, and distributed. A single domain can be spread across multiple bundle files — for example, a `scoring` domain might have `scoring_core.mthds` and `scoring_advanced.mthds`.
+
+**LibraryCrate** is a flat, source-agnostic, serializable snapshot. It contains concept blueprints keyed by `concept_ref` and pipe blueprints keyed by `pipe_ref` — both fully-qualified with their domain prefix. It carries no memory of which file or package each blueprint came from. When multiple bundles contribute to the same domain, their blueprints simply land in the same flat dicts (strict merge — same ref appearing twice is an error).
+
+**Library** is the live runtime. Concepts are instantiated as `Concept` objects with generated structure classes. Pipes are instantiated as `PipeAbstract` subclass instances. The library is the execution truth — what pipe controllers query when resolving child pipes at runtime.
+
+### What about domains?
+
+Domains are a **namespace convention**, not a runtime container. A domain like `scoring` provides the prefix in `scoring.WeightedScore` (concept) and `scoring.compute_score` (pipe). Domains help organize methods at authoring time and prevent naming conflicts, but at runtime they carry no meaningful state. The `Domain` object in the library has only `code`, `description`, and an optional `system_prompt` — none of which are needed for pipe or concept resolution. The LibraryCrate doesn't need domain-level grouping; the namespace is already encoded in the refs.
+
+### Why a middle stage?
+
+Without the LibraryCrate, the system jumps directly from file-system artifacts to live objects. This creates two problems:
+
+1. **Serialization**: Live objects contain runtime state (generated classes, resolved references) that cannot be cleanly serialized. Blueprints are pure Pydantic models — they serialize trivially.
+
+2. **Decoupling**: The live library shouldn't know about files, packages, or remote repositories. The crate is the clean handoff point: everything upstream of it deals with sourcing and parsing; everything downstream deals with instantiation and execution.
 
 ---
 
 ## 2. What a Pipeline Execution Actually Needs
 
-When a pipeline runs, it needs access to **concepts and pipes** — not files. Specifically:
+When a pipeline runs, it needs access to **concepts and pipes** — not files.
 
-1. **It needs all the concepts and pipes in its dependency graph.** A pipe controller resolves child pipes, which resolve their children, and so on. Each pipe may reference concepts for its inputs and outputs. The full transitive closure of these references defines what the execution needs.
+1. **It needs all the concepts and pipes in its dependency graph.** A pipe controller resolves child pipes, which resolve their children, and so on. Each pipe references concepts for its inputs and outputs. The full transitive closure of these references defines what the execution needs.
 
-2. **It does not need anything outside that dependency graph.** A library loaded from the file system might contain 50 pipes. A given pipeline execution might only touch 15 of them and a quarter of the concepts. The rest is dead weight.
+2. **It does not need anything outside that dependency graph.** A library loaded from the file system might contain 50 pipes. A given pipeline execution might only touch 15 of them and a fraction of the concepts. The rest is dead weight.
 
 This is possible to determine statically because Pipelex's execution is deterministic — the dependency graph of a pipeline is known before execution begins. There are no dynamic pipe lookups or runtime-resolved references.
 
-### Implication: Library Stripping
+### How dependencies are resolved today
 
-This opens a path (not yet implemented) to **strip the library down to the minimal subset** required for a given pipeline execution. This would reduce payload sizes and clarify exactly what context is needed. But it is an optimization, not a prerequisite.
+When a pipeline is executed via CLI or API:
 
----
+1. The caller provides a bundle (as `mthds_content` or by referencing a file) and optionally a `pipe_code` (defaults to the bundle's `main_pipe`).
 
-## 3. The Compact Library Object
+2. `pipeline_run_setup()` loads **all** bundles from the provided library directories (`PIPELEXPATH`, `-L` flag, `library_dirs` parameter) and from installed methods (`.mthds/methods/` directories). This is a brute-force approach — everything available gets loaded.
 
-For distributed execution, what we need to pass around is not a mirror of the file system or a mirror of method packages. It should be a **compact library object** — a self-contained, serializable representation of the concepts and pipes needed for execution.
+3. If `mthds_content` was provided, its blueprint is loaded on top.
 
-This object would be:
+4. After loading, the library is validated: every pipe's dependencies (child pipes for controllers, concepts for inputs/outputs) must exist in the loaded library. If something is missing, validation fails.
 
-- Built from the loaded library state (post-resolution, post-namespace-enforcement)
-- Scoped to a pipeline execution (either the full library or a stripped subset)
-- Serializable and deserializable without requiring access to the original file system
+This "load everything, validate after" approach works but is wasteful. It loads pipes and concepts that will never be used, and it requires that all transitive dependencies be available on the file system at load time.
 
 ---
 
-## 4. The Payload Size Problem
+## 3. The LibraryCrate
 
-Temporal imposes limits on data passed into and out of workflows (default 2MB). Two things need to travel with the execution:
+The LibraryCrate is a self-contained, serializable representation of the concepts and pipes needed for execution, organized by domain.
 
-1. **The library context** — concepts and pipes needed for execution. Can be arbitrarily large depending on the library.
-2. **The working memory** — runtime data being processed. Can include images, documents, and other large payloads.
+### Structure
 
-Neither of these can be reliably passed inline as workflow arguments. The working memory is especially problematic — it carries user data that can be far larger than any library.
-
----
-
-## 5. Proposed Solution: External Storage Keyed by Pipeline Run
-
-Each pipeline execution already has a **pipeline run ID**. This ID can serve as the key for external storage:
-
-- Before dispatching to Temporal, the API process uploads the library context and working memory to a storage backend (using the existing storage provider system).
-- Each workflow activity fetches the library context and working memory from storage using the pipeline run ID.
-- After execution, updated working memory is written back to storage for the next step.
-
-This pattern:
-
-- **Decouples payload size from Temporal limits** — workflows receive a lightweight reference (the run ID), not the full data.
-- **Works for both library context and working memory** — same mechanism, same storage backend.
-- **Leverages existing infrastructure** — the storage provider system is already in place.
-- **Scales naturally** — large libraries and large working memories are handled identically.
-
-### Flow
-
-```
-API Process                          Storage                     Temporal Worker
-─────────────                        ───────                     ───────────────
-pipeline_run_setup()
-  ├─ Load library
-  ├─ Build compact library object
-  ├─ Upload library + working_memory ──► store(run_id, ...)
-  └─ Dispatch to Temporal (run_id)
-                                                                 WfPipeRouter.run()
-                                                                   ├─ Fetch library ◄── fetch(run_id)
-                                                                   ├─ Load library into process
-                                                                   ├─ Fetch working_memory ◄── fetch(run_id)
-                                                                   ├─ Execute pipe
-                                                                   └─ Upload updated working_memory ──► store(run_id, ...)
+```python
+class LibraryCrate(BaseModel):
+    """Complete library content, ready to load into a live Library."""
+    concepts: dict[str, ConceptBlueprint]    # concept_ref (domain.Code) -> blueprint
+    pipes: dict[str, PipeBlueprintUnion]     # pipe_ref (domain.pipe_code) -> blueprint
+    fingerprint: str                         # SHA256 of serialized content
 ```
 
+The crate is flat. No domain-level grouping — the domain is implicit in the keys (`scoring.WeightedScore`, `scoring.compute_score`). This mirrors how the live library already works for concepts (keyed by `concept_ref`), and how it will work for pipes once the `pipe_ref` fix lands.
+
+### Properties
+
+- **Flat and ref-keyed**: Two dicts, keyed by fully-qualified refs. Domain is a namespace prefix, not a structural container.
+- **Source-agnostic**: No file paths, no bundle identity, no package provenance. The crate doesn't know (or care) where its blueprints came from.
+- **Serializable**: Pure Pydantic models. JSON round-trip is trivial. This is what makes it suitable for both in-process use and wire transfer.
+- **Fingerprinted**: A SHA256 digest of the serialized content enables caching — if the same crate has already been loaded, skip the work.
+
+### How it's built
+
+```python
+# 1. Parse bundles from files
+blueprints: list[PipelexBundleBlueprint] = [
+    PipelexInterpreter.make_pipelex_bundle_blueprint(bundle_path=path)
+    for path in mthds_file_paths
+]
+
+# 2. Build crate: qualify refs with domain, merge into flat dicts
+crate = LibraryCrateFactory.make_from_blueprints(blueprints)
+
+# 3. Load into live library
+library_manager.load_from_crate(library_id, crate)
+```
+
+Each bundle declares a domain (e.g., `scoring`). During crate construction, concept codes become `concept_ref`s (`Score` → `scoring.Score`) and pipe codes become `pipe_ref`s (`compute_score` → `scoring.compute_score`). Multiple bundles — even for the same domain — simply add entries to the flat dicts. If the same ref appears twice, that's a conflict — error, not silent override.
+
+### What blueprints contain
+
+**ConceptBlueprint** (`core/concepts/concept_blueprint.py`): `description`, `structure`, `refines`. Clean Pydantic BaseModel.
+
+**PipeBlueprintUnion** (`core/bundles/pipelex_bundle_blueprint.py`): Discriminated union of 10 pipe blueprint types (`PipeFuncBlueprint`, `PipeLLMBlueprint`, `PipeSequenceBlueprint`, etc.). All are Pydantic models with fields for inputs, output, type-specific configuration (prompts, steps, branches, etc.).
+
+These are already the "data form" of pipes and concepts. They parse cleanly from `.mthds` files, they serialize cleanly to JSON, and the existing factory methods (`ConceptFactory.make_from_blueprint()`, `PipeFactory.make_from_blueprint()`) know how to instantiate live objects from them.
+
 ---
 
-## 6. Open Questions
+## 4. Namespace Prerequisites
 
-- **Caching across runs**: If the same library context is used across multiple pipeline runs (common), can we cache by library fingerprint rather than re-uploading per run?
-- **Granularity of storage**: One blob per run, or separate keys for library context vs. working memory vs. intermediate results?
-- **Library stripping**: When do we implement minimal-subset extraction? Is it worth the complexity now, or is shipping the full loaded library sufficient for the near term?
-- **Storage backend choice**: S3-compatible? Redis for short-lived data? The storage provider abstraction should make this pluggable.
-- **Consistency with v2 proposals**: How does this relate to the `LibraryContext` model and `TemporalPipeJobEnvelope` from the v2 proposals? This document argues for a more fundamental shift — externalizing both library and working memory — rather than embedding library context in the workflow input.
+Before building the LibraryCrate, a fundamental asymmetry in the library must be fixed.
+
+**Concepts are properly namespaced.** The `ConceptLibrary` indexes concepts by `concept_ref` = `domain.ConceptCode` (e.g., `scoring.WeightedScore`). Two concepts with the same code in different domains coexist without conflict.
+
+**Pipes are NOT namespaced.** The `PipeLibrary` indexes pipes by bare `code` (e.g., `compute_score`, not `scoring.compute_score`). If two domains define a pipe with the same code, the second one collides with the first — the library raises an error as if it were a duplicate, even though they're in different domains.
+
+This must be fixed by introducing `pipe_ref` = `domain.pipe_code` on `PipeAbstract` and rekeying `PipeLibrary` by `pipe_ref`, symmetric with how concepts work. The domain library must also support additive merging (multiple bundles contributing to the same domain).
+
+Once `pipe_ref` is in place, the flat LibraryCrate keying becomes natural — both concepts and pipes use fully-qualified refs as dict keys, and the domain is just the prefix before the dot.
+
+See [E-pipe-namespace-fix.md](E-pipe-namespace-fix.md) for the detailed technical spec.
+
+---
+
+## 5. Dependency Resolution Roadmap
+
+Dependency resolution improves in phases, from brute-force to precise.
+
+### Current state: Load everything
+
+`pipeline_run_setup()` loads all bundles from all provided library paths. Validation checks that dependencies exist, but nothing is selective. The full library travels to execution even if only a fraction is needed.
+
+### Near-term: Full crate, validated
+
+The LibraryCrate contains everything that was loaded — the full set of domains, concepts, and pipes. This is equivalent to today's behavior but with the crate as the clean intermediate. No stripping yet.
+
+### Planned: Static dependency tree analysis (crate stripping)
+
+From the entry pipe, walk the transitive closure:
+- For each pipe controller, collect its `pipe_dependencies()` (child pipe codes)
+- For each pipe (controller or operator), collect its `concept_dependencies` (input/output concepts)
+- Recursively resolve until the full dependency graph is known
+
+Then strip the crate to only the domains, concepts, and pipes in the dependency graph. This reduces payload sizes for distributed execution and clarifies exactly what context is needed.
+
+This is feasible because execution is deterministic — the dependency graph is fully known at build time.
+
+### Future: Remote dependency resolution
+
+Resolve dependencies from GitHub method package addresses. When a bundle declares a dependency on `github:org/repo`, clone to a temp directory, parse the bundles, and merge into the crate. This enables running pipelines whose dependencies aren't pre-installed locally.
+
+---
+
+## 6. Generalization Across Execution Modes
+
+The LibraryCrate is **not** a Temporal-specific construct. It is the universal intermediate representation for all execution modes.
+
+**Direct execution** (in-process):
+```
+Bundles → LibraryCrate → Library (live, in same process)
+```
+
+**Distributed execution** (Temporal):
+```
+Bundles → LibraryCrate → serialize → send to worker → deserialize → Library (live, on worker)
+```
+
+The only difference is that distributed execution adds a serialize/deserialize step. The crate itself is identical.
+
+This means we build and validate the LibraryCrate in direct mode first. Once it works — once all existing tests pass through the `bundles → crate → library` path — distributed execution gets serialization for free because the crate is already a Pydantic model.
+
+---
+
+## 7. External Storage for Large Payloads
+
+When payloads grow beyond Temporal's 2MB limit (large libraries, WorkingMemory with images/documents), external storage becomes necessary.
+
+Each pipeline execution has a **pipeline run ID** that can serve as the storage key:
+
+- Before dispatching to Temporal, upload the crate and working memory to a storage backend
+- Workers fetch by run ID, load, execute, write back results
+- Uses the existing `StorageProviderAbstract` system
+
+This is a later optimization (Phase 4 in the master plan), not part of the core LibraryCrate design. The crate's serialization is a prerequisite — you can't upload what you can't serialize — but the storage mechanism is independent.
+
+---
+
+## 8. Open Questions
+
+- **Caching by fingerprint**: If the same LibraryCrate (same fingerprint) is used across multiple pipeline runs, can workers cache the loaded library and skip re-loading? This is especially valuable for Temporal workers processing many runs with the same library.
+
+- **Storage backend choice**: S3-compatible? Redis for short-lived data? The `StorageProviderAbstract` makes this pluggable, but the default choice matters for developer experience.
+
+- **Domain `system_prompt` migration**: The bundle-level `system_prompt` currently flows into the `Domain` object and is used as a fallback by PipeLLM pipes that don't define their own. When we flatten the crate (no domain-level data), this fallback must be inlined at pipe factory time — each PipeLLM gets its system_prompt resolved during construction, before entering the crate. This is a small change in `PipeLLMFactory` but needs to be done as part of Phase 0 or Phase 1.

--- a/wip/D-master-plan-distributed-execution-v2.md
+++ b/wip/D-master-plan-distributed-execution-v2.md
@@ -1,144 +1,180 @@
-# Master Plan v2: Distributed Execution with Library Context
+# Master Plan v2: LibraryCrate & Distributed Execution
 
 > **Status**: Master plan for phased implementation
 > **Date**: 2026-03-23
-> **Related**: [A-temporal-library-fix-proposals-v2.md](A-temporal-library-fix-proposals-v2.md), [B-library-as-execution-context.md](B-library-as-execution-context.md), [C-temporal-payload-codec-strategy.md](C-temporal-payload-codec-strategy.md)
+> **Related**: [B-library-as-execution-context.md](B-library-as-execution-context.md), [E-pipe-namespace-fix.md](E-pipe-namespace-fix.md), [C-temporal-payload-codec-strategy.md](C-temporal-payload-codec-strategy.md)
 
 ---
 
 ## Goal
 
-Enable distributed execution (Temporal) to work with full library context, so pipe controllers (PipeSequence, PipeCondition, PipeBatch, PipeParallel) can run on workers. Get there incrementally with fast, testable results at each phase.
+Introduce the LibraryCrate as the universal intermediate representation for library loading, then leverage it to enable distributed execution (Temporal) with full library context. Get there incrementally with fast, testable results at each phase.
 
 ---
 
 ## Design Principles
 
-1. **Same API for direct and distributed execution.** `library_context` is an optional parameter on `PipeJob` / `run_pipe`, not a Temporal-specific wrapper. No `TemporalPipeJobEnvelope`.
+1. **Three-stage pipeline.** `Bundles (files) → LibraryCrate (data) → Library (live)`. The crate is the clean boundary between sourcing and execution.
 
-2. **Library context = domains, not bundles.** The serializable unit is a domain containing concept blueprints and pipe blueprints (structured Pydantic models), not raw `.mthds` file text or bundle-level objects.
+2. **Flat and ref-keyed.** The crate is two flat dicts: concepts keyed by `concept_ref`, pipes keyed by `pipe_ref`. Domain is a namespace prefix in the key, not a structural container. No source paths, no package provenance.
 
-3. **Transparency in dashboards.** Everything in PipeJob remains visible as structured JSON in Temporal dashboards. No opaque bytes.
+3. **Same API for direct and distributed execution.** The LibraryCrate is not Temporal-specific. Direct mode builds and loads it in-process. Distributed mode serializes and ships it. The crate model is identical.
 
-4. **Deferred hydration, not deferred deserialization.** When WorkingMemory contains Stuff with dynamic concept classes unknown to the worker, it travels as a raw JSON dict (fully visible). After the library context is loaded and classes are registered, the dict is hydrated into typed `WorkingMemory`. This avoids both opaque bytes and Kajson modifications.
+4. **Transparency in dashboards.** Everything in PipeJob remains visible as structured JSON in Temporal dashboards. No opaque bytes.
+
+5. **TDD where it makes sense.** Each phase defines clear "done" criteria with specific tests. Write tests first for the new models and interfaces.
 
 ---
 
 ## Architecture Summary
 
-| Component | What it solves | Phase |
-|-----------|---------------|-------|
-| **LibraryContext + act_library_setup** | Library loading on worker (Layer 2: pipe resolution) | Phase 1 |
-| **Deferred WorkingMemory hydration** | Dynamic class registration timing (Layer 1: Kajson deser) | Phase 2 |
-| **StoragePayloadCodec** | Payload size limits (2MB) for large libraries and WorkingMemory | Phase 3 |
+| Phase | Component | What it solves |
+|-------|-----------|----------------|
+| **0** | Pipe namespace fix (`pipe_ref`) | Prerequisite: pipes indexed by domain-qualified ref, symmetric with concepts |
+| **1** | LibraryCrate (direct mode) | Universal intermediate between bundles and live library |
+| **2** | LibraryCrate on Temporal | Library loading on workers (Layer 2: pipe resolution) |
+| **3** | Deferred WorkingMemory hydration | Dynamic class registration timing (Layer 1: Kajson deser) |
+| **4** | StoragePayloadCodec | Payload size limits (2MB) for large libraries and WorkingMemory |
 
 ---
 
-## Phase 1: LibraryContext + act_library_setup
+## Phase 0: Pipe Namespace Fix (`pipe_ref`)
 
-**Goal**: Pipe controllers work on Temporal workers when all concepts come from the worker's base library (PIPELEXPATH). This covers the majority of use cases.
+**Goal**: Pipes are indexed by domain-qualified `pipe_ref` (`domain.pipe_code`), symmetric with how concepts use `concept_ref` (`domain.ConceptCode`). Multiple bundles can contribute to the same domain.
 
-**What it solves**: Layer 2 (pipe resolution). When the API loads additional library content (beyond PIPELEXPATH), that content travels with the workflow and is loaded on the worker before execution. `get_required_pipe()` finds everything.
+**Why first**: The LibraryCrate organizes content by domain. If pipes can collide across domains, the crate can't reliably merge content. This fix is also valuable independently — it eliminates a latent bug.
 
-**What it does NOT solve yet**: Layer 1 (dynamic class deserialization) for concepts introduced by `mthds_content` that aren't in PIPELEXPATH. That's Phase 2.
+See [E-pipe-namespace-fix.md](E-pipe-namespace-fix.md) for the full technical spec.
 
-### LibraryContext model
+### Changes
 
-The library context is organized by domain -- the semantic unit of the loaded library -- not by bundle (the file-system artifact).
-
-```python
-class DomainContext(BaseModel):
-    """A domain's worth of concept and pipe blueprints, ready to load."""
-    domain_code: str
-    description: str | None = None
-    concepts: dict[str, ConceptBlueprint]       # concept_code -> blueprint
-    pipes: dict[str, PipeBlueprintUnion]         # pipe_code -> blueprint
-
-class LibraryContext(BaseModel):
-    """Library content that must be loaded on the worker before execution."""
-    domains: list[DomainContext]
-    fingerprint: str                             # SHA256 for caching
-```
-
-**How it's built** (API side, in `PipeRouterTop`):
-- After `pipeline_run_setup()` loads the library, extract the domains that came from additional content (not from PIPELEXPATH base)
-- Build `DomainContext` for each, pulling concept/pipe blueprints from the loaded `PipelexBundleBlueprint` objects
-- Compute fingerprint from serialized domains
-- If no additional content beyond PIPELEXPATH, `library_context = None`
-
-**Where it lives**: On `PipeJob` as an optional field.
-
-```python
-class PipeJob(BaseModel):
-    pipe: PipeAbstract
-    working_memory: WorkingMemory
-    pipe_run_params: PipeRunParams
-    job_metadata: JobMetadata
-    output_name: str | None = None
-    library_context: LibraryContext | None = None    # NEW
-```
-
-This is the same PipeJob used by both direct and distributed execution. In direct mode, `library_context` is always `None` (the library is already in-process). In distributed mode, it's populated when there's additional content beyond the worker's base.
-
-### act_library_setup activity
-
-```python
-@activity.defn
-async def act_library_setup(library_context: LibraryContext) -> None:
-    # 1. Check cache: if fingerprint already loaded, skip
-    # 2. Convert DomainContexts -> PipelexBundleBlueprints (or load directly)
-    # 3. Call library_manager.load_from_blueprints(library_id, blueprints)
-    # 4. Cache fingerprint
-```
-
-- Retry-safe (activities may re-execute due to retries/failures)
-- Idempotent (same fingerprint = no-op via in-process cache)
-- Uses `library_manager.load_from_blueprints()` (already exists)
-
-### WfPipeRouter changes
-
-```python
-@workflow.run
-async def run(self, pipe_job: PipeJob) -> PipeOutput:
-    # NEW: if library context present, load it first
-    if pipe_job.library_context is not None:
-        await workflow.execute_activity(
-            act_library_setup,
-            pipe_job.library_context,
-            start_to_close_timeout=timedelta(seconds=30),
-        )
-    # Then execute pipe as before
-    return await pipe_job.pipe.run_pipe(...)
-```
-
-### What to test
-
-- Integration test: Send a PipeSequence through Temporal with PIPELEXPATH-based library only (no library_context needed, Tier 1)
-- Integration test: Send a PipeSequence with `mthds_content` containing additional pipes (library_context shipped, loaded via activity)
-- Verify `get_required_pipe()` works on worker for child pipes
+- Add `pipe_ref` property to `PipeAbstract` = `f"{domain_code}.{code}"`
+- Rekey `PipeLibrary` root dict from bare `code` to `pipe_ref`
+- Update `add_new_pipe()`, `get_optional_pipe()`, `get_required_pipe()` to use `pipe_ref` as primary key
+- Update `library_manager.load_from_blueprints()` pipe tracking and source mapping
+- Fix `DomainLibrary.add_domain()` to support additive merging (or make idempotent for same-domain re-adds)
+- Update all call sites that assume bare-code pipe indexing
 
 ### Key files
 
 | File | Change |
 |------|--------|
-| `pipelex/temporal/library_context.py` | **New** -- DomainContext, LibraryContext models |
-| `pipelex/temporal/tprl_pipe/act_library_setup.py` | **New** -- Library setup activity |
-| `pipelex/temporal/tprl_pipe/wf_pipe_router.py` | Call act_library_setup before pipe execution |
-| `pipelex/temporal/tprl_pipe/pipe_router_top.py` | Build LibraryContext when dispatching |
-| `pipelex/pipe_run/pipe_job.py` | Add `library_context: LibraryContext | None` field |
-| `pipelex/temporal/temporal_tasks.py` | Register act_library_setup |
+| `pipelex/core/pipes/pipe_abstract.py` | Add `pipe_ref` property |
+| `pipelex/libraries/pipe/pipe_library.py` | Rekey root dict by `pipe_ref`, update all lookup methods |
+| `pipelex/libraries/pipe/pipe_library_abstract.py` | Update interface signatures |
+| `pipelex/libraries/library_manager.py` | Update `pipe_source_in_this_load`, source map tracking |
+| `pipelex/libraries/domain/domain_library.py` | Support additive domain merging |
+| `pipelex/hub.py` | Update global pipe lookup helpers |
+| `pipelex/pipe_controllers/sub_pipe.py` | Update pipe resolution |
+| Multiple call sites | Audit all `get_required_pipe(pipe_code=...)` calls |
 
-### Future expansion
+### Done when
 
-- Multi-package dependencies in LibraryContext
-- Library fingerprint validation (worker base matches API expectation)
-- Cross-worker cache via shared storage
+- [ ] All existing tests pass with `pipe_ref`-based indexing
+- [ ] New unit test: two pipes with same code in different domains coexist in one `PipeLibrary`
+- [ ] New unit test: domain-qualified lookup returns correct pipe when same code exists in multiple domains
+- [ ] New unit test: bare-code lookup still works when unambiguous (single domain)
+- [ ] New unit test: bare-code lookup raises when ambiguous (same code in multiple domains)
+- [ ] New unit test: multiple bundles for the same domain can be loaded (domain merging)
+- [ ] `make agent-check` passes
+- [ ] `make agent-test` passes
 
 ---
 
-## Phase 2: Deferred WorkingMemory Hydration
+## Phase 1: LibraryCrate (Direct Mode)
 
-**Goal**: Handle the Layer 1 problem -- when `mthds_content` introduces dynamic concept classes that the worker doesn't know about at deserialization time.
+**Goal**: All library loading goes through `LibraryCrate` as an intermediate. The three-stage pipeline (`bundles → crate → library`) is the only path. Works in direct execution mode.
+
+### LibraryCrate model
+
+```python
+class LibraryCrate(BaseModel):
+    """Complete library content, ready to load into a live Library."""
+    concepts: dict[str, ConceptBlueprint]    # concept_ref (domain.Code) -> blueprint
+    pipes: dict[str, PipeBlueprintUnion]     # pipe_ref (domain.pipe_code) -> blueprint
+    fingerprint: str                         # SHA256 of serialized content
+```
+
+Flat structure. Domain is implicit in the keys — `scoring.WeightedScore`, `scoring.compute_score`. No `DomainCrate` wrapper.
+
+### Changes
+
+- Define `LibraryCrate` model with serialization tests
+- `LibraryCrateFactory.make_from_blueprints(blueprints)`: for each bundle, qualify concept codes and pipe codes with the bundle's domain, add to flat dicts, compute fingerprint. Same ref appearing twice = error.
+- New `LibraryManager.load_from_crate(library_id, crate)`: extract domain codes from refs, create domains/concepts/pipes. This becomes the single entry point for loading.
+- Refactor `load_from_blueprints()`: internally builds a crate, then calls `load_from_crate()`. Callers don't change yet, but the path goes through the crate.
+- Update `pipeline_run_setup()` to route through the crate path.
+
+### Key files
+
+| File | Change |
+|------|--------|
+| `pipelex/libraries/library_crate.py` | **New** — `LibraryCrate` model |
+| `pipelex/libraries/library_crate_factory.py` | **New** — `make_from_blueprints()`, fingerprint computation |
+| `pipelex/libraries/library_manager.py` | Add `load_from_crate()`, refactor `load_from_blueprints()` to go through crate |
+| `pipelex/pipeline/pipeline_run_setup.py` | Route through crate |
+
+### Done when
+
+- [ ] `LibraryCrate` model serializes and deserializes correctly (unit test: JSON round-trip)
+- [ ] `make_from_blueprints()` merges correctly (unit test: two blueprints for same domain → both pipes/concepts in flat crate with qualified refs)
+- [ ] `make_from_blueprints()` raises on concept/pipe code collision within a domain (unit test)
+- [ ] `load_from_crate()` produces a valid library equivalent to `load_from_blueprints()` (integration test)
+- [ ] All existing pipeline tests pass through the new `bundles → crate → library` path
+- [ ] `make agent-check` passes
+- [ ] `make agent-test` passes
+
+---
+
+## Phase 2: LibraryCrate on Temporal
+
+**Goal**: Temporal workers receive and load a LibraryCrate. Pipe controllers (PipeSequence, PipeCondition, PipeBatch, PipeParallel) work on workers. This solves Layer 2 (pipe resolution).
+
+**What it does NOT solve yet**: Layer 1 (dynamic class deserialization) for concepts introduced by `mthds_content` that aren't in PIPELEXPATH. That's Phase 3.
+
+### Changes
+
+- Add `library_crate: LibraryCrate | None` field to `PipeJob`
+- In `PipeRouterTop`: after `pipeline_run_setup()` loads the library, build the flat crate from the blueprints that were loaded beyond PIPELEXPATH base. Attach to `PipeJob`.
+- New `act_library_setup` activity: receives a `LibraryCrate`, calls `load_from_crate()`. Idempotent via fingerprint caching.
+- Update `WfPipeRouter`: call `act_library_setup` before pipe execution if `library_crate` is present.
+
+```python
+@workflow.run
+async def run(self, pipe_job: PipeJob) -> PipeOutput:
+    if pipe_job.library_crate is not None:
+        await workflow.execute_activity(
+            act_library_setup,
+            pipe_job.library_crate,
+            start_to_close_timeout=timedelta(seconds=30),
+        )
+    return await pipe_job.pipe.run_pipe(...)
+```
+
+### Key files
+
+| File | Change |
+|------|--------|
+| `pipelex/pipe_run/pipe_job.py` | Add `library_crate: LibraryCrate | None` field |
+| `pipelex/temporal/tprl_pipe/act_library_setup.py` | **New** — library setup activity |
+| `pipelex/temporal/tprl_pipe/wf_pipe_router.py` | Call `act_library_setup` before pipe execution |
+| `pipelex/temporal/tprl_pipe/pipe_router_top.py` | Build `LibraryCrate` when dispatching |
+| `pipelex/temporal/temporal_tasks.py` | Register `act_library_setup` |
+
+### Done when
+
+- [ ] Integration test: PipeSequence through Temporal with PIPELEXPATH-based library only (no crate needed)
+- [ ] Integration test: PipeSequence with `mthds_content` containing additional pipes (crate shipped, loaded via activity)
+- [ ] `get_required_pipe()` works on worker for child pipes
+- [ ] Crate is visible as structured JSON in Temporal dashboard
+- [ ] `make agent-check` passes
+- [ ] `make agent-test` passes
+
+---
+
+## Phase 3: Deferred WorkingMemory Hydration
+
+**Goal**: Handle Layer 1 — when `mthds_content` introduces dynamic concept classes that the worker doesn't know about at deserialization time.
 
 **The problem**: Temporal auto-deserializes PipeJob via the Kajson data converter. If WorkingMemory contains Stuff objects with dynamic content classes (e.g., `RawText`), Kajson fails because those classes aren't registered on the worker yet. The `act_library_setup` activity can't run until the workflow starts, but the workflow input must be deserialized first.
 
@@ -154,68 +190,8 @@ class PipeJob(BaseModel):
     pipe_run_params: PipeRunParams
     job_metadata: JobMetadata
     output_name: str | None = None
-    library_context: LibraryContext | None = None
+    library_crate: LibraryCrate | None = None
 ```
-
-- **Direct mode**: `working_memory` is always set, `working_memory_raw` is always `None`
-- **Temporal, base concepts only**: `working_memory` is set (Kajson can deserialize because classes are registered at worker startup)
-- **Temporal, dynamic concepts**: `working_memory = None`, `working_memory_raw` is the raw JSON dict. After library setup, hydrate it.
-
-### PipeRouterTop changes
-
-When dispatching to Temporal:
-1. Check if the WorkingMemory contains Stuff with dynamic concepts (beyond PIPELEXPATH base)
-2. If yes: serialize WorkingMemory to dict via `kajson.dumps()` / `json.loads()`, set `working_memory_raw`, clear `working_memory`
-3. If no: leave `working_memory` as-is (normal path)
-
-### WfPipeRouter changes
-
-```python
-@workflow.run
-async def run(self, pipe_job: PipeJob) -> PipeOutput:
-    # Load library context if present
-    if pipe_job.library_context is not None:
-        await workflow.execute_activity(
-            act_library_setup,
-            pipe_job.library_context,
-            start_to_close_timeout=timedelta(seconds=30),
-        )
-
-    # Hydrate working memory if deferred
-    working_memory: WorkingMemory
-    if pipe_job.working_memory is not None:
-        working_memory = pipe_job.working_memory
-    elif pipe_job.working_memory_raw is not None:
-        # Classes now registered by act_library_setup
-        working_memory = hydrate_working_memory(pipe_job.working_memory_raw)
-    else:
-        raise WorkflowInputError("No working memory")
-
-    return await pipe_job.pipe.run_pipe(working_memory=working_memory, ...)
-```
-
-### Hydration
-
-```python
-def hydrate_working_memory(raw: dict[str, Any]) -> WorkingMemory:
-    """Reconstruct typed WorkingMemory from raw JSON dict using Kajson."""
-    json_str = json.dumps(raw)
-    return kajson.loads(json_str, WorkingMemory)
-```
-
-Kajson now succeeds because `act_library_setup` registered the dynamic classes.
-
-### Dashboard visibility
-
-- `working_memory_raw` is a plain JSON dict -- fully visible and inspectable in Temporal dashboards
-- `library_context` is structured Pydantic data -- also fully visible
-- No opaque bytes anywhere
-
-### What to test
-
-- Integration test: PipeSequence with `mthds_content` containing a custom concept with inline structure (dynamic class)
-- Verify working_memory_raw hydrates correctly after library setup
-- Verify Stuff objects have correct typed content after hydration
 
 ### Key files
 
@@ -224,24 +200,28 @@ Kajson now succeeds because `act_library_setup` registered the dynamic classes.
 | `pipelex/pipe_run/pipe_job.py` | Add `working_memory_raw: dict[str, Any] | None` field |
 | `pipelex/temporal/tprl_pipe/pipe_router_top.py` | Detect dynamic concepts, serialize WM to raw dict |
 | `pipelex/temporal/tprl_pipe/wf_pipe_router.py` | Hydration logic after library setup |
-| `pipelex/temporal/tprl_pipe/hydration.py` | **New** -- `hydrate_working_memory()` utility |
+| `pipelex/temporal/tprl_pipe/hydration.py` | **New** — `hydrate_working_memory()` utility |
 
-### Future expansion
+### Done when
 
-- Smarter detection of "needs deferred hydration" (check if all content classes are in base registry)
-- Partial hydration (only defer Stuff objects with unknown classes)
+- [ ] Integration test: PipeSequence with `mthds_content` containing a custom concept with inline structure (dynamic class)
+- [ ] `working_memory_raw` hydrates correctly after library setup
+- [ ] Stuff objects have correct typed content after hydration
+- [ ] `working_memory_raw` is visible as plain JSON in Temporal dashboard
+- [ ] `make agent-check` passes
+- [ ] `make agent-test` passes
 
 ---
 
-## Phase 3: StoragePayloadCodec
+## Phase 4: StoragePayloadCodec
 
 **Goal**: Remove the 2MB payload size limit for production workloads with large libraries or WorkingMemory containing images/documents.
 
-**Why third**: Phases 1-2 work for small-to-medium payloads. Phase 3 is needed when payloads grow beyond Temporal's limits.
+**Why last**: Phases 0-3 work for small-to-medium payloads. Phase 4 is needed when payloads grow beyond Temporal's limits.
 
 ### StoragePayloadCodec
 
-Extends `temporalio.converter.PayloadCodec`. Operates at the wire boundary -- transparent to all application code.
+Extends `temporalio.converter.PayloadCodec`. Operates at the wire boundary — transparent to all application code.
 
 ```
 Application code                    StoragePayloadCodec               Temporal Server
@@ -258,43 +238,67 @@ return WorkingMemory (50MB)       reconstruct original payload        Event Hist
 - V1: `LocalStorageProvider` (same filesystem for dev)
 - Threshold: 1MB (configurable, well under 2MB hard limit)
 
-### Integration
-
-The codec is composed into the existing `DataConverter` and passed to both client and worker.
-
 ### Key files
 
 | File | Change |
 |------|--------|
-| `pipelex/temporal/storage_payload_codec.py` | **New** -- StoragePayloadCodec class |
+| `pipelex/temporal/storage_payload_codec.py` | **New** — StoragePayloadCodec class |
 | `pipelex/temporal/temporal_data_converter.py` | Add codec to DataConverter |
 | `pipelex/temporal/temporal_connect.py` | Pass codec-enabled converter |
 | `pipelex/temporal/worker_cli.py` | Pass codec-enabled converter |
 | `pipelex/temporal/config_temporal.py` | Add payload codec config |
 | `pipelex/pipelex.toml` | Add `[pipelex.temporal.payload_codec]` |
 
-### Future expansion
+### Done when
 
-- S3/GCP backend (swap storage provider config)
-- TTL/lifecycle rules
-- Codec Server for Temporal Web UI observability
-- Migration to Temporal's native `ExternalStorage` API when released
+- [ ] Unit test: payloads above threshold are stored externally, below threshold pass through
+- [ ] Unit test: content-addressed deduplication works
+- [ ] Integration test: large WorkingMemory survives Temporal round-trip
+- [ ] `make agent-check` passes
+- [ ] `make agent-test` passes
+
+---
+
+## Future Phases (Out of Scope)
+
+These are documented for roadmap visibility but not planned for implementation now.
+
+### Crate Stripping (Static Dependency Tree)
+
+From the entry pipe, walk the transitive closure of `pipe_dependencies()` + `concept_dependencies` to determine the minimal subset of the library needed. Strip the crate to only those domains/concepts/pipes. Reduces payload size and clarifies execution context.
+
+### Remote Dependency Resolution
+
+Resolve dependencies from GitHub method package addresses (e.g., `github:org/repo`). Clone to a temp directory, parse bundles, merge into the crate. Enables running pipelines whose dependencies aren't pre-installed.
+
+### Library Fingerprint Validation
+
+Verify that the worker's base library (PIPELEXPATH) matches the API's expectation. Detect version drift between API and worker deployments.
+
+### Cross-Worker Cache via Shared Storage
+
+Cache loaded libraries in shared storage (Redis, S3) so multiple workers don't redundantly load the same crate. Keyed by fingerprint.
 
 ---
 
 ## Dependencies Between Phases
 
 ```
-Phase 1 (LibraryContext + act_library_setup)
-    |
-    v
-Phase 2 (Deferred WM Hydration)        -- requires Phase 1's library_context and activity
-    |
-    v
-Phase 3 (StoragePayloadCodec)           -- independent, but needed for production payloads
+Phase 0 (pipe_ref fix)
+    │
+    ▼
+Phase 1 (LibraryCrate, direct mode)
+    │
+    ▼
+Phase 2 (LibraryCrate on Temporal)
+    │
+    ▼
+Phase 3 (Deferred WM Hydration)        ← requires Phase 2's library_crate and activity
+
+Phase 4 (StoragePayloadCodec)           ← independent, can parallel with Phase 3
 ```
 
-Phase 1 is immediately testable with small payloads. Phase 2 builds on Phase 1's activity. Phase 3 is independently useful and can be done in parallel with Phase 2 if needed.
+Phase 0 is a prerequisite for Phase 1 (domain-qualified indexing). Phase 1 is a prerequisite for Phase 2 (crate must exist to ship it). Phase 3 builds on Phase 2's activity. Phase 4 is independently useful.
 
 ---
 
@@ -306,17 +310,18 @@ Phase 1 is immediately testable with small payloads. Phase 2 builds on Phase 1's
 | Kajson data converter | `temporal_data_converter.py` | Done |
 | Storage provider system (local/S3/GCP) | `pipelex/tools/storage/` | Done |
 | Library manager with multi-library + ContextVar | `pipelex/libraries/library_manager.py` | Done |
-| `load_from_blueprints()` | `library_manager.py` | Done |
+| `load_from_blueprints()` | `library_manager.py` | Done (will refactor through crate) |
 | `PipelexInterpreter.make_pipelex_bundle_blueprint()` | interpreter | Done |
 | ConceptBlueprint, PipeBlueprintUnion models | `pipelex/core/` | Done |
+| `concept_ref` on Concept | `pipelex/core/concepts/concept.py` | Done (model for `pipe_ref`) |
 
 ---
 
 ## Implementation Pattern Per Phase
 
-1. **Model + unit tests** -- Define new models, test serialization
-2. **Core logic + unit tests** -- Activity / codec / hydration logic
-3. **Integration** -- Wire into Temporal plumbing
-4. **`make agent-check`** -- Lint + type check
-5. **Integration test** -- End-to-end through Temporal
-6. **`make agent-test`** -- Full suite passes
+1. **Tests first** — Define new models, write serialization/unit tests before implementation
+2. **Model + core logic** — Implement models and core functions, pass unit tests
+3. **Integration** — Wire into existing plumbing, pass integration tests
+4. **`make agent-check`** — Lint + type check
+5. **`make agent-test`** — Full suite passes
+6. **Review "done" checklist** — All criteria met before moving to next phase

--- a/wip/E-pipe-namespace-fix.md
+++ b/wip/E-pipe-namespace-fix.md
@@ -1,0 +1,195 @@
+# Pipe Namespace Fix: Domain-Qualified `pipe_ref`
+
+> **Status**: Technical spec — Phase 0 of the master plan
+> **Date**: 2026-03-23
+> **Related**: [D-master-plan-distributed-execution-v2.md](D-master-plan-distributed-execution-v2.md), [B-library-as-execution-context.md](B-library-as-execution-context.md)
+
+---
+
+## 1. Problem
+
+Pipes and concepts have asymmetric namespace behavior in the library.
+
+**Concepts** are indexed by `concept_ref` = `domain.ConceptCode` (e.g., `scoring.WeightedScore`). Two concepts with the same code in different domains coexist without conflict. This is correct.
+
+**Pipes** are indexed by bare `code` (e.g., `compute_score`, not `scoring.compute_score`). If two domains define a pipe with the same code, the second collides with the first.
+
+### Where the asymmetry lives
+
+| Component | Concept key | Pipe key |
+|-----------|-------------|----------|
+| `ConceptLibrary.root` | `concept_ref` = `domain.Code` | — |
+| `PipeLibrary.root` | — | bare `code` |
+| `add_new_concept()` | checks `concept.concept_ref` | — |
+| `add_new_pipe()` | — | checks `pipe.code` |
+| `get_optional_concept()` | looks up by `concept_ref` | — |
+| `get_optional_pipe()` | looks up by bare `code`, domain validation is a fallback | — |
+
+### Code references
+
+- `PipeLibrary.add_new_pipe()` at `pipe_library.py:39-48`: keys by `pipe.code`
+- `PipeLibrary.get_optional_pipe()` at `pipe_library.py:56-82`: primary lookup by bare code, domain-qualified lookup is a fallback that still resolves to bare code internally
+- `ConceptLibrary.add_new_concept()` at `concept_library.py:81-85`: keys by `concept.concept_ref`
+- `library_manager.py:378`: `pipe_source_in_this_load` tracks by bare `pipe_code`
+- `library_manager.py:402`: `_pipe_source_map` tracks by bare `pipe_code`
+
+### Additional issue: Domain merging
+
+`DomainLibrary.add_domain()` at `domain_library.py:32-37` raises if the domain already exists. This prevents multiple bundles from contributing to the same domain — a legitimate use case (e.g., `scoring_core.mthds` and `scoring_advanced.mthds` both declaring `domain: scoring`).
+
+---
+
+## 2. The Fix
+
+### 2.1 Add `pipe_ref` to `PipeAbstract`
+
+```python
+# pipelex/core/pipes/pipe_abstract.py
+class PipeAbstract(ABC, BaseModel):
+    code: str
+    domain_code: str
+    # ...
+
+    @property
+    def pipe_ref(self) -> str:
+        """Domain-qualified pipe reference, e.g. 'scoring.compute_score'."""
+        return f"{self.domain_code}.{self.code}"
+```
+
+This mirrors `concept_ref` on `Concept` (which is `domain.ConceptCode`).
+
+### 2.2 Rekey `PipeLibrary`
+
+```python
+# pipelex/libraries/pipe/pipe_library.py
+PipeLibraryRoot = dict[str, PipeAbstract]  # key changes from code to pipe_ref
+
+def add_new_pipe(self, pipe: PipeAbstract):
+    if pipe.pipe_ref in self.root:
+        msg = f"Pipe '{pipe.pipe_ref}' already exists in the library. ..."
+        raise PipeLibraryError(msg)
+    self.root[pipe.pipe_ref] = pipe
+```
+
+### 2.3 Update lookup methods
+
+`get_optional_pipe()` needs to handle three lookup forms:
+
+1. **Domain-qualified** (`scoring.compute_score`): Direct lookup by `pipe_ref` — this becomes the primary path
+2. **Bare code** (`compute_score`): Search across all domains. If exactly one match, return it. If multiple matches (same code in different domains), raise ambiguity error. If zero matches, return None.
+3. **Cross-package** (`alias->scoring.compute_score` or `alias->compute_score`): Existing aliased lookup, adjusted for `pipe_ref` keying
+
+```python
+def get_optional_pipe(self, pipe_code: str) -> PipeAbstract | None:
+    # 1. Direct lookup (works for pipe_ref and cross-package keys)
+    pipe = self.root.get(pipe_code)
+    if pipe is not None:
+        return pipe
+
+    # 2. Cross-package refs
+    if QualifiedRef.has_cross_package_prefix(pipe_code):
+        alias, remainder = QualifiedRef.split_cross_package_ref(pipe_code)
+        # Try domain-qualified remainder
+        pipe = self.root.get(f"{alias}->{remainder}")
+        if pipe is not None:
+            return pipe
+        # Try bare code remainder — search aliased entries
+        if "." not in remainder:
+            # ... search alias->domain.code entries
+            pass
+        return None
+
+    # 3. Bare code — search across domains
+    if "." not in pipe_code:
+        matches = [p for p in self.root.values() if p.code == pipe_code]
+        if len(matches) == 1:
+            return matches[0]
+        if len(matches) > 1:
+            domains = [p.domain_code for p in matches]
+            msg = f"Ambiguous pipe code '{pipe_code}' found in domains: {domains}. Use domain-qualified ref."
+            raise PipeLibraryError(msg)
+        return None
+
+    return None
+```
+
+### 2.4 Update `library_manager.py`
+
+In `load_from_blueprints()`:
+- `pipe_source_in_this_load` should key by `pipe_ref` (= `f"{blueprint.domain}.{pipe_code}"`)
+- `_pipe_source_map` should key by `pipe_ref`
+
+### 2.5 Fix domain merging
+
+Domains are namespace metadata — they carry `code`, `description`, and `system_prompt`. Since the LibraryCrate is flat (no domain-level grouping), domains exist only in the live `Library` as lightweight metadata objects extracted from the refs.
+
+`DomainLibrary.add_domain()` should be idempotent for re-adds of the same domain:
+
+```python
+def add_domain(self, domain: Domain):
+    domain_code = domain.code
+    if domain_code in self.root:
+        # Same domain from another bundle — idempotent (Domain is just namespace metadata)
+        return
+    self.root[domain_code] = domain
+```
+
+Since domains carry no meaningful runtime state beyond the namespace itself, simple idempotency is sufficient. The `system_prompt` field on Domain is a legacy convenience (PipeLLM fallback) that should be inlined at pipe factory time before crate construction.
+
+---
+
+## 3. Migration: Call Sites to Update
+
+Every place that passes a bare pipe code as a lookup key needs to be audited. Most will continue to work because the bare-code fallback handles unambiguous lookups. But some sites may need to pass domain-qualified refs.
+
+### Direct `get_required_pipe()` / `get_optional_pipe()` callers
+
+These are the 41 files identified in the investigation. Key categories:
+
+- **Pipe controllers** (`sub_pipe.py`, `pipe_sequence.py`, `pipe_batch.py`, `pipe_parallel.py`, `pipe_condition.py`): These call `get_required_pipe()` with the sub-pipe code from the blueprint. Currently bare codes. If the pipe is in the same domain, the bare code lookup will find it (unambiguous). If cross-domain, the blueprint already uses domain-qualified or cross-package refs.
+
+- **Pipeline setup** (`pipeline_run_setup.py`, `pipeline_manager.py`): Calls `get_required_pipe(pipe_code=pipe_code)` where `pipe_code` comes from user input or `main_pipe`. User input may be bare or qualified — the fallback handles both.
+
+- **Hub helpers** (`hub.py`): Thin wrappers, no change needed beyond forwarding.
+
+- **Temporal routers** (`pipe_router_top.py`, `pipe_router_child.py`): Same pattern as pipeline setup.
+
+- **CLI commands**: Various show/validate/run commands that resolve pipes by code. Should work via fallback.
+
+### `_pipe_source_map` consumers
+
+`library_manager.py` uses `_pipe_source_map` to track which file a pipe came from. Must rekey by `pipe_ref`. Check `get_pipe_source()` method.
+
+### Tests
+
+Existing test helpers that create pipes and add them to libraries will need to provide `domain_code` for proper `pipe_ref` generation. Check all test fixtures and factories.
+
+---
+
+## 4. Test Plan
+
+### Unit tests for `PipeLibrary`
+
+1. **Multi-domain coexistence**: Create two pipes with same code (`compute_score`) in different domains (`scoring`, `analytics`). Add both to same `PipeLibrary`. Both exist and are retrievable by `pipe_ref`.
+
+2. **Domain-qualified lookup**: Look up `scoring.compute_score` → returns scoring domain's pipe. Look up `analytics.compute_score` → returns analytics domain's pipe.
+
+3. **Bare-code unambiguous**: When only one pipe with code `compute_score` exists, bare lookup `compute_score` returns it.
+
+4. **Bare-code ambiguous**: When two domains both have `compute_score`, bare lookup `compute_score` raises `PipeLibraryError` with helpful message listing the domains.
+
+5. **Cross-package refs still work**: `alias->scoring.compute_score` lookup works with `pipe_ref`-keyed entries.
+
+### Unit tests for `DomainLibrary`
+
+6. **Domain idempotency**: Add domain `scoring` twice → no error, domain exists once.
+
+### Integration tests
+
+7. **Load multi-bundle same domain**: Create two `.mthds` files both declaring `domain: scoring` with different pipes. Load both. All pipes accessible. Domain exists once.
+
+8. **Full pipeline through multi-domain library**: A PipeSequence referencing pipes from multiple domains runs correctly.
+
+### Regression
+
+9. **All existing tests pass**: `make agent-test` green.


### PR DESCRIPTION
## Summary

- **Pipe namespace fix**: Pipes are now indexed by domain-qualified `pipe_ref` (`domain.pipe_code`) instead of bare `code`, symmetric with how concepts use `concept_ref`. Two pipes with the same code in different domains now coexist without collision.
- **Concept duplicate detection**: Fixed a bug where two `.mthds` files declaring the same concept in the same domain silently deduplicated (last-write-wins). Now raises `ConceptLibraryError` with a clear message identifying both source files.
- **Domain merging**: `DomainLibrary.add_domain()` is now idempotent — multiple bundles can contribute to the same domain without error.
- **Architecture docs**: Added LibraryCrate vision doc, master plan v2, and pipe namespace fix spec.

### Key changes
- `PipeAbstract.pipe_ref` property: `f"{domain_code}.{code}"`
- `PipeLibrary` rekeyed by `pipe_ref` with bare-code fallback (ambiguity detection)
- `LibraryManager` pipe/concept source tracking uses `pipe_ref`/`concept_ref`
- Renamed `remove_pipes_by_codes` → `remove_pipes_by_refs`

## Test plan
- [x] Unit tests: pipe_ref lookup, multi-domain coexistence, ambiguity detection, collision, cross-package refs, malformed refs
- [x] Unit tests: domain idempotency
- [x] Integration tests: load real `.mthds` files for multi-domain coexistence, multi-bundle same domain, duplicate pipe/concept detection, bare code lookup, wrong domain lookup
- [x] `make agent-check` passes (pyright, mypy, ruff, plxt)
- [x] `make agent-test` passes (4132 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pipes are now keyed by domain-qualified pipe_ref (domain.code) across dry-run, validation, controllers, and pipeline setup to prevent cross-domain collisions. Duplicate concept declarations now error with clear source locations, and multi-line TOML strings are emitted via a shared formatter.

- **New Features**
  - Index pipes by `pipe_ref` with bare-code fallback and ambiguity detection; cross‑package refs continue to work (`alias->domain.code`).
  - Concept duplicate detection across bundles raises `ConceptLibraryError`; domains can be added idempotently; pipe source tracking uses `pipe_ref`.
  - Introduced `format_toml_string` and applied to CLI and factory output for `description`, `prompt`, `system_prompt`, and `template`.

- **Bug Fixes**
  - Dry-run results keyed by `pipe_ref`; allowed-to-fail comparison uses the bare code from `DryRunOutput`; clarified loop variable names to match `pipe_ref` keys; added TODO to address domain-ambiguous `allowed_to_fail_pipes` matching.
  - Qualify `main_pipe` with domain during pipeline setup to avoid ambiguity.
  - Recursion detection in `PipeSequence`, `PipeParallel`, and `PipeCondition` uses `pipe_ref`.
  - Validation output reports pipes by `pipe_ref`; domain merging warns on conflicting metadata.

<sup>Written for commit 7e73ddb15f22aadb1c00bae27c5bb6c38d3b334f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

