### PR TITLE
Rule sync: clarify top-level import guidance in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,7 +144,7 @@ This document outlines the core coding standards, best practices, and quality co
 
 #### **Imports at the top of the file**
 
-    - Import all necessary libraries at the top of the file
+    - Avoid as much as possible import statements outside of a module's top-level scope.
     - Do not import libraries in functions or classes unless in very specific cases, to be discussed with the user, as they would required a `# noqa: ...` comment to pass linting
     - Do not bother with ordering the imports or removing unused imports, our Ruff linter will handle it for us.
     - `if TYPE_CHECKING:` blocks must always be the **last** block in the imports section, placed after all regular imports.


### PR DESCRIPTION
## Summary
- Updated CLAUDE.md import rule to explicitly discourage imports outside module top-level scope, replacing the vague "import all necessary libraries at the top" wording

## Test plan
- [ ] Verify CLAUDE.md renders correctly
- [ ] Confirm linting rules align with the updated guidance

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified import guidance in `CLAUDE.md` by explicitly discouraging imports outside a module’s top-level scope to better align with our linting rules.

<sup>Written for commit b66db85ff9c99421745396591eb01442496d7da6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

