### PR TITLE
feature/set-credentials-and-check-version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - **Builder Operations module** (`pipelex/builder/operations/`): New standalone operation functions for the build agent — `concept_ops`, `inputs_ops`, `models_ops`, `output_ops`, `pipe_ops`, `runner_code_ops`, `validate_ops`. These decouple build logic from CLI commands so it can be reused by agents and the API.
 - **`dry_run_pipeline`** (`pipelex/pipe_run/dry_run_pipeline.py`): New shared entrypoint to dry-run a pipeline from MTHDS contents and produce a `GraphSpec`. Used by both CLI graph commands and the API.
+- **PyPI Version Check**: Both `pipelex` and `pipelex-agent` CLIs now check PyPI for newer versions on startup and display a warning when an update is available. The check has a 3-second timeout and fails silently on network errors. Agent CLI outputs the warning to stderr to preserve JSON output.
+- **`pipelex init credentials` Override Mode**: `pipelex init credentials` now prompts for all required credentials (showing masked current values), allowing users to update existing API keys. Use `--missing` to only prompt for credentials not yet set.
 
 ### Changed
 

--- a/pipelex/cli/_cli.py
+++ b/pipelex/cli/_cli.py
@@ -157,7 +157,12 @@ def init_command(
         bool, typer.Option("--local", "-l", help="Create project-level .pipelex/ at the detected project root instead of global ~/.pipelex/")
     ] = False,
     missing_only: Annotated[
-        bool, typer.Option("--missing", "-m", help="Only prompt for credentials that are not yet set (skip already configured ones)")
+        bool,
+        typer.Option(
+            "--missing",
+            "-m",
+            help="Only prompt for credentials that are not yet set (skip already configured ones). Only applies to 'credentials' focus.",
+        ),
     ] = False,
 ) -> None:
     """Initialize Pipelex configuration in ~/.pipelex (global) or project .pipelex (--local).

--- a/pipelex/cli/_cli.py
+++ b/pipelex/cli/_cli.py
@@ -86,7 +86,7 @@ def _warn_if_update_available() -> None:
         current_version = get_package_version()
         console = get_console()
         console.print()
-        console.print(f"[bold yellow]A new version of Pipelex is available: {latest_version} (current: {current_version})[/bold yellow]")
+        console.print(f"A new version of Pipelex is available: {latest_version} (current: {current_version})", style="bold yellow")
         console.print("[dim]You can update by running:[/dim] [cyan]pip install --upgrade pipelex[/cyan]")
         console.print()
 
@@ -173,7 +173,7 @@ def init_command(
 
       config       Reset configuration files and prompt for missing API keys
 
-      credentials  Set API keys for enabled backends (prompts for all; use --missing to skip already set ones)
+      credentials  Set API keys for enabled backends (always saved to ~/.pipelex/.env; use --missing to skip already set ones)
 
       inference    Reset inference backends selection and prompt for missing API keys
 

--- a/pipelex/cli/_cli.py
+++ b/pipelex/cli/_cli.py
@@ -17,6 +17,7 @@ from pipelex.cli.commands.show_cmd import show_app
 from pipelex.cli.commands.validate.app import validate_app
 from pipelex.cli.commands.which_cmd import which_cmd
 from pipelex.cli.readiness import check_readiness
+from pipelex.cli.version_check import check_for_update
 from pipelex.hub import get_console
 from pipelex.tools.misc.package_utils import get_package_version
 
@@ -74,7 +75,20 @@ def version_callback(value: bool) -> None:
     if value:
         package_version = get_package_version()
         typer.echo(f"pipelex {package_version}")
+        _warn_if_update_available()
         raise typer.Exit
+
+
+def _warn_if_update_available() -> None:
+    """Print a warning if a newer version is available on PyPI."""
+    latest_version = check_for_update()
+    if latest_version is not None:
+        current_version = get_package_version()
+        console = get_console()
+        console.print()
+        console.print(f"[bold yellow]A new version of Pipelex is available: {latest_version} (current: {current_version})[/bold yellow]")
+        console.print("[dim]You can update by running:[/dim] [cyan]pip install --upgrade pipelex[/cyan]")
+        console.print()
 
 
 @app.callback(invoke_without_command=True)
@@ -115,6 +129,8 @@ def app_callback(
                ░██                                     v[cyan]{package_version}[/cyan]
 """
         )
