### PR TITLE
Release v0.23.3

### DIFF
--- a/.badges/tests.json
+++ b/.badges/tests.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "label": "tests",
-  "message": "4044",
+  "message": "4046",
   "color": "blue",
   "cacheSeconds": 300
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [v0.23.3] - 2026-04-02
+
+### Changed
+
+- **Pipe spec output aliases**: `parse_pipe_spec` now accepts `output_concept` and `output_type` as aliases for the `output` field, with smart fallback when both alias and canonical field are present.
+
+### Fixed
+
+- **Gateway terms check**: Terms acceptance is now only required for inference operations, not for read-only operations like model spec fetching during validation.
+
 ## [v0.23.2] - 2026-03-30
 
 ### Changed

--- a/pipelex/builder/operations/pipe_ops.py
+++ b/pipelex/builder/operations/pipe_ops.py
@@ -8,6 +8,7 @@
 from typing import Any
 
 import tomlkit
+from pydantic import ValidationError
 from tomlkit.items import Table
 
 from pipelex import log
@@ -26,6 +27,9 @@ from pipelex.builder.pipe.pipe_spec_map import pipe_type_to_spec_class
 
 # Aliases that agents may use instead of "pipe_code". First found is promoted when canonical key is absent; extras are dropped.
 _PIPE_CODE_ALIASES = ("pipe", "the_pipe_code", "code", "name", "pipe_name", "pipe_ref")
+
+# Aliases that agents may use instead of "output".
+_OUTPUT_ALIASES = ("output_concept", "output_type")
 
 
 def _normalize_sub_pipe_dict(data: dict[str, Any]) -> None:
@@ -106,6 +110,20 @@ def parse_pipe_spec(pipe_type: str, spec_data: dict[str, Any]) -> PipeSpec:
         else:
             spec_data.pop("expression")
 
+    # Accept output aliases (e.g. "output_concept", "output_type") → promote to "output".
+    # When both "output" and an alias coexist, try the alias value first (agents often put
+    # the correct concept name in the alias), falling back to the original "output" value.
+    output_fallback: Any | None = None
+    for alias in _OUTPUT_ALIASES:
+        if alias in spec_data:
+            alias_value = spec_data.pop(alias)
+            if "output" not in spec_data:
+                spec_data["output"] = alias_value
+            else:
+                output_fallback = spec_data["output"]
+                spec_data["output"] = alias_value
+            break
+
     # Accept output as dict → extract the concept string
     # Agents sometimes structure the output like inputs (as a dict).
     # Handle {"type": "ConceptName"} and single-item dicts like {"result": "Text"}.
@@ -116,6 +134,13 @@ def parse_pipe_spec(pipe_type: str, spec_data: dict[str, Any]) -> PipeSpec:
         elif len(output_dict) == 1:
             spec_data["output"] = next(iter(output_dict.values()))
 
+    # When an output alias conflicted with an existing "output", try the alias value first
+    # and fall back to the original value if validation fails.
+    if output_fallback is not None:
+        try:
+            return spec_class.model_validate(spec_data)
+        except ValidationError:
+            spec_data["output"] = output_fallback
     return spec_class.model_validate(spec_data)
 
 

--- a/pipelex/pipelex.py
+++ b/pipelex/pipelex.py
@@ -198,8 +198,10 @@ If you need help, drop by our Discord: we're happy to assist: {URLs.discord}.
                 gateway_model_specs = remote_config.backend_model_specs
                 log.verbose("Using dummy remote config (inference not needed)")
             else:
-                # Skip terms check for CI mode - automated CI/CD pipelines don't require human consent
-                if integration_mode.requires_terms_acceptance:
+                # Terms acceptance is only required for actual inference usage, not for
+                # read-only operations like fetching model specs for validation.
+                # Also skip for CI mode — automated pipelines don't require human consent.
+                if needs_inference and integration_mode.requires_terms_acceptance:
                     # Check if terms are accepted
                     pipelex_service_config = load_pipelex_service_config_if_exists(config_dir=config_manager.global_config_dir)
                     if pipelex_service_config is None or not pipelex_service_config.agreement.terms_accepted:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pipelex"
-version = "0.23.2"
+version = "0.23.3"
 description = "Execute composable AI methods declared in the MTHDS open standard"
 authors = [{ name = "Evotis S.A.S.", email = "oss@pipelex.com" }]
 maintainers = [{ name = "Pipelex staff", email = "oss@pipelex.com" }]

