### PR TITLE
Release v0.23.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Changed
 
-- **Plugin install command**: Updated `mthds-ai-mthds-plugins` → `mthds-plugins` across README and docs.
-- **Plugin reload instructions**: Added `/reload-plugins` as the primary method to activate the plugin, with exit/reopen as fallback.
+- **Claude Code plugin install command**: Fixed as → `/plugin install mthds@mthds-plugins` across README and docs.
+- **Claude Code plugin reload instructions**: Added `/reload-plugins` as the primary method to activate the plugin, with exit/reopen as fallback.
 
 ## [v0.23.1] - 2026-03-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [v0.23.2] - 2026-03-30
+
+### Changed
+
+- **Plugin install command**: Updated `mthds-ai-mthds-plugins` → `mthds-plugins` across README and docs.
+- **Plugin reload instructions**: Added `/reload-plugins` as the primary method to activate the plugin, with exit/reopen as fallback.
+
 ## [v0.23.1] - 2026-03-30
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -86,10 +86,16 @@ Tell Claude to install the MTHDS skills marketplace:
 then install the MTHDS skills plugin:
 
 ```
-/plugin install mthds@mthds-ai-mthds-plugins
+/plugin install mthds@mthds-plugins
 ```
 
-then you must exit Claude Code and reopen it.
+then reload plugins:
+
+```
+/reload-plugins
+```
+
+If that doesn't work, exit Claude Code and reopen it:
 
 ```
 /exit

--- a/docs/features/claude-code-skills-plugin.md
+++ b/docs/features/claude-code-skills-plugin.md
@@ -37,8 +37,10 @@ Install from [mthds-ai/mthds-plugins](https://github.com/mthds-ai/mthds-plugins)
 then:
 
 ```
-/plugin install mthds@mthds-ai-mthds-plugins
+/plugin install mthds@mthds-plugins
 ```
+
+Then reload plugins with `/reload-plugins` (or exit and reopen Claude Code if that doesn't work).
 
 Once installed, type `/mthds-build` in Claude Code to create your first method from a natural language description.
 

--- a/docs/get-started/build-with-claude-code.md
+++ b/docs/get-started/build-with-claude-code.md
@@ -18,16 +18,22 @@ Launch Claude Code and tell it to install the MTHDS plugin:
 ```
 
 ```
-/plugin install mthds@mthds-ai-mthds-plugins
+/plugin install mthds@mthds-plugins
 ```
 
-then exit Claude Code and reopen it:
+then reload plugins:
+
+```
+/reload-plugins
+```
+
+If that doesn't work, exit Claude Code and reopen it:
 
 ```
 /exit
 ```
 
-Reopen Claude Code, and build your first method:
+Build your first method:
 
 ```
 /mthds-build A method to analyze a Job offer to build a scorecard, then batch process CVs to score them

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pipelex"
-version = "0.23.1"
+version = "0.23.2"
 description = "Execute composable AI methods declared in the MTHDS open standard"
 authors = [{ name = "Evotis S.A.S.", email = "oss@pipelex.com" }]
 maintainers = [{ name = "Pipelex staff", email = "oss@pipelex.com" }]

--- a/uv.lock
+++ b/uv.lock
@@ -3449,7 +3449,7 @@ wheels = [
 
 [[package]]
 name = "pipelex"
-version = "0.23.1"
+version = "0.23.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Release v0.23.2

Bumps version from `0.23.1` to `0.23.2`.

### Changelog

### Changed

- **Plugin install command**: Updated `mthds-ai-mthds-plugins` → `mthds-plugins` across README and docs.
- **Plugin reload instructions**: Added `/reload-plugins` as the primary method to activate the plugin, with exit/reopen as fallback.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v0.23.2 fixes the Claude Code plugin install command to `/plugin install mthds@mthds-plugins` and makes `/reload-plugins` the recommended way to activate (exit/reopen as fallback). Bumps `pipelex` to `0.23.2`.

<sup>Written for commit fd9529827f9d0ea8a071b9d0a4e63edb951dbde5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