+    _warn_if_update_available()
+
     # Skip checks if no command is being run (e.g., just --help) or if running init/doctor command
     if ctx.invoked_subcommand is None or ctx.invoked_subcommand in {"login", "init", "doctor"}:
         return
@@ -140,6 +156,9 @@ def init_command(
     local: Annotated[
         bool, typer.Option("--local", "-l", help="Create project-level .pipelex/ at the detected project root instead of global ~/.pipelex/")
     ] = False,
+    missing_only: Annotated[
+        bool, typer.Option("--missing", "-m", help="Only prompt for credentials that are not yet set (skip already configured ones)")
+    ] = False,
 ) -> None:
     """Initialize Pipelex configuration in ~/.pipelex (global) or project .pipelex (--local).
 
@@ -149,7 +168,7 @@ def init_command(
 
       config       Reset configuration files and prompt for missing API keys
 
-      credentials  Prompt for missing API keys only (reads enabled backends, saves to ~/.pipelex/.env)
+      credentials  Set API keys for enabled backends (prompts for all; use --missing to skip already set ones)
 
       inference    Reset inference backends selection and prompt for missing API keys
 
@@ -159,7 +178,7 @@ def init_command(
 
       agreement    Review/accept Pipelex Gateway terms of service
     """
-    init_cmd(focus=focus, local=local)
+    init_cmd(focus=focus, local=local, missing_only=missing_only)
 
 
 @app.command(name="doctor", help="Check Pipelex configuration health and suggest fixes")

--- a/pipelex/cli/agent_cli/_agent_cli.py
+++ b/pipelex/cli/agent_cli/_agent_cli.py
@@ -19,6 +19,7 @@ from pipelex.cli.agent_cli.commands.models_cmd import agent_models_cmd
 from pipelex.cli.agent_cli.commands.pipe_cmd import pipe_cmd
 from pipelex.cli.agent_cli.commands.run.app import run_app
 from pipelex.cli.agent_cli.commands.validate.app import validate_app
+from pipelex.cli.version_check import check_for_update
 from pipelex.tools.misc.package_utils import get_package_version
 
 
@@ -66,11 +67,26 @@ app = typer.Typer(
 )
 
 
+def _warn_if_update_available_stderr() -> None:
+    """Print a version warning to stderr so it doesn't break JSON output."""
+    import sys  # noqa: PLC0415
+
+    latest_version = check_for_update()
+    if latest_version is not None:
+        current_version = get_package_version()
+        print(
+            f"\nA new version of Pipelex is available: {latest_version} (current: {current_version})"
+            f"\nYou can update by running: pip install --upgrade pipelex\n",
+            file=sys.stderr,
+        )
+
+
 def version_callback(value: bool) -> None:
     """Print version and exit when --version is passed."""
     if value:
         package_version = get_package_version()
         typer.echo(f"pipelex-agent {package_version}")
+        _warn_if_update_available_stderr()
         raise typer.Exit
 
 
