### PR TITLE
Add distributed content generation docs and upgrade kajson to 0.4.1

### DIFF
--- a/.claude/skills/temporal-e2e-validate/SKILL.md
+++ b/.claude/skills/temporal-e2e-validate/SKILL.md
@@ -168,8 +168,10 @@ costs, validates serialization and crate propagation. But dry-run produces tiny 
 data, so it **cannot catch payload size issues** (e.g. large image payloads blowing up
 Temporal's data converter).
 
-Ask the user which mode they want. If they say "live", replace `--dry-run --mock-inputs`
-with `--pipe-run-mode live` in all commands below. Live mode makes real LLM and image
+Ask the user which mode they want. If they say "live", simply omit `--dry-run --mock-inputs`
+from all commands below. The `pipelex run bundle` CLI has no `--pipe-run-mode` flag — live
+is the default when neither `--dry-run` nor `--mock-inputs` is specified (note: pytest in
+Mode 1 does accept `--pipe-run-mode live`, but the CLI does not). Live mode makes real LLM and image
 generation calls — it costs money and is slower, but it's the only way to validate that
 real-sized payloads (especially images) flow correctly through Temporal.
 
@@ -281,7 +283,7 @@ Live (real image generation — required to catch payload size bugs):
 .venv/bin/pipelex run bundle \
   tests/integration/pipelex/pipes/pipelines/crazy_image_generation.mthds \
   --pipe generate_crazy_image \
-  --temporal --pipe-run-mode live --no-logo --graph
+  --temporal --no-logo --graph
 ```
 
 After this completes, tell the user: PASS/FAIL, output dir, graph file path.
@@ -322,7 +324,7 @@ Live (real image generation + vision — required to catch payload size bugs):
 .venv/bin/pipelex run bundle \
   tests/integration/pipelex/pipes/pipelines/test_image_out_in.mthds \
   --pipe image_out_in \
-  --temporal --pipe-run-mode live --no-logo --graph
+  --temporal --no-logo --graph
 ```
 
 After this completes, tell the user: PASS/FAIL, output dir, graph file path.

--- a/.claude/skills/temporal-e2e-validate/SKILL.md
+++ b/.claude/skills/temporal-e2e-validate/SKILL.md
@@ -6,12 +6,15 @@ description: >
   all test cases, and (2) true 3-process setup (server + separate worker process
   + submitter) that validates the actual deployment topology including cross-process
   serialization, LibraryCrate propagation, deferred hydration, concurrent
-  isolation, and cross-worker graph tracing with GraphSpec assembly.
+  isolation, image payload storage, and cross-worker graph tracing with GraphSpec
+  assembly. Includes image generation and image flow tests that verify large binary
+  payloads are stored at the activity level (not passed inline through Temporal).
   Use when the user says "validate temporal", "e2e temporal",
   "temporal regression", "temporal validation", "3-process test", "full temporal
-  test", "validate phases", or wants comprehensive verification that distributed
-  execution works end-to-end. Also use proactively after changes to LibraryCrate,
-  deferred hydration, ClassRegistry scoping, graph tracing, or Temporal workflow code.
+  test", "validate phases", "image temporal", or wants comprehensive verification
+  that distributed execution works end-to-end. Also use proactively after changes
+  to LibraryCrate, deferred hydration, ClassRegistry scoping, graph tracing,
+  image generation activities, content storage, or Temporal workflow code.
 allowed-tools:
   - Bash(tmux *)
   - Bash(curl *)
@@ -28,8 +31,10 @@ This skill validates that Pipelex pipelines execute correctly when distributed a
 Temporal workers — separate processes that receive serialized work, run pipes, and return
 results. It covers the full chain: shipping pipe definitions to the worker (Phase 2),
 deserializing dynamic concepts the worker has never seen (Phase 3), isolating concurrent
-workflows so they don't corrupt each other (Phase 4), and assembling an execution graph
-from trace events emitted across workers (Phase 4.5).
+workflows so they don't corrupt each other (Phase 4), assembling an execution graph
+from trace events emitted across workers (Phase 4.5), and verifying that image-heavy
+pipelines (image generation, image-to-LLM flow) don't blow up Temporal's payload
+limits by ensuring images are stored at the activity level.
 
 ## Important: surface results immediately
 
@@ -156,6 +161,23 @@ Each command runs a pipeline through Temporal with `--graph`, which also validat
 the worker emits NDJSON trace events and the submitter assembles them into a GraphSpec
 with an interactive ReactFlow HTML visualization.
 
+### Run mode: dry-run vs live
+
+By default, Mode 2 runs in **dry-run** mode (`--dry-run --mock-inputs`) — fast, no LLM
+costs, validates serialization and crate propagation. But dry-run produces tiny mock
+data, so it **cannot catch payload size issues** (e.g. large image payloads blowing up
+Temporal's data converter).
+
+Ask the user which mode they want. If they say "live", replace `--dry-run --mock-inputs`
+with `--pipe-run-mode live` in all commands below. Live mode makes real LLM and image
+generation calls — it costs money and is slower, but it's the only way to validate that
+real-sized payloads (especially images) flow correctly through Temporal.
+
+**This matters most for Tiers 4 and 5** (image generation and image flow). In dry-run,
+mock images are trivially small, so payload size bugs don't surface. In live mode,
+generated images are hundreds of KB to several MB — exactly the size that breaks Temporal
+if activity-level storage isn't implemented.
+
 ### Step 1: Ensure Temporal server is running
 
 Same as Mode 1 Step 1.
@@ -226,6 +248,89 @@ ReactFlow visualization.
 ```
 
 After this completes, tell the user: PASS/FAIL, output dir, graph file path.
+
+**Tier 4 — Can the worker handle image generation pipelines?**
+
+**Important:** This tier only catches payload size bugs in **live mode**. In dry-run,
+mock images are tiny and will pass even without activity-level storage. If the user
+wants to validate image payload handling, they must run live.
+
+This is a critical payload-size test. Image generation produces large binary data
+(base64-encoded images) that must be stored at the activity level and passed as
+storage URIs through Temporal — not inline in the workflow payload. If storage is
+missing, this will either fail with a Temporal payload size error or trigger
+`PayloadSizeWarning` in the worker logs.
+
+The `generate_crazy_image` bundle runs a 2-step PipeSequence: an LLM imagines a
+scene description, then PipeImgGen renders it as an image. This exercises the full
+image generation path through Temporal, including the custom `ImagePrompt` concept
+(which refines `Text`).
+
+Dry-run:
+
+```bash
+.venv/bin/pipelex run bundle \
+  tests/integration/pipelex/pipes/pipelines/crazy_image_generation.mthds \
+  --pipe generate_crazy_image \
+  --temporal --dry-run --mock-inputs --no-logo --graph
+```
+
+Live (real image generation — required to catch payload size bugs):
+
+```bash
+.venv/bin/pipelex run bundle \
+  tests/integration/pipelex/pipes/pipelines/crazy_image_generation.mthds \
+  --pipe generate_crazy_image \
+  --temporal --pipe-run-mode live --no-logo --graph
+```
+
+After this completes, tell the user: PASS/FAIL, output dir, graph file path.
+Also check worker logs for `PayloadSizeWarning`:
+
+```bash
+tmux capture-pane -t temporal-worker -p -S -50 | grep -i "payload\|warning\|size" || echo "No payload warnings"
+```
+
+**Tier 5 — Can generated images flow between pipes in a sequence?**
+
+**Important:** Like Tier 4, this only catches real payload bugs in **live mode**.
+
+This is the "image out → image in" test. A PipeSequence first generates an image
+via PipeImgGen, then passes that image as input to a PipeLLM (vision model) that
+describes it. This exercises:
+- Image generation storage at the activity level
+- Image content serialization through Temporal's data converter
+- Image content deserialization on the worker for the next pipe step
+- Vision model receiving an image reference (URI) rather than inline base64
+
+If activity-level storage is not implemented, this will fail because the raw image
+bytes exceed Temporal's payload limit, or because the worker can't deserialize the
+`ImageContent` object from the previous step.
+
+Dry-run:
+
+```bash
+.venv/bin/pipelex run bundle \
+  tests/integration/pipelex/pipes/pipelines/test_image_out_in.mthds \
+  --pipe image_out_in \
+  --temporal --dry-run --mock-inputs --no-logo --graph
+```
+
+Live (real image generation + vision — required to catch payload size bugs):
+
+```bash
+.venv/bin/pipelex run bundle \
+  tests/integration/pipelex/pipes/pipelines/test_image_out_in.mthds \
+  --pipe image_out_in \
+  --temporal --pipe-run-mode live --no-logo --graph
+```
+
+After this completes, tell the user: PASS/FAIL, output dir, graph file path.
+Also check for payload warnings:
+
+```bash
+tmux capture-pane -t temporal-worker -p -S -50 | grep -i "payload\|warning\|size" || echo "No payload warnings"
+```
 
 If any tier hangs for more than 30 seconds, check worker output:
 
@@ -340,17 +445,19 @@ List all graph files and present a summary table with results:
 ls results/*/reactflow.html
 ```
 
-| Test | What it proved | Status | Graph |
-|------|---------------|--------|-------|
-| Tier 1: Sequence | Worker can unpack crate and run a pipe sequence | PASS/FAIL | path |
-| Tier 2: Hydration | Worker handles dynamic concepts it has never seen | PASS/FAIL | path |
-| Tier 3: Parallel | Branches execute as concurrent child workflows | PASS/FAIL | path |
-| Concept isolation (alpha) | Conflicting `Result` concepts don't cross-contaminate | PASS/FAIL | path |
-| Concept isolation (beta) | (same test, other side) | PASS/FAIL | path |
-| Pipe isolation (alpha) | Conflicting `shared_step` pipes use correct version | PASS/FAIL | path |
-| Pipe isolation (beta) | (same test, other side) | PASS/FAIL | path |
-| Multi-concept (alpha) | Two overlapping concepts with incompatible structures | PASS/FAIL | path |
-| Multi-concept (beta) | (same test, other side) | PASS/FAIL | path |
+| Test | What it proved | Status | Graph | Payload warnings |
+|------|---------------|--------|-------|-----------------|
+| Tier 1: Sequence | Worker can unpack crate and run a pipe sequence | PASS/FAIL | path | — |
+| Tier 2: Hydration | Worker handles dynamic concepts it has never seen | PASS/FAIL | path | — |
+| Tier 3: Parallel | Branches execute as concurrent child workflows | PASS/FAIL | path | — |
+| Tier 4: ImgGen | Image generation pipeline works through Temporal | PASS/FAIL | path | yes/no |
+| Tier 5: Image flow | Generated image flows as input to next pipe step | PASS/FAIL | path | yes/no |
+| Concept isolation (alpha) | Conflicting `Result` concepts don't cross-contaminate | PASS/FAIL | path | — |
+| Concept isolation (beta) | (same test, other side) | PASS/FAIL | path | — |
+| Pipe isolation (alpha) | Conflicting `shared_step` pipes use correct version | PASS/FAIL | path | — |
+| Pipe isolation (beta) | (same test, other side) | PASS/FAIL | path | — |
+| Multi-concept (alpha) | Two overlapping concepts with incompatible structures | PASS/FAIL | path | — |
+| Multi-concept (beta) | (same test, other side) | PASS/FAIL | path | — |
 
 After reporting, propose opening the PipeParallel graph (most interesting cross-worker view):
 
@@ -390,12 +497,16 @@ Leave the server running if the user plans to iterate.
 | Submitter hangs indefinitely | The worker crashed during deserialization — check `tmux capture-pane -t temporal-worker -p -S -200` |
 | Both concurrent jobs succeed but wrong data | ContextVar leak between workflows — per-workflow scoping is broken, one workflow's class definitions bled into the other |
 | No `reactflow.html` generated | GraphSpec assembly failed — either tracing is disabled in `pipelex.toml` or NDJSON events weren't emitted by the worker |
+| `PayloadSizeWarning` in worker logs | Image data (base64) is being passed inline through Temporal payloads instead of being stored at the activity level — the fix is to call storage in the image generation activity before returning results |
+| `NotImplementedError` during image generation | The image generation or content storage path isn't wired up for the Temporal execution path — activity-level storage is missing |
+| Payload too large / `DataConverterError` on image pipes | Raw image bytes exceed Temporal's payload size limit (~2MB default) — images must be stored and referenced by URI, not passed inline |
+| `ImageContent` missing or has no `uri` field | The image generation activity returned raw image data instead of a stored `ImageContent` with a storage URI |
 
 ---
 
 ## Bundle reference
 
-All bundles are in `tests/integration/pipelex/temporal/library_crate/`:
+**Crate/isolation bundles** — in `tests/integration/pipelex/temporal/library_crate/`:
 
 | Bundle | What it tests | Main pipe |
 |--------|--------------|-----------|
@@ -412,3 +523,10 @@ All bundles are in `tests/integration/pipelex/temporal/library_crate/`:
 | `temporal_condition.mthds` | PipeCondition — conditional routing via child workflow | `temporal_condition_sequence` |
 | `temporal_compose.mthds` | PipeCompose — operator composition + deferred hydration | `temporal_compose_sequence` |
 | `temporal_combined.mthds` | Nested PipeParallel + PipeCondition | `temporal_combined_pipeline` |
+
+**Image payload bundles** — in `tests/integration/pipelex/pipes/pipelines/`:
+
+| Bundle | What it tests | Main pipe |
+|--------|--------------|-----------|
+| `crazy_image_generation.mthds` | Image generation pipeline — LLM imagines scene + PipeImgGen renders it, custom ImagePrompt concept | `generate_crazy_image` |
+| `test_image_out_in.mthds` | Image flow — PipeImgGen generates image, then PipeLLM (vision) describes it | `image_out_in` |

--- a/docs/under-the-hood/distributed-content-generation.md
+++ b/docs/under-the-hood/distributed-content-generation.md
@@ -1,0 +1,226 @@
+---
+title: "Distributed Content Generation"
+description: "How Pipelex serializes dynamic Pydantic models and large binary content across Temporal workflow/activity boundaries — JSON schema propagation, class source injection, and storage-based payload offloading."
+---
+
+# Distributed Content Generation
+
+This page covers the serialization mechanisms that enable content generation (LLM structured output, image generation, PDF extraction) to run across Temporal worker processes. For the broader Temporal architecture — LibraryCrate propagation, deferred hydration, per-workflow scoping — see [Temporal Integration](./temporal-integration.md).
+
+---
+
+## The Two Serialization Challenges
+
+Content generation introduces two cross-cutting problems that don't exist in single-process mode:
+
+| Challenge | Trigger | Root cause | Solution |
+|-----------|---------|------------|----------|
+| **Dynamic class propagation** | LLM structured output (`PipeLLM` with object concept) | Submitter creates a Pydantic model at runtime from `.mthds` concept definitions; the worker process has no such class | Embed JSON schema in assignment, reconstruct class on worker, carry source code through Temporal payload metadata |
+| **Large payload management** | Image generation (`PipeImgGen`), PDF extraction (`PipeExtract`) | Binary data (base64 images, rendered pages) exceeds Temporal's ~2MB payload limit | Activities store binary data to external storage, return lightweight URI references |
+
+---
+
+## Dynamic Class Propagation
+
+### Schema embedding
+
+When a pipe produces structured output, the caller captures the Pydantic model's JSON schema into the assignment — a serializable Temporal argument that carries everything the worker needs:
+
+```python
+class ObjectAssignment(BaseModel):
+    object_class_name: str
+    object_class_schema: dict[str, Any]
+    llm_assignment_for_object: LLMAssignment
+
+    @staticmethod
+    def make_for_class(
+        object_class: type[BaseModel],
+        llm_assignment: LLMAssignment,
+    ) -> "ObjectAssignment":
+        return ObjectAssignment(
+            object_class_name=object_class.__name__,
+            object_class_schema=object_class.model_json_schema(),
+            llm_assignment_for_object=llm_assignment,
+        )
+```
+
+The schema is a plain `dict` — fully serializable, visible in the Temporal dashboard, and self-contained. No class reference crosses the process boundary.
+
+### Schema-to-model reconstruction
+
+On the worker, `model_class_from_json_schema()` rebuilds a live Pydantic class from the embedded schema:
+
+```python
+source_code = _generate_source_from_schema(schema)        # datamodel-code-generator
+reconstructed_class = _exec_and_extract_class(source_code, class_name)  # exec()
+reconstructed_class.__kajson_class_source__ = source_code  # attached for downstream use
+```
+
+The reconstruction pipeline:
+
+1. **Generate** — `datamodel-code-generator` converts the JSON schema into Python source code defining a `BaseModel` subclass.
+2. **Execute** — `exec()` compiles the source in an isolated namespace and extracts the named class.
+3. **Cache** — A thread-safe SHA-256 hash cache avoids redundant generation for the same schema.
+4. **Tag** — The generated source code is attached as `__kajson_class_source__` on the class, enabling Kajson to carry it through Temporal payloads.
+
+!!! warning "Class name normalization"
+    `datamodel-code-generator` normalizes schema titles to PascalCase (e.g., `dynamic_concept_test__Greeting` becomes `DynamicConceptTestGreeting`). The code tries both the original and normalized names. If neither matches, it raises `ValueError` listing the available classes.
+
+### Source code injection into Temporal payloads
+
+When the activity returns a `BaseModel` whose class has `__kajson_class_source__`, the custom `BaseModelPayloadConverter` injects it into the Temporal payload metadata:
+
+**Serialization** (`to_payload`):
+
+```python
+class_source = getattr(type(value), "__kajson_class_source__", None)
+if class_source is not None:
+    metadata["kajson_class_source"] = class_source.encode()
+```
+
+**Deserialization** (`from_payload`):
+
+```python
+source_bytes = payload.metadata.get("kajson_class_source")
+class_source_code = source_bytes.decode() if source_bytes else None
+pydantic_gizmo = kajson.loads(
+    data,
+    class_registry=get_class_registry(),
+    class_source_code=class_source_code,
+)
+```
+
+The source code rides in Temporal metadata (not the payload data itself), keeping the JSON payload clean and the class reconstruction transparent.
+
+### The type bridge
+
+The class reconstructed on the worker is a structural match to the original, but it is a different Python class in memory. Standard `isinstance()` checks would fail. The caller bridges this gap with a `model_validate` round-trip:
+
+```python
+raw_obj = await llm_gen_object(object_assignment=object_assignment)
+return object_class.model_validate(raw_obj.model_dump(serialize_as_any=True))
+```
+
+`model_dump(serialize_as_any=True)` produces a plain dict from the reconstructed object, and `model_validate()` rebuilds it as a proper instance of the original class. This restores type safety for downstream code.
+
+### End-to-end flow
+
+```mermaid
+sequenceDiagram
+    participant S as Submitter
+    participant W as Worker Activity
+    participant LLM as LLM Provider
+
+    S->>S: object_class.model_json_schema()
+    S->>W: ObjectAssignment (class_name + schema)
+
+    Note over W: model_class_from_json_schema()
+    W->>W: datamodel-code-generator → source
+    W->>W: exec() → class + __kajson_class_source__
+
+    W->>LLM: gen_object(schema=reconstructed_class)
+    LLM-->>W: structured JSON
+
+    W-->>S: BaseModel result<br/>(metadata: kajson_class_source)
+
+    Note over S: kajson.loads(class_source_code=...)
+    S->>S: model_validate() → original type
+```
+
+---
+
+## Large Payload Management
+
+### The payload size constraint
+
+Temporal payloads have a practical limit around 2MB. A single generated image can exceed this in base64 encoding. PDF extraction produces multiple page images. Sending raw binary through Temporal would either fail with a `DataConverterError` or severely degrade workflow history performance.
+
+### The store-then-reference pattern
+
+Activities handle the full binary lifecycle internally — generate, store, return a lightweight reference:
+
+```python
+@activity.defn
+async def act_img_gen_images(img_gen_assignment: ImgGenAssignment) -> list[ImageContent]:
+    """Generate images and store them, returning lightweight ImageContent references.
+
+    Large binary data (base64/bytes) is stored within the activity and never crosses
+    the Temporal workflow boundary — only URLs are returned.
+    """
+    storage_provider = get_storage_provider()
+    generated_content_factory = GeneratedContentFactory(storage_provider=storage_provider)
+    return await img_gen_image_list_and_store(
+        img_gen_assignment=img_gen_assignment,
+        generated_content_factory=generated_content_factory,
+    )
+```
+
+`GeneratedContentFactory` uploads binary data via the configured `StorageProviderAbstract` (S3, local filesystem, etc.) and returns `ImageContent` or `PageContent` — Pydantic models carrying URIs, MIME types, and metadata, but never raw bytes.
+
+!!! info "What crosses the boundary"
+    `ImageContent` carries `url` (storage URI), `public_url`, `mime_type`, `size`, `caption` — but never raw bytes. The `url` can be an S3 URI, HTTP URL, or local file path depending on storage configuration.
+
+### Content type scenarios
+
+| Content type | Activity | What gets stored | What crosses the Temporal boundary |
+|-------------|----------|-----------------|-----------------------------------|
+| Generated image | `act_img_gen_images` | Base64/bytes → S3 via `GeneratedContentFactory` | `list[ImageContent]` with URIs |
+| Extracted pages | `act_extract_gen_extract_pages` | Extracted page images → S3 | `list[PageContent]` with URI references |
+| Rendered page views | `act_render_page_views` | PDF page renders → S3 | `list[ImageContent]` with URIs |
+| LLM text | `act_llm_gen_text` | Nothing stored (text is small) | Plain `str` |
+| LLM object | `act_llm_gen_object` | Nothing stored (JSON is small) | `BaseModel` + `__kajson_class_source__` in metadata |
+
+---
+
+## Kajson Class Resolution
+
+When `kajson.loads()` receives both a `class_registry` and `class_source_code`, the resolution follows a priority chain:
+
+```python
+if class_source_code is not None:
+    source_registry = _build_registry_from_source(class_source_code)
+    if class_registry is not None:
+        # Source-derived classes fill gaps; explicit registry takes priority
+        for name, cls in source_registry.root.items():
+            if not class_registry.has_class(name):
+                class_registry.register_class(cls, name=name, ...)
+    else:
+        class_registry = source_registry
+```
+
+Resolution order:
+
+1. **Explicit `class_registry`** — the per-workflow scoped registry (see [Temporal Integration](./temporal-integration.md#per-workflow-scoping))
+2. **Source-derived classes** — from `class_source_code`, filling gaps in the explicit registry
+3. **`sys.modules`** — already-imported classes
+4. **Dynamic import** — last resort, importing the module path from `__module__` metadata
+
+!!! note "exec() safety"
+    `_build_registry_from_source()` uses `exec()` internally. The source code originates from `datamodel-code-generator` running against the same JSON schema the submitter used — it is never user-supplied arbitrary code.
+
+---
+
+## File Reference
+
+| Component | File |
+|-----------|------|
+| Assignment models (schema embedding) | `pipelex/cogt/content_generation/assignment_models.py` |
+| Schema-to-model reconstruction | `pipelex/cogt/content_generation/schema_to_model.py` |
+| Content generator (type bridge) | `pipelex/cogt/content_generation/content_generator.py` |
+| LLM generation functions | `pipelex/cogt/content_generation/llm_generate.py` |
+| Generated content factory (storage) | `pipelex/cogt/content_generation/generated_content_factory.py` |
+| Temporal data converter | `pipelex/temporal/temporal_data_converter.py` |
+| Image generation activity | `pipelex/temporal/tprl_content_generation/act_img_gen_generate.py` |
+| Extract activity | `pipelex/temporal/tprl_content_generation/act_extract_generate.py` |
+| Page view rendering activity | `pipelex/temporal/tprl_content_generation/act_render_page_views.py` |
+| Kajson serialization | `kajson/kajson/kajson.py` |
+| ImageContent model | `pipelex/core/stuffs/image_content.py` |
+| PageContent model | `pipelex/core/stuffs/page_content.py` |
+
+---
+
+## Next Steps
+
+- [Temporal Integration](./temporal-integration.md) — LibraryCrate propagation, deferred hydration, per-workflow scoping
+- [Pipe Routing & Execution](./pipe-routing-and-execution.md) — how PipeJobs travel through the system
+- [Architecture Overview](./architecture-overview.md) — the two-layer design and how components fit together

--- a/docs/under-the-hood/distributed-content-generation.md
+++ b/docs/under-the-hood/distributed-content-generation.md
@@ -213,7 +213,7 @@ Resolution order:
 | Image generation activity | `pipelex/temporal/tprl_content_generation/act_img_gen_generate.py` |
 | Extract activity | `pipelex/temporal/tprl_content_generation/act_extract_generate.py` |
 | Page view rendering activity | `pipelex/temporal/tprl_content_generation/act_render_page_views.py` |
-| Kajson serialization | `kajson/kajson/kajson.py` |
+| Kajson serialization | `kajson` (external PyPI package) |
 | ImageContent model | `pipelex/core/stuffs/image_content.py` |
 | PageContent model | `pipelex/core/stuffs/page_content.py` |
 

--- a/docs/under-the-hood/index.md
+++ b/docs/under-the-hood/index.md
@@ -17,6 +17,7 @@ Welcome to the technical deep-dives of Pipelex. This section is for contributors
 - **Test Profile Configuration** - How to configure which models are used in tests
 - **Dry Run Mock Generation** - How mock objects satisfy field validation constraints
 - **Init CLI Flows** - How `pipelex init` sets up the configuration directory
+- **Distributed Content Generation** - How dynamic classes and large payloads cross Temporal boundaries
 - **Technical Design Decisions** - Why we chose X over Y
 - **Module Deep-Dives** - Detailed explanations of specific subsystems
 
@@ -37,3 +38,4 @@ Welcome to the technical deep-dives of Pipelex. This section is for contributors
 - [:material-console: Init CLI Flows](./init-cli-flows.md){ .md-button }
 - [:material-pipe: Pipe Routing & Execution](./pipe-routing-and-execution.md){ .md-button }
 - [:material-cloud-sync: Temporal Integration](./temporal-integration.md){ .md-button }
+- [:material-swap-horizontal: Distributed Content Generation](./distributed-content-generation.md){ .md-button }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -305,6 +305,7 @@ plugins:
         - under-the-hood/init-cli-flows.md: "Init CLI Flows"
         - under-the-hood/pipe-routing-and-execution.md: "Pipe Routing & Execution"
         - under-the-hood/temporal-integration.md: "Temporal Integration"
+        - under-the-hood/distributed-content-generation.md: "Distributed Content Generation"
         Project:
         - contributing.md: "Contributing"
         - contribute/configuration-defaults-and-overrides.md: "Configuration Internals"
@@ -491,6 +492,7 @@ nav:
       - Init CLI Flows: under-the-hood/init-cli-flows.md
       - Pipe Routing & Execution: under-the-hood/pipe-routing-and-execution.md
       - Temporal Integration: under-the-hood/temporal-integration.md
+      - Distributed Content Generation: under-the-hood/distributed-content-generation.md
   - Project:
     - Contributing: contributing.md
     - Configuration Internals: contribute/configuration-defaults-and-overrides.md

--- a/pipelex/cogt/content_generation/assignment_models.py
+++ b/pipelex/cogt/content_generation/assignment_models.py
@@ -139,3 +139,9 @@ class ExtractAssignment(BaseModel):
     extract_input: ExtractInput
     extract_job_params: ExtractJobParams
     extract_job_config: ExtractJobConfig
+
+
+class RenderPageViewsAssignment(BaseModel):
+    job_metadata: JobMetadata
+    document_uri: str
+    page_views_dpi: int

--- a/pipelex/cogt/content_generation/assignment_models.py
+++ b/pipelex/cogt/content_generation/assignment_models.py
@@ -13,7 +13,6 @@ from pipelex.cogt.llm.llm_prompt_factory_abstract import LLMPromptFactoryAbstrac
 from pipelex.cogt.llm.llm_setting import LLMSetting
 from pipelex.cogt.templating.template_category import TemplateCategory
 from pipelex.cogt.templating.templating_style import TemplatingStyle
-from pipelex.hub import get_class_registry
 from pipelex.pipeline.job_metadata import JobMetadata
 
 
@@ -84,6 +83,7 @@ class LLMAssignment(BaseModel):
 
 class ObjectAssignment(BaseModel):
     object_class_name: str
+    object_class_schema: dict[str, Any]
     llm_assignment_for_object: LLMAssignment
 
     @staticmethod
@@ -91,21 +91,16 @@ class ObjectAssignment(BaseModel):
         object_class: type[BaseModel],
         llm_assignment: LLMAssignment,
     ) -> "ObjectAssignment":
-        object_class_name = object_class.__name__
-        get_class_registry().register_class(
-            class_type=object_class,
-            name=object_class_name,
-            should_warn_if_already_registered=False,
-        )
-
         return ObjectAssignment(
-            object_class_name=object_class_name,
+            object_class_name=object_class.__name__,
+            object_class_schema=object_class.model_json_schema(),
             llm_assignment_for_object=llm_assignment,
         )
 
 
 class TextThenObjectAssignment(BaseModel):
     object_class_name: str
+    object_class_schema: dict[str, Any]
     llm_assignment_for_text: LLMAssignment
     llm_assignment_factory_to_object: LLMAssignmentFactory
 

--- a/pipelex/cogt/content_generation/assignment_models.py
+++ b/pipelex/cogt/content_generation/assignment_models.py
@@ -3,7 +3,6 @@ from typing import Any
 from pydantic import BaseModel
 from typing_extensions import override
 
-from pipelex.cogt.exceptions import LLMAssignmentError
 from pipelex.cogt.extract.extract_input import ExtractInput
 from pipelex.cogt.extract.extract_job_components import ExtractJobConfig, ExtractJobParams
 from pipelex.cogt.img_gen.img_gen_job_components import ImgGenJobConfig, ImgGenJobParams
@@ -86,12 +85,6 @@ class LLMAssignment(BaseModel):
 class ObjectAssignment(BaseModel):
     object_class_name: str
     llm_assignment_for_object: LLMAssignment
-
-    def __init__(self, **kwargs: Any):
-        super().__init__(**kwargs)
-        if not get_class_registry().has_class(name=self.object_class_name):
-            error_msg = f"Could not create ObjectAssignment for class '{self.object_class_name}' because it is not in the class registry."
-            raise LLMAssignmentError(error_msg)
 
     @staticmethod
     def make_for_class(

--- a/pipelex/cogt/content_generation/content_generator.py
+++ b/pipelex/cogt/content_generation/content_generator.py
@@ -1,4 +1,4 @@
-from typing import Any, cast
+from typing import Any
 
 from typing_extensions import override
 
@@ -84,9 +84,12 @@ class ContentGenerator(ContentGeneratorProtocol):
             object_class=object_class,
             llm_assignment=llm_assignment_for_object,
         )
-        obj = await llm_gen_object(object_assignment=object_assignment)
-        log.verbose(f"{self.__class__.__name__} generated object direct: {obj}")
-        return cast("BaseModelTypeVar", obj)
+        raw_obj = await llm_gen_object(object_assignment=object_assignment)
+        log.verbose(f"{self.__class__.__name__} generated object direct: {raw_obj}")
+        # llm_gen_object returns a plain BaseModel reconstructed from the JSON schema.
+        # Validate its data against the original class so the result is a proper subtype
+        # (e.g. StructuredContent) expected by the caller.
+        return object_class.model_validate(raw_obj.model_dump(serialize_as_any=True))
 
     @override
     @update_job_metadata
@@ -113,8 +116,10 @@ class ContentGenerator(ContentGeneratorProtocol):
             llm_prompt_factory=llm_prompt_factory_for_object or LLMPromptTemplate.make_for_structuring_from_preliminary_text(),
         )
 
+        object_class_schema = object_class.model_json_schema()
         workflow_arg = TextThenObjectAssignment(
             object_class_name=object_class.__name__,
+            object_class_schema=object_class_schema,
             llm_assignment_for_text=llm_assignment_for_text,
             llm_assignment_factory_to_object=llm_assignment_factory_to_object,
         )
@@ -130,11 +135,12 @@ class ContentGenerator(ContentGeneratorProtocol):
         fup_obj_assignment = ObjectAssignment(
             llm_assignment_for_object=fup_llm_assignment,
             object_class_name=object_class.__name__,
+            object_class_schema=object_class_schema,
         )
 
-        obj = await llm_gen_object(object_assignment=fup_obj_assignment)
-        log.verbose(f"{self.__class__.__name__} generated object after text: {obj}")
-        return cast("BaseModelTypeVar", obj)
+        raw_obj = await llm_gen_object(object_assignment=fup_obj_assignment)
+        log.verbose(f"{self.__class__.__name__} generated object after text: {raw_obj}")
+        return object_class.model_validate(raw_obj.model_dump(serialize_as_any=True))
 
     @override
     @update_job_metadata
@@ -156,9 +162,9 @@ class ContentGenerator(ContentGeneratorProtocol):
             object_class=object_class,
             llm_assignment=llm_assignment_for_object,
         )
-        obj_list = await llm_gen_object_list(object_assignment=object_assignment)
-        log.verbose(f"{self.__class__.__name__} generated object list direct: {obj_list}")
-        return cast("list[BaseModelTypeVar]", obj_list)
+        raw_list = await llm_gen_object_list(object_assignment=object_assignment)
+        log.verbose(f"{self.__class__.__name__} generated object list direct: {raw_list}")
+        return [object_class.model_validate(raw_obj.model_dump(serialize_as_any=True)) for raw_obj in raw_list]
 
     @override
     @update_job_metadata
@@ -184,8 +190,10 @@ class ContentGenerator(ContentGeneratorProtocol):
             llm_setting=llm_setting_for_object_list,
             llm_prompt_factory=llm_prompt_factory_for_object_list or LLMPromptTemplate.make_for_structuring_from_preliminary_text(),
         )
