### PR TITLE
Restore flat StorageConfig using inheritance

### DIFF
--- a/.pipelex/pipelex.toml
+++ b/.pipelex/pipelex.toml
@@ -79,28 +79,26 @@ traces_dir = ".pipelex/traces"
 is_fetch_remote_content_enabled = true
 # Whether to upload local file paths to storage and replace with pipelex-storage:// URIs
 is_upload_local_content_enabled = true
-
-[pipelex.storage_config.storage_provider_config]
 # Storage method: "local", "in_memory", "s3", or "gcp"
 method = "local"
 
-[pipelex.storage_config.storage_provider_config.local]
+[pipelex.storage_config.local]
 # Local storage settings
 uri_format = "{primary_id}/{secondary_id}/{hash}.{extension}"
 local_storage_path = ".pipelex/storage"
 
-[pipelex.storage_config.storage_provider_config.in_memory]
+[pipelex.storage_config.in_memory]
 # In-memory storage settings
 uri_format = "{primary_id}/{secondary_id}/{hash}.{extension}"
 
-[pipelex.storage_config.storage_provider_config.s3]
+[pipelex.storage_config.s3]
 # AWS S3 storage settings (requires boto3: `uv pip install "pipelex[s3]"`)
 uri_format = "{primary_id}/{secondary_id}/{hash}.{extension}"
 bucket_name = ""
 region = ""
 signed_urls_lifespan_seconds = 3600                           # Set to "disabled" for public URLs
 
-[pipelex.storage_config.storage_provider_config.gcp]
+[pipelex.storage_config.gcp]
 # Google Cloud Storage settings (requires google-cloud-storage: `uv pip install "pipelex[gcp-storage]"`)
 uri_format = "{primary_id}/{secondary_id}/{hash}.{extension}"
 bucket_name = ""

--- a/pipelex/kit/configs/pipelex.toml
+++ b/pipelex/kit/configs/pipelex.toml
@@ -79,28 +79,26 @@ traces_dir = ".pipelex/traces"
 is_fetch_remote_content_enabled = true
 # Whether to upload local file paths to storage and replace with pipelex-storage:// URIs
 is_upload_local_content_enabled = true
-
-[pipelex.storage_config.storage_provider_config]
 # Storage method: "local", "in_memory", "s3", or "gcp"
 method = "local"
 
-[pipelex.storage_config.storage_provider_config.local]
+[pipelex.storage_config.local]
 # Local storage settings
 uri_format = "{primary_id}/{secondary_id}/{hash}.{extension}"
 local_storage_path = ".pipelex/storage"
 
-[pipelex.storage_config.storage_provider_config.in_memory]
+[pipelex.storage_config.in_memory]
 # In-memory storage settings
 uri_format = "{primary_id}/{secondary_id}/{hash}.{extension}"
 
-[pipelex.storage_config.storage_provider_config.s3]
+[pipelex.storage_config.s3]
 # AWS S3 storage settings (requires boto3: `uv pip install "pipelex[s3]"`)
 uri_format = "{primary_id}/{secondary_id}/{hash}.{extension}"
 bucket_name = ""
 region = ""
 signed_urls_lifespan_seconds = 3600                           # Set to "disabled" for public URLs
 
-[pipelex.storage_config.storage_provider_config.gcp]
+[pipelex.storage_config.gcp]
 # Google Cloud Storage settings (requires google-cloud-storage: `uv pip install "pipelex[gcp-storage]"`)
 uri_format = "{primary_id}/{secondary_id}/{hash}.{extension}"
 bucket_name = ""

--- a/pipelex/pipelex.py
+++ b/pipelex/pipelex.py
@@ -245,7 +245,7 @@ If you need help, drop by our Discord: we're happy to assist: {URLs.discord}.
         self.pipelex_hub.set_secrets_provider(secrets_provider=secrets_provider)
         if storage_provider is None:
             storage_config = get_config().pipelex.storage_config
-            storage_provider = make_storage_provider_from_config(storage_config.storage_provider_config)
+            storage_provider = make_storage_provider_from_config(storage_config)
         self.pipelex_hub.set_storage_provider(storage_provider)
 
         # Register stuff templates first (used by mermaid, reactflow, and stuff_viewer)

--- a/pipelex/pipelex.toml
+++ b/pipelex/pipelex.toml
@@ -5,24 +5,22 @@
 [pipelex.storage_config]
 is_fetch_remote_content_enabled = true
 is_upload_local_content_enabled = true
+method = "local"                       # local, in_memory, s3, gcp
 
-[pipelex.storage_config.storage_provider_config]
-method = "local" # local, in_memory, s3, gcp
-
-[pipelex.storage_config.storage_provider_config.local]
+[pipelex.storage_config.local]
 uri_format = "{primary_id}/{secondary_id}/{hash}.{extension}"
 local_storage_path = ".pipelex/storage"
 
-[pipelex.storage_config.storage_provider_config.in_memory]
+[pipelex.storage_config.in_memory]
 uri_format = "{primary_id}/{secondary_id}/{hash}.{extension}"
 
