### PR TITLE
Skip gateway models file write when only date changed

### DIFF
--- a/pipelex/cli/dev_cli/commands/check_gateway_models_cmd.py
+++ b/pipelex/cli/dev_cli/commands/check_gateway_models_cmd.py
@@ -13,6 +13,7 @@ from pipelex.cli.dev_cli.commands.gateway_models_generator import (
     fetch_gateway_model_specs,
     generate_reference_markdown,
     generate_reference_pure_markdown,
+    normalize_for_comparison,
 )
 from pipelex.cli.dev_cli.commands.update_gateway_models_cmd import (
     GATEWAY_MODELS_PLAIN_REFERENCE_PATH,
@@ -23,12 +24,6 @@ from pipelex.system.pipelex_service.exceptions import RemoteConfigFetchError, Re
 
 if TYPE_CHECKING:
     from rich.console import Console
-
-
-def _normalize_for_comparison(content: str) -> str:
-    """Remove timestamp line for comparison since it changes every generation."""
-    lines = content.split("\n")
-    return "\n".join(line for line in lines if not line.startswith("> Last updated:"))
 
 
 def check_gateway_models_cmd(show_diff: bool = True, quiet: bool = False) -> None:
@@ -127,8 +122,8 @@ def check_gateway_models_cmd(show_diff: bool = True, quiet: bool = False) -> Non
         sys.exit(1)
 
     # Compare content (ignoring timestamp line for comparison)
-    html_matches = _normalize_for_comparison(existing_html_content) == _normalize_for_comparison(expected_html_content)
-    plain_matches = _normalize_for_comparison(existing_plain_content) == _normalize_for_comparison(expected_plain_content)
+    html_matches = normalize_for_comparison(existing_html_content) == normalize_for_comparison(expected_html_content)
+    plain_matches = normalize_for_comparison(existing_plain_content) == normalize_for_comparison(expected_plain_content)
 
     if html_matches and plain_matches:
         # No differences found in either file

--- a/pipelex/cli/dev_cli/commands/gateway_models_generator.py
+++ b/pipelex/cli/dev_cli/commands/gateway_models_generator.py
@@ -27,6 +27,12 @@ PREFERRED_INPUT_ORDER = ["text", "images", "image", "pdf"]
 PREFERRED_OUTPUT_ORDER = ["text", "structured", "image", "pages"]
 
 
+def normalize_for_comparison(content: str) -> str:
+    """Remove timestamp line for comparison since it changes every generation."""
+    lines = content.split("\n")
+    return "\n".join(line for line in lines if not line.startswith("> Last updated:"))
+
+
 def fetch_gateway_model_specs() -> BackendModelSpecs:
     """Fetch model specifications from Pipelex Gateway remote config.
 

--- a/pipelex/cli/dev_cli/commands/update_gateway_models_cmd.py
+++ b/pipelex/cli/dev_cli/commands/update_gateway_models_cmd.py
@@ -77,26 +77,30 @@ def update_gateway_models_cmd(quiet: bool = False) -> None:
 
     # Skip writing if the only change is the timestamp (avoids noisy diffs in PRs)
     if GATEWAY_MODELS_REFERENCE_PATH.exists() and GATEWAY_MODELS_PLAIN_REFERENCE_PATH.exists():
-        existing_html = GATEWAY_MODELS_REFERENCE_PATH.read_text(encoding="utf-8")
-        existing_plain = GATEWAY_MODELS_PLAIN_REFERENCE_PATH.read_text(encoding="utf-8")
-        html_unchanged = normalize_for_comparison(existing_html) == normalize_for_comparison(markdown_content)
-        plain_unchanged = normalize_for_comparison(existing_plain) == normalize_for_comparison(plain_markdown_content)
-        if html_unchanged and plain_unchanged:
-            if quiet:
-                console.print(f"[green]✓ Gateway models update: UP-TO-DATE[/green] ({model_count} models, no changes)")
-            else:
-                up_to_date_panel = Panel(
-                    f"[green]✓[/green] Reference files are already up-to-date (skipped write)\n\n"
-                    f"[dim]HTML-styled: {GATEWAY_MODELS_REFERENCE_PATH}[/dim]\n"
-                    f"[dim]Plain text:  {GATEWAY_MODELS_PLAIN_REFERENCE_PATH}[/dim]\n"
-                    f"[dim]Models: {model_count}[/dim]",
-                    title="[bold green]Gateway Models Update: UP-TO-DATE[/bold green]",
-                    border_style="green",
-                    padding=(1, 2),
-                )
-                console.print(up_to_date_panel)
-                console.print()
-            return
+        try:
+            existing_html = GATEWAY_MODELS_REFERENCE_PATH.read_text(encoding="utf-8")
+            existing_plain = GATEWAY_MODELS_PLAIN_REFERENCE_PATH.read_text(encoding="utf-8")
+        except OSError:
+            pass  # File disappeared or is unreadable — fall through and rewrite
+        else:
+            html_unchanged = normalize_for_comparison(existing_html) == normalize_for_comparison(markdown_content)
+            plain_unchanged = normalize_for_comparison(existing_plain) == normalize_for_comparison(plain_markdown_content)
+            if html_unchanged and plain_unchanged:
+                if quiet:
+                    console.print(f"[green]✓ Gateway models update: UP-TO-DATE[/green] ({model_count} models, no changes)")
+                else:
+                    up_to_date_panel = Panel(
+                        f"[green]✓[/green] Reference files are already up-to-date (skipped write)\n\n"
+                        f"[dim]HTML-styled: {GATEWAY_MODELS_REFERENCE_PATH}[/dim]\n"
+                        f"[dim]Plain text:  {GATEWAY_MODELS_PLAIN_REFERENCE_PATH}[/dim]\n"
+                        f"[dim]Models: {model_count}[/dim]",
+                        title="[bold green]Gateway Models Update: UP-TO-DATE[/bold green]",
+                        border_style="green",
+                        padding=(1, 2),
+                    )
+                    console.print(up_to_date_panel)
+                    console.print()
+                return
 
     # Ensure parent directory exists
     GATEWAY_MODELS_REFERENCE_PATH.parent.mkdir(parents=True, exist_ok=True)

--- a/pipelex/cli/dev_cli/commands/update_gateway_models_cmd.py
+++ b/pipelex/cli/dev_cli/commands/update_gateway_models_cmd.py
@@ -12,6 +12,7 @@ from pipelex.cli.dev_cli.commands.gateway_models_generator import (
     fetch_gateway_model_specs,
     generate_reference_markdown,
     generate_reference_pure_markdown,
+    normalize_for_comparison,
 )
 from pipelex.hub import get_console
 from pipelex.system.pipelex_service.exceptions import RemoteConfigFetchError, RemoteConfigValidationError
@@ -71,15 +72,38 @@ def update_gateway_models_cmd(quiet: bool = False) -> None:
     markdown_content = generate_reference_markdown(model_specs)
     plain_markdown_content = generate_reference_pure_markdown(model_specs)
 
+    # Count models for reporting
+    model_count = sum(1 for key in model_specs if key != "defaults" and ".rules" not in key and isinstance(model_specs[key], dict))
+
+    # Skip writing if the only change is the timestamp (avoids noisy diffs in PRs)
+    if GATEWAY_MODELS_REFERENCE_PATH.exists() and GATEWAY_MODELS_PLAIN_REFERENCE_PATH.exists():
+        existing_html = GATEWAY_MODELS_REFERENCE_PATH.read_text(encoding="utf-8")
+        existing_plain = GATEWAY_MODELS_PLAIN_REFERENCE_PATH.read_text(encoding="utf-8")
+        html_unchanged = normalize_for_comparison(existing_html) == normalize_for_comparison(markdown_content)
+        plain_unchanged = normalize_for_comparison(existing_plain) == normalize_for_comparison(plain_markdown_content)
+        if html_unchanged and plain_unchanged:
+            if quiet:
+                console.print(f"[green]✓ Gateway models update: UP-TO-DATE[/green] ({model_count} models, no changes)")
+            else:
+                up_to_date_panel = Panel(
+                    f"[green]✓[/green] Reference files are already up-to-date (skipped write)\n\n"
+                    f"[dim]HTML-styled: {GATEWAY_MODELS_REFERENCE_PATH}[/dim]\n"
+                    f"[dim]Plain text:  {GATEWAY_MODELS_PLAIN_REFERENCE_PATH}[/dim]\n"
+                    f"[dim]Models: {model_count}[/dim]",
+                    title="[bold green]Gateway Models Update: UP-TO-DATE[/bold green]",
+                    border_style="green",
+                    padding=(1, 2),
+                )
+                console.print(up_to_date_panel)
+                console.print()
+            return
+
     # Ensure parent directory exists
     GATEWAY_MODELS_REFERENCE_PATH.parent.mkdir(parents=True, exist_ok=True)
 
     # Write both reference files
     GATEWAY_MODELS_REFERENCE_PATH.write_text(markdown_content, encoding="utf-8")
     GATEWAY_MODELS_PLAIN_REFERENCE_PATH.write_text(plain_markdown_content, encoding="utf-8")
-
-    # Count models for reporting
-    model_count = sum(1 for key in model_specs if key != "defaults" and ".rules" not in key and isinstance(model_specs[key], dict))
 
     if quiet:
         console.print(f"[green]✓ Gateway models update: PASSED[/green] ({model_count} models)")


### PR DESCRIPTION
## Summary

- Skip writing gateway model reference files when the only difference is the timestamp, avoiding noisy diffs in PRs
- Move `normalize_for_comparison` to the shared `gateway_models_generator` module to avoid circular imports between check and update commands
- When content is unchanged, display "UP-TO-DATE" message instead of silently rewriting files

## Test plan

- [ ] Run `make ugm` twice — second run should say "UP-TO-DATE" and not modify files
- [ ] Run `make cgm` — should still pass
- [ ] Verify no circular import issues by running `make agent-check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip rewriting gateway model reference files when only the timestamp changes, reducing noisy diffs. Centralizes timestamp normalization and shows a clear UP-TO-DATE message, with safe handling of file read races.

- **New Features**
  - Skip writes for timestamp-only changes to both reference files.
  - Show "UP-TO-DATE" with model count; respects quiet mode.

- **Bug Fixes**
  - Handle `OSError` when reading existing files during comparison to avoid crashes and fall back to rewrite.

<sup>Written for commit 2cb5a05a9c2491b0c618f80a4cba95d4b67268c6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