@@ -99,6 +115,8 @@ def app_callback(
     """Agent CLI callback - no logo, minimal output."""
     from pipelex.cli.agent_cli.commands.agent_output import agent_error  # noqa: PLC0415
     from pipelex.tools.log.log_levels import LogLevel  # noqa: PLC0415
+
+    _warn_if_update_available_stderr()
 
     ctx.ensure_object(dict)
     try:

--- a/pipelex/cli/agent_cli/_agent_cli.py
+++ b/pipelex/cli/agent_cli/_agent_cli.py
@@ -1,5 +1,6 @@
 """Main entry point for the agent CLI."""
 
+import sys
 from typing import Annotated
 
 import typer
@@ -69,8 +70,6 @@ app = typer.Typer(
 
 def _warn_if_update_available_stderr() -> None:
     """Print a version warning to stderr so it doesn't break JSON output."""
-    import sys  # noqa: PLC0415
-
     latest_version = check_for_update()
     if latest_version is not None:
         current_version = get_package_version()

--- a/pipelex/cli/commands/init/command.py
+++ b/pipelex/cli/commands/init/command.py
@@ -271,9 +271,9 @@ def execute_initialization(
             if selected_backend_keys:
                 customize_routing_profile(selected_backend_keys, target_config_dir=target_config_dir)
 
-    # Step 2.5: Prompt for missing credentials
+    # Step 2.5: Prompt for missing credentials (during full init, only ask for missing ones)
     if check_credentials:
-        prompt_credentials(console, backends_toml_path)
+        prompt_credentials(console, backends_toml_path, missing_only=True)
 
     # Step 3: Set up routing profile if specifically requested
     if needs_routing:
@@ -356,6 +356,7 @@ def init_cmd(
     focus: InitFocus = InitFocus.ALL,
     skip_confirmation: bool = False,
     local: bool = False,
+    missing_only: bool = False,
 ):
     """Initialize Pipelex configuration, inference backends, credentials, routing, and telemetry.
 
@@ -366,6 +367,7 @@ def init_cmd(
         focus: What to initialize - 'all', 'agreement', 'config', 'credentials', 'inference', 'routing', or 'telemetry'
         skip_confirmation: If True, skip the confirmation prompt (used when called from doctor --fix)
         local: If True, create project-level .pipelex/ at the detected project root. Otherwise, create global ~/.pipelex/.
+        missing_only: If True, only prompt for credentials not yet set. Only applies to the 'credentials' focus.
     """
     console = get_console()
 
@@ -382,7 +384,7 @@ def init_cmd(
             console.print("[yellow]No backends.toml found. Please run 'pipelex init' first.[/yellow]")
             console.print()
             return
-        prompt_credentials(console, backends_toml_path)
+        prompt_credentials(console, backends_toml_path, missing_only=missing_only)
         console.print()
         return
 

--- a/pipelex/cli/commands/init/credentials.py
+++ b/pipelex/cli/commands/init/credentials.py
@@ -165,10 +165,10 @@ def prompt_credentials(console: Console, backends_toml_path: str, missing_only: 
         else:
             current_value = os.getenv(var_name) or entries.get(var_name)
             if current_value:
-                status = f"[green]current: {escape(_mask_value(current_value))}[/green]"
+                status = f"[green]\\[current: {escape(_mask_value(current_value))}][/green]"
             else:
-                status = "[red]not set[/red]"
-            prompt_text = f"  [bold]{escape(var_name)}[/bold] [dim](required by {escape(backends_str)})[/dim] [{status}]"
+                status = "[red]\\[not set][/red]"
+            prompt_text = f"  [bold]{escape(var_name)}[/bold] [dim](required by {escape(backends_str)})[/dim] {status}"
 
         value = Prompt.ask(prompt_text, default="", console=console, password=True)
         if value == "done":

--- a/pipelex/cli/commands/init/credentials.py
+++ b/pipelex/cli/commands/init/credentials.py
@@ -101,43 +101,78 @@ def get_required_vars_for_enabled_backends(backends_toml_path: str) -> dict[str,
     return var_to_backends
 
 
-def prompt_credentials(console: Console, backends_toml_path: str) -> None:
-    """Prompt the user for missing credentials and persist them to ~/.pipelex/.env.
+def _mask_value(value: str) -> str:
+    """Mask a credential value, showing only the last 4 characters.
 
-    Reads the backends.toml to find which env vars are needed by enabled backends,
-    checks which are already set, and prompts only for missing ones.
+    Args:
+        value: The credential value to mask.
+
+    Returns:
+        Masked string like '****abcd'.
+    """
+    if len(value) <= 4:
+        return "****"
+    return "****" + value[-4:]
+
+
+def prompt_credentials(console: Console, backends_toml_path: str, missing_only: bool = False) -> None:
+    """Prompt the user for credentials and persist them to ~/.pipelex/.env.
 
     Args:
         console: Rich Console instance for user interaction.
         backends_toml_path: Path to the backends.toml file.
+        missing_only: If True, only prompt for credentials not yet set in the environment.
+            If False, prompt for all required credentials, allowing override of existing ones.
     """
     var_to_backends = get_required_vars_for_enabled_backends(backends_toml_path)
     if not var_to_backends:
+        if not missing_only:
+            console.print("[yellow]No enabled backends require credentials.[/yellow]")
         return
 
-    # Determine which vars are missing from the environment
-    missing_vars = {var_name: backend_names for var_name, backend_names in var_to_backends.items() if not os.getenv(var_name)}
+    if missing_only:
+        # Filter to only vars missing from the environment
+        vars_to_prompt = {var_name: backend_names for var_name, backend_names in var_to_backends.items() if not os.getenv(var_name)}
 
-    if not missing_vars:
-        console.print("[green]All required credentials are already set.[/green]")
-        return
+        if not vars_to_prompt:
+            console.print("[green]All required credentials are already set.[/green]")
+            return
 
-    console.print()
-    console.print("[bold cyan]Credential Setup[/bold cyan]")
-    console.print(f"[dim]{len(missing_vars)} credential(s) needed for your enabled backends.[/dim]")
-    console.print("[dim]Press Enter to skip any credential — you can set it later.[/dim]")
-    console.print()
+        console.print()
+        console.print("[bold cyan]Credential Setup[/bold cyan]")
+        console.print(f"[dim]{len(vars_to_prompt)} credential(s) needed for your enabled backends.[/dim]")
+        console.print("[dim]Press Enter to skip a credential, type 'done' to stop.[/dim]")
+        console.print()
+    else:
+        vars_to_prompt = var_to_backends
+
+        console.print()
+        console.print("[bold cyan]Credential Setup[/bold cyan]")
+        console.print(f"[dim]{len(vars_to_prompt)} credential(s) required by your enabled backends.[/dim]")
+        console.print("[dim]Press Enter to keep the current value, type 'done' to stop.[/dim]")
+        console.print()
 
     # Read existing .env file to preserve manually-set values
     global_env_path = get_global_env_path()
     entries = read_env_file(global_env_path)
 
     collected_count = 0
-    for var_name, backend_names in sorted(missing_vars.items()):
+    for var_name, backend_names in sorted(vars_to_prompt.items()):
         backends_str = ", ".join(backend_names)
-        value = Prompt.ask(
-            f"  [bold]{escape(var_name)}[/bold] [dim](required by {escape(backends_str)})[/dim]", default="", console=console, password=True
-        )
+
+        if missing_only:
+            prompt_text = f"  [bold]{escape(var_name)}[/bold] [dim](required by {escape(backends_str)})[/dim]"
+        else:
+            current_value = os.getenv(var_name) or entries.get(var_name)
+            if current_value:
+                status = f"[green]current: {escape(_mask_value(current_value))}[/green]"
+            else:
+                status = "[red]not set[/red]"
+            prompt_text = f"  [bold]{escape(var_name)}[/bold] [dim](required by {escape(backends_str)})[/dim] [{status}]"
+
+        value = Prompt.ask(prompt_text, default="", console=console, password=True)
+        if value == "done":
+            break
         if value:
             entries[var_name] = value
             os.environ[var_name] = value
@@ -149,4 +184,7 @@ def prompt_credentials(console: Console, backends_toml_path: str) -> None:
         console.print(f"[green]Saved {collected_count} credential(s) to {global_env_path}[/green]")
     else:
         console.print()
-        console.print("[dim]No credentials entered. You can set them later by running:[/dim] [cyan]pipelex init credentials[/cyan]")
+        if missing_only:
+            console.print("[dim]No credentials entered. You can set them later by running:[/dim] [cyan]pipelex init credentials[/cyan]")
+        else:
+            console.print("[dim]No changes made.[/dim]")

--- a/pipelex/cli/version_check.py
+++ b/pipelex/cli/version_check.py
@@ -1,0 +1,46 @@
+"""Check for newer Pipelex versions on PyPI."""
+
+import httpx
+
+from pipelex.tools.misc.package_utils import get_package_version
+from pipelex.tools.misc.semver import SemVerError, parse_version
+
+PYPI_PACKAGE_NAME = "pipelex"
+
+
+def _get_latest_pypi_version() -> str | None:
+    """Fetch the latest version of Pipelex from PyPI.
+
+    Returns:
+        The latest version string, or None if the check fails.
+    """
+    url = f"https://pypi.org/pypi/{PYPI_PACKAGE_NAME}/json"
+    try:
+        response = httpx.get(url, timeout=3, follow_redirects=True)
+        response.raise_for_status()
+        data = response.json()
+        return str(data["info"]["version"])
+    except (httpx.HTTPError, KeyError, ValueError):
+        return None
+
+
+def check_for_update() -> str | None:
+    """Check if a newer version of Pipelex is available on PyPI.
+
+    Returns:
+        The latest version string if an update is available, or None if up to date or check fails.
+    """
+    latest_version = _get_latest_pypi_version()
+    if latest_version is None:
+        return None
+
+    current_version = get_package_version()
+    try:
+        current = parse_version(current_version)
+        latest = parse_version(latest_version)
+    except SemVerError:
+        return None
+
+    if latest > current:
+        return latest_version
+    return None

--- a/pipelex/cli/version_check.py
+++ b/pipelex/cli/version_check.py
@@ -1,11 +1,39 @@
 """Check for newer Pipelex versions on PyPI."""
 
+import time
+from pathlib import Path
+
 import httpx
 
 from pipelex.tools.misc.package_utils import get_package_version
 from pipelex.tools.misc.semver import SemVerError, parse_version
 
 PYPI_PACKAGE_NAME = "pipelex"
+_COOLDOWN_SECONDS = 86400  # 24 hours
+
+
+def _get_cache_path() -> Path:
+    """Return the path to the version check cache file."""
+    return Path.home() / ".pipelex" / ".version_check_cache"
+
+
+def _is_check_due() -> bool:
+    """Return True if enough time has passed since the last version check."""
+    try:
+        mtime = _get_cache_path().stat().st_mtime
+        return (time.time() - mtime) > _COOLDOWN_SECONDS
+    except OSError:
+        return True
+
+
+def _touch_cache() -> None:
+    """Update the cache file timestamp to record a successful check."""
+    cache_path = _get_cache_path()
+    try:
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        cache_path.touch()
+    except OSError:
+        pass
 
 
 def _get_latest_pypi_version() -> str | None:
@@ -27,10 +55,17 @@ def _get_latest_pypi_version() -> str | None:
 def check_for_update() -> str | None:
     """Check if a newer version of Pipelex is available on PyPI.
 
+    Checks at most once every 24 hours to avoid slowing down every CLI invocation.
+
     Returns:
         The latest version string if an update is available, or None if up to date or check fails.
     """
+    if not _is_check_due():
+        return None
+
     latest_version = _get_latest_pypi_version()
+    _touch_cache()
+
     if latest_version is None:
         return None
 

--- a/tests/unit/pipelex/cli/test_init_credentials.py
+++ b/tests/unit/pipelex/cli/test_init_credentials.py
@@ -119,8 +119,8 @@ class TestInitCredentials:
         result = get_required_vars_for_enabled_backends(str(backends_toml))
         assert result["OPENAI_API_KEY"] == ["OpenAI"]
 
-    def test_prompt_credentials_skips_when_all_set(self, tmp_path: Path, mocker: MockerFixture) -> None:
-        """No prompts issued when all required vars are already set."""
+    def test_prompt_credentials_skips_when_all_set_missing_only(self, tmp_path: Path, mocker: MockerFixture) -> None:
+        """No prompts issued when all required vars are already set and missing_only=True."""
         backends_toml = tmp_path / "backends.toml"
         backends_toml.write_text('[openai]\nenabled = true\napi_key = "${OPENAI_API_KEY}"\n\n[internal]\nenabled = true\n')
         mocker.patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test"})
@@ -130,10 +130,25 @@ class TestInitCredentials:
         )
         mock_prompt = mocker.patch("pipelex.cli.commands.init.credentials.Prompt.ask")
         mock_console: MagicMock = mocker.MagicMock()
-        prompt_credentials(mock_console, str(backends_toml))
+        prompt_credentials(mock_console, str(backends_toml), missing_only=True)
         # Should print "already set" message, no Prompt.ask calls
         mock_console.print.assert_called()
         mock_prompt.assert_not_called()
+
+    def test_prompt_credentials_prompts_all_when_not_missing_only(self, tmp_path: Path, mocker: MockerFixture) -> None:
+        """All credentials are prompted even when already set, if missing_only=False."""
+        backends_toml = tmp_path / "backends.toml"
+        backends_toml.write_text('[openai]\nenabled = true\napi_key = "${OPENAI_API_KEY}"\n\n[internal]\nenabled = true\n')
+        mocker.patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test"})
+        mocker.patch(
+            "pipelex.cli.commands.init.credentials.config_manager",
+            global_config_dir=tmp_path,
+        )
+        mock_prompt = mocker.patch("pipelex.cli.commands.init.credentials.Prompt.ask", return_value="")
+        mock_console: MagicMock = mocker.MagicMock()
+        prompt_credentials(mock_console, str(backends_toml), missing_only=False)
+        # Should still prompt even though the var is set
+        mock_prompt.assert_called_once()
 
     def test_prompt_credentials_writes_entered_values(self, tmp_path: Path, mocker: MockerFixture) -> None:
         """Entered values are written to ~/.pipelex/.env and set in os.environ."""
@@ -152,7 +167,7 @@ class TestInitCredentials:
             return_value="sk-test-value",
         )
         mock_console: MagicMock = mocker.MagicMock()
-        prompt_credentials(mock_console, str(backends_toml))
+        prompt_credentials(mock_console, str(backends_toml), missing_only=True)
 
         # Verify .env was written
         env_path = tmp_path / ".env"
@@ -182,7 +197,7 @@ class TestInitCredentials:
             return_value="",
         )
         mock_console: MagicMock = mocker.MagicMock()
-        prompt_credentials(mock_console, str(backends_toml))
+        prompt_credentials(mock_console, str(backends_toml), missing_only=True)
 
         # Verify .env was NOT written (no values entered)
         env_path = tmp_path / ".env"
@@ -207,7 +222,7 @@ class TestInitCredentials:
             return_value="sk-new",
         )
         mock_console: MagicMock = mocker.MagicMock()
-        prompt_credentials(mock_console, str(backends_toml))
+        prompt_credentials(mock_console, str(backends_toml), missing_only=True)
 
         result = read_env_file(env_path)
         assert result["EXISTING_KEY"] == "existing_value"
@@ -226,5 +241,5 @@ class TestInitCredentials:
         )
         mock_prompt = mocker.patch("pipelex.cli.commands.init.credentials.Prompt.ask")
         mock_console: MagicMock = mocker.MagicMock()
-        prompt_credentials(mock_console, str(backends_toml))
+        prompt_credentials(mock_console, str(backends_toml), missing_only=True)
         mock_prompt.assert_not_called()


### PR DESCRIPTION
- **PyPI Version Check**: Both `pipelex` and `pipelex-agent` CLIs now check PyPI for newer versions on startup and display a warning when an update is available. The check has a 3-second timeout and fails silently on network errors. Agent CLI outputs the warning to stderr to preserve JSON output.
- **`pipelex init credentials` Override Mode**: `pipelex init credentials` now prompts for all required credentials (showing masked current values), allowing users to update existing API keys. Use `--missing` to only prompt for credentials not yet set.