-[pipelex.storage_config.storage_provider_config.s3]
+[pipelex.storage_config.s3]
 uri_format = "{primary_id}/{secondary_id}/{hash}.{extension}"
 bucket_name = ""
 region = ""
 signed_urls_lifespan_seconds = 3600
 
-[pipelex.storage_config.storage_provider_config.gcp]
+[pipelex.storage_config.gcp]
 uri_format = "{primary_id}/{secondary_id}/{hash}.{extension}"
 bucket_name = ""
 project_id = ""

--- a/pipelex/system/configuration/configs.py
+++ b/pipelex/system/configuration/configs.py
@@ -12,7 +12,7 @@ from pipelex.system.configuration.config_root import ConfigRoot
 from pipelex.temporal.config_temporal import Temporal
 from pipelex.tools.aws.aws_config import AwsConfig
 from pipelex.tools.log.log_config import LogConfig
-from pipelex.tools.storage.storage_config import AssetStorageConfig
+from pipelex.tools.storage.storage_config import StorageConfig
 from pipelex.types import Self, StrEnum
 
 
@@ -161,7 +161,7 @@ class PipelineExecutionConfig(ConfigModel):
 
 
 class Pipelex(ConfigModel):
-    storage_config: AssetStorageConfig
+    storage_config: StorageConfig
     feature_config: FeatureConfig
     log_config: LogConfig
     aws_config: AwsConfig

--- a/pipelex/tools/storage/storage_config.py
+++ b/pipelex/tools/storage/storage_config.py
@@ -161,37 +161,6 @@ class StorageProviderConfig(ConfigModel):
                 return self.gcp.uri_format
 
 
-class AssetStorageConfig(ConfigModel):
-    """Storage config for asset content (images, documents, etc.)."""
-
+class StorageConfig(StorageProviderConfig):
     is_fetch_remote_content_enabled: bool
     is_upload_local_content_enabled: bool
-    storage_provider_config: StorageProviderConfig
-
-    @property
-    def method(self) -> StorageMethod:
-        return self.storage_provider_config.method
-
-    @property
-    def local(self) -> StorageLocalConfig | None:
-        return self.storage_provider_config.local
-
-    @property
-    def in_memory(self) -> StorageInMemoryConfig | None:
-        return self.storage_provider_config.in_memory
-
-    @property
-    def s3(self) -> StorageS3Config | None:
-        return self.storage_provider_config.s3
-
-    @property
-    def gcp(self) -> StorageGcpConfig | None:
-        return self.storage_provider_config.gcp
-
-    @property
-    def storage_path(self) -> str:
-        return self.storage_provider_config.storage_path
-
-    @property
-    def uri_format(self) -> str:
-        return self.storage_provider_config.uri_format

--- a/tests/integration/pipelex/fixtures/generator_fixtures.py
+++ b/tests/integration/pipelex/fixtures/generator_fixtures.py
@@ -20,7 +20,7 @@ def generated_content_factory(tmp_path: Path) -> GeneratedContentFactory:
 
     Applies test overrides for bucket names and signed URL lifespans.
     """
-    storage_provider_config = get_config().pipelex.storage_config.storage_provider_config
+    storage_provider_config = get_config().pipelex.storage_config
     match storage_provider_config.method:
         case StorageMethod.S3:
             assert storage_provider_config.s3 is not None

--- a/tests/pipelex_unit_test.toml
+++ b/tests/pipelex_unit_test.toml
@@ -1,5 +1,5 @@
 
-[pipelex.storage_config.storage_provider_config]
+[pipelex.storage_config]
 method = "local"
 
 [cogt.model_deck_config]


### PR DESCRIPTION
## Summary
- Restores the original flat `[pipelex.storage_config]` TOML shape by making `StorageConfig` inherit from `StorageProviderConfig` instead of wrapping it via composition (`AssetStorageConfig`)
- Removes the unnecessary `storage_provider_config` nesting level from all TOML config files
- `PayloadCodecConfig` continues to use `StorageProviderConfig` directly — no changes to the Temporal payload codec config

## Test plan
- [x] `make tb` — boot test passes (config loading validates correctly)
- [x] `make agent-check` — 0 errors across ruff, pyright, mypy
- [x] `make agent-test` — full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the flat [pipelex.storage_config] TOML shape by making StorageConfig inherit from StorageProviderConfig. Removes the storage_provider_config nesting and updates call sites; no changes to the Temporal payload codec config.

- **Refactors**
  - Replaced AssetStorageConfig with inheritance: StorageConfig now extends StorageProviderConfig.
  - Flattened TOML: provider sections now live under [pipelex.storage_config.*] with method at [pipelex.storage_config].

- **Migration**
  - If you used the nested shape, rename [pipelex.storage_config.storage_provider_config] to [pipelex.storage_config] and move provider blocks accordingly.
  - Update code from storage_config.storage_provider_config to storage_config.

<sup>Written for commit abd0a555a3ee5a2736a4ddbb33126ab61ed46717. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

