### PR TITLE
fix/README-install-message

### DIFF
--- a/.pipelex/inference/backends/pipelex_gateway_models.md
+++ b/.pipelex/inference/backends/pipelex_gateway_models.md
@@ -77,6 +77,14 @@ For configuration details, see the [documentation](https://docs.pipelex.com/late
 <td style="text-align:center;background-color:rgba(76,175,80,0.15)">✅</td>
 </tr>
 <tr>
+<td>claude-4.6-sonnet</td>
+<td style="text-align:center;background-color:rgba(33,150,243,0.15)">✅</td>
+<td style="text-align:center;background-color:rgba(33,150,243,0.15)">✅</td>
+<td style="text-align:center;background-color:rgba(33,150,243,0.15)">✅</td>
+<td style="text-align:center;background-color:rgba(76,175,80,0.15)">✅</td>
+<td style="text-align:center;background-color:rgba(76,175,80,0.15)">✅</td>
+</tr>
+<tr>
 <td>deepseek-v3.2</td>
 <td style="text-align:center;background-color:rgba(33,150,243,0.15)">✅</td>
 <td style="text-align:center;background-color:rgba(33,150,243,0.15)">❌</td>
@@ -528,6 +536,6 @@ For configuration details, see the [documentation](https://docs.pipelex.com/late
 
 
 > **AUTO-GENERATED FILE** - Do not edit manually.
-> Last updated: 2026-04-04T17:05:38Z
+> Last updated: 2026-04-14T09:23:56Z
 >
 > Run `pipelex-dev update-gateway-models` or `make ugm` to regenerate.

--- a/.pipelex/inference/backends/pipelex_gateway_models_plain.md
+++ b/.pipelex/inference/backends/pipelex_gateway_models_plain.md
@@ -28,6 +28,9 @@ For configuration details, see the [documentation](https://docs.pipelex.com/late
 - **claude-4.6-opus**
   - inputs: text, images, pdf
   - outputs: text, structured
+- **claude-4.6-sonnet**
+  - inputs: text, images, pdf
+  - outputs: text, structured
 - **deepseek-v3.2**
   - inputs: text
   - outputs: text, structured
@@ -196,6 +199,6 @@ For configuration details, see the [documentation](https://docs.pipelex.com/late
 
 
 > **AUTO-GENERATED FILE** - Do not edit manually.
-> Last updated: 2026-04-04T17:05:38Z
+> Last updated: 2026-04-14T09:23:56Z
 >
 > Run `pipelex-dev update-gateway-models` or `make ugm` to regenerate.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- **README install instructions**: Replaced step-by-step Claude Code setup with single copy-paste messages for Claude Code and Codex, added manual install section
+
 ## [v0.23.8] - 2026-04-07
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -58,23 +58,12 @@ From here, Pipelex handles model routing across 60+ models, structured output pa
 
 # Quick Start
 
-```bash
-uv tool install pipelex
-pipelex init
-```
-
 ## With Claude Code (Recommended)
 
 Paste this into Claude Code:
 
 ```
 Install mthds: run bash -c 'npm install -g mthds && mthds-agent bootstrap && claude plugin marketplace add mthds-ai/mthds-plugins && claude plugin install mthds@mthds-plugins'. Then tell me to restart Claude Code.
-```
-
-Then build your first method:
-
-```
-/mthds-build A method to summarize articles with key takeaways for different audiences
 ```
 
 ## With Codex
@@ -85,21 +74,18 @@ Paste this into Codex:
 Install mthds: run bash -c 'npm install -g mthds && mthds-agent bootstrap && bash <(curl -fsSL https://raw.githubusercontent.com/mthds-ai/mthds-plugins/main/bin/install-codex.sh)'. Then tell me to run /plugins, search for MTHDS, and install it.
 ```
 
-## Without an AI Agent
+Install the [VS Code extension](https://go.pipelex.com/vscode) for `.mthds` syntax highlighting and flowchart visualization.
 
-1. Install the [VS Code extension](https://go.pipelex.com/vscode) for `.mthds` syntax highlighting
-2. Install the tools and plugin manually:
-   ```bash
-   npm install -g mthds
-   mthds-agent bootstrap
-   claude plugin marketplace add mthds-ai/mthds-plugins
-   claude plugin install mthds@mthds-plugins
-   ```
-3. Browse methods on the [MTHDS Hub](https://mthds.sh) for inspiration
-4. Author your own `.mthds` methods based on these examples
-5. Validate with `pipelex validate bundle your_method.mthds`
-6. Run them with `pipelex run bundle your_method.mthds`
-7. View the flowchart in VS Code thanks to the extension
+## Manual Install
+
+```bash
+uv tool install pipelex
+pipelex init
+npm install -g mthds
+mthds-agent bootstrap
+```
+
+Install the [VS Code extension](https://go.pipelex.com/vscode) for `.mthds` syntax highlighting and flowchart visualization.
 
 ## Configure AI Access
 

--- a/README.md
+++ b/README.md
@@ -65,62 +65,41 @@ pipelex init
 
 ## With Claude Code (Recommended)
 
-Install the `mthds` npm package:
-
-```bash
-npm install -g mthds
-```
-
-Start Claude Code:
-
-```bash
-claude
-```
-
-Tell Claude to install the MTHDS skills marketplace:
+Paste this into Claude Code:
 
 ```
-/plugin marketplace add mthds-ai/mthds-plugins
+Install mthds: run bash -c 'npm install -g mthds && mthds-agent bootstrap && claude plugin marketplace add mthds-ai/mthds-plugins && claude plugin install mthds@mthds-plugins'. Then tell me to restart Claude Code.
 ```
 
-then install the MTHDS skills plugin:
-
-```
-/plugin install mthds@mthds-plugins
-```
-
-then reload plugins:
-
-```
-/reload-plugins
-```
-
-If that doesn't work, exit Claude Code and reopen it:
-
-```
-/exit
-```
-
-Build your first method:
+Then build your first method:
 
 ```
 /mthds-build A method to summarize articles with key takeaways for different audiences
 ```
 
-Run it:
+## With Codex
+
+Paste this into Codex:
 
 ```
-/mthds-run
+Install mthds: run bash -c 'npm install -g mthds && mthds-agent bootstrap && bash <(curl -fsSL https://raw.githubusercontent.com/mthds-ai/mthds-plugins/main/bin/install-codex.sh)'. Then tell me to run /plugins, search for MTHDS, and install it.
 ```
 
-## Without Claude Code
+## Without an AI Agent
 
 1. Install the [VS Code extension](https://go.pipelex.com/vscode) for `.mthds` syntax highlighting
-2. Browse methods on the [MTHDS Hub](https://mthds.sh) for inspiration
-3. Author your own `.mthds` methods based on these examples
-4. Validate with `pipelex validate bundle your_method.mthds`
-5. Run them with `pipelex run bundle your_method.mthds`
-6. View the flowchart in VS Code thanks to the extension
+2. Install the tools and plugin manually:
+   ```bash
+   npm install -g mthds
+   mthds-agent bootstrap
+   claude plugin marketplace add mthds-ai/mthds-plugins
+   claude plugin install mthds@mthds-plugins
+   ```
+3. Browse methods on the [MTHDS Hub](https://mthds.sh) for inspiration
+4. Author your own `.mthds` methods based on these examples
+5. Validate with `pipelex validate bundle your_method.mthds`
+6. Run them with `pipelex run bundle your_method.mthds`
+7. View the flowchart in VS Code thanks to the extension
 
 ## Configure AI Access
 

--- a/README.md
+++ b/README.md
@@ -76,16 +76,30 @@ Install mthds: run bash -c 'npm install -g mthds && mthds-agent bootstrap && bas
 
 Install the [VS Code extension](https://go.pipelex.com/vscode) for `.mthds` syntax highlighting and flowchart visualization.
 
-## Manual Install
+## From the Terminal
+
+```bash
+npm install -g mthds
+mthds-agent bootstrap
+pipelex init
+```
+
+Install the [VS Code extension](https://go.pipelex.com/vscode) for `.mthds` syntax highlighting and flowchart visualization.
+
+Verify everything is set up correctly:
+
+```bash
+pipelex doctor
+```
+
+## Python Package Only
+
+If you just need the Pipelex runtime without agent integration:
 
 ```bash
 uv tool install pipelex
 pipelex init
-npm install -g mthds
-mthds-agent bootstrap
 ```
-
-Install the [VS Code extension](https://go.pipelex.com/vscode) for `.mthds` syntax highlighting and flowchart visualization.
 
 ## Configure AI Access
 

--- a/pipelex/cli/commands/init/credentials.py
+++ b/pipelex/cli/commands/init/credentials.py
@@ -10,6 +10,7 @@ from rich.markup import escape
 from rich.prompt import Prompt
 
 from pipelex.system.configuration.config_loader import config_manager
+from pipelex.system.pipelex_service.pipelex_details import PipelexDetails
 from pipelex.tools.misc.dict_utils import extract_vars_from_strings_recursive
 from pipelex.tools.misc.file_utils import path_exists
 from pipelex.tools.misc.toml_utils import load_toml_from_path
@@ -135,6 +136,8 @@ def prompt_credentials(console: Console, backends_toml_path: str) -> None:
     collected_count = 0
     for var_name, backend_names in sorted(missing_vars.items()):
         backends_str = ", ".join(backend_names)
+        if var_name == PipelexDetails.PIPELEX_GATEWAY_API_KEY_VAR:
+            console.print("  [dim]Get a free API key at[/dim] [cyan]https://app.pipelex.com[/cyan]")
         value = Prompt.ask(
             f"  [bold]{escape(var_name)}[/bold] [dim](required by {escape(backends_str)})[/dim]", default="", console=console, password=True
         )


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Streamlined the README install flow with single copy‑paste commands for Claude Code and Codex, plus a terminal path and a Python‑only path; added VS Code extension steps and a quick “pipelex doctor” check. Consolidated plugin setup for `mthds`, `mthds-agent`, `claude`, and `mthds-ai/mthds-plugins`, added an API key hint in `pipelex init`, and updated gateway model docs to include `claude-4.6-sonnet`.

<sup>Written for commit 45be95a3fe480c16701562e27c542842479a11c4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