+        object_class_schema = object_class.model_json_schema()
         workflow_arg = TextThenObjectAssignment(
             object_class_name=object_class.__name__,
+            object_class_schema=object_class_schema,
             llm_assignment_for_text=llm_assignment_for_text,
             llm_assignment_factory_to_object=llm_assignment_factory_to_object,
         )
@@ -201,11 +209,12 @@ class ContentGenerator(ContentGeneratorProtocol):
         fup_obj_assignment = ObjectAssignment(
             llm_assignment_for_object=fup_llm_assignment,
             object_class_name=object_class.__name__,
+            object_class_schema=object_class_schema,
         )
 
-        obj_list = await llm_gen_object_list(object_assignment=fup_obj_assignment)
-        log.verbose(f"{self.__class__.__name__} generated object list after text: {obj_list}")
-        return cast("list[BaseModelTypeVar]", obj_list)
+        raw_list = await llm_gen_object_list(object_assignment=fup_obj_assignment)
+        log.verbose(f"{self.__class__.__name__} generated object list after text: {raw_list}")
+        return [object_class.model_validate(raw_obj.model_dump(serialize_as_any=True)) for raw_obj in raw_list]
 
     @override
     async def make_image_content(

--- a/pipelex/cogt/content_generation/content_generator.py
+++ b/pipelex/cogt/content_generation/content_generator.py
@@ -316,6 +316,7 @@ class ContentGenerator(ContentGeneratorProtocol):
         return await templating_gen_text(templating_assignment=templating_assignment)
 
     @override
+    @update_job_metadata
     async def make_render_page_views(
         self,
         job_metadata: JobMetadata,

--- a/pipelex/cogt/content_generation/content_generator_protocol.py
+++ b/pipelex/cogt/content_generation/content_generator_protocol.py
@@ -137,7 +137,7 @@ class ContentGeneratorProtocol(Protocol):
         wfid: str | None = None,
     ) -> Coroutine[Any, Any, str]: ...
 
-    async def make_render_page_views(
+    def make_render_page_views(
         self,
         job_metadata: JobMetadata,
         extract_input: ExtractInput,
@@ -145,7 +145,7 @@ class ContentGeneratorProtocol(Protocol):
         extract_job_params: ExtractJobParams | None = None,
         extract_job_config: ExtractJobConfig | None = None,
         wfid: str | None = None,
-    ) -> list[ImageContent]: ...
+    ) -> Coroutine[Any, Any, list[ImageContent]]: ...
 
     def make_extract_pages(
         self,

--- a/pipelex/cogt/content_generation/extract_generate.py
+++ b/pipelex/cogt/content_generation/extract_generate.py
@@ -1,6 +1,8 @@
 from pipelex.cogt.content_generation.assignment_models import ExtractAssignment
+from pipelex.cogt.content_generation.generated_content_factory import GeneratedContentFactory
 from pipelex.cogt.extract.extract_job_factory import ExtractJobFactory
 from pipelex.cogt.extract.extract_output import ExtractOutput
+from pipelex.core.stuffs.page_content import PageContent
 from pipelex.hub import get_extract_worker
 
 
@@ -13,3 +15,16 @@ async def extract_gen_pages(extract_assignment: ExtractAssignment) -> ExtractOut
         job_metadata=extract_assignment.job_metadata,
     )
     return await extract_worker.extract_pages(extract_job=extract_job)
+
+
+async def extract_gen_pages_and_store(
+    extract_assignment: ExtractAssignment,
+    generated_content_factory: GeneratedContentFactory,
+) -> list[PageContent]:
+    """Extract pages and store extracted images, returning PageContent with URLs (no raw binary data)."""
+    extract_output = await extract_gen_pages(extract_assignment)
+    return await generated_content_factory.make_page_contents(
+        primary_id=extract_assignment.job_metadata.user_id,
+        secondary_id=extract_assignment.job_metadata.pipeline_run_id,
+        extract_output=extract_output,
+    )

--- a/pipelex/cogt/content_generation/img_gen_generate.py
+++ b/pipelex/cogt/content_generation/img_gen_generate.py
@@ -53,9 +53,8 @@ async def img_gen_single_image_and_store(
         secondary_id=img_gen_assignment.job_metadata.pipeline_run_id,
         raw_details=generated_image,
     )
-    if img_gen_assignment.img_gen_prompt:
-        image_content.source_prompt = img_gen_assignment.img_gen_prompt.positive_text
-        image_content.source_negative_prompt = img_gen_assignment.img_gen_prompt.negative_text
+    image_content.source_prompt = img_gen_assignment.img_gen_prompt.positive_text
+    image_content.source_negative_prompt = img_gen_assignment.img_gen_prompt.negative_text
     return image_content
 
 
@@ -72,8 +71,7 @@ async def img_gen_image_list_and_store(
             secondary_id=img_gen_assignment.job_metadata.pipeline_run_id,
             raw_details=raw_details,
         )
-        if img_gen_assignment.img_gen_prompt:
-            image_content.source_prompt = img_gen_assignment.img_gen_prompt.positive_text
-            image_content.source_negative_prompt = img_gen_assignment.img_gen_prompt.negative_text
+        image_content.source_prompt = img_gen_assignment.img_gen_prompt.positive_text
+        image_content.source_negative_prompt = img_gen_assignment.img_gen_prompt.negative_text
         image_contents.append(image_content)
     return image_contents

--- a/pipelex/cogt/content_generation/img_gen_generate.py
+++ b/pipelex/cogt/content_generation/img_gen_generate.py
@@ -1,7 +1,9 @@
 from pipelex import log
 from pipelex.cogt.content_generation.assignment_models import ImgGenAssignment
+from pipelex.cogt.content_generation.generated_content_factory import GeneratedContentFactory
 from pipelex.cogt.image.generated_image import GeneratedImageRawDetails
 from pipelex.cogt.img_gen.img_gen_job_factory import ImgGenJobFactory
+from pipelex.core.stuffs.image_content import ImageContent
 from pipelex.hub import get_img_gen_worker
 
 
@@ -38,3 +40,40 @@ async def img_gen_image(img_gen_assignment: ImgGenAssignment) -> GeneratedImageR
     if img_gen_assignment.nb_images > 1:
         return await img_gen_image_list(img_gen_assignment)
     return await img_gen_single_image(img_gen_assignment)
+
+
+async def img_gen_single_image_and_store(
+    img_gen_assignment: ImgGenAssignment,
+    generated_content_factory: GeneratedContentFactory,
+) -> ImageContent:
+    """Generate a single image and store it, returning an ImageContent with URLs (no raw binary data)."""
+    generated_image = await img_gen_single_image(img_gen_assignment)
+    image_content = await generated_content_factory.make_image_content(
+        primary_id=img_gen_assignment.job_metadata.user_id,
+        secondary_id=img_gen_assignment.job_metadata.pipeline_run_id,
+        raw_details=generated_image,
+    )
+    if img_gen_assignment.img_gen_prompt:
+        image_content.source_prompt = img_gen_assignment.img_gen_prompt.positive_text
+        image_content.source_negative_prompt = img_gen_assignment.img_gen_prompt.negative_text
+    return image_content
+
+
+async def img_gen_image_list_and_store(
+    img_gen_assignment: ImgGenAssignment,
+    generated_content_factory: GeneratedContentFactory,
+) -> list[ImageContent]:
+    """Generate multiple images and store them, returning ImageContent list with URLs (no raw binary data)."""
+    generated_image_list = await img_gen_image_list(img_gen_assignment)
+    image_contents: list[ImageContent] = []
+    for raw_details in generated_image_list:
+        image_content = await generated_content_factory.make_image_content(
+            primary_id=img_gen_assignment.job_metadata.user_id,
+            secondary_id=img_gen_assignment.job_metadata.pipeline_run_id,
+            raw_details=raw_details,
+        )
+        if img_gen_assignment.img_gen_prompt:
+            image_content.source_prompt = img_gen_assignment.img_gen_prompt.positive_text
+            image_content.source_negative_prompt = img_gen_assignment.img_gen_prompt.negative_text
+        image_contents.append(image_content)
+    return image_contents

--- a/pipelex/cogt/content_generation/llm_generate.py
+++ b/pipelex/cogt/content_generation/llm_generate.py
@@ -4,8 +4,9 @@ from pydantic import BaseModel
 
 from pipelex import log
 from pipelex.cogt.content_generation.assignment_models import LLMAssignment, ObjectAssignment
+from pipelex.cogt.content_generation.schema_to_model import model_class_from_json_schema
 from pipelex.cogt.llm.llm_job_factory import LLMJobFactory
-from pipelex.hub import get_class_registry, get_llm_worker
+from pipelex.hub import get_llm_worker
 
 
 async def llm_gen_text(llm_assignment: LLMAssignment) -> str:
@@ -28,8 +29,10 @@ async def llm_gen_object(object_assignment: ObjectAssignment) -> BaseModel:
         llm_prompt=llm_assignment.llm_prompt,
         llm_job_params=llm_assignment.llm_job_params,
     )
