### PR TITLE
fix Temporal deadlocks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,13 +101,17 @@
    The `--class-registry` option controls whether dynamic concept classes leak to the
    global KajsonManager registry or are scoped to the library:
 
-   - `--class-registry shared` (default): dynamic classes go to global registry (standard behavior)
+   - `--class-registry both` (default): runs tests in both shared and isolated modes
+   - `--class-registry shared`: dynamic classes go to global registry (standard behavior)
    - `--class-registry isolated`: dynamic classes are scoped to the library registry,
      keeping the global clean — forces deferred hydration paths, catching regressions
      that only manifest in multi-process deployments
 
    ```bash
-   # Test with isolated class registry (simulates clean worker process)
+   # Default: runs both modes automatically
+   .venv/bin/pytest tests/integration/pipelex/temporal/
+
+   # Force single mode (useful for debugging)
    .venv/bin/pytest tests/integration/pipelex/temporal/ \
      --class-registry isolated
    ```

--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ make test-extract             - Run unit tests only for extract (with prints)
 make te                       - Shorthand -> test-extract
 make test-img-gen             - Run unit tests only for img_gen (with prints)
 make test-g					  - Shorthand -> test-img-gen
-make test-temporal            - Run temporal tests (SRV=local|testing MODE=live)
+make test-temporal            - Run temporal tests (SRV=local|testing MODE=live REG=isolated)
 make ttm                      - Shorthand -> test-temporal
 
 make check-unused-imports     - Check for unused imports without fixing
@@ -629,6 +629,7 @@ tg: test-img-gen
 
 SRV ?=
 MODE ?=
+REG ?=
 TEMPORAL_PYTEST_MARKERS := $(if $(filter live,$(MODE)),"temporal","temporal and (dry_runnable or not inference)")
 TEMPORAL_TESTS_DIR := tests/integration/pipelex/temporal/
 
@@ -637,20 +638,23 @@ test-temporal: env
 	@if [ -n "$(TEST)" ]; then \
 		if [ "$(TEST)" = "LF" ] || [ "$(TEST)" = "lf" ]; then \
 			$(VENV_PYTEST) --exitfirst -m $(TEMPORAL_PYTEST_MARKERS) -s --lf \
-				$(if $(SRV),--temporal-server $(SRV) --temporal-worker external,) \
+				$(if $(SRV),--temporal-server $(SRV),) \
+				$(if $(REG),--class-registry $(REG),) \
 				$(if $(filter live,$(MODE)),--pipe-run-mode live,) \
 				$(if $(filter 1,$(VERBOSE)),-v,$(if $(filter 2,$(VERBOSE)),-vv,$(if $(filter 3,$(VERBOSE)),-vvv,))) \
 				$(TEMPORAL_TESTS_DIR); \
 		else \
 			$(VENV_PYTEST) --exitfirst -m $(TEMPORAL_PYTEST_MARKERS) -s -k "$(TEST)" \
-				$(if $(SRV),--temporal-server $(SRV) --temporal-worker external,) \
+				$(if $(SRV),--temporal-server $(SRV),) \
+				$(if $(REG),--class-registry $(REG),) \
 				$(if $(filter live,$(MODE)),--pipe-run-mode live,) \
 				$(if $(filter 1,$(VERBOSE)),-v,$(if $(filter 2,$(VERBOSE)),-vv,$(if $(filter 3,$(VERBOSE)),-vvv,))) \
 				$(TEMPORAL_TESTS_DIR); \
 		fi; \
 	else \
 		$(VENV_PYTEST) --exitfirst -m $(TEMPORAL_PYTEST_MARKERS) -s \
-			$(if $(SRV),--temporal-server $(SRV) --temporal-worker external,) \
+			$(if $(SRV),--temporal-server $(SRV),) \
+			$(if $(REG),--class-registry $(REG),) \
 			$(if $(filter live,$(MODE)),--pipe-run-mode live,) \
 			$(if $(filter 1,$(VERBOSE)),-v,$(if $(filter 2,$(VERBOSE)),-vv,$(if $(filter 3,$(VERBOSE)),-vvv,))) \
 			$(TEMPORAL_TESTS_DIR); \

--- a/pipelex/cogt/llm/llm_prompt_template.py
+++ b/pipelex/cogt/llm/llm_prompt_template.py
@@ -9,10 +9,10 @@ from pipelex.cogt.llm.llm_prompt import LLMPrompt
 from pipelex.cogt.llm.llm_prompt_factory_abstract import LLMPromptFactoryAbstract
 from pipelex.cogt.llm.llm_prompt_template_inputs import LLMPromptTemplateInputs
 from pipelex.cogt.templating.template_category import TemplateCategory
+from pipelex.cogt.templating.template_rendering import render_template
 from pipelex.cogt.templating.templating_style import TagStyle, TemplatingStyle
 from pipelex.cogt.templating.text_format import TextFormat
 from pipelex.config import get_config
-from pipelex.hub import get_content_generator
 from pipelex.tools.misc.string_utils import is_none_or_has_text
 
 