--- a/tests/unit/pipelex/system/pipelex_service/test_gateway_terms_check.py
+++ b/tests/unit/pipelex/system/pipelex_service/test_gateway_terms_check.py
@@ -1,0 +1,76 @@
+"""Regression test: gateway terms check must be gated on needs_inference, not needs_model_specs.
+
+Commands like ``pipelex-agent validate bundle`` use ``needs_inference=False, needs_model_specs=True``
+to load model specs for validation without actually calling inference APIs. These commands must
+NOT require gateway terms acceptance.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from pipelex.pipelex import Pipelex
+from pipelex.system.pipelex_service.exceptions import GatewayTermsNotAcceptedError
+from pipelex.system.runtime import IntegrationMode
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+PIPELEX_MODULE = "pipelex.pipelex"
+
+
+class TestGatewayTermsCheck:
+    """Verify that the terms check in Pipelex.setup() respects needs_inference."""
+
+    @pytest.fixture
+    def _gateway_enabled_terms_not_accepted(self, mocker: MockerFixture) -> None:
+        """Configure mocks: gateway is enabled but terms have NOT been accepted."""
+        mocker.patch(f"{PIPELEX_MODULE}.is_pipelex_gateway_enabled", return_value=True)
+        mocker.patch(f"{PIPELEX_MODULE}.load_pipelex_service_config_if_exists", return_value=None)
+
+    @pytest.mark.usefixtures("_gateway_enabled_terms_not_accepted")
+    def test_needs_inference_true_raises_when_terms_not_accepted(
+        self,
+    ) -> None:
+        """With needs_inference=True and terms not accepted, setup must raise GatewayTermsNotAcceptedError."""
+        pipelex_instance = Pipelex.__new__(Pipelex)
+
+        with pytest.raises(GatewayTermsNotAcceptedError):
+            pipelex_instance.setup(
+                integration_mode=IntegrationMode.CLI,
+                needs_inference=True,
+                needs_model_specs=True,
+            )
+
+    @pytest.mark.usefixtures("_gateway_enabled_terms_not_accepted")
+    def test_needs_inference_false_does_not_raise_when_terms_not_accepted(
+        self,
+        mocker: MockerFixture,
+    ) -> None:
+        """With needs_inference=False and needs_model_specs=True, setup must NOT raise GatewayTermsNotAcceptedError.
+
+        It may fail later (e.g., during remote config fetch), but the terms check itself must be skipped.
+        """
+        # Mock the remote config fetch so we don't hit the network
+        mock_remote_config = mocker.MagicMock()
+        mock_remote_config.backend_model_specs = {}
+        mocker.patch(f"{PIPELEX_MODULE}.RemoteConfigFetcher.fetch_remote_config", return_value=mock_remote_config)
+
+        pipelex_instance = Pipelex.__new__(Pipelex)
+
+        # setup() will fail somewhere after the gateway check (telemetry, models, etc.)
+        # but it must NOT fail with GatewayTermsNotAcceptedError
+        try:
+            pipelex_instance.setup(
+                integration_mode=IntegrationMode.CLI,
+                needs_inference=False,
+                needs_model_specs=True,
+            )
+        except GatewayTermsNotAcceptedError:
+            pytest.fail("setup() raised GatewayTermsNotAcceptedError even though needs_inference=False")
+        except Exception:  # noqa: S110
+            # Expected: setup() will fail later in the init chain (telemetry, models, etc.)
+            # We only care that it did NOT fail with GatewayTermsNotAcceptedError
+            pass

--- a/uv.lock
+++ b/uv.lock
@@ -3449,7 +3449,7 @@ wheels = [
 
 [[package]]
 name = "pipelex"
-version = "0.23.2"
+version = "0.23.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Release v0.23.3

Bumps version from `0.23.2` to `0.23.3`.

### Changelog

### Changed

- **Pipe spec output aliases**: `parse_pipe_spec` now accepts `output_concept` and `output_type` as aliases for the `output` field, with smart fallback when both alias and canonical field are present.

### Fixed

- **Gateway terms check**: Terms acceptance is now only required for inference operations, not for read-only operations like model spec fetching during validation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v0.23.3 adds `parse_pipe_spec` support for output aliases and restricts gateway terms acceptance to inference-only operations to avoid blocking read-only validation.

- **New Features**
  - `parse_pipe_spec` accepts `output_concept` and `output_type` as aliases for `output`, with smart fallback if both are present.

- **Bug Fixes**
  - Gateway terms check runs only when `needs_inference=True`; read-only flows like model spec validation no longer require terms.

<sup>Written for commit 9827273b4e2e33cc5491867d46280ac634dc5e36. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

