### PR TITLE
Release v0.23.9

### DIFF
--- a/.pipelex/inference/backends/pipelex_gateway_models.md
+++ b/.pipelex/inference/backends/pipelex_gateway_models.md
@@ -77,6 +77,14 @@ For configuration details, see the [documentation](https://docs.pipelex.com/late
 <td style="text-align:center;background-color:rgba(76,175,80,0.15)">✅</td>
 </tr>
 <tr>
+<td>claude-4.6-sonnet</td>
+<td style="text-align:center;background-color:rgba(33,150,243,0.15)">✅</td>
+<td style="text-align:center;background-color:rgba(33,150,243,0.15)">✅</td>
+<td style="text-align:center;background-color:rgba(33,150,243,0.15)">✅</td>
+<td style="text-align:center;background-color:rgba(76,175,80,0.15)">✅</td>
+<td style="text-align:center;background-color:rgba(76,175,80,0.15)">✅</td>
+</tr>
+<tr>
 <td>deepseek-v3.2</td>
 <td style="text-align:center;background-color:rgba(33,150,243,0.15)">✅</td>
 <td style="text-align:center;background-color:rgba(33,150,243,0.15)">❌</td>
@@ -528,6 +536,6 @@ For configuration details, see the [documentation](https://docs.pipelex.com/late
 
 
 > **AUTO-GENERATED FILE** - Do not edit manually.
-> Last updated: 2026-04-04T17:05:38Z
+> Last updated: 2026-04-14T09:23:56Z
 >
 > Run `pipelex-dev update-gateway-models` or `make ugm` to regenerate.

--- a/.pipelex/inference/backends/pipelex_gateway_models_plain.md
+++ b/.pipelex/inference/backends/pipelex_gateway_models_plain.md
@@ -28,6 +28,9 @@ For configuration details, see the [documentation](https://docs.pipelex.com/late
 - **claude-4.6-opus**
   - inputs: text, images, pdf
   - outputs: text, structured
+- **claude-4.6-sonnet**
+  - inputs: text, images, pdf
+  - outputs: text, structured
 - **deepseek-v3.2**
   - inputs: text
   - outputs: text, structured
@@ -196,6 +199,6 @@ For configuration details, see the [documentation](https://docs.pipelex.com/late
 
 
 > **AUTO-GENERATED FILE** - Do not edit manually.
-> Last updated: 2026-04-04T17:05:38Z
+> Last updated: 2026-04-14T09:23:56Z
 >
 > Run `pipelex-dev update-gateway-models` or `make ugm` to regenerate.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [v0.23.9] - 2026-04-14
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- **README install instructions**: Replaced step-by-step Claude Code setup with single copy-paste messages for Claude Code and Codex, added manual install section
+
 ## [v0.23.8] - 2026-04-07
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -58,69 +58,48 @@ From here, Pipelex handles model routing across 60+ models, structured output pa
 
 # Quick Start
 
+## With Claude Code (Recommended)
+
+Paste this into Claude Code:
+
+```
+Install mthds: run bash -c 'npm install -g mthds && mthds-agent bootstrap && claude plugin marketplace add mthds-ai/mthds-plugins && claude plugin install mthds@mthds-plugins'. Then tell me to restart Claude Code.
+```
+
+## With Codex
+
+Paste this into Codex:
+
+```
+Install mthds: run bash -c 'npm install -g mthds && mthds-agent bootstrap && bash <(curl -fsSL https://raw.githubusercontent.com/mthds-ai/mthds-plugins/main/bin/install-codex.sh)'. Then tell me to run /plugins, search for MTHDS, and install it.
+```
+
+Install the [VS Code extension](https://go.pipelex.com/vscode) for `.mthds` syntax highlighting and flowchart visualization.
+
+## From the Terminal
+
+```bash
+npm install -g mthds
+mthds-agent bootstrap
+pipelex init
+```
+
+Install the [VS Code extension](https://go.pipelex.com/vscode) for `.mthds` syntax highlighting and flowchart visualization.
+
+Verify everything is set up correctly:
+
+```bash
+pipelex doctor
+```
+
+## Python Package Only
+
+If you just need the Pipelex runtime without agent integration:
+
 ```bash
 uv tool install pipelex
 pipelex init
 ```
-
-## With Claude Code (Recommended)
-
-Install the `mthds` npm package:
-
-```bash
-npm install -g mthds
-```
-
-Start Claude Code:
-
-```bash
-claude
-```
-
-Tell Claude to install the MTHDS skills marketplace:
-
-```
-/plugin marketplace add mthds-ai/mthds-plugins
-```
-
-then install the MTHDS skills plugin:
-
-```
-/plugin install mthds@mthds-plugins
-```
-
-then reload plugins:
-
-```
-/reload-plugins
-```
-
-If that doesn't work, exit Claude Code and reopen it:
-
-```
-/exit
-```
-
-Build your first method:
-
-```
-/mthds-build A method to summarize articles with key takeaways for different audiences
-```
-
-Run it:
-
-```
-/mthds-run
-```
-
-## Without Claude Code
-
-1. Install the [VS Code extension](https://go.pipelex.com/vscode) for `.mthds` syntax highlighting
-2. Browse methods on the [MTHDS Hub](https://mthds.sh) for inspiration
-3. Author your own `.mthds` methods based on these examples
-4. Validate with `pipelex validate bundle your_method.mthds`
-5. Run them with `pipelex run bundle your_method.mthds`
-6. View the flowchart in VS Code thanks to the extension
 
 ## Configure AI Access
 

--- a/pipelex/cli/commands/init/credentials.py
+++ b/pipelex/cli/commands/init/credentials.py
@@ -10,6 +10,7 @@ from rich.markup import escape
 from rich.prompt import Prompt
 
 from pipelex.system.configuration.config_loader import config_manager
+from pipelex.system.pipelex_service.pipelex_details import PipelexDetails
 from pipelex.tools.misc.dict_utils import extract_vars_from_strings_recursive
 from pipelex.tools.misc.file_utils import path_exists
 from pipelex.tools.misc.toml_utils import load_toml_from_path
@@ -135,6 +136,8 @@ def prompt_credentials(console: Console, backends_toml_path: str) -> None:
     collected_count = 0
     for var_name, backend_names in sorted(missing_vars.items()):
         backends_str = ", ".join(backend_names)
+        if var_name == PipelexDetails.PIPELEX_GATEWAY_API_KEY_VAR:
+            console.print("  [dim]Get a free API key at[/dim] [cyan]https://app.pipelex.com[/cyan]")
         value = Prompt.ask(
             f"  [bold]{escape(var_name)}[/bold] [dim](required by {escape(backends_str)})[/dim]", default="", console=console, password=True
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pipelex"
-version = "0.23.8"
+version = "0.23.9"
 description = "Execute composable AI methods declared in the MTHDS open standard"
 authors = [{ name = "Evotis S.A.S.", email = "oss@pipelex.com" }]
 maintainers = [{ name = "Pipelex staff", email = "oss@pipelex.com" }]

--- a/uv.lock
+++ b/uv.lock
@@ -3502,7 +3502,7 @@ wheels = [
 
 [[package]]
 name = "pipelex"
-version = "0.23.8"
+version = "0.23.9"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Release v0.23.9

Bumps version from `0.23.8` to `0.23.9`.

### Changelog

### Changed

- **README install instructions**: Replaced step-by-step Claude Code setup with single copy-paste messages for Claude Code and Codex, added manual install section

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Streamlines onboarding and updates model docs for v0.23.9. README now uses single copy-paste install messages for Claude Code and Codex, adds a manual terminal flow, `pipelex init` shows where to get a free API key, gateway docs list claude-4.6-sonnet, and the package is bumped to `0.23.9`.

<sup>Written for commit de511e800341a07eb0819aa1b0d39a2dfe00bba7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