@@ -90,25 +90,23 @@ class LLMPromptTemplate(LLMPromptFactoryAbstract):
                 llm_prompt.user_images = user_images
 
         # input variables can be applied to prompt texts used as templates
+        llm_prompt_templating_style = TemplatingStyle(
+            tag_style=TagStyle.XML,
+            text_format=TextFormat.MARKDOWN,
+        )
         if llm_prompt.system_text:
-            llm_prompt.system_text = await get_content_generator().make_templated_text(
-                context=all_template_inputs.root,
+            llm_prompt.system_text = await render_template(
                 template=llm_prompt.system_text,
-                templating_style=TemplatingStyle(
-                    tag_style=TagStyle.XML,
-                    text_format=TextFormat.MARKDOWN,
-                ),
-                template_category=TemplateCategory.LLM_PROMPT,
+                category=TemplateCategory.LLM_PROMPT,
+                context=all_template_inputs.root,
+                templating_style=llm_prompt_templating_style,
             )
         if llm_prompt.user_text:
-            llm_prompt.user_text = await get_content_generator().make_templated_text(
-                context=all_template_inputs.root,
+            llm_prompt.user_text = await render_template(
                 template=llm_prompt.user_text,
-                templating_style=TemplatingStyle(
-                    tag_style=TagStyle.XML,
-                    text_format=TextFormat.MARKDOWN,
-                ),
-                template_category=TemplateCategory.LLM_PROMPT,
+                category=TemplateCategory.LLM_PROMPT,
+                context=all_template_inputs.root,
+                templating_style=llm_prompt_templating_style,
             )
 
         return llm_prompt

--- a/pipelex/core/memory/working_memory.py
+++ b/pipelex/core/memory/working_memory.py
@@ -20,7 +20,7 @@ from pipelex.core.stuffs.mermaid_content import MermaidContent
 from pipelex.core.stuffs.number_content import NumberContent
 from pipelex.core.stuffs.stuff import Stuff
 from pipelex.core.stuffs.stuff_artefact import StuffArtefact
-from pipelex.core.stuffs.stuff_content import StuffContentType
+from pipelex.core.stuffs.stuff_content import StuffContent, StuffContentType
 from pipelex.core.stuffs.text_and_images_content import TextAndImagesContent
 from pipelex.core.stuffs.text_content import TextContent
 from pipelex.tools.misc.context_provider_abstract import ContextProviderAbstract
@@ -468,3 +468,20 @@ class WorkingMemory(WorkingMemoryAbstract[Stuff], ContextProviderAbstract):
     def smart_dump(self) -> dict[str, Any]:
         """Serialize the working memory as a dictionary."""
         return self.model_dump(serialize_as_any=True)
+
+    def dump_for_temporal(self) -> dict[str, Any]:
+        """Serialize for Temporal transit with explicit ListContent representation.
+
+        Like smart_dump(), but serializes ListContent as a plain list instead of
+        ``{"items": [...]}``.  This removes the ambiguity at hydration time: a
+        ``list`` content value is always a ListContent, a ``dict`` is always a
+        single StuffContent.
+        """
+        raw = self.model_dump(serialize_as_any=True)
+        raw_root = raw.get("root", {})
+        for stuff_name, stuff in self.root.items():
+            content = stuff.content
+            if isinstance(content, ListContent) and stuff_name in raw_root:
+                list_content = cast("ListContent[StuffContent]", content)
+                raw_root[stuff_name]["content"] = [item.model_dump(serialize_as_any=True) for item in list_content.items]
+        return raw

--- a/pipelex/core/pipes/pipe_output.py
+++ b/pipelex/core/pipes/pipe_output.py
@@ -35,7 +35,7 @@ class PipeOutput(PipeOutputAbstract[WorkingMemory]):
             return self
         return self.model_copy(
             update={
-                "working_memory_raw": self.working_memory.smart_dump(),
+                "working_memory_raw": self.working_memory.dump_for_temporal(),
                 "working_memory": WorkingMemory(),
             }
         )

--- a/pipelex/pipe_controllers/condition/pipe_condition.py
+++ b/pipelex/pipe_controllers/condition/pipe_condition.py
@@ -4,13 +4,14 @@ from typing_extensions import override
 
 from pipelex import log
 from pipelex.cogt.templating.template_category import TemplateCategory
+from pipelex.cogt.templating.template_rendering import render_template
 from pipelex.core.concepts.native.concept_native import NativeConceptCode
 from pipelex.core.memory.working_memory import WorkingMemory, WorkingMemoryStuffNotFoundError
 from pipelex.core.pipes.exceptions import PipeValidationError, PipeValidationErrorType
 from pipelex.core.pipes.inputs.input_stuff_specs import InputStuffSpecs
 from pipelex.core.pipes.inputs.input_stuff_specs_factory import InputStuffSpecsFactory
 from pipelex.core.pipes.pipe_output import PipeOutput
-from pipelex.hub import get_content_generator, get_optional_pipe, get_pipe_router, get_required_pipe
+from pipelex.hub import get_optional_pipe, get_pipe_router, get_required_pipe
 from pipelex.pipe_controllers.condition.special_outcome import SpecialOutcome
 from pipelex.pipe_controllers.pipe_controller import PipeController
 from pipelex.pipe_run.exceptions import PipeRunError
@@ -174,10 +175,10 @@ class PipeCondition(PipeController):
     async def _validate_before_run(
         self, job_metadata: JobMetadata, working_memory: WorkingMemory, pipe_run_params: PipeRunParams, output_name: str | None = None
     ):
-        evaluated_expression = await get_content_generator().make_templated_text(
-            context=working_memory.generate_context(),
+        evaluated_expression = await render_template(
             template=self.expression,
-            template_category=TemplateCategory.EXPRESSION,
+            category=TemplateCategory.EXPRESSION,
+            context=working_memory.generate_context(),
         )
         if not evaluated_expression or evaluated_expression == "None":
             error_msg = f"PipeCondition '{self.code}': Conditional expression returned no result"
@@ -205,10 +206,10 @@ class PipeCondition(PipeController):
         Returns:
             The evaluated expression
         """
-        evaluated_expression = await get_content_generator().make_templated_text(
-            context=working_memory.generate_context(),
+        evaluated_expression = await render_template(
             template=self.expression,
-            template_category=TemplateCategory.EXPRESSION,
+            category=TemplateCategory.EXPRESSION,
+            context=working_memory.generate_context(),
         )
 
         log.verbose(f"add_alias: {evaluated_expression} -> {self.add_alias_from_expression_to}")

--- a/pipelex/pipe_controllers/condition/pipe_condition.py
+++ b/pipelex/pipe_controllers/condition/pipe_condition.py
@@ -317,6 +317,7 @@ class PipeCondition(PipeController):
                 job_metadata=job_metadata,
                 working_memory=working_memory,
                 pipe_run_params=pipe_run_params,
+                output_name=output_name,
                 library_crate=library_crate,
             )
         return PipeOutput(working_memory=working_memory)

--- a/pipelex/pipe_operators/compose/pipe_compose.py
+++ b/pipelex/pipe_operators/compose/pipe_compose.py
@@ -7,6 +7,7 @@ from pipelex.cogt.content_generation.content_generator_dry import ContentGenerat
 from pipelex.cogt.content_generation.content_generator_protocol import ContentGeneratorProtocol
 from pipelex.cogt.content_generation.dry_run_factory import DryRunFactory
 from pipelex.cogt.templating.template_category import TemplateCategory
+from pipelex.cogt.templating.template_rendering import render_template
 from pipelex.cogt.templating.templating_style import TemplatingStyle
 from pipelex.config import get_config
 from pipelex.core.concepts.native.concept_native import NativeConceptCode
@@ -172,7 +173,7 @@ class PipeCompose(PipeOperator[PipeComposeOutput]):
         working_memory: WorkingMemory,
         pipe_run_params: PipeRunParams,
         output_name: str | None,
-        content_generator: ContentGeneratorProtocol,
+        content_generator: ContentGeneratorProtocol,  # noqa: ARG002
     ) -> PipeComposeOutput:
         """Run PipeCompose in template mode (produces Text or Html output)."""
         if self.template is None:
@@ -185,11 +186,11 @@ class PipeCompose(PipeOperator[PipeComposeOutput]):
         if self.extra_context:
             context.update(**self.extra_context)
 
-        jinja2_text = await content_generator.make_templated_text(
-            context=context,
+        jinja2_text = await render_template(
             template=self.template,
+            category=self.category,
+            context=context,
             templating_style=self.templating_style,
-            template_category=self.category,
         )
         log.verbose(f"Jinja2 rendered text:\n{jinja2_text}")
         assert isinstance(jinja2_text, str)

--- a/pipelex/pipe_operators/compose/pipe_compose.py
+++ b/pipelex/pipe_operators/compose/pipe_compose.py
@@ -165,7 +165,6 @@ class PipeCompose(PipeOperator[PipeComposeOutput]):
                 working_memory=working_memory,
                 pipe_run_params=pipe_run_params,
                 output_name=output_name,
-                content_generator=content_generator,
             )
 
     async def _run_template_mode(
@@ -174,7 +173,6 @@ class PipeCompose(PipeOperator[PipeComposeOutput]):
         working_memory: WorkingMemory,
         pipe_run_params: PipeRunParams,
         output_name: str | None,
-        content_generator: ContentGeneratorProtocol,  # noqa: ARG002
     ) -> PipeComposeOutput:
         """Run PipeCompose in template mode (produces Text or Html output)."""
         if self.template is None:
@@ -187,6 +185,7 @@ class PipeCompose(PipeOperator[PipeComposeOutput]):
         if self.extra_context:
             context.update(**self.extra_context)
 
+        # TODO: dry-run templating is being removed — this direct render_template call is intentional
         jinja2_text = await render_template(
             template=self.template,
             category=self.category,

--- a/pipelex/pipe_operators/compose/pipe_compose.py
+++ b/pipelex/pipe_operators/compose/pipe_compose.py
@@ -1,5 +1,6 @@
 from typing import Any, Literal
 
+from pydantic import Field
 from typing_extensions import override
 
 from pipelex import log
@@ -41,7 +42,7 @@ class PipeCompose(PipeOperator[PipeComposeOutput]):
     # Template mode fields (used when template is provided)
     template: str | None = None
     templating_style: TemplatingStyle | None = None
-    category: TemplateCategory = TemplateCategory.BASIC
+    category: TemplateCategory = Field(default=TemplateCategory.BASIC, strict=False)
     extra_context: dict[str, Any] | None = None
 
     # Construct mode field (used when construct is provided)

--- a/pipelex/pipe_operators/compose/pipe_compose_blueprint.py
+++ b/pipelex/pipe_operators/compose/pipe_compose_blueprint.py
@@ -31,14 +31,23 @@ class PipeComposeBlueprint(PipeBlueprint):
     @model_validator(mode="before")
     @classmethod
     def validate_template_or_construct(cls, values: dict[str, Any]) -> dict[str, Any]:
-        """Validate that exactly one of template or construct is provided."""
+        """Validate that exactly one of template or construct is provided.
+
+        Handles two deserialization paths:
+        - MTHDS loading: 'construct' key with raw dict data → needs make_from_raw
+        - Kajson round-trip: 'construct_blueprint' key with ConstructBlueprint object
+          (Kajson serializes using field names, not aliases)
+        """
         has_template = values.get("template") is not None
         construct_raw = values.get("construct")
+        construct_bp = values.get("construct_blueprint")
 
-        if not has_template and construct_raw is None:
+        has_construct = construct_raw is not None or construct_bp is not None
+
+        if not has_template and not has_construct:
             msg = "PipeComposeBlueprint requires either 'template' or 'construct' to be provided"
             raise ValueError(msg)
-        if has_template and construct_raw is not None:
+        if has_template and has_construct:
             msg = "PipeComposeBlueprint cannot have both 'template' and 'construct' - use one or the other"
             raise ValueError(msg)
 

--- a/pipelex/pipe_operators/compose/structured_content_composer.py
+++ b/pipelex/pipe_operators/compose/structured_content_composer.py
@@ -7,7 +7,7 @@ from pydantic import ValidationError
 from pipelex import log
 from pipelex.cogt.content_generation.content_generator_protocol import ContentGeneratorProtocol
 from pipelex.cogt.templating.template_category import TemplateCategory
-from pipelex.cogt.templating.template_preprocessor import preprocess_template
+from pipelex.cogt.templating.template_rendering import render_template
 from pipelex.core.memory.working_memory import WorkingMemory
 from pipelex.core.stuffs.list_content import ListContent
 from pipelex.core.stuffs.stuff_content import StuffContent
@@ -650,14 +650,10 @@ class StructuredContentComposer:
         if self.extra_context:
             context.update(**self.extra_context)
 
-        # Preprocess the template (handles $ -> {{ }} conversion)
-        preprocessed = preprocess_template(field_blueprint.template)
-
-        # Render the template using the provided content generator (supports dry run mode)
-        return await self.content_generator.make_templated_text(
+        return await render_template(
+            template=field_blueprint.template,
+            category=TemplateCategory.BASIC,
             context=context,
-            template=preprocessed,
-            template_category=TemplateCategory.BASIC,
         )
 
     async def _resolve_nested(self, field_blueprint: ConstructFieldBlueprint, field_name: str) -> StuffContent:

--- a/pipelex/pipe_operators/compose/structured_content_composer.py
+++ b/pipelex/pipe_operators/compose/structured_content_composer.py
@@ -650,6 +650,7 @@ class StructuredContentComposer:
         if self.extra_context:
             context.update(**self.extra_context)
 
+        # TODO: dry-run templating is being removed — this direct render_template call is intentional
         return await render_template(
             template=field_blueprint.template,
             category=TemplateCategory.BASIC,

--- a/pipelex/pipe_operators/llm/helpers.py
+++ b/pipelex/pipe_operators/llm/helpers.py
@@ -1,9 +1,9 @@
 from pipelex.cogt.templating.template_category import TemplateCategory
+from pipelex.cogt.templating.template_rendering import render_template
 from pipelex.config import get_config
 from pipelex.core.stuffs.stuff_content import StuffContent
 from pipelex.hub import (
     get_class_registry,
-    get_content_generator,
     get_required_concept,
 )
 from pipelex.tools.typing.structure_printer import StructurePrinter
@@ -26,10 +26,10 @@ async def get_output_structure_prompt(concept_ref: str, is_with_preliminary_text
     else:
         template_source = llm_config.get_template(template_name="output_structure_prompt_no_preliminary_text")
 
-    return await get_content_generator().make_templated_text(
+    return await render_template(
+        template=template_source,
+        category=TemplateCategory.LLM_PROMPT,
         context={
             "class_structure_str": class_structure_str,
         },
-        template=template_source,
-        template_category=TemplateCategory.LLM_PROMPT,
     )

--- a/pipelex/pipe_run/pipe_job.py
+++ b/pipelex/pipe_run/pipe_job.py
@@ -42,7 +42,7 @@ class PipeJob(BaseModel):
         if self.working_memory is not None:
             return self.model_copy(
                 update={
-                    "working_memory_raw": self.working_memory.smart_dump(),
+                    "working_memory_raw": self.working_memory.dump_for_temporal(),
                     "working_memory": None,
                 }
             )

--- a/pipelex/temporal/tprl_pipe/hydration.py
+++ b/pipelex/temporal/tprl_pipe/hydration.py
@@ -1,13 +1,37 @@
-from typing import Any
+from typing import Any, cast
 
 from kajson.exceptions import KajsonException
 from pydantic import ValidationError
 
 from pipelex.core.concepts.concept import Concept
 from pipelex.core.memory.working_memory import WorkingMemory
+from pipelex.core.stuffs.list_content import ListContent
 from pipelex.core.stuffs.stuff import Stuff
+from pipelex.core.stuffs.stuff_content import StuffContent
 from pipelex.core.stuffs.stuff_content_factory import StuffContentFactory
+from pipelex.hub import get_class_registry
 from pipelex.pipe_run.exceptions import PipeJobError
+
+
+def _hydrate_content(concept: Concept, raw_content: dict[str, Any] | str) -> StuffContent:
+    """Hydrate a single StuffContent from a raw value.
+
+    Handles both plain content and ListContent. When the raw value is a dict
+    with an 'items' key containing a list, the content is deserialized as
+    ListContent with each item validated as the concept's structure class.
+    This is necessary because the concept's structure_class_name always refers
+    to the *item* type, even when the stuff holds a list of those items.
+    """
+    if isinstance(raw_content, dict) and "items" in raw_content and isinstance(raw_content["items"], list):
+        item_class = get_class_registry().get_required_subclass(name=concept.structure_class_name, base_class=StuffContent)
+        raw_items = cast("list[dict[str, Any]]", raw_content["items"])
+        items = [item_class.model_validate(raw_item) for raw_item in raw_items]
+        return ListContent(items=items)
+
+    return StuffContentFactory.make_stuff_content_from_concept_required(
+        concept=concept,
+        value=raw_content,
+    )
 
 
 def hydrate_working_memory(working_memory_raw: dict[str, Any]) -> WorkingMemory:
@@ -23,10 +47,7 @@ def hydrate_working_memory(working_memory_raw: dict[str, Any]) -> WorkingMemory:
     for stuff_name, stuff_dict in raw_root.items():
         try:
             concept = Concept.model_validate(stuff_dict["concept"])
-            content = StuffContentFactory.make_stuff_content_from_concept_required(
-                concept=concept,
-                value=stuff_dict["content"],
-            )
+            content = _hydrate_content(concept=concept, raw_content=stuff_dict["content"])
             stuff = Stuff(
                 stuff_code=stuff_dict["stuff_code"],
                 stuff_name=stuff_dict.get("stuff_name"),

--- a/pipelex/temporal/tprl_pipe/hydration.py
+++ b/pipelex/temporal/tprl_pipe/hydration.py
@@ -13,18 +13,20 @@ from pipelex.hub import get_class_registry
 from pipelex.pipe_run.exceptions import PipeJobError
 
 
-def _hydrate_content(concept: Concept, raw_content: dict[str, Any] | str) -> StuffContent:
+def _hydrate_content(concept: Concept, raw_content: list[Any] | dict[str, Any] | str) -> StuffContent:
     """Hydrate a single StuffContent from a raw value.
 
-    Handles both plain content and ListContent. When the raw value is a dict
-    with an 'items' key containing a list, the content is deserialized as
-    ListContent with each item validated as the concept's structure class.
-    This is necessary because the concept's structure_class_name always refers
-    to the *item* type, even when the stuff holds a list of those items.
+    Handles both plain content and ListContent.  The Temporal serialization
+    format (produced by ``WorkingMemory.dump_for_temporal()``) encodes
+    ListContent as a plain JSON list and single StuffContent as a dict,
+    so the type check is unambiguous — no heuristic required.
+
+    The concept's ``structure_class_name`` always refers to the *item* type,
+    even when the stuff holds a list of those items.
     """
-    if isinstance(raw_content, dict) and "items" in raw_content and isinstance(raw_content["items"], list):
+    if isinstance(raw_content, list):
         item_class = get_class_registry().get_required_subclass(name=concept.structure_class_name, base_class=StuffContent)
-        raw_items = cast("list[dict[str, Any]]", raw_content["items"])
+        raw_items = cast("list[dict[str, Any]]", raw_content)
         items = [item_class.model_validate(raw_item) for raw_item in raw_items]
         return ListContent(items=items)
 

--- a/pipelex/test_extras/shared_pytest_plugins.py
+++ b/pipelex/test_extras/shared_pytest_plugins.py
@@ -10,6 +10,14 @@ from pipelex.pipe_run.pipe_run_params import PipeRunMode
 from pipelex.system.environment import is_env_var_set, is_env_var_truthy, set_env
 from pipelex.system.runtime import CODEX_CLOUD_ENV_VAR_KEY, RunMode, runtime_manager
 from pipelex.tools.misc.placeholder import make_placeholder_value, value_is_placeholder
+from pipelex.types import StrEnum
+
+
+class ClassRegistryMode(StrEnum):
+    SHARED = "shared"
+    ISOLATED = "isolated"
+    BOTH = "both"
+
 
 # List of environment variables that may need placeholders in CI
 ENV_VAR_KEYS_WHICH_MAY_NEED_PLACEHOLDERS_IN_CI = [
@@ -75,9 +83,10 @@ def pytest_addoption(parser: Parser):
     )
     parser.addoption(
         "--class-registry",
-        default="shared",
-        choices=("shared", "isolated"),
-        help="Class registry mode: 'shared' leaks dynamic classes to global (default), 'isolated' scopes them to the library registry",
+        default=ClassRegistryMode.BOTH,
+        choices=list(ClassRegistryMode),
+        help="Class registry mode: 'both' runs tests in shared and isolated modes (default), "
+        "'shared' leaks dynamic classes to global, 'isolated' scopes them to the library registry",
     )
 
 

--- a/tests/integration/pipelex/temporal/conftest.py
+++ b/tests/integration/pipelex/temporal/conftest.py
@@ -13,6 +13,7 @@ from pipelex.temporal.temporal_connect import connect_to_temporal_selected_serve
 from pipelex.temporal.temporal_data_converter import data_converter
 from pipelex.temporal.temporal_hub import temporal_hub
 from pipelex.temporal.temporal_task_manager import TemporalTaskManager
+from pipelex.test_extras.shared_pytest_plugins import ClassRegistryMode
 
 TEMPORAL_SERVER_NONE = "none"
 TEMPORAL_SERVER_TIME_SKIPPING = "time-skipping"
@@ -113,15 +114,23 @@ async def env(request: FixtureRequest) -> AsyncGenerator[WorkflowEnvironment, No
     elif server_option == TEMPORAL_SERVER_TIME_SKIPPING:
         workflow_env = await WorkflowEnvironment.start_time_skipping(data_converter=data_converter)
     else:
-        # Session-scoped fixtures run before module-scoped ones, so
-        # reset_pipelex_config_fixture hasn't initialized Pipelex yet.
-        # Bootstrap temporarily to access server connection config.
-        Pipelex.make(
-            integration_mode=IntegrationMode.CI if runtime_manager.is_ci_testing else IntegrationMode.PYTEST,
-        )
+        # Bootstrap Pipelex temporarily to read server connection config.
+        # If a module-scoped fixture already initialized Pipelex (happens when
+        # env is lazily triggered after reset_pipelex_config_fixture), skip init
+        # and just read the config from the existing instance.
+
+        # TODO: Pipelex.make() is heavy — it initializes inference, registries, etc.
+        # We only need the config here. Design a lightweight boot path (e.g.
+        # Pipelex.load_config_only()) that parses pipelex.toml without full init.
+        needs_teardown = False
+        if Pipelex.get_optional_instance() is None:
+            Pipelex.make(
+                integration_mode=IntegrationMode.CI if runtime_manager.is_ci_testing else IntegrationMode.PYTEST,
+            )
+            needs_teardown = True
         temporal_client = await connect_to_temporal_selected_server(selected_server_config=server_option)
-        # Teardown so the module-scoped fixture can re-initialize cleanly per module.
-        Pipelex.teardown_if_needed()
+        if needs_teardown:
+            Pipelex.teardown_if_needed()
         workflow_env = WorkflowEnvironment.from_client(temporal_client)
     yield workflow_env
     await workflow_env.shutdown()
@@ -133,13 +142,22 @@ async def temporal_client(env: WorkflowEnvironment) -> TemporalClient:  # noqa: 
     return env.client
 
 
-@pytest.fixture(scope="class")
-def is_class_registry_isolated(request: FixtureRequest) -> bool:
-    """Whether dynamic classes should be scoped to the library registry (not global).
+def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
+    """Auto-parametrize is_class_registry_isolated based on --class-registry.
 
-    When True, simulates a process that hasn't pre-loaded the bundle — dynamic concept
-    classes exist only in the library's scoped ClassRegistry, not in the global
-    KajsonManager registry. This forces code paths that rely on crate-based class
-    loading and deferred hydration.
+    By default (``--class-registry both``), every test class that requests
+    ``is_class_registry_isolated`` runs twice: once with classes in the global
+    registry (shared) and once scoped to the library (isolated).  Pass
+    ``--class-registry shared`` or ``--class-registry isolated`` to force a
+    single mode (useful for debugging).
     """
-    return cast("str", request.config.getoption("--class-registry")) == "isolated"
+    if "is_class_registry_isolated" not in metafunc.fixturenames:
+        return
+    mode = ClassRegistryMode(metafunc.config.getoption("--class-registry"))
+    match mode:
+        case ClassRegistryMode.BOTH:
+            metafunc.parametrize("is_class_registry_isolated", [False, True], ids=["shared", "isolated"], scope="class")
+        case ClassRegistryMode.ISOLATED:
+            metafunc.parametrize("is_class_registry_isolated", [True], ids=["isolated"], scope="class")
+        case ClassRegistryMode.SHARED:
+            metafunc.parametrize("is_class_registry_isolated", [False], ids=["shared"], scope="class")

--- a/tests/integration/pipelex/temporal/library_crate/test_wf_combined_pipeline.py
+++ b/tests/integration/pipelex/temporal/library_crate/test_wf_combined_pipeline.py
@@ -40,7 +40,6 @@ class TestWfCombinedPipeline:
         """Verify the crate has all pipe_refs from parallel, condition, and LLM pipes."""
         self._assert_crate_structure(combined_job)
 
-    @pytest.mark.xfail(reason="PipeCondition expression evaluation dispatches WfMakeJinja2Text which fails to serialize dry-run StuffArtefact")
     async def test_combined_pipeline_via_temporal(
         self,
         combined_job: PipeJob,

--- a/tests/integration/pipelex/temporal/library_crate/test_wf_pipe_batch.py
+++ b/tests/integration/pipelex/temporal/library_crate/test_wf_pipe_batch.py
@@ -37,7 +37,7 @@ class TestWfPipeBatch:
         """Verify the crate has all pipe_refs including the batch branch pipe."""
         self._assert_crate_structure(batch_job)
 
-    @pytest.mark.xfail(reason="PipeBatch fan-out fails in Temporal dry-run — likely StuffArtefact serialization issue in child workflows")
+    @pytest.mark.xfail(reason="ListContent deferred hydration fails: list container deserialized as single Topic instead of ListContent[Topic]")
     async def test_batch_sequence_via_temporal(
         self,
         batch_job: PipeJob,

--- a/tests/integration/pipelex/temporal/library_crate/test_wf_pipe_batch.py
+++ b/tests/integration/pipelex/temporal/library_crate/test_wf_pipe_batch.py
@@ -37,7 +37,6 @@ class TestWfPipeBatch:
         """Verify the crate has all pipe_refs including the batch branch pipe."""
         self._assert_crate_structure(batch_job)
 
-    @pytest.mark.xfail(reason="ListContent deferred hydration fails: list container deserialized as single Topic instead of ListContent[Topic]")
     async def test_batch_sequence_via_temporal(
         self,
         batch_job: PipeJob,

--- a/tests/integration/pipelex/temporal/library_crate/test_wf_pipe_compose.py
+++ b/tests/integration/pipelex/temporal/library_crate/test_wf_pipe_compose.py
@@ -43,7 +43,6 @@ class TestWfPipeCompose:
         report_ref = f"{PipeComposeTemporalTestData.DOMAIN}.Report"
         assert report_ref in crate.concepts, f"Expected concept_ref '{report_ref}' not found in crate"
 
-    @pytest.mark.xfail(reason="PipeComposeBlueprint deserialization fails: Kajson rejects template=None + construct_blueprint combination")
     async def test_compose_sequence_via_temporal(
         self,
         compose_job: PipeJob,

--- a/tests/integration/pipelex/temporal/library_crate/test_wf_pipe_compose.py
+++ b/tests/integration/pipelex/temporal/library_crate/test_wf_pipe_compose.py
@@ -43,7 +43,7 @@ class TestWfPipeCompose:
         report_ref = f"{PipeComposeTemporalTestData.DOMAIN}.Report"
         assert report_ref in crate.concepts, f"Expected concept_ref '{report_ref}' not found in crate"
 
-    @pytest.mark.xfail(reason="PipeCompose construct dispatches WfMakeJinja2Text which fails to serialize dry-run StuffArtefact")
+    @pytest.mark.xfail(reason="PipeComposeBlueprint deserialization fails: Kajson rejects template=None + construct_blueprint combination")
     async def test_compose_sequence_via_temporal(
         self,
         compose_job: PipeJob,

--- a/tests/integration/pipelex/temporal/library_crate/test_wf_pipe_condition.py
+++ b/tests/integration/pipelex/temporal/library_crate/test_wf_pipe_condition.py
@@ -38,7 +38,7 @@ class TestWfPipeCondition:
         """Verify the crate has all pipe_refs including condition outcomes."""
         self._assert_crate_structure(condition_job)
 
-    @pytest.mark.xfail(reason="PipeCondition expression evaluation dispatches WfMakeJinja2Text which fails to serialize dry-run StuffArtefact")
+    @pytest.mark.xfail(reason="Condition expression renders correctly but dry-run output stored as 'main_stuff' instead of 'routed_result'")
     async def test_condition_sequence_via_temporal(
         self,
         condition_job: PipeJob,

--- a/tests/integration/pipelex/temporal/library_crate/test_wf_pipe_condition.py
+++ b/tests/integration/pipelex/temporal/library_crate/test_wf_pipe_condition.py
@@ -38,7 +38,6 @@ class TestWfPipeCondition:
         """Verify the crate has all pipe_refs including condition outcomes."""
         self._assert_crate_structure(condition_job)
 
-    @pytest.mark.xfail(reason="Condition expression renders correctly but dry-run output stored as 'main_stuff' instead of 'routed_result'")
     async def test_condition_sequence_via_temporal(
         self,
         condition_job: PipeJob,

--- a/tests/unit/pipelex/temporal/tprl_pipe/test_hydration.py
+++ b/tests/unit/pipelex/temporal/tprl_pipe/test_hydration.py
@@ -1,8 +1,11 @@
+from typing import cast
+
 import pytest
 
 from pipelex.core.concepts.concept import Concept
 from pipelex.core.domains.domain import SpecialDomain
 from pipelex.core.memory.working_memory import WorkingMemory
+from pipelex.core.stuffs.list_content import ListContent
 from pipelex.core.stuffs.stuff import Stuff
 from pipelex.core.stuffs.text_content import TextContent
 from pipelex.hub import get_class_registry
@@ -43,7 +46,7 @@ class TestHydrateWorkingMemory:
         working_memory = WorkingMemory()
         working_memory.root["greeting"] = _make_text_stuff("greeting", "Hello, world!")
 
-        raw = working_memory.smart_dump()
+        raw = working_memory.dump_for_temporal()
         hydrated = hydrate_working_memory(raw)
 
         assert "greeting" in hydrated.root
@@ -55,7 +58,7 @@ class TestHydrateWorkingMemory:
     def test_hydrate_empty(self) -> None:
         """An empty WorkingMemory raw dict hydrates to empty WorkingMemory."""
         working_memory = WorkingMemory()
-        raw = working_memory.smart_dump()
+        raw = working_memory.dump_for_temporal()
 
         hydrated = hydrate_working_memory(raw)
 
@@ -68,11 +71,46 @@ class TestHydrateWorkingMemory:
         working_memory.root["greeting"] = _make_text_stuff("greeting", "Hello!")
         working_memory.aliases["main_stuff"] = "greeting"
 
-        raw = working_memory.smart_dump()
+        raw = working_memory.dump_for_temporal()
         hydrated = hydrate_working_memory(raw)
 
         assert hydrated.aliases == {"main_stuff": "greeting"}
         assert "greeting" in hydrated.root
+
+    def test_hydrate_list_content_round_trip(self) -> None:
+        """ListContent survives dump_for_temporal/hydrate round-trip as a plain list."""
+        working_memory = WorkingMemory()
+        list_stuff = Stuff(
+            stuff_code="test",
+            stuff_name="colors",
+            concept=_make_text_concept(),
+            content=ListContent(
+                items=[
+                    TextContent(text="blue"),
+                    TextContent(text="red"),
+                    TextContent(text="green"),
+                ]
+            ),
+        )
+        working_memory.root["colors"] = list_stuff
+
+        raw = working_memory.dump_for_temporal()
+
+        # Verify the Temporal format uses a plain list, not {"items": [...]}
+        assert isinstance(raw["root"]["colors"]["content"], list)
+
+        hydrated = hydrate_working_memory(raw)
+
+        assert "colors" in hydrated.root
+        stuff = hydrated.root["colors"]
+        content = stuff.content
+        assert isinstance(content, ListContent)
+        list_content = cast("ListContent[TextContent]", content)
+        assert len(list_content.items) == 3
+        assert all(isinstance(item, TextContent) for item in list_content.items)
+        assert list_content.items[0].text == "blue"
+        assert list_content.items[1].text == "red"
+        assert list_content.items[2].text == "green"
 
     def test_hydrate_raises_on_missing_registry_class(self) -> None:
         """Hydration raises PipeJobError when the concept's structure_class_name is not in the registry."""


### PR DESCRIPTION
## Summary

- Refactor template rendering in PipeCondition, PipeCompose, and StructuredContentComposer to call `render_template` directly instead of going through async Temporal activity wrappers
- Fix PipeBatch Temporal deadlock caused by nested activity calls during LLM prompt templating
- Update integration tests to reflect changes in expected dry-run outputs

## Test plan

- [ ] Run `make agent-test` to verify all unit and integration tests pass
- [ ] Run Temporal integration tests with `--temporal-server local` to confirm deadlock is resolved
- [ ] Verify PipeBatch workflows complete successfully on Temporal workers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render templates inline to remove nested Temporal activities and deadlocks, and make `ListContent` round-trips unambiguous by serializing lists as JSON arrays. Enables dual class‑registry test mode by default to catch hydration regressions.

- **Bug Fixes**
  - Stopped deadlocks by calling `render_template` directly in LLM prompts, `PipeCompose`, `PipeCondition`, `StructuredContentComposer`, and the LLM output-structure helper (removes nested `WfMakeJinja2Text`, notably in `PipeBatch` fan‑out).
  - Temporal round‑trip for `ListContent`: `WorkingMemory.dump_for_temporal()` now encodes list content as a plain list; `hydrate_working_memory()` reconstructs via the item class and wraps in `ListContent` (updated `PipeOutput`/`PipeJob` to use it).
  - `PipeCompose` Kajson round‑trip: blueprint validator accepts `construct_blueprint`; `category` is now `strict=False` to accept string input. `PipeCondition` dry‑run passes `output_name` so results land under the step name.
  - Test infra: `--class-registry both` is the default (runs shared and isolated); Makefile supports `REG` flag; guarded Pipelex bootstrap in Temporal env fixture; removed xfails for compose, condition, combined, and batch Temporal tests.

- **Refactors**
  - Replaced `get_content_generator().make_templated_text` with `render_template` and removed `preprocess_template`.

<sup>Written for commit 1c3929d3b31a0ebb290206f7ef6d5ee92826c238. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

