### PR TITLE
Release v0.23.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v0.23.6] - 2026-04-06
+
+### Changed
+
+- **Sub-pipe input normalization**: Silently drop unsupported `inputs` field from step/branch dicts instead of logging a warning.
+
 ## [v0.23.5] - 2026-04-04
 
 ### Added

--- a/pipelex/builder/operations/pipe_ops.py
+++ b/pipelex/builder/operations/pipe_ops.py
@@ -11,7 +11,6 @@ import tomlkit
 from pydantic import ValidationError
 from tomlkit.items import Table
 
-from pipelex import log
 from pipelex.builder.pipe.pipe_batch_spec import PipeBatchSpec
 from pipelex.builder.pipe.pipe_compose_spec import PipeComposeSpec
 from pipelex.builder.pipe.pipe_condition_spec import PipeConditionSpec
@@ -35,14 +34,9 @@ _OUTPUT_ALIASES = ("output_concept", "output_type")
 def _normalize_sub_pipe_dict(data: dict[str, Any]) -> None:
     """Normalize a step/branch dict: resolve pipe_code aliases and drop extraneous fields."""
     _normalize_pipe_code_aliases(data)
-    # Agents sometimes add "inputs" to individual steps; drop with a warning.
-    if "inputs" in data:
-        log.warning(
-            f"Dropping unsupported 'inputs' field from step/branch dict "
-            f"(pipe_code={data.get('pipe_code', '?')}). "
-            f"Step-level inputs are not supported; inputs are inherited from the parent pipe."
-        )
-        data.pop("inputs")
+    # Agents sometimes add "inputs" to individual steps — silently drop.
+    # Step-level inputs are not supported; inputs set by the pipe definition.
+    data.pop("inputs", None)
 
 
 def _normalize_pipe_code_aliases(data: dict[str, Any]) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pipelex"
-version = "0.23.5"
+version = "0.23.6"
 description = "Execute composable AI methods declared in the MTHDS open standard"
 authors = [{ name = "Evotis S.A.S.", email = "oss@pipelex.com" }]
 maintainers = [{ name = "Pipelex staff", email = "oss@pipelex.com" }]

--- a/uv.lock
+++ b/uv.lock
@@ -3502,7 +3502,7 @@ wheels = [
 
 [[package]]
 name = "pipelex"
-version = "0.23.5"
+version = "0.23.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Release v0.23.6

Bumps version from `0.23.5` to `0.23.6`.

### Changelog

### Changed

- **Sub-pipe input normalization**: Silently drop unsupported `inputs` field from step/branch dicts instead of logging a warning.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v0.23.6: sub-pipe normalization now silently drops unsupported step-level `inputs` fields instead of logging a warning. This reduces log noise and keeps inputs inherited from the parent pipe.

<sup>Written for commit bcabaa30dcfeb2261ef9b574f86d2ba042b5a59c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

