### PR TITLE
Release v0.23.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v0.23.4] - 2026-04-02
+
+### Changed
+
+- **Pipe spec output alias**: Removed `output_type` alias from `parse_pipe_spec`, keeping only `output_concept` as the single alias for the `output` field. Simplified the alias resolution logic accordingly.
+
 ## [v0.23.3] - 2026-04-02
 
 ### Changed

--- a/pipelex/builder/operations/pipe_ops.py
+++ b/pipelex/builder/operations/pipe_ops.py
@@ -28,8 +28,8 @@ from pipelex.builder.pipe.pipe_spec_map import pipe_type_to_spec_class
 # Aliases that agents may use instead of "pipe_code". First found is promoted when canonical key is absent; extras are dropped.
 _PIPE_CODE_ALIASES = ("pipe", "the_pipe_code", "code", "name", "pipe_name", "pipe_ref")
 
-# Aliases that agents may use instead of "output".
-_OUTPUT_ALIASES = ("output_concept", "output_type")
+# Alias that agents may use instead of "output".
+_OUTPUT_ALIAS = "output_concept"
 
 
 def _normalize_sub_pipe_dict(data: dict[str, Any]) -> None:
@@ -110,19 +110,17 @@ def parse_pipe_spec(pipe_type: str, spec_data: dict[str, Any]) -> PipeSpec:
         else:
             spec_data.pop("expression")
 
-    # Accept output aliases (e.g. "output_concept", "output_type") → promote to "output".
-    # When both "output" and an alias coexist, try the alias value first (agents often put
+    # Accept "output_concept" as an alias for "output".
+    # When both "output" and the alias coexist, try the alias value first (agents often put
     # the correct concept name in the alias), falling back to the original "output" value.
     output_fallback: Any | None = None
-    for alias in _OUTPUT_ALIASES:
-        if alias in spec_data:
-            alias_value = spec_data.pop(alias)
-            if "output" not in spec_data:
-                spec_data["output"] = alias_value
-            else:
-                output_fallback = spec_data["output"]
-                spec_data["output"] = alias_value
-            break
+    if _OUTPUT_ALIAS in spec_data:
+        alias_value = spec_data.pop(_OUTPUT_ALIAS)
+        if "output" not in spec_data:
+            spec_data["output"] = alias_value
+        else:
+            output_fallback = spec_data["output"]
+            spec_data["output"] = alias_value
 
     # Accept output as dict → extract the concept string
     # Agents sometimes structure the output like inputs (as a dict).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pipelex"
-version = "0.23.3"
+version = "0.23.4"
 description = "Execute composable AI methods declared in the MTHDS open standard"
 authors = [{ name = "Evotis S.A.S.", email = "oss@pipelex.com" }]
 maintainers = [{ name = "Pipelex staff", email = "oss@pipelex.com" }]

--- a/uv.lock
+++ b/uv.lock
@@ -3449,7 +3449,7 @@ wheels = [
 
 [[package]]
 name = "pipelex"
-version = "0.23.3"
+version = "0.23.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Release v0.23.4

Bumps version from `0.23.3` to `0.23.4`.

### Changelog

### Changed

- **Pipe spec output alias**: Removed `output_type` alias from `parse_pipe_spec`, keeping only `output_concept` as the single alias for the `output` field. Simplified the alias resolution logic accordingly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplifies pipe spec parsing by removing the `output_type` alias; only `output_concept` is accepted for `output`. Bumps `pipelex` to v0.23.4 and updates `uv.lock`.

- **Migration**
  - Replace any `output_type` usage with `output_concept` (or set `output` directly).

<sup>Written for commit 22a8ed8a606f98f3fa4b6ed64afe5086b687993d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