-    content_class_name = object_assignment.object_class_name
-    content_class = get_class_registry().get_required_base_model(name=content_class_name)
+    content_class = model_class_from_json_schema(
+        schema=object_assignment.object_class_schema,
+        class_name=object_assignment.object_class_name,
+    )
     generated_object: BaseModel = await llm_worker.gen_object(
         llm_job=llm_job,
         schema=content_class,
@@ -47,7 +50,10 @@ async def llm_gen_object_list(object_assignment: ObjectAssignment) -> list[BaseM
         llm_job_params=llm_assignment.llm_job_params,
     )
     item_class_name = object_assignment.object_class_name
-    item_class = get_class_registry().get_required_class(name=item_class_name)
+    item_class = model_class_from_json_schema(
+        schema=object_assignment.object_class_schema,
+        class_name=item_class_name,
+    )
 
     class ListSchema(BaseModel):
         items: list[item_class]  # type: ignore[valid-type] # pyright: ignore[reportInvalidTypeForm]

--- a/pipelex/cogt/content_generation/schema_to_model.py
+++ b/pipelex/cogt/content_generation/schema_to_model.py
@@ -1,0 +1,99 @@
+"""Reconstruct a Pydantic BaseModel class from a JSON schema using datamodel-code-generator.
+
+This module is the bridge between JSON schema (from model_json_schema()) and a live
+BaseModel class that can be used as a structured output schema for LLM generation.
+The generated class carries its own source code as __kajson_class_source__, enabling
+kajson to deserialize it across process boundaries without a class registry.
+"""
+
+import hashlib
+import json
+import tempfile
+import threading
+from pathlib import Path
+from typing import Any
+
+from datamodel_code_generator.parser.base import title_to_class_name
+from pydantic import BaseModel
+
+_schema_cache: dict[str, type[BaseModel]] = {}
+_cache_lock = threading.Lock()
+
+
+def model_class_from_json_schema(schema: dict[str, Any], class_name: str) -> type[BaseModel]:
+    """Reconstruct a BaseModel class from a JSON schema dict.
+
+    Args:
+        schema: The JSON schema as returned by SomeModel.model_json_schema().
+        class_name: The expected class name (must match the schema's title).
+
+    Returns:
+        A BaseModel subclass with __kajson_class_source__ attached.
+    """
+    cache_key = hashlib.sha256(json.dumps(schema, sort_keys=True).encode()).hexdigest()
+
+    with _cache_lock:
+        if cache_key in _schema_cache:
+            return _schema_cache[cache_key]
+
+    source_code = _generate_source_from_schema(schema)
+    reconstructed_class = _exec_and_extract_class(source_code, class_name)
+    reconstructed_class.__kajson_class_source__ = source_code  # type: ignore[attr-defined]
+
+    with _cache_lock:
+        _schema_cache[cache_key] = reconstructed_class
+
+    return reconstructed_class
+
+
+def _generate_source_from_schema(schema: dict[str, Any]) -> str:
+    """Generate Python source code from a JSON schema using datamodel-code-generator."""
+    from datamodel_code_generator import InputFileType, generate  # noqa: PLC0415
+    from datamodel_code_generator.enums import DataModelType  # noqa: PLC0415
+
+    schema_str = json.dumps(schema)
+
+    with tempfile.NamedTemporaryFile(suffix=".py", delete=False) as tmp:
+        output_path = Path(tmp.name)
+
+    try:
+        generate(
+            input_=schema_str,
+            input_file_type=InputFileType.JsonSchema,
+            output=output_path,
+            output_model_type=DataModelType.PydanticV2BaseModel,
+        )
+        return output_path.read_text(encoding="utf-8")
+    finally:
+        output_path.unlink(missing_ok=True)
+
+
+def _exec_and_extract_class(source_code: str, class_name: str) -> type[BaseModel]:
+    """Execute source code and extract the named BaseModel class."""
+    namespace: dict[str, Any] = {}
+    exec(compile(source_code, "<schema_to_model>", "exec"), namespace)
+
+    # Collect all BaseModel subclasses from the exec'd namespace
+    model_classes: dict[str, type[BaseModel]] = {
+        name: obj for name, obj in namespace.items() if isinstance(obj, type) and issubclass(obj, BaseModel) and obj is not BaseModel
+    }
+
+    # datamodel-code-generator normalizes schema titles to PascalCase class names
+    # (e.g. "dynamic_concept_test__Greeting" → "DynamicConceptTestGreeting"),
+    # so try both the original name and the normalized version.
+    extracted_class = model_classes.get(class_name)
+    if extracted_class is None:
+        normalized_name = title_to_class_name(class_name)
+        extracted_class = model_classes.get(normalized_name)
+    if extracted_class is None:
+        available = list(model_classes.keys())
+        msg = f"Class '{class_name}' not found in generated source. Available BaseModel classes: {available}"
+        raise ValueError(msg)
+
+    # datamodel-code-generator uses `from __future__ import annotations` which turns
+    # type annotations into strings. For nested models, we need to rebuild so Pydantic
+    # resolves the forward references against all classes in the generated namespace.
+    for model_cls in model_classes.values():
+        model_cls.model_rebuild(_types_namespace=model_classes)
+
+    return extracted_class

--- a/pipelex/cogt/content_generation/schema_to_model.py
+++ b/pipelex/cogt/content_generation/schema_to_model.py
@@ -8,12 +8,12 @@ kajson to deserialize it across process boundaries without a class registry.
 
 import hashlib
 import json
+import re
 import tempfile
 import threading
 from pathlib import Path
 from typing import Any
 
-from datamodel_code_generator.parser.base import title_to_class_name
 from pydantic import BaseModel
 
 _schema_cache: dict[str, type[BaseModel]] = {}
@@ -41,9 +41,17 @@ def model_class_from_json_schema(schema: dict[str, Any], class_name: str) -> typ
     reconstructed_class.__kajson_class_source__ = source_code  # type: ignore[attr-defined]
 
     with _cache_lock:
+        if cache_key in _schema_cache:
+            return _schema_cache[cache_key]
         _schema_cache[cache_key] = reconstructed_class
 
     return reconstructed_class
+
+
+def _normalize_class_name(title: str) -> str:
+    """Convert a schema title to a PascalCase class name (matching datamodel-code-generator behavior)."""
+    classname = re.sub(r"[^A-Za-z0-9]+", " ", title)
+    return "".join(part for part in classname.title() if not part.isspace())
 
 
 def _generate_source_from_schema(schema: dict[str, Any]) -> str:
@@ -83,7 +91,7 @@ def _exec_and_extract_class(source_code: str, class_name: str) -> type[BaseModel
     # so try both the original name and the normalized version.
     extracted_class = model_classes.get(class_name)
     if extracted_class is None:
-        normalized_name = title_to_class_name(class_name)
+        normalized_name = _normalize_class_name(class_name)
         extracted_class = model_classes.get(normalized_name)
     if extracted_class is None:
         available = list(model_classes.keys())

--- a/pipelex/temporal/tasks.py
+++ b/pipelex/temporal/tasks.py
@@ -5,11 +5,13 @@ from pipelex.temporal.tprl_content_generation.act_extract_generate import act_ex
 from pipelex.temporal.tprl_content_generation.act_img_gen_generate import act_img_gen_images
 from pipelex.temporal.tprl_content_generation.act_jinja2_generate import act_jinja2_gen_text
 from pipelex.temporal.tprl_content_generation.act_llm_generate import act_llm_gen_object, act_llm_gen_object_list, act_llm_gen_text
+from pipelex.temporal.tprl_content_generation.act_render_page_views import act_render_page_views
 from pipelex.temporal.tprl_content_generation.wf_make_extract import WfMakeExtract
 from pipelex.temporal.tprl_content_generation.wf_make_images import WfMakeImages
 from pipelex.temporal.tprl_content_generation.wf_make_jinja2_text import WfMakeJinja2Text
 from pipelex.temporal.tprl_content_generation.wf_make_llm_text import WfMakeLLMText
 from pipelex.temporal.tprl_content_generation.wf_make_object import WfMakeObject, WfMakeObjectList, WfMakeTextThenObject, WfMakeTextThenObjectList
+from pipelex.temporal.tprl_content_generation.wf_render_page_views import WfRenderPageViews
 from pipelex.temporal.tprl_pipe.wf_pipe_router import WfPipeRouter
 from pipelex.types import StrEnum
 
@@ -31,6 +33,7 @@ class Tasks:
                 WfMakeImages,
                 WfMakeExtract,
                 WfMakeJinja2Text,
+                WfRenderPageViews,
             ],
             activity_list=[
                 act_llm_gen_object,
@@ -39,6 +42,7 @@ class Tasks:
                 act_img_gen_images,
                 act_jinja2_gen_text,
                 act_extract_gen_extract_pages,
+                act_render_page_views,
             ],
         ),
         PackName.PIPE: TaskPack(

--- a/pipelex/temporal/temporal_data_converter.py
+++ b/pipelex/temporal/temporal_data_converter.py
@@ -25,7 +25,7 @@ For examples, see the tests in `test_top_crafter.py`:
      allowing the calling method to cast the list to the required generic type with `cast(List[BaseModelType], obj_list)`.
 """
 
-from typing import Any
+from typing import Any, cast
 
 from kajson import kajson
 from pydantic import BaseModel
@@ -79,6 +79,10 @@ class BaseModelPayloadConverter(JSONPlainPayloadConverter):
         else:
             return super().to_payload(value)
 
+    def _restore_class_source(self, value: BaseModel, class_source_code: str) -> None:
+        value_class = cast("Any", type(value))
+        value_class.__kajson_class_source__ = class_source_code
+
     def _kajson_deserialize_from_payload(self, payload: Payload) -> Any:
         data = payload.data.decode()
         log.verbose(f"unijson_deserialize_payload — data: {data}")
@@ -89,8 +93,15 @@ class BaseModelPayloadConverter(JSONPlainPayloadConverter):
             class_registry=get_class_registry(),
             class_source_code=class_source_code,
         )
+        if class_source_code is not None:
+            if isinstance(pydantic_gizmo, BaseModel):
+                self._restore_class_source(pydantic_gizmo, class_source_code)
+            elif isinstance(pydantic_gizmo, list):
+                for item in cast("list[Any]", pydantic_gizmo):
+                    if isinstance(item, BaseModel):
+                        self._restore_class_source(item, class_source_code)
         log.verbose(f"unijson_deserialize_payload — pydantic_gizmo: {pydantic_gizmo}")
-        return pydantic_gizmo
+        return cast("Any", pydantic_gizmo)
 
     @override
     def from_payload(

--- a/pipelex/temporal/temporal_data_converter.py
+++ b/pipelex/temporal/temporal_data_converter.py
@@ -58,14 +58,22 @@ class BaseModelPayloadConverter(JSONPlainPayloadConverter):
     def to_payload(self, value: Any) -> Payload | None:
         if isinstance(value, BaseModel):
             payload_str: str = kajson.dumps(value)
+            metadata: dict[str, bytes] = {"encoding": self.encoding.encode()}
+            class_source = getattr(type(value), "__kajson_class_source__", None)
+            if class_source is not None:
+                metadata["kajson_class_source"] = class_source.encode()
             return Payload(
-                metadata={"encoding": self.encoding.encode()},
+                metadata=metadata,
                 data=payload_str.encode(),
             )
         elif isinstance(value, list) and value and isinstance(value[0], BaseModel):
             list_payload_str: str = kajson.dumps(value)
+            metadata = {"encoding": self.encoding.encode()}
+            class_source = getattr(type(value[0]), "__kajson_class_source__", None)
+            if class_source is not None:
+                metadata["kajson_class_source"] = class_source.encode()
             return Payload(
-                metadata={"encoding": self.encoding.encode()},
+                metadata=metadata,
                 data=list_payload_str.encode(),
             )
         else:
@@ -74,7 +82,13 @@ class BaseModelPayloadConverter(JSONPlainPayloadConverter):
     def _kajson_deserialize_from_payload(self, payload: Payload) -> Any:
         data = payload.data.decode()
         log.verbose(f"unijson_deserialize_payload — data: {data}")
-        pydantic_gizmo = kajson.loads(data, class_registry=get_class_registry())
+        source_bytes = payload.metadata.get("kajson_class_source")
+        class_source_code = source_bytes.decode() if source_bytes else None
+        pydantic_gizmo = kajson.loads(
+            data,
+            class_registry=get_class_registry(),
+            class_source_code=class_source_code,
+        )
         log.verbose(f"unijson_deserialize_payload — pydantic_gizmo: {pydantic_gizmo}")
         return pydantic_gizmo
 

--- a/pipelex/temporal/tprl_content_generation/act_extract_generate.py
+++ b/pipelex/temporal/tprl_content_generation/act_extract_generate.py
@@ -2,11 +2,23 @@ from temporalio import activity
 
 from pipelex import log
 from pipelex.cogt.content_generation.assignment_models import ExtractAssignment
-from pipelex.cogt.content_generation.extract_generate import extract_gen_pages
-from pipelex.cogt.extract.extract_output import ExtractOutput
+from pipelex.cogt.content_generation.extract_generate import extract_gen_pages_and_store
+from pipelex.cogt.content_generation.generated_content_factory import GeneratedContentFactory
+from pipelex.core.stuffs.page_content import PageContent
+from pipelex.hub import get_storage_provider
 
 
 @activity.defn
-async def act_extract_gen_extract_pages(extract_assignment: ExtractAssignment) -> ExtractOutput:
+async def act_extract_gen_extract_pages(extract_assignment: ExtractAssignment) -> list[PageContent]:
+    """Extract pages and store extracted images, returning lightweight PageContent references.
+
+    Large binary data (extracted images) is stored within the activity and never crosses
+    the Temporal workflow boundary — only URLs are returned.
+    """
     log.dev("act_extract_gen_extract_pages")
-    return await extract_gen_pages(extract_assignment=extract_assignment)
+    storage_provider = get_storage_provider()
+    generated_content_factory = GeneratedContentFactory(storage_provider=storage_provider)
+    return await extract_gen_pages_and_store(
+        extract_assignment=extract_assignment,
+        generated_content_factory=generated_content_factory,
+    )

--- a/pipelex/temporal/tprl_content_generation/act_img_gen_generate.py
+++ b/pipelex/temporal/tprl_content_generation/act_img_gen_generate.py
@@ -2,18 +2,29 @@ from temporalio import activity
 
 from pipelex import log
 from pipelex.cogt.content_generation.assignment_models import ImgGenAssignment
-from pipelex.cogt.content_generation.img_gen_generate import img_gen_image
-from pipelex.cogt.image.generated_image import GeneratedImageRawDetails
+from pipelex.cogt.content_generation.generated_content_factory import GeneratedContentFactory
+from pipelex.cogt.content_generation.img_gen_generate import img_gen_image_list_and_store, img_gen_single_image_and_store
+from pipelex.core.stuffs.image_content import ImageContent
+from pipelex.hub import get_storage_provider
 
 
 @activity.defn
-async def act_img_gen_images(img_gen_assignment: ImgGenAssignment) -> list[GeneratedImageRawDetails]:
-    """This activity is used to generate a single image or a list of images.
-    In case of a single image, the activity returns a list containing the single image.
+async def act_img_gen_images(img_gen_assignment: ImgGenAssignment) -> list[ImageContent]:
+    """Generate images and store them, returning lightweight ImageContent references.
+
+    Large binary data (base64/bytes) is stored within the activity and never crosses
+    the Temporal workflow boundary — only URLs are returned.
     """
     log.dev("act_img_gen_images")
-    image_or_list = await img_gen_image(img_gen_assignment=img_gen_assignment)
-    if isinstance(image_or_list, list):
-        return image_or_list
-    else:
-        return [image_or_list]
+    storage_provider = get_storage_provider()
+    generated_content_factory = GeneratedContentFactory(storage_provider=storage_provider)
+    if img_gen_assignment.nb_images > 1:
+        return await img_gen_image_list_and_store(
+            img_gen_assignment=img_gen_assignment,
+            generated_content_factory=generated_content_factory,
+        )
+    image_content = await img_gen_single_image_and_store(
+        img_gen_assignment=img_gen_assignment,
+        generated_content_factory=generated_content_factory,
+    )
+    return [image_content]

--- a/pipelex/temporal/tprl_content_generation/act_render_page_views.py
+++ b/pipelex/temporal/tprl_content_generation/act_render_page_views.py
@@ -1,0 +1,39 @@
+from temporalio import activity
+
+from pipelex import log
+from pipelex.cogt.content_generation.assignment_models import RenderPageViewsAssignment
+from pipelex.cogt.content_generation.generated_content_factory import GeneratedContentFactory
+from pipelex.cogt.image.generated_image import GeneratedImageRawDetails
+from pipelex.core.stuffs.image_content import ImageContent
+from pipelex.hub import get_storage_provider
+from pipelex.tools.misc.image_utils import ImageFormat
+from pipelex.tools.pdf.pypdfium2_renderer import pypdfium2_renderer
+
+
+@activity.defn
+async def act_render_page_views(render_assignment: RenderPageViewsAssignment) -> list[ImageContent]:
+    """Render PDF pages as images, store them, and return lightweight ImageContent references.
+
+    Performs pypdfium2 rendering and S3 storage within the activity so that
+    large binary data never crosses a Temporal workflow boundary.
+    """
+    log.dev("act_render_page_views")
+    page_view_images = await pypdfium2_renderer.render_pdf_pages_from_uri(
+        pdf_uri=render_assignment.document_uri,
+        dpi=render_assignment.page_views_dpi,
+    )
+    storage_provider = get_storage_provider()
+    generated_content_factory = GeneratedContentFactory(storage_provider=storage_provider)
+    image_contents: list[ImageContent] = []
+    for page_view_image in page_view_images:
+        raw_details = GeneratedImageRawDetails.make_from_pil_image(
+            pil_image=page_view_image,
+            image_format=ImageFormat.PNG,
+        )
+        image_content = await generated_content_factory.make_image_content(
+            primary_id=render_assignment.job_metadata.user_id,
+            secondary_id=render_assignment.job_metadata.pipeline_run_id,
+            raw_details=raw_details,
+        )
+        image_contents.append(image_content)
+    return image_contents

--- a/pipelex/temporal/tprl_content_generation/content_generator_child.py
+++ b/pipelex/temporal/tprl_content_generation/content_generator_child.py
@@ -1,4 +1,4 @@
-from typing import Any, cast
+from typing import Any
 
 from pydantic import BaseModel
 from temporalio import workflow
@@ -154,7 +154,7 @@ class ContentGeneratorChild(WorkflowExecutor[AssignmentType, ResultType], Conten
                 raise TemporalError.from_app_error(exc=exc.cause) from exc
             raise
         log.verbose(f"ContentGeneratorChild generated object direct: {obj}")
-        return cast("BaseModelTypeVar", obj)
+        return object_class.model_validate(obj.model_dump(serialize_as_any=True))
 
     @override
     @update_job_metadata
@@ -182,6 +182,7 @@ class ContentGeneratorChild(WorkflowExecutor[AssignmentType, ResultType], Conten
             )
             tto_assignment = TextThenObjectAssignment(
                 object_class_name=object_class.__name__,
+                object_class_schema=object_class.model_json_schema(),
                 llm_assignment_for_text=llm_assignment_for_text,
                 llm_assignment_factory_to_object=llm_assignment_factory_to_object,
             )
@@ -203,7 +204,7 @@ class ContentGeneratorChild(WorkflowExecutor[AssignmentType, ResultType], Conten
                 raise TemporalError.from_app_error(exc=exc.cause) from exc
             raise
         log.verbose(f"ContentGeneratorChild generated object after text: {obj}")
-        return cast("BaseModelTypeVar", obj)
+        return object_class.model_validate(obj.model_dump(serialize_as_any=True))
 
     @override
     @update_job_metadata
@@ -244,7 +245,7 @@ class ContentGeneratorChild(WorkflowExecutor[AssignmentType, ResultType], Conten
                 raise TemporalError.from_app_error(exc=exc.cause) from exc
             raise
         log.verbose(f"ContentGeneratorChild generated object list direct: {obj_list}")
-        return cast("list[BaseModelTypeVar]", obj_list)
+        return [object_class.model_validate(raw_obj.model_dump(serialize_as_any=True)) for raw_obj in obj_list]
 
     @override
     @update_job_metadata
@@ -273,6 +274,7 @@ class ContentGeneratorChild(WorkflowExecutor[AssignmentType, ResultType], Conten
             )
             tto_assignment = TextThenObjectAssignment(
                 object_class_name=object_class.__name__,
+                object_class_schema=object_class.model_json_schema(),
                 llm_assignment_for_text=llm_assignment_for_text,
                 llm_assignment_factory_to_object=llm_assignment_factory_to_object,
             )
@@ -294,7 +296,7 @@ class ContentGeneratorChild(WorkflowExecutor[AssignmentType, ResultType], Conten
                 raise TemporalError.from_app_error(exc=exc.cause) from exc
             raise
         log.verbose(f"ContentGeneratorChild generated object list after text: {obj_list}")
-        return cast("list[BaseModelTypeVar]", obj_list)
+        return [object_class.model_validate(raw_obj.model_dump(serialize_as_any=True)) for raw_obj in obj_list]
 
     @override
     async def make_image_content(

--- a/pipelex/temporal/tprl_content_generation/content_generator_child.py
+++ b/pipelex/temporal/tprl_content_generation/content_generator_child.py
@@ -448,6 +448,7 @@ class ContentGeneratorChild(WorkflowExecutor[AssignmentType, ResultType], Conten
         return jinja2_text
 
     @override
+    @update_job_metadata
     async def make_render_page_views(
         self,
         job_metadata: JobMetadata,

--- a/pipelex/temporal/tprl_content_generation/content_generator_child.py
+++ b/pipelex/temporal/tprl_content_generation/content_generator_child.py
@@ -13,6 +13,7 @@ from pipelex.cogt.content_generation.assignment_models import (
     LLMAssignment,
     LLMAssignmentFactory,
     ObjectAssignment,
+    RenderPageViewsAssignment,
     TemplatingAssignment,
     TextThenObjectAssignment,
 )
@@ -49,8 +50,7 @@ from pipelex.temporal.tprl_content_generation.wf_make_object import (
     WfMakeTextThenObject,
     WfMakeTextThenObjectList,
 )
-from pipelex.tools.misc.image_utils import ImageFormat
-from pipelex.tools.pdf.pypdfium2_renderer import pypdfium2_renderer
+from pipelex.temporal.tprl_content_generation.wf_render_page_views import WfRenderPageViews
 from pipelex.tools.typing.pydantic_utils import BaseModelTypeVar
 
 
@@ -338,7 +338,6 @@ class ContentGeneratorChild(WorkflowExecutor[AssignmentType, ResultType], Conten
     ) -> ImageContent:
         img_gen_config = get_config().cogt.img_gen_config
         try:
-            # We're using workflowWfMakeImages which can generate several images but we're asking for only one
             img_gen_assignment = ImgGenAssignment(
                 job_metadata=job_metadata,
                 img_gen_handle=img_gen_handle,
@@ -348,8 +347,8 @@ class ContentGeneratorChild(WorkflowExecutor[AssignmentType, ResultType], Conten
                 nb_images=1,
             )
 
-            generated_image_list = (
-                await WorkflowExecutorFactory[ImgGenAssignment, list[GeneratedImageRawDetails]]
+            image_content_list = (
+                await WorkflowExecutorFactory[ImgGenAssignment, list[ImageContent]]
                 .create_executor()
                 .execute_child_workflow(
                     workflow_class=WfMakeImages,
@@ -357,10 +356,9 @@ class ContentGeneratorChild(WorkflowExecutor[AssignmentType, ResultType], Conten
                     workflow_id=make_child_workflow_id(base_id=wfid or "craft-image"),
                 )
             )
-            if len(generated_image_list) != 1:
-                msg = f"Expected 1 image, got {len(generated_image_list)}"
+            if len(image_content_list) != 1:
+                msg = f"Expected 1 image, got {len(image_content_list)}"
                 raise ContentGenerationError(msg)
-            generated_image = generated_image_list[0]
         except PipelexError as exc:
             raise TemporalError.from_message_exception(exc) from exc
         except ChildWorkflowError as exc:
@@ -368,12 +366,9 @@ class ContentGeneratorChild(WorkflowExecutor[AssignmentType, ResultType], Conten
             if isinstance(exc.cause, ApplicationError):
                 raise TemporalError.from_app_error(exc=exc.cause) from exc
             raise
-        log.verbose(f"ContentGeneratorChild generated image: {generated_image}")
-        return await self.make_image_content(
-            job_metadata=job_metadata,
-            generated_image_raw_details=generated_image,
-            img_gen_prompt=img_gen_prompt,
-        )
+        image_content = image_content_list[0]
+        log.verbose(f"ContentGeneratorChild generated image: {image_content}")
+        return image_content
 
     @override
     @update_job_metadata
@@ -398,8 +393,8 @@ class ContentGeneratorChild(WorkflowExecutor[AssignmentType, ResultType], Conten
                 nb_images=nb_images,
             )
 
-            generated_image_list = (
-                await WorkflowExecutorFactory[ImgGenAssignment, list[GeneratedImageRawDetails]]
+            image_content_list = (
+                await WorkflowExecutorFactory[ImgGenAssignment, list[ImageContent]]
                 .create_executor()
                 .execute_child_workflow(
                     workflow_class=WfMakeImages,
@@ -414,15 +409,8 @@ class ContentGeneratorChild(WorkflowExecutor[AssignmentType, ResultType], Conten
             if isinstance(exc.cause, ApplicationError):
                 raise TemporalError.from_app_error(exc=exc.cause) from exc
             raise
-        log.verbose(f"ContentGeneratorChild generated image list: {generated_image_list}")
-        return [
-            await self.make_image_content(
-                job_metadata=job_metadata,
-                generated_image_raw_details=raw_details,
-                img_gen_prompt=img_gen_prompt,
-            )
-            for raw_details in generated_image_list
-        ]
+        log.verbose(f"ContentGeneratorChild generated image list: {image_content_list}")
+        return image_content_list
 
     @override
     async def make_templated_text(
@@ -474,20 +462,30 @@ class ContentGeneratorChild(WorkflowExecutor[AssignmentType, ResultType], Conten
             raise ValueError(msg)
         job_params = extract_job_params or ExtractJobParams.make_default_extract_job_params()
         page_views_dpi = job_params.page_views_dpi or get_config().cogt.extract_config.default_page_views_dpi
-        page_view_images = await pypdfium2_renderer.render_pdf_pages_from_uri(pdf_uri=extract_input.document_uri, dpi=page_views_dpi)
-        page_view_images_resolved: list[ImageContent] = []
-        for page_view_image in page_view_images:
-            image_content = await self.make_image_content(
+        try:
+            render_assignment = RenderPageViewsAssignment(
                 job_metadata=job_metadata,
-                generated_image_raw_details=GeneratedImageRawDetails.make_from_pil_image(
-                    pil_image=page_view_image,
-                    image_format=ImageFormat.PNG,
-                ),
-                img_gen_prompt=None,
+                document_uri=extract_input.document_uri,
+                page_views_dpi=page_views_dpi,
             )
-            page_view_images_resolved.append(image_content)
-
-        return page_view_images_resolved
+            image_content_list = (
+                await WorkflowExecutorFactory[RenderPageViewsAssignment, list[ImageContent]]
+                .create_executor()
+                .execute_child_workflow(
+                    workflow_class=WfRenderPageViews,
+                    workflow_arg=render_assignment,
+                    workflow_id=make_child_workflow_id(base_id=wfid or "render-page-views"),
+                )
+            )
+        except PipelexError as exc:
+            raise TemporalError.from_message_exception(exc) from exc
+        except ChildWorkflowError as exc:
+            log.error(f"ChildWorkflowError caused by: {exc.cause}")
+            if isinstance(exc.cause, ApplicationError):
+                raise TemporalError.from_app_error(exc=exc.cause) from exc
+            raise
+        log.verbose(f"ContentGeneratorChild rendered page views: {image_content_list}")
+        return image_content_list
 
     @override
     @update_job_metadata
@@ -509,8 +507,8 @@ class ContentGeneratorChild(WorkflowExecutor[AssignmentType, ResultType], Conten
                 extract_job_config=extract_job_config,
             )
 
-            extract_output = (
-                await WorkflowExecutorFactory[ExtractAssignment, ExtractOutput]
+            page_content_list = (
+                await WorkflowExecutorFactory[ExtractAssignment, list[PageContent]]
                 .create_executor()
                 .execute_child_workflow(
                     workflow_class=WfMakeExtract,
@@ -525,5 +523,5 @@ class ContentGeneratorChild(WorkflowExecutor[AssignmentType, ResultType], Conten
             if isinstance(exc.cause, ApplicationError):
                 raise TemporalError.from_app_error(exc=exc.cause) from exc
             raise
-        log.verbose(f"ContentGeneratorChild generated extract output: {extract_output}")
-        return await self.make_page_contents(job_metadata=job_metadata, extract_output=extract_output)
+        log.verbose(f"ContentGeneratorChild generated page contents: {page_content_list}")
+        return page_content_list

--- a/pipelex/temporal/tprl_content_generation/content_generator_top.py
+++ b/pipelex/temporal/tprl_content_generation/content_generator_top.py
@@ -377,6 +377,7 @@ class ContentGeneratorTop(WorkflowExecutor[AssignmentType, ResultType], ContentG
 
     @override
     @with_conditional_worker
+    @update_job_metadata
     async def make_render_page_views(
         self,
         job_metadata: JobMetadata,

--- a/pipelex/temporal/tprl_content_generation/content_generator_top.py
+++ b/pipelex/temporal/tprl_content_generation/content_generator_top.py
@@ -148,6 +148,7 @@ class ContentGeneratorTop(WorkflowExecutor[AssignmentType, ResultType], ContentG
         )
         tto_assignment = TextThenObjectAssignment(
             object_class_name=object_class.__name__,
+            object_class_schema=object_class.model_json_schema(),
             llm_assignment_for_text=llm_assignment_for_text,
             llm_assignment_factory_to_object=llm_assignment_factory_to_object,
         )
@@ -227,6 +228,7 @@ class ContentGeneratorTop(WorkflowExecutor[AssignmentType, ResultType], ContentG
         )
         tto_assignment = TextThenObjectAssignment(
             object_class_name=object_class.__name__,
+            object_class_schema=object_class.model_json_schema(),
             llm_assignment_for_text=llm_assignment_for_text,
             llm_assignment_factory_to_object=llm_assignment_factory_to_object,
         )

--- a/pipelex/temporal/tprl_content_generation/content_generator_top.py
+++ b/pipelex/temporal/tprl_content_generation/content_generator_top.py
@@ -10,6 +10,7 @@ from pipelex.cogt.content_generation.assignment_models import (
     LLMAssignment,
     LLMAssignmentFactory,
     ObjectAssignment,
+    RenderPageViewsAssignment,
     TemplatingAssignment,
     TextThenObjectAssignment,
 )
@@ -45,8 +46,7 @@ from pipelex.temporal.tprl_content_generation.wf_make_object import (
     WfMakeTextThenObject,
     WfMakeTextThenObjectList,
 )
-from pipelex.tools.misc.image_utils import ImageFormat
-from pipelex.tools.pdf.pypdfium2_renderer import pypdfium2_renderer
+from pipelex.temporal.tprl_content_generation.wf_render_page_views import WfRenderPageViews
 from pipelex.tools.typing.pydantic_utils import BaseModelTypeVar
 
 
@@ -296,7 +296,7 @@ class ContentGeneratorTop(WorkflowExecutor[AssignmentType, ResultType], ContentG
             nb_images=1,
         )
         temporal_client = await self.temporal_client()
-        generated_image_list = await temporal_client.execute_workflow(  # pyright: ignore[reportUnknownMemberType]
+        image_content_list = await temporal_client.execute_workflow(  # pyright: ignore[reportUnknownMemberType]
             workflow=WfMakeImages.run,
             arg=img_gen_assignment,
             id=workflow_id,
@@ -304,16 +304,12 @@ class ContentGeneratorTop(WorkflowExecutor[AssignmentType, ResultType], ContentG
             execution_timeout=self.execution_timeout,
             retry_policy=self.retry_policy,
         )
-        if len(generated_image_list) != 1:
-            msg = f"Expected 1 image, got {len(generated_image_list)}"
+        if len(image_content_list) != 1:
+            msg = f"Expected 1 image, got {len(image_content_list)}"
             raise ContentGenerationError(msg)
-        generated_image = generated_image_list[0]
-        log.dev(f"TopCrafter generated image: {generated_image}")
-        return await self.make_image_content(
-            job_metadata=job_metadata,
-            generated_image_raw_details=generated_image,
-            img_gen_prompt=img_gen_prompt,
-        )
+        image_content = image_content_list[0]
+        log.dev(f"TopCrafter generated image: {image_content}")
+        return image_content
 
     @override
     @with_conditional_worker
@@ -339,7 +335,7 @@ class ContentGeneratorTop(WorkflowExecutor[AssignmentType, ResultType], ContentG
             nb_images=nb_images,
         )
         temporal_client = await self.temporal_client()
-        generated_image_list = await temporal_client.execute_workflow(  # pyright: ignore[reportUnknownMemberType]
+        image_content_list = await temporal_client.execute_workflow(  # pyright: ignore[reportUnknownMemberType]
             workflow=WfMakeImages.run,
             arg=img_gen_assignment,
             id=workflow_id,
@@ -347,15 +343,8 @@ class ContentGeneratorTop(WorkflowExecutor[AssignmentType, ResultType], ContentG
             execution_timeout=self.execution_timeout,
             retry_policy=self.retry_policy,
         )
-        log.dev(f"TopCrafter generated image list: {generated_image_list}")
-        return [
-            await self.make_image_content(
-                job_metadata=job_metadata,
-                generated_image_raw_details=raw_details,
-                img_gen_prompt=img_gen_prompt,
-            )
-            for raw_details in generated_image_list
-        ]
+        log.dev(f"TopCrafter generated image list: {image_content_list}")
+        return image_content_list
 
     @override
     @with_conditional_worker
@@ -387,6 +376,7 @@ class ContentGeneratorTop(WorkflowExecutor[AssignmentType, ResultType], ContentG
         return jinja2_text
 
     @override
+    @with_conditional_worker
     async def make_render_page_views(
         self,
         job_metadata: JobMetadata,
@@ -401,20 +391,23 @@ class ContentGeneratorTop(WorkflowExecutor[AssignmentType, ResultType], ContentG
             raise ValueError(msg)
         job_params = extract_job_params or ExtractJobParams.make_default_extract_job_params()
         page_views_dpi = job_params.page_views_dpi or get_config().cogt.extract_config.default_page_views_dpi
-        page_view_images = await pypdfium2_renderer.render_pdf_pages_from_uri(pdf_uri=extract_input.document_uri, dpi=page_views_dpi)
-        page_view_images_resolved: list[ImageContent] = []
-        for page_view_image in page_view_images:
-            image_content = await self.make_image_content(
-                job_metadata=job_metadata,
-                generated_image_raw_details=GeneratedImageRawDetails.make_from_pil_image(
-                    pil_image=page_view_image,
-                    image_format=ImageFormat.PNG,
-                ),
-                img_gen_prompt=None,
-            )
-            page_view_images_resolved.append(image_content)
-
-        return page_view_images_resolved
+        workflow_id = self.make_workflow_id(base_id=wfid or "render-page-views")
+        render_assignment = RenderPageViewsAssignment(
+            job_metadata=job_metadata,
+            document_uri=extract_input.document_uri,
+            page_views_dpi=page_views_dpi,
+        )
+        temporal_client = await self.temporal_client()
+        image_content_list = await temporal_client.execute_workflow(  # pyright: ignore[reportUnknownMemberType]
+            workflow=WfRenderPageViews.run,
+            arg=render_assignment,
+            id=workflow_id,
+            task_queue=self.task_queue or get_config().temporal.worker_config.task_queue,
+            execution_timeout=self.execution_timeout,
+            retry_policy=self.retry_policy,
+        )
+        log.dev(f"TopCrafter rendered page views: {image_content_list}")
+        return image_content_list
 
     @override
     @with_conditional_worker
@@ -437,7 +430,7 @@ class ContentGeneratorTop(WorkflowExecutor[AssignmentType, ResultType], ContentG
             extract_job_config=extract_job_config,
         )
         temporal_client = await self.temporal_client()
-        extract_output = await temporal_client.execute_workflow(  # pyright: ignore[reportUnknownMemberType]
+        page_content_list = await temporal_client.execute_workflow(  # pyright: ignore[reportUnknownMemberType]
             workflow=WfMakeExtract.run,
             arg=extract_assignment,
             id=workflow_id,
@@ -445,5 +438,5 @@ class ContentGeneratorTop(WorkflowExecutor[AssignmentType, ResultType], ContentG
             execution_timeout=self.execution_timeout,
             retry_policy=self.retry_policy,
         )
-        log.dev(f"TopCrafter extract output: {extract_output}")
-        return await self.make_page_contents(job_metadata=job_metadata, extract_output=extract_output)
+        log.dev(f"TopCrafter page contents: {page_content_list}")
+        return page_content_list

--- a/pipelex/temporal/tprl_content_generation/wf_make_images.py
+++ b/pipelex/temporal/tprl_content_generation/wf_make_images.py
@@ -5,8 +5,8 @@ from typing_extensions import override
 with workflow.unsafe.imports_passed_through():
     from pipelex import log
     from pipelex.cogt.content_generation.assignment_models import ImgGenAssignment
-    from pipelex.cogt.image.generated_image import GeneratedImageRawDetails
     from pipelex.config import get_config
+    from pipelex.core.stuffs.image_content import ImageContent
     from pipelex.temporal.log_temporal import workflow_log
     from pipelex.temporal.tprl.temporal_error import TemporalError
     from pipelex.temporal.tprl.workflow_caller import WorkflowClass
@@ -14,17 +14,17 @@ with workflow.unsafe.imports_passed_through():
 
 
 @workflow.defn(name="wf_make_image")
-class WfMakeImages(WorkflowClass[ImgGenAssignment, list[GeneratedImageRawDetails]]):
+class WfMakeImages(WorkflowClass[ImgGenAssignment, list[ImageContent]]):
     @override
     @workflow.run
     async def run(
         self,
         workflow_arg: ImgGenAssignment,
-    ) -> list[GeneratedImageRawDetails]:
+    ) -> list[ImageContent]:
         workflow_log.debug("Workflow start")
         worker_config = get_config().temporal.worker_config
         try:
-            generated_image_list = await workflow.start_activity(  # pyright: ignore[reportUnknownMemberType, reportAssignmentType]
+            image_content_list = await workflow.start_activity(  # pyright: ignore[reportUnknownMemberType, reportAssignmentType]
                 activity=act_img_gen_images,
                 arg=workflow_arg,
                 start_to_close_timeout=worker_config.workflow_execution_timeout,
@@ -37,4 +37,4 @@ class WfMakeImages(WorkflowClass[ImgGenAssignment, list[GeneratedImageRawDetails
             raise
 
         workflow_log.debug("Workflow complete")
-        return generated_image_list
+        return image_content_list

--- a/pipelex/temporal/tprl_content_generation/wf_make_object.py
+++ b/pipelex/temporal/tprl_content_generation/wf_make_object.py
@@ -100,6 +100,7 @@ class WfMakeTextThenObject(WorkflowClass[TextThenObjectAssignment, BaseModel]):
             fup_obj_assignment = ObjectAssignment(
                 llm_assignment_for_object=fup_llm_assignment,
                 object_class_name=workflow_arg.object_class_name,
+                object_class_schema=workflow_arg.object_class_schema,
             )
 
             obj: BaseModel = await workflow.start_activity(  # pyright: ignore[reportUnknownMemberType, reportAssignmentType]
@@ -145,6 +146,7 @@ class WfMakeTextThenObjectList(WorkflowClass[TextThenObjectAssignment, list[Base
 
             object_assignment = ObjectAssignment(
                 object_class_name=workflow_arg.object_class_name,
+                object_class_schema=workflow_arg.object_class_schema,
                 llm_assignment_for_object=llm_assignment_for_object,
             )
 

--- a/pipelex/temporal/tprl_content_generation/wf_render_page_views.py
+++ b/pipelex/temporal/tprl_content_generation/wf_render_page_views.py
@@ -4,28 +4,28 @@ from typing_extensions import override
 
 with workflow.unsafe.imports_passed_through():
     from pipelex import log
-    from pipelex.cogt.content_generation.assignment_models import ExtractAssignment
+    from pipelex.cogt.content_generation.assignment_models import RenderPageViewsAssignment
     from pipelex.config import get_config
-    from pipelex.core.stuffs.page_content import PageContent
+    from pipelex.core.stuffs.image_content import ImageContent
     from pipelex.temporal.log_temporal import workflow_log
     from pipelex.temporal.tprl.temporal_error import TemporalError
     from pipelex.temporal.tprl.workflow_caller import WorkflowClass
-    from pipelex.temporal.tprl_content_generation.act_extract_generate import act_extract_gen_extract_pages
+    from pipelex.temporal.tprl_content_generation.act_render_page_views import act_render_page_views
 
 
-@workflow.defn(name="wf_make_extract")
-class WfMakeExtract(WorkflowClass[ExtractAssignment, list[PageContent]]):
+@workflow.defn(name="wf_render_page_views")
+class WfRenderPageViews(WorkflowClass[RenderPageViewsAssignment, list[ImageContent]]):
     @override
     @workflow.run
     async def run(
         self,
-        workflow_arg: ExtractAssignment,
-    ) -> list[PageContent]:
+        workflow_arg: RenderPageViewsAssignment,
+    ) -> list[ImageContent]:
         workflow_log.debug("Workflow start")
         worker_config = get_config().temporal.worker_config
         try:
-            page_content_list = await workflow.start_activity(  # pyright: ignore[reportUnknownMemberType, reportAssignmentType]
-                activity=act_extract_gen_extract_pages,
+            image_content_list = await workflow.start_activity(  # pyright: ignore[reportUnknownMemberType, reportAssignmentType]
+                activity=act_render_page_views,
                 arg=workflow_arg,
                 start_to_close_timeout=worker_config.workflow_execution_timeout,
                 retry_policy=worker_config.retry_policy,
@@ -37,4 +37,4 @@ class WfMakeExtract(WorkflowClass[ExtractAssignment, list[PageContent]]):
             raise
 
         workflow_log.debug("Workflow complete")
-        return page_content_list
+        return image_content_list

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   "instructor>=1.8.3,!=1.11.*,!=1.12.*",                # 1.11.x caused typing errors with mypy
   "jinja2>=3.1.4",
   "json2html>=1.3.0",
-  "kajson==0.4.0",
+  "kajson==0.4.1",
   "markdown>=3.6",
   "mthds>=0.2.0",
   "networkx>=3.4.2",
@@ -104,9 +104,6 @@ dev = [
   "types-networkx>=3.3.0.20241020",
   "types-PyYAML>=6.0.12.20250326",
 ]
-
-[tool.uv.sources]
-kajson = { path = "../kajson", editable = true }
 
 [project.scripts]
 pipelex = "pipelex.cli._cli:app"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,9 +54,6 @@ dependencies = [
   "typing-extensions>=4.13.2",
 ]
 
-[tool.uv.sources]
-kajson = { path = "../kajson", editable = true }
-
 [project.urls]
 Homepage = "https://pipelex.com"
 Repository = "https://github.com/Pipelex/pipelex"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
 dependencies = [
   "aiofiles>=23.2.1",
   "backports.strenum>=1.3.0 ; python_version < '3.11'",
+  "datamodel-code-generator>=0.55.0",
   "filetype>=1.2.0",
   "httpx>=0.23.0,<1.0.0",
   "instructor>=1.8.3,!=1.11.*,!=1.12.*",                # 1.11.x caused typing errors with mypy
@@ -103,6 +104,9 @@ dev = [
   "types-networkx>=3.3.0.20241020",
   "types-PyYAML>=6.0.12.20250326",
 ]
+
+[tool.uv.sources]
+kajson = { path = "../kajson", editable = true }
 
 [project.scripts]
 pipelex = "pipelex.cli._cli:app"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   "instructor>=1.8.3,!=1.11.*,!=1.12.*",                # 1.11.x caused typing errors with mypy
   "jinja2>=3.1.4",
   "json2html>=1.3.0",
-  "kajson==0.4.1",
+  "kajson==0.4.2",
   "markdown>=3.6",
   "mthds>=0.2.0",
   "networkx>=3.4.2",
@@ -53,6 +53,9 @@ dependencies = [
   "typer>=0.16.0",
   "typing-extensions>=4.13.2",
 ]
+
+[tool.uv.sources]
+kajson = { path = "../kajson", editable = true }
 
 [project.urls]
 Homepage = "https://pipelex.com"

--- a/tests/unit/pipelex/cogt/content_generation/test_assignment_models_schema.py
+++ b/tests/unit/pipelex/cogt/content_generation/test_assignment_models_schema.py
@@ -1,0 +1,78 @@
+"""Unit tests for object_class_schema field on ObjectAssignment and TextThenObjectAssignment."""
+
+from pydantic import BaseModel
+
+from pipelex.cogt.content_generation.assignment_models import (
+    LLMAssignment,
+    LLMAssignmentFactory,
+    ObjectAssignment,
+    TextThenObjectAssignment,
+)
+from pipelex.cogt.llm.llm_prompt import LLMPrompt
+from pipelex.cogt.llm.llm_prompt_template import LLMPromptTemplate
+from pipelex.cogt.llm.llm_setting import LLMSetting
+from pipelex.pipeline.job_metadata import JobMetadata
+
+
+class SampleOutputModel(BaseModel):
+    name: str
+    value: int
+
+
+def _make_stub_job_metadata() -> JobMetadata:
+    return JobMetadata(
+        user_id="test-user",
+        pipeline_run_id="test-run",
+    )
+
+
+def _make_stub_llm_assignment() -> LLMAssignment:
+    return LLMAssignment(
+        job_metadata=_make_stub_job_metadata(),
+        llm_setting=LLMSetting(model="test-model", temperature=0.7),
+        llm_prompt=LLMPrompt(user_text="test prompt"),
+    )
+
+
+def _make_stub_llm_assignment_factory() -> LLMAssignmentFactory:
+    return LLMAssignmentFactory(
+        job_metadata=_make_stub_job_metadata(),
+        llm_setting=LLMSetting(model="test-model", temperature=0.7),
+        llm_prompt_factory=LLMPromptTemplate.make_for_structuring_from_preliminary_text(),
+    )
+
+
+class TestAssignmentModelsSchema:
+    def test_make_for_class_captures_schema(self) -> None:
+        """ObjectAssignment.make_for_class() captures the JSON schema."""
+        assignment = ObjectAssignment.make_for_class(
+            object_class=SampleOutputModel,
+            llm_assignment=_make_stub_llm_assignment(),
+        )
+        assert assignment.object_class_name == "SampleOutputModel"
+        assert assignment.object_class_schema is not None
+        assert assignment.object_class_schema["title"] == "SampleOutputModel"
+        assert "name" in assignment.object_class_schema["properties"]
+        assert "value" in assignment.object_class_schema["properties"]
+
+    def test_object_assignment_json_roundtrip(self) -> None:
+        """ObjectAssignment with schema survives JSON round-trip."""
+        assignment = ObjectAssignment.make_for_class(
+            object_class=SampleOutputModel,
+            llm_assignment=_make_stub_llm_assignment(),
+        )
+        json_str = assignment.model_dump_json()
+        restored = ObjectAssignment.model_validate_json(json_str)
+        assert restored.object_class_schema == assignment.object_class_schema
+        assert restored.object_class_name == "SampleOutputModel"
+
+    def test_text_then_object_assignment_carries_schema(self) -> None:
+        """TextThenObjectAssignment can carry an object_class_schema."""
+        schema = SampleOutputModel.model_json_schema()
+        assignment = TextThenObjectAssignment(
+            object_class_name="SampleOutputModel",
+            object_class_schema=schema,
+            llm_assignment_for_text=_make_stub_llm_assignment(),
+            llm_assignment_factory_to_object=_make_stub_llm_assignment_factory(),
+        )
+        assert assignment.object_class_schema["title"] == "SampleOutputModel"

--- a/tests/unit/pipelex/cogt/content_generation/test_model_dump_subclass.py
+++ b/tests/unit/pipelex/cogt/content_generation/test_model_dump_subclass.py
@@ -1,0 +1,50 @@
+"""Regression guard: model_dump(serialize_as_any=True) roundtrip for schema-reconstructed models.
+
+content_generator.py uses `object_class.model_validate(raw_obj.model_dump(serialize_as_any=True))`
+where raw_obj is a dynamically-reconstructed BaseModel from schema_to_model. This test verifies
+the roundtrip preserves all data, including nested models.
+"""
+
+from pydantic import BaseModel, Field
+
+from pipelex.cogt.content_generation.schema_to_model import model_class_from_json_schema
+
+
+class InnerDetail(BaseModel):
+    label: str = Field(description="A label")
+    value: int = Field(description="A numeric value")
+
+
+class OuterModel(BaseModel):
+    title: str = Field(description="The title")
+    detail: InnerDetail = Field(description="Nested detail object")
+
+
+class TestModelDumpSubclass:
+    def test_reconstructed_flat_model_roundtrip(self) -> None:
+        """Flat reconstructed model roundtrips through model_dump(serialize_as_any=True) → model_validate."""
+        schema = InnerDetail.model_json_schema()
+        reconstructed_class = model_class_from_json_schema(schema, "InnerDetail")
+
+        raw_obj: BaseModel = reconstructed_class(label="score", value=42)
+
+        dumped = raw_obj.model_dump(serialize_as_any=True)
+        restored = InnerDetail.model_validate(dumped)
+        assert restored.label == "score"
+        assert restored.value == 42
+
+    def test_reconstructed_nested_model_roundtrip(self) -> None:
+        """Nested reconstructed model roundtrips through model_dump(serialize_as_any=True) → model_validate."""
+        schema = OuterModel.model_json_schema()
+        reconstructed_class = model_class_from_json_schema(schema, "OuterModel")
+
+        raw_obj: BaseModel = reconstructed_class(
+            title="Test",
+            detail={"label": "score", "value": 42},
+        )
+
+        dumped = raw_obj.model_dump(serialize_as_any=True)
+        restored = OuterModel.model_validate(dumped)
+        assert restored.title == "Test"
+        assert restored.detail.label == "score"
+        assert restored.detail.value == 42

--- a/tests/unit/pipelex/cogt/content_generation/test_schema_to_model.py
+++ b/tests/unit/pipelex/cogt/content_generation/test_schema_to_model.py
@@ -1,0 +1,103 @@
+"""Unit tests for schema_to_model: reconstructing BaseModel classes from JSON schemas."""
+
+from pydantic import BaseModel, Field
+
+from pipelex.cogt.content_generation.schema_to_model import model_class_from_json_schema
+
+
+class SimpleModel(BaseModel):
+    name: str = Field(description="The name")
+    age: int = Field(description="The age")
+
+
+class Address(BaseModel):
+    street: str
+    city: str
+
+
+class PersonWithAddress(BaseModel):
+    name: str
+    address: Address
+
+
+class TestSchemaToModel:
+    def test_simple_model_reconstruction(self) -> None:
+        """A simple model can be reconstructed from its JSON schema."""
+        schema = SimpleModel.model_json_schema()
+        result_class = model_class_from_json_schema(schema, "SimpleModel")
+
+        assert result_class.__name__ == "SimpleModel"
+        assert "name" in result_class.model_fields
+        assert "age" in result_class.model_fields
+
+    def test_reconstructed_model_can_validate(self) -> None:
+        """The reconstructed model can validate data."""
+        schema = SimpleModel.model_json_schema()
+        result_class = model_class_from_json_schema(schema, "SimpleModel")
+
+        instance = result_class(name="Alice", age=30)
+        assert instance.name == "Alice"  # type: ignore[attr-defined]
+        assert instance.age == 30  # type: ignore[attr-defined]
+
+    def test_nested_model_reconstruction(self) -> None:
+        """A model with nested BaseModel fields (producing $defs) can be reconstructed."""
+        schema = PersonWithAddress.model_json_schema()
+        result_class = model_class_from_json_schema(schema, "PersonWithAddress")
+
+        instance = result_class(
+            name="Bob",
+            address={"street": "123 Main", "city": "NYC"},
+        )
+        assert instance.name == "Bob"  # type: ignore[attr-defined]
+        assert instance.address.city == "NYC"  # type: ignore[attr-defined]
+
+    def test_kajson_class_source_attached(self) -> None:
+        """The reconstructed class has __kajson_class_source__ with the generated Python source."""
+        schema = SimpleModel.model_json_schema()
+        result_class = model_class_from_json_schema(schema, "SimpleModel")
+
+        source = getattr(result_class, "__kajson_class_source__", None)
+        assert source is not None
+        assert "class SimpleModel" in source
+        assert "BaseModel" in source
+
+    def test_caching_returns_same_class(self) -> None:
+        """Calling with the same schema returns the same class object (cached)."""
+        schema = SimpleModel.model_json_schema()
+        class_1 = model_class_from_json_schema(schema, "SimpleModel")
+        class_2 = model_class_from_json_schema(schema, "SimpleModel")
+
+        assert class_1 is class_2
+
+    def test_different_schemas_different_classes(self) -> None:
+        """Different schemas produce different classes even if class names differ."""
+        schema_simple = SimpleModel.model_json_schema()
+        schema_nested = PersonWithAddress.model_json_schema()
+
+        class_simple = model_class_from_json_schema(schema_simple, "SimpleModel")
+        class_nested = model_class_from_json_schema(schema_nested, "PersonWithAddress")
+
+        assert class_simple is not class_nested
+
+    def test_json_roundtrip_with_reconstructed_class(self) -> None:
+        """An instance of the reconstructed class survives JSON round-trip."""
+        schema = SimpleModel.model_json_schema()
+        result_class = model_class_from_json_schema(schema, "SimpleModel")
+
+        instance = result_class(name="Charlie", age=25)
+        json_str = instance.model_dump_json()
+        restored = result_class.model_validate_json(json_str)
+        assert restored.name == "Charlie"  # type: ignore[attr-defined]
+        assert restored.age == 25  # type: ignore[attr-defined]
+
+    def test_normalized_class_name_lookup(self) -> None:
+        """A class_name with underscores/double-underscores resolves via PascalCase normalization."""
+        schema = SimpleModel.model_json_schema()
+        # Override the title to simulate a dynamic concept code like "my_namespace__Greeting"
+        schema["title"] = "my_namespace__Greeting"
+        result_class = model_class_from_json_schema(schema, "my_namespace__Greeting")
+
+        assert "name" in result_class.model_fields
+        assert "age" in result_class.model_fields
+        instance = result_class(name="Ada", age=40)
+        assert instance.name == "Ada"  # type: ignore[attr-defined]

--- a/uv.lock
+++ b/uv.lock
@@ -1886,15 +1886,28 @@ wheels = [
 
 [[package]]
 name = "kajson"
-version = "0.4.1"
-source = { registry = "https://pypi.org/simple" }
+version = "0.4.2"
+source = { editable = "../kajson" }
 dependencies = [
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cf/58/ced2096f15fcccd5cb6954f67f3bfaaf7e3f5c95ab85de9e03779cec2838/kajson-0.4.1.tar.gz", hash = "sha256:0de2bc94153ab8cc7b3d72dd26701f7320f2dbbd6d19196b8ff2517ef6432265", size = 21643, upload-time = "2026-04-02T02:09:28.213Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/02/37/8687a8d3f7e983975cdab1d2e66f995df0c0c022c2905093c62b6b611eee/kajson-0.4.1-py3-none-any.whl", hash = "sha256:c46e6f705da7f93777c3d859a2ecc4e81ffa7f0ce9c4ef44ffa3b5a94764fe02", size = 28070, upload-time = "2026-04-02T02:09:26.647Z" },
+
+[package.metadata]
+requires-dist = [
+    { name = "mkdocs", marker = "extra == 'docs'", specifier = "==1.6.1" },
+    { name = "mkdocs-glightbox", marker = "extra == 'docs'", specifier = "==0.4.0" },
+    { name = "mkdocs-material", marker = "extra == 'docs'", specifier = "==9.6.14" },
+    { name = "mkdocs-meta-manager", marker = "extra == 'docs'", specifier = "==1.1.0" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11.2" },
+    { name = "pydantic", specifier = ">=2.10.6" },
+    { name = "pyright", marker = "extra == 'dev'", specifier = "==1.1.398" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.3" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.1.1" },
+    { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.14.0" },
+    { name = "pytest-sugar", marker = "extra == 'dev'", specifier = ">=1.0.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6.8" },
 ]
+provides-extras = ["docs", "dev"]
 
 [[package]]
 name = "latex2mathml"
@@ -3697,7 +3710,7 @@ requires-dist = [
     { name = "instructor", extras = ["google-genai"], marker = "extra == 'google-genai'" },
     { name = "jinja2", specifier = ">=3.1.4" },
     { name = "json2html", specifier = ">=1.3.0" },
-    { name = "kajson", specifier = "==0.4.1" },
+    { name = "kajson", editable = "../kajson" },
     { name = "linkup-sdk", marker = "extra == 'linkup'", specifier = ">=0.12.0" },
     { name = "markdown", specifier = ">=3.6" },
     { name = "mike", marker = "extra == 'docs'", specifier = ">=2.1.3" },

--- a/uv.lock
+++ b/uv.lock
@@ -1886,28 +1886,15 @@ wheels = [
 
 [[package]]
 name = "kajson"
-version = "0.4.0"
-source = { editable = "../kajson" }
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
 ]
-
-[package.metadata]
-requires-dist = [
-    { name = "mkdocs", marker = "extra == 'docs'", specifier = "==1.6.1" },
-    { name = "mkdocs-glightbox", marker = "extra == 'docs'", specifier = "==0.4.0" },
-    { name = "mkdocs-material", marker = "extra == 'docs'", specifier = "==9.6.14" },
-    { name = "mkdocs-meta-manager", marker = "extra == 'docs'", specifier = "==1.1.0" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11.2" },
-    { name = "pydantic", specifier = ">=2.10.6" },
-    { name = "pyright", marker = "extra == 'dev'", specifier = "==1.1.398" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.3" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.1.1" },
-    { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.14.0" },
-    { name = "pytest-sugar", marker = "extra == 'dev'", specifier = ">=1.0.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6.8" },
+sdist = { url = "https://files.pythonhosted.org/packages/cf/58/ced2096f15fcccd5cb6954f67f3bfaaf7e3f5c95ab85de9e03779cec2838/kajson-0.4.1.tar.gz", hash = "sha256:0de2bc94153ab8cc7b3d72dd26701f7320f2dbbd6d19196b8ff2517ef6432265", size = 21643, upload-time = "2026-04-02T02:09:28.213Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/37/8687a8d3f7e983975cdab1d2e66f995df0c0c022c2905093c62b6b611eee/kajson-0.4.1-py3-none-any.whl", hash = "sha256:c46e6f705da7f93777c3d859a2ecc4e81ffa7f0ce9c4ef44ffa3b5a94764fe02", size = 28070, upload-time = "2026-04-02T02:09:26.647Z" },
 ]
-provides-extras = ["docs", "dev"]
 
 [[package]]
 name = "latex2mathml"
@@ -3710,7 +3697,7 @@ requires-dist = [
     { name = "instructor", extras = ["google-genai"], marker = "extra == 'google-genai'" },
     { name = "jinja2", specifier = ">=3.1.4" },
     { name = "json2html", specifier = ">=1.3.0" },
-    { name = "kajson", editable = "../kajson" },
+    { name = "kajson", specifier = "==0.4.1" },
     { name = "linkup-sdk", marker = "extra == 'linkup'", specifier = ">=0.12.0" },
     { name = "markdown", specifier = ">=3.6" },
     { name = "mike", marker = "extra == 'docs'", specifier = ">=2.1.3" },

--- a/uv.lock
+++ b/uv.lock
@@ -290,6 +290,15 @@ wheels = [
 ]
 
 [[package]]
+name = "argcomplete"
+version = "3.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/61/0b9ae6399dd4a58d8c1b1dc5a27d6f2808023d0b5dd3104bb99f45a33ff6/argcomplete-3.6.3.tar.gz", hash = "sha256:62e8ed4fd6a45864acc8235409461b72c9a28ee785a2011cc5eb78318786c89c", size = 73754, upload-time = "2025-10-20T03:33:34.741Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/f5/9373290775639cb67a2fce7f629a1c240dce9f12fe927bc32b2736e16dfc/argcomplete-3.6.3-py3-none-any.whl", hash = "sha256:f5007b3a600ccac5d25bbce33089211dfd49eab4a7718da3f10e3082525a92ce", size = 43846, upload-time = "2025-10-20T03:33:33.021Z" },
+]
+
+[[package]]
 name = "astroid"
 version = "4.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -380,6 +389,50 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload-time = "2025-11-30T15:08:26.084Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload-time = "2025-11-30T15:08:24.087Z" },
+]
+
+[[package]]
+name = "black"
+version = "26.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "mypy-extensions" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "platformdirs" },
+    { name = "pytokens" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e1/c5/61175d618685d42b005847464b8fb4743a67b1b8fdb75e50e5a96c31a27a/black-26.3.1.tar.gz", hash = "sha256:2c50f5063a9641c7eed7795014ba37b0f5fa227f3d408b968936e24bc0566b07", size = 666155, upload-time = "2026-03-12T03:36:03.593Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/a8/11170031095655d36ebc6664fe0897866f6023892396900eec0e8fdc4299/black-26.3.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:86a8b5035fce64f5dcd1b794cf8ec4d31fe458cf6ce3986a30deb434df82a1d2", size = 1866562, upload-time = "2026-03-12T03:39:58.639Z" },
+    { url = "https://files.pythonhosted.org/packages/69/ce/9e7548d719c3248c6c2abfd555d11169457cbd584d98d179111338423790/black-26.3.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5602bdb96d52d2d0672f24f6ffe5218795736dd34807fd0fd55ccd6bf206168b", size = 1703623, upload-time = "2026-03-12T03:40:00.347Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/0a/8d17d1a9c06f88d3d030d0b1d4373c1551146e252afe4547ed601c0e697f/black-26.3.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c54a4a82e291a1fee5137371ab488866b7c86a3305af4026bdd4dc78642e1ac", size = 1768388, upload-time = "2026-03-12T03:40:01.765Z" },
+    { url = "https://files.pythonhosted.org/packages/52/79/c1ee726e221c863cde5164f925bacf183dfdf0397d4e3f94889439b947b4/black-26.3.1-cp310-cp310-win_amd64.whl", hash = "sha256:6e131579c243c98f35bce64a7e08e87fb2d610544754675d4a0e73a070a5aa3a", size = 1412969, upload-time = "2026-03-12T03:40:03.252Z" },
+    { url = "https://files.pythonhosted.org/packages/73/a5/15c01d613f5756f68ed8f6d4ec0a1e24b82b18889fa71affd3d1f7fad058/black-26.3.1-cp310-cp310-win_arm64.whl", hash = "sha256:5ed0ca58586c8d9a487352a96b15272b7fa55d139fc8496b519e78023a8dab0a", size = 1220345, upload-time = "2026-03-12T03:40:04.892Z" },
+    { url = "https://files.pythonhosted.org/packages/17/57/5f11c92861f9c92eb9dddf515530bc2d06db843e44bdcf1c83c1427824bc/black-26.3.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:28ef38aee69e4b12fda8dba75e21f9b4f979b490c8ac0baa7cb505369ac9e1ff", size = 1851987, upload-time = "2026-03-12T03:40:06.248Z" },
+    { url = "https://files.pythonhosted.org/packages/54/aa/340a1463660bf6831f9e39646bf774086dbd8ca7fc3cded9d59bbdf4ad0a/black-26.3.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:bf9bf162ed91a26f1adba8efda0b573bc6924ec1408a52cc6f82cb73ec2b142c", size = 1689499, upload-time = "2026-03-12T03:40:07.642Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/01/b726c93d717d72733da031d2de10b92c9fa4c8d0c67e8a8a372076579279/black-26.3.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:474c27574d6d7037c1bc875a81d9be0a9a4f9ee95e62800dab3cfaadbf75acd5", size = 1754369, upload-time = "2026-03-12T03:40:09.279Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/09/61e91881ca291f150cfc9eb7ba19473c2e59df28859a11a88248b5cbbc4d/black-26.3.1-cp311-cp311-win_amd64.whl", hash = "sha256:5e9d0d86df21f2e1677cc4bd090cd0e446278bcbbe49bf3659c308c3e402843e", size = 1413613, upload-time = "2026-03-12T03:40:10.943Z" },
+    { url = "https://files.pythonhosted.org/packages/16/73/544f23891b22e7efe4d8f812371ab85b57f6a01b2fc45e3ba2e52ba985b8/black-26.3.1-cp311-cp311-win_arm64.whl", hash = "sha256:9a5e9f45e5d5e1c5b5c29b3bd4265dcc90e8b92cf4534520896ed77f791f4da5", size = 1219719, upload-time = "2026-03-12T03:40:12.597Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/f8/da5eae4fc75e78e6dceb60624e1b9662ab00d6b452996046dfa9b8a6025b/black-26.3.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b5e6f89631eb88a7302d416594a32faeee9fb8fb848290da9d0a5f2903519fc1", size = 1895920, upload-time = "2026-03-12T03:40:13.921Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/9f/04e6f26534da2e1629b2b48255c264cabf5eedc5141d04516d9d68a24111/black-26.3.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:41cd2012d35b47d589cb8a16faf8a32ef7a336f56356babd9fcf70939ad1897f", size = 1718499, upload-time = "2026-03-12T03:40:15.239Z" },
+    { url = "https://files.pythonhosted.org/packages/04/91/a5935b2a63e31b331060c4a9fdb5a6c725840858c599032a6f3aac94055f/black-26.3.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f76ff19ec5297dd8e66eb64deda23631e642c9393ab592826fd4bdc97a4bce7", size = 1794994, upload-time = "2026-03-12T03:40:17.124Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/0a/86e462cdd311a3c2a8ece708d22aba17d0b2a0d5348ca34b40cdcbea512e/black-26.3.1-cp312-cp312-win_amd64.whl", hash = "sha256:ddb113db38838eb9f043623ba274cfaf7d51d5b0c22ecb30afe58b1bb8322983", size = 1420867, upload-time = "2026-03-12T03:40:18.83Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/e5/22515a19cb7eaee3440325a6b0d95d2c0e88dd180cb011b12ae488e031d1/black-26.3.1-cp312-cp312-win_arm64.whl", hash = "sha256:dfdd51fc3e64ea4f35873d1b3fb25326773d55d2329ff8449139ebaad7357efb", size = 1230124, upload-time = "2026-03-12T03:40:20.425Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/77/5728052a3c0450c53d9bb3945c4c46b91baa62b2cafab6801411b6271e45/black-26.3.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:855822d90f884905362f602880ed8b5df1b7e3ee7d0db2502d4388a954cc8c54", size = 1895034, upload-time = "2026-03-12T03:40:21.813Z" },
+    { url = "https://files.pythonhosted.org/packages/52/73/7cae55fdfdfbe9d19e9a8d25d145018965fe2079fa908101c3733b0c55a0/black-26.3.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8a33d657f3276328ce00e4d37fe70361e1ec7614da5d7b6e78de5426cb56332f", size = 1718503, upload-time = "2026-03-12T03:40:23.666Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/87/af89ad449e8254fdbc74654e6467e3c9381b61472cc532ee350d28cfdafb/black-26.3.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f1cd08e99d2f9317292a311dfe578fd2a24b15dbce97792f9c4d752275c1fa56", size = 1793557, upload-time = "2026-03-12T03:40:25.497Z" },
+    { url = "https://files.pythonhosted.org/packages/43/10/d6c06a791d8124b843bf325ab4ac7d2f5b98731dff84d6064eafd687ded1/black-26.3.1-cp313-cp313-win_amd64.whl", hash = "sha256:c7e72339f841b5a237ff14f7d3880ddd0fc7f98a1199e8c4327f9a4f478c1839", size = 1422766, upload-time = "2026-03-12T03:40:27.14Z" },
+    { url = "https://files.pythonhosted.org/packages/59/4f/40a582c015f2d841ac24fed6390bd68f0fc896069ff3a886317959c9daf8/black-26.3.1-cp313-cp313-win_arm64.whl", hash = "sha256:afc622538b430aa4c8c853f7f63bc582b3b8030fd8c80b70fb5fa5b834e575c2", size = 1232140, upload-time = "2026-03-12T03:40:28.882Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/da/e36e27c9cebc1311b7579210df6f1c86e50f2d7143ae4fcf8a5017dc8809/black-26.3.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:2d6bfaf7fd0993b420bed691f20f9492d53ce9a2bcccea4b797d34e947318a78", size = 1889234, upload-time = "2026-03-12T03:40:30.964Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/7b/9871acf393f64a5fa33668c19350ca87177b181f44bb3d0c33b2d534f22c/black-26.3.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:f89f2ab047c76a9c03f78d0d66ca519e389519902fa27e7a91117ef7611c0568", size = 1720522, upload-time = "2026-03-12T03:40:32.346Z" },
+    { url = "https://files.pythonhosted.org/packages/03/87/e766c7f2e90c07fb7586cc787c9ae6462b1eedab390191f2b7fc7f6170a9/black-26.3.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b07fc0dab849d24a80a29cfab8d8a19187d1c4685d8a5e6385a5ce323c1f015f", size = 1787824, upload-time = "2026-03-12T03:40:33.636Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/94/2424338fb2d1875e9e83eed4c8e9c67f6905ec25afd826a911aea2b02535/black-26.3.1-cp314-cp314-win_amd64.whl", hash = "sha256:0126ae5b7c09957da2bdbd91a9ba1207453feada9e9fe51992848658c6c8e01c", size = 1445855, upload-time = "2026-03-12T03:40:35.442Z" },
+    { url = "https://files.pythonhosted.org/packages/86/43/0c3338bd928afb8ee7471f1a4eec3bdbe2245ccb4a646092a222e8669840/black-26.3.1-cp314-cp314-win_arm64.whl", hash = "sha256:92c0ec1f2cc149551a2b7b47efc32c866406b6891b0ee4625e95967c8f4acfb1", size = 1258109, upload-time = "2026-03-12T03:40:36.832Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/0d/52d98722666d6fc6c3dd4c76df339501d6efd40e0ff95e6186a7b7f0befd/black-26.3.1-py3-none-any.whl", hash = "sha256:2bd5aa94fc267d38bb21a70d7410a89f1a1d318841855f698746f8e7f51acd1b", size = 207542, upload-time = "2026-03-12T03:36:01.668Z" },
 ]
 
 [[package]]
@@ -878,6 +931,26 @@ wheels = [
 ]
 
 [[package]]
+name = "datamodel-code-generator"
+version = "0.55.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "argcomplete" },
+    { name = "black" },
+    { name = "genson" },
+    { name = "inflect" },
+    { name = "isort" },
+    { name = "jinja2" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "tomli", marker = "python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/33/36/ec505ce62c143c0f045e82e2bb0360e2ede765c0cfe3a70bf32c5661b8a2/datamodel_code_generator-0.55.0.tar.gz", hash = "sha256:20ae7a4fbbb12be380f0bd02544db4abae96c5b644d4b3f2b9c3fc0bc9ee1184", size = 833828, upload-time = "2026-03-10T20:41:15.796Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/c6/2abc9d11adbbf689b6b4dfb7a136d57b9ccaa3b3f1ba83504462109e8dbb/datamodel_code_generator-0.55.0-py3-none-any.whl", hash = "sha256:efa5a925288ca2a135fdc3361c7d774ae5b24b4fd632868363e249d55ea2f137", size = 256860, upload-time = "2026-03-10T20:41:13.488Z" },
+]
+
+[[package]]
 name = "defusedxml"
 version = "0.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1275,6 +1348,15 @@ wheels = [
 ]
 
 [[package]]
+name = "genson"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c5/cf/2303c8ad276dcf5ee2ad6cf69c4338fd86ef0f471a5207b069adf7a393cf/genson-1.3.0.tar.gz", hash = "sha256:e02db9ac2e3fd29e65b5286f7135762e2cd8a986537c075b06fc5f1517308e37", size = 34919, upload-time = "2024-05-15T22:08:49.123Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/5c/e226de133afd8bb267ec27eead9ae3d784b95b39a287ed404caab39a5f50/genson-1.3.0-py3-none-any.whl", hash = "sha256:468feccd00274cc7e4c09e84b08704270ba8d95232aa280f65b986139cec67f7", size = 21470, upload-time = "2024-05-15T22:08:47.056Z" },
+]
+
+[[package]]
 name = "ghp-import"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1562,6 +1644,19 @@ wheels = [
 ]
 
 [[package]]
+name = "inflect"
+version = "7.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+    { name = "typeguard" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/c6/943357d44a21fd995723d07ccaddd78023eace03c1846049a2645d4324a3/inflect-7.5.0.tar.gz", hash = "sha256:faf19801c3742ed5a05a8ce388e0d8fe1a07f8d095c82201eb904f5d27ad571f", size = 73751, upload-time = "2024-12-28T17:11:18.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/eb/427ed2b20a38a4ee29f24dbe4ae2dafab198674fe9a85e3d6adf9e5f5f41/inflect-7.5.0-py3-none-any.whl", hash = "sha256:2aea70e5e70c35d8350b8097396ec155ffd68def678c7ff97f51aa69c1d92344", size = 35197, upload-time = "2024-12-28T17:11:15.931Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1792,14 +1887,27 @@ wheels = [
 [[package]]
 name = "kajson"
 version = "0.4.0"
-source = { registry = "https://pypi.org/simple" }
+source = { editable = "../kajson" }
 dependencies = [
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b5/6e/064f61ba227cbeced716df25d3ce1d7dea921653ce29e864a7dacb345ff2/kajson-0.4.0.tar.gz", hash = "sha256:c510bf9324df4d388929bedaa94b53c5571d51f802d6086a55d4a2583002a8d9", size = 20854, upload-time = "2026-03-30T06:27:12.965Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/65/1fc56174ccf9716e570254db1906ae6518ad15db4d2fa6b87aa030aa1245/kajson-0.4.0-py3-none-any.whl", hash = "sha256:a1e72baff9d47706384ab569fd1d7dddfbf8583463d0525cb1ad41c894bc2d78", size = 27345, upload-time = "2026-03-30T06:27:11.418Z" },
+
+[package.metadata]
+requires-dist = [
+    { name = "mkdocs", marker = "extra == 'docs'", specifier = "==1.6.1" },
+    { name = "mkdocs-glightbox", marker = "extra == 'docs'", specifier = "==0.4.0" },
+    { name = "mkdocs-material", marker = "extra == 'docs'", specifier = "==9.6.14" },
+    { name = "mkdocs-meta-manager", marker = "extra == 'docs'", specifier = "==1.1.0" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11.2" },
+    { name = "pydantic", specifier = ">=2.10.6" },
+    { name = "pyright", marker = "extra == 'dev'", specifier = "==1.1.398" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.3" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.1.1" },
+    { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.14.0" },
+    { name = "pytest-sugar", marker = "extra == 'dev'", specifier = ">=1.0.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6.8" },
 ]
+provides-extras = ["docs", "dev"]
 
 [[package]]
 name = "latex2mathml"
@@ -2329,6 +2437,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f1/a8/6d44a6cf07e969c7420cb36ab287b0669da636a2044de38a7d2208d5a758/mkdocs_redirects-1.2.2.tar.gz", hash = "sha256:3094981b42ffab29313c2c1b8ac3969861109f58b2dd58c45fc81cd44bfa0095", size = 7162, upload-time = "2024-11-07T14:57:21.109Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c4/ec/38443b1f2a3821bbcb24e46cd8ba979154417794d54baf949fefde1c2146/mkdocs_redirects-1.2.2-py3-none-any.whl", hash = "sha256:7dbfa5647b79a3589da4401403d69494bd1f4ad03b9c15136720367e1f340ed5", size = 6142, upload-time = "2024-11-07T14:57:19.143Z" },
+]
+
+[[package]]
+name = "more-itertools"
+version = "10.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ea/5d/38b681d3fce7a266dd9ab73c66959406d565b3e85f21d5e66e1181d93721/more_itertools-10.8.0.tar.gz", hash = "sha256:f638ddf8a1a0d134181275fb5d58b086ead7c6a72429ad725c67503f13ba30bd", size = 137431, upload-time = "2025-09-02T15:23:11.018Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/8e/469e5a4a2f5855992e425f3cb33804cc07bf18d48f2db061aec61ce50270/more_itertools-10.8.0-py3-none-any.whl", hash = "sha256:52d4362373dcf7c52546bc4af9a86ee7c4579df9a8dc268be0a2f949d376cc9b", size = 69667, upload-time = "2025-09-02T15:23:09.635Z" },
 ]
 
 [[package]]
@@ -3466,6 +3583,7 @@ source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },
     { name = "backports-strenum", marker = "python_full_version < '3.11'" },
+    { name = "datamodel-code-generator" },
     { name = "filetype" },
     { name = "httpx" },
     { name = "instructor" },
@@ -3579,6 +3697,7 @@ requires-dist = [
     { name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.34.131" },
     { name = "boto3", marker = "extra == 's3'", specifier = ">=1.34.131" },
     { name = "boto3-stubs", marker = "extra == 'dev'", specifier = ">=1.35.24" },
+    { name = "datamodel-code-generator", specifier = ">=0.55.0" },
     { name = "docling", marker = "extra == 'docling'", specifier = ">=2.64.0" },
     { name = "fal-client", marker = "extra == 'fal'", specifier = ">=0.4.1" },
     { name = "filetype", specifier = ">=1.2.0" },
@@ -3591,7 +3710,7 @@ requires-dist = [
     { name = "instructor", extras = ["google-genai"], marker = "extra == 'google-genai'" },
     { name = "jinja2", specifier = ">=3.1.4" },
     { name = "json2html", specifier = ">=1.3.0" },
-    { name = "kajson", specifier = "==0.4.0" },
+    { name = "kajson", editable = "../kajson" },
     { name = "linkup-sdk", marker = "extra == 'linkup'", specifier = ">=0.12.0" },
     { name = "markdown", specifier = ">=3.6" },
     { name = "mike", marker = "extra == 'docs'", specifier = ">=2.1.3" },
@@ -4440,6 +4559,45 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/52/a9/0c0db8d37b2b8a645666f7fd8accea4c6224e013c42b1d5c17c93590cd06/python_pptx-1.0.2.tar.gz", hash = "sha256:479a8af0eaf0f0d76b6f00b0887732874ad2e3188230315290cd1f9dd9cc7095", size = 10109297, upload-time = "2024-08-07T17:33:37.772Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d9/4f/00be2196329ebbff56ce564aa94efb0fbc828d00de250b1980de1a34ab49/python_pptx-1.0.2-py3-none-any.whl", hash = "sha256:160838e0b8565a8b1f67947675886e9fea18aa5e795db7ae531606d68e785cba", size = 472788, upload-time = "2024-08-07T17:33:28.192Z" },
+]
+
+[[package]]
+name = "pytokens"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/34/b4e015b99031667a7b960f888889c5bd34ef585c85e1cb56a594b92836ac/pytokens-0.4.1.tar.gz", hash = "sha256:292052fe80923aae2260c073f822ceba21f3872ced9a68bb7953b348e561179a", size = 23015, upload-time = "2026-01-30T01:03:45.924Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/24/f206113e05cb8ef51b3850e7ef88f20da6f4bf932190ceb48bd3da103e10/pytokens-0.4.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2a44ed93ea23415c54f3face3b65ef2b844d96aeb3455b8a69b3df6beab6acc5", size = 161522, upload-time = "2026-01-30T01:02:50.393Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/e9/06a6bf1b90c2ed81a9c7d2544232fe5d2891d1cd480e8a1809ca354a8eb2/pytokens-0.4.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:add8bf86b71a5d9fb5b89f023a80b791e04fba57960aa790cc6125f7f1d39dfe", size = 246945, upload-time = "2026-01-30T01:02:52.399Z" },
+    { url = "https://files.pythonhosted.org/packages/69/66/f6fb1007a4c3d8b682d5d65b7c1fb33257587a5f782647091e3408abe0b8/pytokens-0.4.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:670d286910b531c7b7e3c0b453fd8156f250adb140146d234a82219459b9640c", size = 259525, upload-time = "2026-01-30T01:02:53.737Z" },
+    { url = "https://files.pythonhosted.org/packages/04/92/086f89b4d622a18418bac74ab5db7f68cf0c21cf7cc92de6c7b919d76c88/pytokens-0.4.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:4e691d7f5186bd2842c14813f79f8884bb03f5995f0575272009982c5ac6c0f7", size = 262693, upload-time = "2026-01-30T01:02:54.871Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/7b/8b31c347cf94a3f900bdde750b2e9131575a61fdb620d3d3c75832262137/pytokens-0.4.1-cp310-cp310-win_amd64.whl", hash = "sha256:27b83ad28825978742beef057bfe406ad6ed524b2d28c252c5de7b4a6dd48fa2", size = 103567, upload-time = "2026-01-30T01:02:56.414Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/92/790ebe03f07b57e53b10884c329b9a1a308648fc083a6d4a39a10a28c8fc/pytokens-0.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d70e77c55ae8380c91c0c18dea05951482e263982911fc7410b1ffd1dadd3440", size = 160864, upload-time = "2026-01-30T01:02:57.882Z" },
+    { url = "https://files.pythonhosted.org/packages/13/25/a4f555281d975bfdd1eba731450e2fe3a95870274da73fb12c40aeae7625/pytokens-0.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a58d057208cb9075c144950d789511220b07636dd2e4708d5645d24de666bdc", size = 248565, upload-time = "2026-01-30T01:02:59.912Z" },
+    { url = "https://files.pythonhosted.org/packages/17/50/bc0394b4ad5b1601be22fa43652173d47e4c9efbf0044c62e9a59b747c56/pytokens-0.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b49750419d300e2b5a3813cf229d4e5a4c728dae470bcc89867a9ad6f25a722d", size = 260824, upload-time = "2026-01-30T01:03:01.471Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/54/3e04f9d92a4be4fc6c80016bc396b923d2a6933ae94b5f557c939c460ee0/pytokens-0.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d9907d61f15bf7261d7e775bd5d7ee4d2930e04424bab1972591918497623a16", size = 264075, upload-time = "2026-01-30T01:03:04.143Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/1b/44b0326cb5470a4375f37988aea5d61b5cc52407143303015ebee94abfd6/pytokens-0.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:ee44d0f85b803321710f9239f335aafe16553b39106384cef8e6de40cb4ef2f6", size = 103323, upload-time = "2026-01-30T01:03:05.412Z" },
+    { url = "https://files.pythonhosted.org/packages/41/5d/e44573011401fb82e9d51e97f1290ceb377800fb4eed650b96f4753b499c/pytokens-0.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:140709331e846b728475786df8aeb27d24f48cbcf7bcd449f8de75cae7a45083", size = 160663, upload-time = "2026-01-30T01:03:06.473Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/e6/5bbc3019f8e6f21d09c41f8b8654536117e5e211a85d89212d59cbdab381/pytokens-0.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d6c4268598f762bc8e91f5dbf2ab2f61f7b95bdc07953b602db879b3c8c18e1", size = 255626, upload-time = "2026-01-30T01:03:08.177Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/3c/2d5297d82286f6f3d92770289fd439956b201c0a4fc7e72efb9b2293758e/pytokens-0.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:24afde1f53d95348b5a0eb19488661147285ca4dd7ed752bbc3e1c6242a304d1", size = 269779, upload-time = "2026-01-30T01:03:09.756Z" },
+    { url = "https://files.pythonhosted.org/packages/20/01/7436e9ad693cebda0551203e0bf28f7669976c60ad07d6402098208476de/pytokens-0.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5ad948d085ed6c16413eb5fec6b3e02fa00dc29a2534f088d3302c47eb59adf9", size = 268076, upload-time = "2026-01-30T01:03:10.957Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/df/533c82a3c752ba13ae7ef238b7f8cdd272cf1475f03c63ac6cf3fcfb00b6/pytokens-0.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:3f901fe783e06e48e8cbdc82d631fca8f118333798193e026a50ce1b3757ea68", size = 103552, upload-time = "2026-01-30T01:03:12.066Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/dc/08b1a080372afda3cceb4f3c0a7ba2bde9d6a5241f1edb02a22a019ee147/pytokens-0.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8bdb9d0ce90cbf99c525e75a2fa415144fd570a1ba987380190e8b786bc6ef9b", size = 160720, upload-time = "2026-01-30T01:03:13.843Z" },
+    { url = "https://files.pythonhosted.org/packages/64/0c/41ea22205da480837a700e395507e6a24425151dfb7ead73343d6e2d7ffe/pytokens-0.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5502408cab1cb18e128570f8d598981c68a50d0cbd7c61312a90507cd3a1276f", size = 254204, upload-time = "2026-01-30T01:03:14.886Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/d2/afe5c7f8607018beb99971489dbb846508f1b8f351fcefc225fcf4b2adc0/pytokens-0.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29d1d8fb1030af4d231789959f21821ab6325e463f0503a61d204343c9b355d1", size = 268423, upload-time = "2026-01-30T01:03:15.936Z" },
+    { url = "https://files.pythonhosted.org/packages/68/d4/00ffdbd370410c04e9591da9220a68dc1693ef7499173eb3e30d06e05ed1/pytokens-0.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:970b08dd6b86058b6dc07efe9e98414f5102974716232d10f32ff39701e841c4", size = 266859, upload-time = "2026-01-30T01:03:17.458Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/c9/c3161313b4ca0c601eeefabd3d3b576edaa9afdefd32da97210700e47652/pytokens-0.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:9bd7d7f544d362576be74f9d5901a22f317efc20046efe2034dced238cbbfe78", size = 103520, upload-time = "2026-01-30T01:03:18.652Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/a7/b470f672e6fc5fee0a01d9e75005a0e617e162381974213a945fcd274843/pytokens-0.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4a14d5f5fc78ce85e426aa159489e2d5961acf0e47575e08f35584009178e321", size = 160821, upload-time = "2026-01-30T01:03:19.684Z" },
+    { url = "https://files.pythonhosted.org/packages/80/98/e83a36fe8d170c911f864bfded690d2542bfcfacb9c649d11a9e6eb9dc41/pytokens-0.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97f50fd18543be72da51dd505e2ed20d2228c74e0464e4262e4899797803d7fa", size = 254263, upload-time = "2026-01-30T01:03:20.834Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/95/70d7041273890f9f97a24234c00b746e8da86df462620194cef1d411ddeb/pytokens-0.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dc74c035f9bfca0255c1af77ddd2d6ae8419012805453e4b0e7513e17904545d", size = 268071, upload-time = "2026-01-30T01:03:21.888Z" },
+    { url = "https://files.pythonhosted.org/packages/da/79/76e6d09ae19c99404656d7db9c35dfd20f2086f3eb6ecb496b5b31163bad/pytokens-0.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f66a6bbe741bd431f6d741e617e0f39ec7257ca1f89089593479347cc4d13324", size = 271716, upload-time = "2026-01-30T01:03:23.633Z" },
+    { url = "https://files.pythonhosted.org/packages/79/37/482e55fa1602e0a7ff012661d8c946bafdc05e480ea5a32f4f7e336d4aa9/pytokens-0.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:b35d7e5ad269804f6697727702da3c517bb8a5228afa450ab0fa787732055fc9", size = 104539, upload-time = "2026-01-30T01:03:24.788Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e8/20e7db907c23f3d63b0be3b8a4fd1927f6da2395f5bcc7f72242bb963dfe/pytokens-0.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8fcb9ba3709ff77e77f1c7022ff11d13553f3c30299a9fe246a166903e9091eb", size = 168474, upload-time = "2026-01-30T01:03:26.428Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/81/88a95ee9fafdd8f5f3452107748fd04c24930d500b9aba9738f3ade642cc/pytokens-0.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:79fc6b8699564e1f9b521582c35435f1bd32dd06822322ec44afdeba666d8cb3", size = 290473, upload-time = "2026-01-30T01:03:27.415Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/35/3aa899645e29b6375b4aed9f8d21df219e7c958c4c186b465e42ee0a06bf/pytokens-0.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d31b97b3de0f61571a124a00ffe9a81fb9939146c122c11060725bd5aea79975", size = 303485, upload-time = "2026-01-30T01:03:28.558Z" },
+    { url = "https://files.pythonhosted.org/packages/52/a0/07907b6ff512674d9b201859f7d212298c44933633c946703a20c25e9d81/pytokens-0.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:967cf6e3fd4adf7de8fc73cd3043754ae79c36475c1c11d514fc72cf5490094a", size = 306698, upload-time = "2026-01-30T01:03:29.653Z" },
+    { url = "https://files.pythonhosted.org/packages/39/2a/cbbf9250020a4a8dd53ba83a46c097b69e5eb49dd14e708f496f548c6612/pytokens-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:584c80c24b078eec1e227079d56dc22ff755e0ba8654d8383b2c549107528918", size = 116287, upload-time = "2026-01-30T01:03:30.912Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/78/397db326746f0a342855b81216ae1f0a32965deccfd7c830a2dbc66d2483/pytokens-0.4.1-py3-none-any.whl", hash = "sha256:26cef14744a8385f35d0e095dc8b3a7583f6c953c2e3d269c7f82484bf5ad2de", size = 13729, upload-time = "2026-01-30T01:03:45.029Z" },
 ]
 
 [[package]]
@@ -5751,6 +5909,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/35/f8/9c66bfc55361ec6d0e4040a0337fb5924ceb23de4648b8a81ae9d33b2b38/triton-3.6.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d002e07d7180fd65e622134fbd980c9a3d4211fb85224b56a0a0efbd422ab72f", size = 188400296, upload-time = "2026-01-20T16:00:56.042Z" },
     { url = "https://files.pythonhosted.org/packages/df/3d/9e7eee57b37c80cec63322c0231bb6da3cfe535a91d7a4d64896fcb89357/triton-3.6.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a17a5d5985f0ac494ed8a8e54568f092f7057ef60e1b0fa09d3fd1512064e803", size = 188273063, upload-time = "2026-01-20T16:01:07.278Z" },
     { url = "https://files.pythonhosted.org/packages/f6/56/6113c23ff46c00aae423333eb58b3e60bdfe9179d542781955a5e1514cb3/triton-3.6.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:46bd1c1af4b6704e554cad2eeb3b0a6513a980d470ccfa63189737340c7746a7", size = 188397994, upload-time = "2026-01-20T16:01:14.236Z" },
+]
+
+[[package]]
+name = "typeguard"
+version = "4.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2b/e8/66e25efcc18542d58706ce4e50415710593721aae26e794ab1dec34fb66f/typeguard-4.5.1.tar.gz", hash = "sha256:f6f8ecbbc819c9bc749983cc67c02391e16a9b43b8b27f15dc70ed7c4a007274", size = 80121, upload-time = "2026-02-19T16:09:03.392Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/88/b55b3117287a8540b76dbdd87733808d4d01c8067a3b339408c250bb3600/typeguard-4.5.1-py3-none-any.whl", hash = "sha256:44d2bf329d49a244110a090b55f5f91aa82d9a9834ebfd30bcc73651e4a8cc40", size = 36745, upload-time = "2026-02-19T16:09:01.6Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1887,27 +1887,14 @@ wheels = [
 [[package]]
 name = "kajson"
 version = "0.4.2"
-source = { editable = "../kajson" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
 ]
-
-[package.metadata]
-requires-dist = [
-    { name = "mkdocs", marker = "extra == 'docs'", specifier = "==1.6.1" },
-    { name = "mkdocs-glightbox", marker = "extra == 'docs'", specifier = "==0.4.0" },
-    { name = "mkdocs-material", marker = "extra == 'docs'", specifier = "==9.6.14" },
-    { name = "mkdocs-meta-manager", marker = "extra == 'docs'", specifier = "==1.1.0" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11.2" },
-    { name = "pydantic", specifier = ">=2.10.6" },
-    { name = "pyright", marker = "extra == 'dev'", specifier = "==1.1.398" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.3" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.1.1" },
-    { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.14.0" },
-    { name = "pytest-sugar", marker = "extra == 'dev'", specifier = ">=1.0.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6.8" },
+sdist = { url = "https://files.pythonhosted.org/packages/79/fa/11fde666e69639165f4bf4c59ebed263b7cce8b06b2d2b64699f6555f484/kajson-0.4.2.tar.gz", hash = "sha256:a8db97020d0e6c868eb4f2e999baeee477f410d8afc47fc91247745c725c271d", size = 21862, upload-time = "2026-04-02T04:30:11.51Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/72/a36ea3e9d5ca919b2a34ee2f4abf0817e97b22c8de89e378c76809ba6cba/kajson-0.4.2-py3-none-any.whl", hash = "sha256:12a9e1cc957d51fbabb89d2975732436df6fe2c9159e6030149169db9b3bbaa4", size = 28224, upload-time = "2026-04-02T04:30:10.319Z" },
 ]
-provides-extras = ["docs", "dev"]
 
 [[package]]
 name = "latex2mathml"
@@ -3710,7 +3697,7 @@ requires-dist = [
     { name = "instructor", extras = ["google-genai"], marker = "extra == 'google-genai'" },
     { name = "jinja2", specifier = ">=3.1.4" },
     { name = "json2html", specifier = ">=1.3.0" },
-    { name = "kajson", editable = "../kajson" },
+    { name = "kajson", specifier = "==0.4.2" },
     { name = "linkup-sdk", marker = "extra == 'linkup'", specifier = ">=0.12.0" },
     { name = "markdown", specifier = ">=3.6" },
     { name = "mike", marker = "extra == 'docs'", specifier = ">=2.1.3" },

--- a/wip/activity_storage-plan.md
+++ b/wip/activity_storage-plan.md
@@ -1,0 +1,123 @@
+# Activity-Level Storage — Execution Plan
+
+> Design: [wip/activity_storage.md](wip/activity_storage.md)
+> Branch: `fix/Temporal-Img`
+
+---
+
+## Phase 1: Image Generation (fixes the immediate bug) ✅
+
+### 1.1 Modify `act_img_gen_images` to include storage
+
+- [x] **File**: `pipelex/cogt/content_generation/img_gen_generate.py`
+  - Add `img_gen_single_image_and_store()` and `img_gen_image_list_and_store()` functions
+  - These call the existing generation logic, then use `GeneratedContentFactory` (with `get_storage_provider()`) to store and return `ImageContent`
+  - Keep the original `img_gen_single_image()` and `img_gen_image_list()` functions for the non-Temporal path
+
+- [x] **File**: `pipelex/temporal/tprl_content_generation/act_img_gen_generate.py`
+  - Change `act_img_gen_images` return type: `list[GeneratedImageRawDetails]` → `list[ImageContent]`
+  - Call the new `_and_store` functions instead of the raw generation functions
+  - The activity receives `ImgGenAssignment` (unchanged) which already has `job_metadata` with `user_id` and `pipeline_run_id`
+
+### 1.2 Update `WfMakeImages`
+
+- [x] **File**: `pipelex/temporal/tprl_content_generation/wf_make_images.py`
+  - Change return type: `list[GeneratedImageRawDetails]` → `list[ImageContent]`
+  - No logic changes — just the type annotation
+
+### 1.3 Update `ContentGeneratorChild` and `ContentGeneratorTop`
+
+- [x] **File**: `pipelex/temporal/tprl_content_generation/content_generator_child.py`
+  - `make_single_image()`: Gets `list[ImageContent]` from `WfMakeImages`, extracts the single item directly. Removed `make_image_content()` call
+  - `make_image_list()`: Gets `list[ImageContent]` from `WfMakeImages`, returns directly. Removed comprehension calling `make_image_content()`
+  - `make_image_content()`: Kept for protocol compliance but no longer called from image generation paths
+
+- [x] **File**: `pipelex/temporal/tprl_content_generation/content_generator_top.py`
+  - Same changes as `ContentGeneratorChild` — `make_single_image()` and `make_image_list()` now use `ImageContent` directly from workflow
+
+### 1.4 Update test workflow
+
+- [x] **File**: `pipelex/temporal/test_extras/wf_test_content_generator_child.py`
+  - Image generation is commented out (pre-existing TODO). No changes needed
+
+### 1.5 Lint + test
+
+- [x] Run `make agent-check` — 0 errors, 0 warnings
+- [x] Run `make agent-test` — all tests passed
+
+---
+
+## Phase 2: Extraction with images ✅
+
+### 2.1 Modify `act_extract_gen_extract_pages` to include storage
+
+- [x] **File**: `pipelex/cogt/content_generation/extract_generate.py`
+  - Added `extract_gen_pages_and_store()` that calls extraction, then uses `GeneratedContentFactory.make_page_contents()` to store extracted images and return `list[PageContent]`
+  - Kept original `extract_gen_pages()` for non-Temporal path
+
+- [x] **File**: `pipelex/temporal/tprl_content_generation/act_extract_generate.py`
+  - Changed return type: `ExtractOutput` → `list[PageContent]`
+  - Calls the new `_and_store` function
+
+### 2.2 Update `WfMakeExtract`
+
+- [x] **File**: `pipelex/temporal/tprl_content_generation/wf_make_extract.py`
+  - Changed return type: `ExtractOutput` → `list[PageContent]`
+
+### 2.3 Update `ContentGeneratorChild.make_extract_pages` and `ContentGeneratorTop`
+
+- [x] **File**: `pipelex/temporal/tprl_content_generation/content_generator_child.py`
+  - `make_extract_pages()`: Gets `list[PageContent]` from `WfMakeExtract`, returns directly. Removed `make_page_contents()` call
+
+- [x] **File**: `pipelex/temporal/tprl_content_generation/content_generator_top.py`
+  - Same changes as `ContentGeneratorChild`
+
+### 2.4 Lint + test
+
+- [x] Run `make agent-check` — 0 errors, 0 warnings
+- [x] Run `make agent-test` — all tests passed
+
+---
+
+## Phase 3: Page view rendering ✅
+
+### 3.1 Create new activity and workflow for page view rendering
+
+- [x] **File**: `pipelex/cogt/content_generation/assignment_models.py`
+  - Added `RenderPageViewsAssignment` model with `job_metadata`, `document_uri`, `page_views_dpi`
+
+- [x] **File** (new): `pipelex/temporal/tprl_content_generation/act_render_page_views.py`
+  - Created `act_render_page_views` activity
+  - Renders PDF pages via pypdfium2, stores images, returns `list[ImageContent]`
+
+- [x] **File** (new): `pipelex/temporal/tprl_content_generation/wf_render_page_views.py`
+  - Created `WfRenderPageViews` workflow wrapping the activity
+
+### 3.2 Update `ContentGeneratorChild.make_render_page_views` and `ContentGeneratorTop`
+
+- [x] **File**: `pipelex/temporal/tprl_content_generation/content_generator_child.py`
+  - `make_render_page_views()`: Delegates to `WfRenderPageViews` child workflow. Removed direct pypdfium2 rendering and `make_image_content` calls
+
+- [x] **File**: `pipelex/temporal/tprl_content_generation/content_generator_top.py`
+  - Same changes — delegates to `WfRenderPageViews` workflow
+
+### 3.3 Register in task catalog
+
+- [x] **File**: `pipelex/temporal/tasks.py`
+  - Added `WfRenderPageViews` to `CRAFTING` workflow list
+  - Added `act_render_page_views` to `CRAFTING` activity list
+
+### 3.4 Lint + test
+
+- [x] Run `make agent-check` — 0 errors, 0 warnings (ruff auto-removed unused imports)
+- [x] Run `make agent-test` — all tests passed
+
+---
+
+## Phase 4: Cleanup and full validation ✅
+
+- [x] Run `make agent-check` (full lint + type check) — 0 errors
+- [x] Run `make agent-test` (full test suite) — all passed
+- [ ] Verify no `PayloadSizeWarning` in worker logs (requires live Temporal test)
+- [ ] Verify no `NotImplementedError` crashes (requires live Temporal test)
+- [ ] Run `/temporal-e2e-validate` Mode 2 (3-process test) — includes image payload tiers

--- a/wip/activity_storage.md
+++ b/wip/activity_storage.md
@@ -1,0 +1,207 @@
+# Activity-Level Storage: Fixing Non-Deterministic I/O in Temporal Workflows
+
+> **Status**: Design
+> **Date**: 2026-04-01
+> **Related**: [phase5-payload-codec-strategy.md](phase5-payload-codec-strategy.md), Temporal img pipeline bug (fix/Temporal-Img branch)
+> **Trigger**: `NotImplementedError` when running `test_image_out_in.mthds` through Temporal — aiohttp's connector cleanup calls `loop.is_closed()` on Temporal's sandboxed event loop
+
+---
+
+## 1. The Bug
+
+When running an image-generation pipeline through Temporal, the workflow crashes at the S3 storage step:
+
+```
+wf_pipe_router.py:127  →  pipe_img_gen.py:214  →  content_generator_child.py:372
+→  content_generator_child.py:306  →  generated_content_factory.py:113
+→  s3_storage_provider.py:157  →  aiohttp connector close  →  NotImplementedError
+```
+
+`ContentGeneratorChild.make_image_content()` calls `GeneratedContentFactory.make_image_content()` directly within the workflow context. The factory does S3 storage via aiobotocore/aiohttp. aiohttp's cleanup calls `loop.is_closed()` on Temporal's restricted event loop, which doesn't implement that method.
+
+**Root cause**: Non-deterministic I/O (S3 upload, HTTP fetch) executing inside a Temporal workflow instead of an activity.
+
+---
+
+## 2. Scope of the Problem
+
+Three methods in `ContentGeneratorChild` perform I/O directly in workflow context:
+
+| Method | Line | I/O performed | Called by |
+|--------|------|---------------|-----------|
+| `make_image_content` | 300-314 | S3 storage via factory | `make_single_image`, `make_image_list`, `make_render_page_views` |
+| `make_page_contents` | 317-326 | S3 storage via factory (for each page image) | `make_extract_pages` |
+| `make_render_page_views` | 462-490 | pypdfium2 PDF rendering + S3 storage via `make_image_content` | `make_extract_pages` |
+
+All other content generation methods (LLM text, objects, image generation, extraction, templating) correctly delegate to child workflows that run activities.
+
+---
+
+## 3. Why a Separate Storage Activity is Not the Right Fix
+
+The naive fix — create an activity that wraps the storage call — has two problems:
+
+1. **Payload size limit**: Temporal enforces a **2MB limit per individual payload** (inputs and outputs of both activities and workflows). The current `act_img_gen_images` already returns `list[GeneratedImageRawDetails]` containing base64 image data. We already see `PayloadSizeWarning` at 1.8MB. Larger images would hard-fail. A separate storage activity would need to receive the same large data as input — hitting the same limit.
+
+2. **Double history pollution**: The large image data would enter workflow history twice — once as the generation activity output, once as the storage activity input.
+
+The Temporal-recommended "Large Data Handling" pattern (see `phase5-payload-codec-strategy.md` section "Large Data Handling" from the Temporal developer skill): activities should read AND write large data internally, passing only small references through the workflow.
+
+---
+
+## 4. The Solution: Merge Storage into Generation Activities
+
+### 4.1 Core Principle
+
+Each content generation activity becomes responsible for the full lifecycle: **generate → store → return lightweight reference**. Large binary data never crosses a Temporal boundary.
+
+### 4.2 New Activity Signatures
+
+**Image generation** (currently returns large `GeneratedImageRawDetails`):
+
+```python
+# BEFORE
+@activity.defn
+async def act_img_gen_images(img_gen_assignment: ImgGenAssignment) -> list[GeneratedImageRawDetails]:
+    ...  # generate, return raw base64 data
+
+# AFTER
+@activity.defn
+async def act_img_gen_images(img_gen_assignment: ImgGenAssignment) -> list[ImageContent]:
+    ...  # generate, store to S3, return ImageContent with URLs
+```
+
+The activity internally:
+1. Generates the image (existing logic)
+2. Calls `GeneratedContentFactory.make_image_content()` to store and build `ImageContent`
+3. Returns `ImageContent` (only URLs, no binary data)
+
+**Extraction** (currently returns `ExtractOutput` which can contain large extracted images):
+
+```python
+# BEFORE
+@activity.defn
+async def act_extract_gen_extract_pages(extract_assignment: ExtractAssignment) -> ExtractOutput:
+    ...  # extract, return raw extracted data with images
+
+# AFTER
+@activity.defn
+async def act_extract_gen_extract_pages(extract_assignment: ExtractAssignment) -> list[PageContent]:
+    ...  # extract, store images, return PageContent with URLs
+```
+
+**Page view rendering** (currently done entirely in workflow context):
+
+```python
+# NEW
+@activity.defn
+async def act_render_page_views(render_assignment: RenderPageViewsAssignment) -> list[ImageContent]:
+    ...  # render PDF pages, store images, return ImageContent with URLs
+```
+
+### 4.3 Workflow Changes
+
+**`WfMakeImages`**: Returns `list[ImageContent]` instead of `list[GeneratedImageRawDetails]`.
+
+**`WfMakeExtract`**: Returns `list[PageContent]` instead of `ExtractOutput`.
+
+**New `WfRenderPageViews`**: Wraps the new `act_render_page_views` activity.
+
+### 4.4 ContentGeneratorChild Changes
+
+`make_image_content` and `make_page_contents` become trivial or eliminated — the child workflows already return the final content types.
+
+| Method | Before | After |
+|--------|--------|-------|
+| `make_single_image` | Calls `WfMakeImages` (returns raw details) → `make_image_content` (S3 I/O in workflow) | Calls `WfMakeImages` (returns `ImageContent`) → done |
+| `make_image_list` | Same pattern as above | Same fix |
+| `make_image_content` | Direct factory call with S3 I/O | No longer needed for Temporal path — storage happens in activity |
+| `make_extract_pages` | Calls `WfMakeExtract` (returns `ExtractOutput`) → `make_page_contents` (S3 I/O in workflow) | Calls `WfMakeExtract` (returns `list[PageContent]`) → done |
+| `make_page_contents` | Direct factory call with S3 I/O | No longer needed for Temporal path |
+| `make_render_page_views` | pypdfium2 rendering + S3 I/O in workflow | Calls `WfRenderPageViews` → done |
+
+### 4.5 Non-Temporal Path Unchanged
+
+`ContentGenerator` (the non-Temporal implementation) continues to work as-is. The factory-level `make_image_content` and `make_page_contents` remain for the non-Temporal path. The change is only in the Temporal activities and `ContentGeneratorChild`.
+
+---
+
+## 5. New Assignment Models
+
+The activities need assignment models that carry enough context for storage:
+
+```python
+class ImgGenAssignment(BaseModel):
+    # existing fields...
+    job_metadata: JobMetadata  # already has user_id, pipeline_run_id for storage keys
+    img_gen_handle: str
+    img_gen_prompt: ImgGenPrompt
+    img_gen_job_params: ImgGenJobParams
+    img_gen_job_config: ImgGenJobConfig
+    nb_images: int
+    # NO NEW FIELDS NEEDED — job_metadata already carries what storage needs
+```
+
+`ImgGenAssignment` already contains `job_metadata` (with `user_id` and `pipeline_run_id`) which the `GeneratedContentFactory` needs for building storage keys. No model changes required for image generation.
+
+For page view rendering, a new assignment model:
+
+```python
+class RenderPageViewsAssignment(BaseModel):
+    job_metadata: JobMetadata
+    document_uri: str
+    page_views_dpi: int
+```
+
+---
+
+## 6. How the Activity Gets the Storage Provider
+
+Activities run in the worker process, which has the full Pipelex runtime initialized. The activity can access storage via:
+
+```python
+from pipelex.hub import get_storage_provider
+
+storage_provider = get_storage_provider()
+generated_content_factory = GeneratedContentFactory(storage_provider=storage_provider)
+```
+
+This is already the pattern used by other worker-side code (`gateway_extract_worker.py`, `pypdfium2_worker.py`).
+
+---
+
+## 7. Impact on the `ContentGeneratorProtocol`
+
+The protocol defines `make_image_content` and `make_page_contents` as public methods. After this change:
+
+- **Non-Temporal** (`ContentGenerator`): Still uses them — no change.
+- **Temporal** (`ContentGeneratorChild`): These methods are no longer called from workflow context. They could be removed from the child, or kept as pass-throughs.
+
+**Decision**: Keep the protocol unchanged. The `ContentGeneratorChild` implementations of `make_image_content` and `make_page_contents` will still exist but won't be called from workflow code paths. They're kept for protocol compliance and in case they're called from non-workflow contexts in the future.
+
+---
+
+## 8. Relationship to PayloadCodec (Phase 5)
+
+The PayloadCodec (`phase5-payload-codec-strategy.md`) is the general solution for large payload offloading — it transparently offloads any payload exceeding a size threshold to external storage at the wire boundary.
+
+This design is complementary, not competing:
+
+| Concern | This design | PayloadCodec |
+|---------|-------------|--------------|
+| Non-deterministic I/O in workflow | **Fixes** — moves I/O to activities | Does not fix — codec doesn't change where I/O happens |
+| Large payloads through Temporal | **Fixes for images** — activities return URLs | **Fixes for everything** — transparent offloading |
+| Required regardless of codec? | **Yes** — even with a codec, S3 I/O cannot run in workflow context | N/A |
+
+Even after PayloadCodec is implemented, activities should still handle their own storage. The codec is a safety net for payloads that are unavoidably large (e.g., library contexts), not a substitute for proper activity design.
+
+---
+
+## 9. Risk Assessment
+
+| Risk | Likelihood | Mitigation |
+|------|-----------|------------|
+| Changing `WfMakeImages` return type breaks existing tests | High | Update test assertions; tests already use `InMemoryStorageProvider` |
+| Extract output loss of detail (returning `PageContent` instead of `ExtractOutput`) | Medium | Ensure all needed fields from `ExtractOutput` are captured in `PageContent` |
+| `make_render_page_views` in `ContentGeneratorChild` also uses pypdfium2 I/O | Known | Covered by the new `WfRenderPageViews` workflow |
+| Storage provider not initialized in worker | Low | Worker init already sets up full Pipelex runtime; other activities use `get_storage_provider()` |

--- a/wip/preserved-from-registry-commits.md
+++ b/wip/preserved-from-registry-commits.md
@@ -1,0 +1,59 @@
+# Preserved changes from rolled-back commits
+
+These are valuable additions from commits e23e5ffc and 799836e8 that should be
+re-applied after the reset to 69a2c9e8.
+
+---
+
+## 1. CLAUDE.md additions
+
+Two new sections to add back to CLAUDE.md under the Temporal testing section:
+
+### Temporal Execution Model — ContextVar Boundaries
+
+**ContextVars do NOT propagate across Temporal execution boundaries.** This is a critical constraint when writing workflows and activities that use `hub.get_class_registry()` or any ContextVar-based state:
+
+- **Workflow -> activity:** Activities run in a fresh execution context (separate thread pool). A ContextVar set in a workflow's coroutine is invisible to activities dispatched by that workflow. Activities can also run on a **different worker** or even a **different server**.
+- **Workflow -> child workflow:** Child workflows run in their own execution context. ContextVars from the parent workflow are not inherited.
+- **Inline await (same coroutine):** ContextVars DO propagate. For example, `pipe.run_pipe()` called directly (as `await`) in `WfPipeRouter.run()` shares the workflow's ContextVar context.
+
+**Practical rule:** Any state that an activity needs must be passed explicitly via its arguments (the assignment models). Never rely on ContextVars being visible in activities.
+
+### Temporal E2E Testing — Clean Slate Rule
+
+When running Mode 2 (3-process) E2E tests, **always start from a clean slate:**
+
+1. Kill existing tmux sessions (`temporal-worker` first, then `temporal-server`)
+2. Clear `__pycache__` under `pipelex/temporal/` (stale bytecode causes the worker to run old code)
+3. **Start a fresh Temporal server** — this is what flushes workflow history. `temporal server start-dev` uses an **in-memory database** by default: killing and restarting the server process is all it takes to get a clean history. There is no persistent state to delete.
+4. Start a fresh worker
+
+**Why restarting the server matters:** Stale workflow history causes **nondeterminism errors** when workflow code has changed between runs. The server remembers the old workflow's event history, and when the new worker replays it, it detects that the code produces different decisions. Simply restarting the worker is NOT enough — the server holds the history, and it must be restarted too.
+
+---
+
+## 2. SKILL.md changes (temporal-e2e-validate)
+
+### Added allowed-tools
+```
+  - Bash(lsof *)
+  - Bash(find *)
+```
+
+### Mode 1 Step 1: added note
+Mode 1 uses in-process workers (not the external tmux worker), so stale server history
+is less of a concern here. But if tests fail with nondeterminism errors, kill and
+restart the server — it uses an in-memory database, so restart = clean history.
+
+### Mode 2: major rewrite
+- Replaced "Step 1: Ensure Temporal server is running" + "Step 2: Start the worker process"
+  with "Step 0: Clean slate (MANDATORY)" + "Step 1: Start fresh Temporal server and worker"
+- Clean slate section: kill worker first, then server, clear __pycache__, sleep
+- Startup section: start server first, verify, then start worker
+- Added port conflict check hint (lsof)
+- Fixed flag usage: removed `--pipe-run-mode live` (not a real flag), just remove `--dry-run --mock-inputs` for live mode
+- Fixed tier 4 and 5 commands: removed `--pipe-run-mode live` flag
+
+### Ask-the-user phrasing fix
+Changed: "replace `--dry-run --mock-inputs` with `--pipe-run-mode live`"
+To: "omit `--dry-run --mock-inputs` (there is no `--pipe-run-mode` flag)"

--- a/wip/tier2-live-bug-recap.md
+++ b/wip/tier2-live-bug-recap.md
@@ -1,0 +1,69 @@
+# Tier 2 Live Bug: DynamicConceptTestGreeting not found
+
+## The bug
+
+When running Tier 2 (deferred hydration) in **live mode** (real LLM calls), the parent workflow `WfPipeRouter` fails to decode the child workflow `WfMakeObject`'s return value:
+
+```
+KajsonDecoderError: Class 'DynamicConceptTestGreeting' not found in module 'builtins' or global registry
+```
+
+Dry-run passes because mock data never triggers the real structured output path.
+
+## How to reproduce
+
+```bash
+# Start Temporal server + worker, then:
+.venv/bin/pipelex run bundle \
+  tests/integration/pipelex/temporal/library_crate/dynamic_concept_sequence.mthds \
+  --pipe dynamic_greeting_sequence \
+  --temporal --no-logo --graph
+```
+
+## Execution flow where it breaks
+
+```
+WfPipeRouter (parent workflow)
+  → set_current_library(wf_library_id)  # sets ContextVar
+  → load_from_crate()                   # registers DynamicConceptTestGreeting in workflow-scoped registry
+  → PipeSequence.run_pipe()
+    → PipeLLM (generate_greeting)
+      → ContentGeneratorChild.make_object_direct()
+        → WfMakeObject (child workflow)
+          → act_llm_gen_object (activity)
+            → model_class_from_json_schema() creates class via exec()
+            → LLM generates structured Greeting instance
+            → Activity returns Greeting (BaseModel subclass)
+          → WfMakeObject returns Greeting to parent
+        → Temporal calls _convert_payloads to decode child result  ← FAILS HERE
+```
+
+## What we verified with diagnostic logs
+
+1. **`to_payload` is NOT called for the Greeting activity return.** Only called for `ObjectAssignment` (activity input). The Greeting is serialized by Temporal's default JSON converter, NOT our `BaseModelPayloadConverter`. Therefore no `kajson_class_source` metadata is attached.
+
+2. **`from_payload` IS called for the child workflow result.** The payload data is:
+   ```json
+   {"message": "Bonjour le monde", "language": "French", "__class__": "DynamicConceptTestGreeting", "__module__": "builtins"}
+   ```
+   With `class_source_code: None` (no metadata).
+
+3. **The ContextVar is NOT propagated into `_convert_payloads`.** Temporal's internal `_apply_resolve_child_workflow_execution` → `_convert_payloads` runs outside the workflow coroutine's async context. So `get_class_registry()` falls back to the global KajsonManager registry, which doesn't have the dynamic class.
+
+## Two independent problems
+
+**Problem A: `to_payload` not called for activity results.**
+The Greeting returned by `act_llm_gen_object` never passes through our `BaseModelPayloadConverter.to_payload()`. Reason unknown — possibly Temporal SDK uses a different serialization path for activity return values, or the exec'd class isn't recognized as `BaseModel` by the converter's `isinstance` check.
+
+**Problem B: ContextVar not available in `_convert_payloads`.**
+Even if `to_payload` worked and attached `kajson_class_source` metadata, the parent workflow's `_convert_payloads` runs in a Temporal-internal context where the `_library_id` ContextVar is not set. So `get_class_registry()` returns the global registry, not the workflow-scoped one.
+
+## What was fixed so far (kajson repo)
+
+**Decoder fallback** in `kajson/json_decoder.py`: When `sys.modules[module_name]` exists but `getattr` fails (the `builtins` case), the decoder now falls through to check `KajsonManager.get_class_registry()` before raising. Previously it raised immediately. This fix is correct but insufficient alone — the class isn't in the global registry either.
+
+Test: `kajson/tests/unit/test_global_registry_fallback.py` — passes.
+
+## What was NOT fixed
+
+The `_collect_class_sources` helper added to `temporal_data_converter.py` is irrelevant since `to_payload` isn't called for the Greeting. The debug logs added should be removed.

--- a/wip/tier2-live-registry-propagation.md
+++ b/wip/tier2-live-registry-propagation.md
@@ -1,0 +1,123 @@
+# Tier 2 Live: ContextVar Registry Doesn't Cross Temporal Boundaries
+
+**Status:** Open — needs architectural decision
+**Branch:** `fix/Temporal-Img`
+**Date:** 2026-04-01
+
+## What works
+
+- Tier 2 **dry-run** passes (no real LLM calls, `ObjectAssignment` never hits the structured output path)
+- Tiers 1, 3, 4, 5 pass in both dry-run and live mode
+- The `ObjectAssignment.__init__` deserialization fix (removing the eager class registry check) is correct and already applied on this branch
+
+## What fails
+
+Tier 2 **live** — `dynamic_concept_sequence.mthds` with `--pipe dynamic_greeting_sequence` through Temporal.
+
+The bundle defines a dynamic concept `Greeting` (with `message` and `language` fields) and a `PipeLLM` that outputs structured data into that concept using `structuring_method = "direct"`.
+
+## Error
+
+```
+Class 'dynamic_concept_test__Greeting' not found in registry
+```
+
+Thrown from `llm_generate.py:32`:
+```python
+content_class = get_class_registry().get_required_base_model(name=content_class_name)
+```
+
+## Root cause
+
+`get_class_registry()` uses a `ContextVar` (`_library_id` in `hub.py:462`) to resolve the workflow-scoped registry. But ContextVars don't propagate across Temporal's execution boundaries:
+
+```
+WfPipeRouter (ContextVar set here via set_current_library)
+  → pipe.run_pipe()
+    → ContentGeneratorChild.make_object_direct()
+      → child workflow WfMakeObject (NEW async context — ContextVar is None)
+        → activity act_llm_gen_object (ANOTHER context — ContextVar is None)
+          → llm_gen_object()
+            → get_class_registry() → returns GLOBAL registry → class not found
+```
+
+The dynamic concept class `dynamic_concept_test__Greeting` was registered in `WfPipeRouter`'s **workflow-scoped** `ClassRegistry`. But two hops later — inside the activity of a child workflow — `get_class_registry()` returns the **global** registry, which doesn't have it.
+
+## Why dry-run works
+
+In dry-run mode, `PipeLLM` never reaches `ContentGeneratorChild.make_object_direct()` — the dry-run path generates mock output without calling the LLM, so it never needs to look up the dynamic class from the registry inside an activity.
+
+## Why other tiers aren't affected
+
+- **Tier 1** (native text sequence): Uses `PipeLLM` with `Text` output (a native concept, always in the global registry). No structured output, no `ObjectAssignment`.
+- **Tier 3** (parallel): Same — text-only pipes, no dynamic concepts in structured output position.
+- **Tiers 4-5** (image): Image generation doesn't go through `ObjectAssignment` or `llm_gen_object`. Images use `ImgGenAssignment` → `act_img_gen` which doesn't need the class registry.
+
+## Fix already applied on this branch
+
+Removed `ObjectAssignment.__init__` class registry validation (`assignment_models.py:90-94`). This was causing a **separate** deserialization failure: when Temporal's data converter called `kajson.loads()` to deserialize the `ObjectAssignment` argument for `WfMakeObject`, pydantic called `__init__` which checked the registry. Removing it fixed the deserialization, but the same lookup fails later in the activity.
+
+## Approach options
+
+### A) Embed the class schema in ObjectAssignment
+
+Add the Pydantic model's JSON schema (or the field definitions) as a field on `ObjectAssignment`. The activity reconstructs the class locally from the schema without needing the registry. This is the "carry everything you need" pattern, similar to how `LibraryCrate` carries pipe definitions.
+
+**Pros:** Self-contained, no cross-boundary coupling, works for any Temporal topology.
+**Cons:** Increases payload size, needs a "reconstruct Pydantic class from schema" utility.
+
+### B) Propagate library_id through Temporal headers
+
+Use Temporal's workflow/activity interceptors to copy the `_library_id` ContextVar into Temporal headers on dispatch, and restore it on the receiving end. This is the transparent approach.
+
+**Pros:** No changes to assignment models, ContextVar "just works" across boundaries.
+**Cons:** Requires Temporal interceptor infrastructure, the receiving side still needs access to the same `LibraryManager` state (child workflows and activities must be on the same worker).
+
+### C) Pre-register dynamic classes in the global registry
+
+When `WfPipeRouter.load_from_crate()` runs, also register dynamic classes in the global registry (not just the workflow-scoped one). Clean up on workflow teardown.
+
+**Pros:** Simplest change, everything finds the class.
+**Cons:** Breaks per-workflow isolation — concurrent workflows with conflicting class names will clobber each other (exactly the bug the scoped registry was designed to prevent).
+
+### D) WfMakeObject loads the crate itself
+
+Pass the `LibraryCrate` to `WfMakeObject` alongside the `ObjectAssignment`. The child workflow sets up its own scoped registry before the activity runs.
+
+**Pros:** Reuses existing crate-loading pattern from `WfPipeRouter`.
+**Cons:** Increases child workflow payload, adds setup/teardown overhead to every structured output call.
+
+## Key files
+
+| File | Role |
+|------|------|
+| `pipelex/hub.py:381-386, 462-467` | `get_class_registry()` and `_library_id` ContextVar |
+| `pipelex/temporal/tprl_pipe/wf_pipe_router.py:46-68` | Crate loading and registry setup |
+| `pipelex/temporal/tprl_content_generation/wf_make_object.py` | Child workflow receiving `ObjectAssignment` |
+| `pipelex/cogt/content_generation/llm_generate.py:32` | Activity calling `get_class_registry()` |
+| `pipelex/cogt/content_generation/assignment_models.py:86` | `ObjectAssignment` model (init check removed) |
+| `pipelex/temporal/temporal_data_converter.py:77` | Kajson deserialization using `get_class_registry()` |
+| `tests/integration/pipelex/temporal/library_crate/dynamic_concept_sequence.mthds` | Test bundle |
+
+## Reproduction
+
+```bash
+# Start Temporal server + worker
+tmux new-session -d -s temporal-server 'temporal server start-dev'
+sleep 3
+tmux new-session -d -c "$PWD" -s temporal-worker \
+  '.venv/bin/python -m pipelex.temporal.worker_cli --is-not-sandboxed'
+sleep 4
+
+# This passes (dry-run)
+.venv/bin/pipelex run bundle \
+  tests/integration/pipelex/temporal/library_crate/dynamic_concept_sequence.mthds \
+  --pipe dynamic_greeting_sequence \
+  --temporal --dry-run --mock-inputs --no-logo
+
+# This fails (live)
+.venv/bin/pipelex run bundle \
+  tests/integration/pipelex/temporal/library_crate/dynamic_concept_sequence.mthds \
+  --pipe dynamic_greeting_sequence \
+  --temporal --no-logo
+```


### PR DESCRIPTION
## Summary
- Add new "Under the Hood" documentation page covering the two serialization challenges in Temporal distributed execution: dynamic class propagation (JSON schema embedding, source code injection, type bridging) and large payload management (store-then-reference pattern)
- Upgrade kajson from 0.4.0 (editable local dep) to 0.4.1 (PyPI release), removing the `[tool.uv.sources]` override

## Test plan
- [ ] Verify `uv sync` resolves kajson 0.4.1 from PyPI
- [ ] Verify docs build with `mkdocs build` — new page renders correctly
- [ ] Check Mermaid diagram renders in the distributed content generation page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds schema-based dynamic model propagation and activity-level storage to make distributed content generation reliable in Temporal. Fixes live deferred hydration by preserving dynamic class source across payloads, upgrades `kajson` to 0.4.2, and ships new “Distributed Content Generation” docs.

- **New Features**
  - Structured LLM outputs now use JSON Schema propagation: assignments include `object_class_schema`, `schema_to_model` rebuilds classes on the worker, payloads embed class source via `kajson` for cross-process deserialization; results validate back into the caller’s original type.
  - Large binaries are stored inside activities and only URIs cross Temporal: image generation, PDF rendering, and extraction return `ImageContent`/`PageContent` with URLs; adds `wf_render_page_views` and updates `wf_make_images`/`wf_make_extract`.
  - Reliability hardening: concurrency-safe schema cache, no reliance on internal `datamodel-code-generator` APIs, and the Temporal payload converter now preserves and re-attaches class source to fix Tier 2 live deferred hydration.

- **Migration**
  - Update callers to expect `list[ImageContent]`/`list[PageContent]` (no inline base64) from image and extraction workflows/activities.
  - If you instantiate `ObjectAssignment` or `TextThenObjectAssignment` directly, pass `object_class_schema = MyModel.model_json_schema()`.
  - Run `uv sync` to install `kajson` `0.4.2` and add `datamodel-code-generator`.

<sup>Written for commit 0c9d61ade7814e20ad450698827dc595567425d9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

