### PR TITLE
claude-opus-4-7

### DIFF
--- a/.pipelex-dev/test_profiles.toml
+++ b/.pipelex-dev/test_profiles.toml
@@ -87,7 +87,12 @@ google = [
   "gemini-2.5-flash-lite",
   "gemini-2.5-pro",
   "gemini-3.0-pro",
-  "gemini-3.0-flash-preview",
+  "gemini-3.0-flash",
+  "gemini-3.1-flash-lite",
+  "gemini-3.1-pro",
+  "gemini-pro-latest",
+  "gemini-flash-latest",
+  "gemini-flash-lite-latest",
 ]
 
 # --- Groq Models ---

--- a/.pipelex/inference/backends/google.toml
+++ b/.pipelex/inference/backends/google.toml
@@ -62,12 +62,51 @@ max_prompt_images = 3000
 costs = { input = 2, output = 12.0 }
 thinking_mode = "adaptive"
 
-["gemini-3.0-flash-preview"]
+["gemini-3.0-flash"]
 model_id = "gemini-3-flash-preview"
 inputs = ["text", "images", "pdf"]
 outputs = ["text", "structured"]
 max_prompt_images = 3000
 costs = { input = 0.5, output = 3.0 }
+thinking_mode = "adaptive"
+
+# --- Gemini 3.1 Series ----------------------------------------
+["gemini-3.1-flash-lite"]
+model_id = "gemini-3.1-flash-lite-preview"
+inputs = ["text", "images", "pdf"]
+outputs = ["text", "structured"]
+max_prompt_images = 3000
+costs = { input = 0.25, output = 1.50 }
+thinking_mode = "adaptive"
+
+["gemini-3.1-pro"]
+model_id = "gemini-3.1-pro-preview"
+inputs = ["text", "images", "pdf"]
+outputs = ["text", "structured"]
+max_prompt_images = 3000
+costs = { input = 2, output = 12.0 }
+thinking_mode = "adaptive"
+
+# --- Latest Aliases (point to current generation, change over time) -----------
+["gemini-pro-latest"]
+inputs = ["text", "images", "pdf"]
+outputs = ["text", "structured"]
+max_prompt_images = 3000
+costs = { input = 1.25, output = 10.0 }
+thinking_mode = "adaptive"
+
+["gemini-flash-latest"]
+inputs = ["text", "images", "pdf"]
+outputs = ["text", "structured"]
+max_prompt_images = 3000
+costs = { input = 0.30, output = 2.50 }
+thinking_mode = "adaptive"
+
+["gemini-flash-lite-latest"]
+inputs = ["text", "images", "pdf"]
+outputs = ["text", "structured"]
+max_prompt_images = 3000
+costs = { input = 0.10, output = 0.40 }
 thinking_mode = "adaptive"
 
 ################################################################################

--- a/.pipelex/inference/backends/pipelex_gateway_models.md
+++ b/.pipelex/inference/backends/pipelex_gateway_models.md
@@ -85,6 +85,14 @@ For configuration details, see the [documentation](https://docs.pipelex.com/late
 <td style="text-align:center;background-color:rgba(76,175,80,0.15)">✅</td>
 </tr>
 <tr>
+<td>claude-4.7-opus</td>
+<td style="text-align:center;background-color:rgba(33,150,243,0.15)">✅</td>
+<td style="text-align:center;background-color:rgba(33,150,243,0.15)">✅</td>
+<td style="text-align:center;background-color:rgba(33,150,243,0.15)">✅</td>
+<td style="text-align:center;background-color:rgba(76,175,80,0.15)">✅</td>
+<td style="text-align:center;background-color:rgba(76,175,80,0.15)">✅</td>
+</tr>
+<tr>
 <td>deepseek-v3.2</td>
 <td style="text-align:center;background-color:rgba(33,150,243,0.15)">✅</td>
 <td style="text-align:center;background-color:rgba(33,150,243,0.15)">❌</td>
@@ -117,7 +125,7 @@ For configuration details, see the [documentation](https://docs.pipelex.com/late
 <td style="text-align:center;background-color:rgba(76,175,80,0.15)">✅</td>
 </tr>
 <tr>
-<td>gemini-3.0-flash-preview</td>
+<td>gemini-3.0-flash</td>
 <td style="text-align:center;background-color:rgba(33,150,243,0.15)">✅</td>
 <td style="text-align:center;background-color:rgba(33,150,243,0.15)">✅</td>
 <td style="text-align:center;background-color:rgba(33,150,243,0.15)">✅</td>
@@ -126,6 +134,46 @@ For configuration details, see the [documentation](https://docs.pipelex.com/late
 </tr>
 <tr>
 <td>gemini-3.0-pro</td>
+<td style="text-align:center;background-color:rgba(33,150,243,0.15)">✅</td>
+<td style="text-align:center;background-color:rgba(33,150,243,0.15)">✅</td>
+<td style="text-align:center;background-color:rgba(33,150,243,0.15)">✅</td>
+<td style="text-align:center;background-color:rgba(76,175,80,0.15)">✅</td>
+<td style="text-align:center;background-color:rgba(76,175,80,0.15)">✅</td>
+</tr>
+<tr>
+<td>gemini-3.1-flash-lite</td>
+<td style="text-align:center;background-color:rgba(33,150,243,0.15)">✅</td>
+<td style="text-align:center;background-color:rgba(33,150,243,0.15)">✅</td>
+<td style="text-align:center;background-color:rgba(33,150,243,0.15)">✅</td>
+<td style="text-align:center;background-color:rgba(76,175,80,0.15)">✅</td>
+<td style="text-align:center;background-color:rgba(76,175,80,0.15)">✅</td>
+</tr>
+<tr>
+<td>gemini-3.1-pro</td>
+<td style="text-align:center;background-color:rgba(33,150,243,0.15)">✅</td>
+<td style="text-align:center;background-color:rgba(33,150,243,0.15)">✅</td>
+<td style="text-align:center;background-color:rgba(33,150,243,0.15)">✅</td>
+<td style="text-align:center;background-color:rgba(76,175,80,0.15)">✅</td>
+<td style="text-align:center;background-color:rgba(76,175,80,0.15)">✅</td>
+</tr>
+<tr>
+<td>gemini-flash-latest</td>
+<td style="text-align:center;background-color:rgba(33,150,243,0.15)">✅</td>
+<td style="text-align:center;background-color:rgba(33,150,243,0.15)">✅</td>
+<td style="text-align:center;background-color:rgba(33,150,243,0.15)">✅</td>
+<td style="text-align:center;background-color:rgba(76,175,80,0.15)">✅</td>
+<td style="text-align:center;background-color:rgba(76,175,80,0.15)">✅</td>
+</tr>
+<tr>
+<td>gemini-flash-lite-latest</td>
+<td style="text-align:center;background-color:rgba(33,150,243,0.15)">✅</td>
+<td style="text-align:center;background-color:rgba(33,150,243,0.15)">✅</td>
+<td style="text-align:center;background-color:rgba(33,150,243,0.15)">✅</td>
+<td style="text-align:center;background-color:rgba(76,175,80,0.15)">✅</td>
+<td style="text-align:center;background-color:rgba(76,175,80,0.15)">✅</td>
+</tr>
+<tr>
+<td>gemini-pro-latest</td>
 <td style="text-align:center;background-color:rgba(33,150,243,0.15)">✅</td>
 <td style="text-align:center;background-color:rgba(33,150,243,0.15)">✅</td>
 <td style="text-align:center;background-color:rgba(33,150,243,0.15)">✅</td>
@@ -536,6 +584,6 @@ For configuration details, see the [documentation](https://docs.pipelex.com/late
 
 
 > **AUTO-GENERATED FILE** - Do not edit manually.
-> Last updated: 2026-04-14T09:23:56Z
+> Last updated: 2026-04-17T12:49:19Z
 >
 > Run `pipelex-dev update-gateway-models` or `make ugm` to regenerate.

--- a/.pipelex/inference/backends/pipelex_gateway_models_plain.md
+++ b/.pipelex/inference/backends/pipelex_gateway_models_plain.md
@@ -31,6 +31,9 @@ For configuration details, see the [documentation](https://docs.pipelex.com/late
 - **claude-4.6-sonnet**
   - inputs: text, images, pdf
   - outputs: text, structured
+- **claude-4.7-opus**
+  - inputs: text, images, pdf
+  - outputs: text, structured
 - **deepseek-v3.2**
   - inputs: text
   - outputs: text, structured
@@ -43,10 +46,25 @@ For configuration details, see the [documentation](https://docs.pipelex.com/late
 - **gemini-2.5-pro**
   - inputs: text, images, pdf
   - outputs: text, structured
-- **gemini-3.0-flash-preview**
+- **gemini-3.0-flash**
   - inputs: text, images, pdf
   - outputs: text, structured
 - **gemini-3.0-pro**
+  - inputs: text, images, pdf
+  - outputs: text, structured
+- **gemini-3.1-flash-lite**
+  - inputs: text, images, pdf
+  - outputs: text, structured
+- **gemini-3.1-pro**
+  - inputs: text, images, pdf
+  - outputs: text, structured
+- **gemini-flash-latest**
+  - inputs: text, images, pdf
+  - outputs: text, structured
+- **gemini-flash-lite-latest**
+  - inputs: text, images, pdf
+  - outputs: text, structured
+- **gemini-pro-latest**
   - inputs: text, images, pdf
   - outputs: text, structured
 - **gpt-4.1**
@@ -199,6 +217,6 @@ For configuration details, see the [documentation](https://docs.pipelex.com/late
 
 
 > **AUTO-GENERATED FILE** - Do not edit manually.
-> Last updated: 2026-04-14T09:23:56Z
+> Last updated: 2026-04-17T12:49:19Z
 >
 > Run `pipelex-dev update-gateway-models` or `make ugm` to regenerate.

--- a/.pipelex/inference/deck/1_llm_deck.toml
+++ b/.pipelex/inference/deck/1_llm_deck.toml
@@ -29,20 +29,20 @@ for_object = "@default-general"
 [llm.aliases]
 best-gpt = "gpt-5.2"
 best-claude = "claude-4.7-opus"
-best-gemini = "gemini-3.0-pro"
+best-gemini = "gemini-pro-latest"
 best-mistral = "mistral-large"
 
 # Default aliases (first choice from waterfalls)
 default-general = "claude-4.6-sonnet"
-default-premium = "claude-4.6-opus"
-default-premium-vision = "claude-4.6-opus"
-default-premium-structured = "claude-4.6-opus"
-default-large-context-code = "gemini-3.0-pro"
-default-large-context-text = "gemini-2.5-flash"
+default-premium = "claude-4.7-opus"
+default-premium-vision = "claude-4.7-opus"
+default-premium-structured = "claude-4.7-opus"
+default-large-context-code = "gemini-pro-latest"
+default-large-context-text = "gemini-flash-latest"
 default-small = "gpt-4o-mini"
 default-small-structured = "gpt-4o-mini"
-default-small-vision = "gemini-3.0-flash-preview"
-default-small-creative = "gemini-3.0-flash-preview"
+default-small-vision = "gemini-flash-latest"
+default-small-creative = "gemini-flash-latest"
 
 ####################################################################################################
 # LLM Presets
@@ -58,7 +58,7 @@ writing-creative-cheap = { model = "@default-small-creative", temperature = 0.9,
 
 # Retrieval
 retrieval = { model = "@default-large-context-text", temperature = 0.1, description = "Data retrieval from large text corpora" }
-retrieval-cheap = { model = "gemini-2.5-flash-lite", temperature = 0.1, description = "Cheap data retrieval from large text corpora" }
+retrieval-cheap = { model = "gemini-flash-lite-latest", temperature = 0.1, description = "Cheap data retrieval from large text corpora" }
 retrieval-premium = { model = "claude-4.7-opus", temperature = 0.1, description = "Premium data retrieval with highest accuracy" }
 
 # Engineering

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - **Anthropic adaptive thinking rejects `reasoning_budget`**: `_build_thinking_params_for_budget` now raises `LLMCapabilityError` for adaptive thinking models, guiding users to `reasoning_effort` instead — extended thinking (`type: "enabled"`) is removed on Opus 4.7+
 - **LLM deck**: Updated `best-claude` alias to `claude-4.7-opus`, switched `img-gen-prompting-cheap` to `@default-small-creative`, removed deprecated builder presets, standardized cheap preset descriptions
+- **Google `MINIMAL` reasoning level**: `ReasoningEffort.MINIMAL` now maps to Google's `ThinkingLevel.MINIMAL` (was previously collapsed to `LOW`); `GoogleThinkingLevel` enum gains `MINIMAL` and the default `google_config.effort_to_level_map` updates accordingly
 
 ## [v0.23.9] - 2026-04-14
 

--- a/pipelex/cogt/models/model_deck.py
+++ b/pipelex/cogt/models/model_deck.py
@@ -861,11 +861,14 @@ class ModelDeck(ConfigModel):
         inference_model = self.get_optional_inference_model(model_handle=model_handle, model_type=model_type)
         if inference_model is None:
             msg = (
-                f"Model handle '{model_handle}' was not found in the model deck. "
-                "Make sure it's defined in one of the model decks '.pipelex/inference/deck/*.toml'. "
-                "If the model handle is indeed in the deck, make sure the required backend for this model to run is enabled in "
-                "'.pipelex/inference/backends.toml' and that you have the necessary credentials. "
-                "To find what backend is required for this model, look at the routing profile in '.pipelex/inference/routing_profiles.toml' "
+                f"Model handle '{model_handle}' was not found in the model deck.\n"
+                "The most likely cause is that your local model deck is out of date: new aliases and presets are added to Pipelex "
+                "over time and existing '.pipelex/inference/deck/*.toml' files are not automatically refreshed (yet). "
+                "To pick up the latest definitions, delete your local deck files under '.pipelex/inference/deck/' "
+                "(or the whole '.pipelex/inference/' directory) and run 'pipelex init inference' to regenerate them.\n"
+                "If that doesn't resolve it: make sure the handle is defined in one of '.pipelex/inference/deck/*.toml', "
+                "that the backend it routes to (see '.pipelex/inference/routing_profiles.toml') is enabled in "
+                "'.pipelex/inference/backends.toml', and that you have the necessary credentials. "
                 "Learn more about the inference backend system in the Pipelex documentation: "
                 f"{URLs.backend_provider_docs}"
             )

--- a/pipelex/graph/reactflow/standalone_assets.py
+++ b/pipelex/graph/reactflow/standalone_assets.py
@@ -5,34 +5,28 @@ in Jinja2 templates via the standard template rendering pipeline.
 """
 
 import importlib.resources
+from functools import cache
 
 _ASSET_PACKAGE = "pipelex.graph.reactflow.assets"
 
-_cached_js: str | None = None
-_cached_css: str | None = None
 
-
+@cache
 def get_standalone_js() -> str:
     """Load the pre-built GraphViewer JS bundle (IIFE).
 
     Returns:
         The JS bundle as a string, cached after first load.
     """
-    global _cached_js  # noqa: PLW0603
-    if _cached_js is None:
-        package_files = importlib.resources.files(_ASSET_PACKAGE)
-        _cached_js = (package_files / "graph-viewer.js").read_text(encoding="utf-8")
-    return _cached_js
+    package_files = importlib.resources.files(_ASSET_PACKAGE)
+    return (package_files / "graph-viewer.js").read_text(encoding="utf-8")
 
 
+@cache
 def get_standalone_css() -> str:
     """Load the pre-built GraphViewer CSS bundle.
 
     Returns:
         The CSS bundle as a string, cached after first load.
     """
-    global _cached_css  # noqa: PLW0603
-    if _cached_css is None:
-        package_files = importlib.resources.files(_ASSET_PACKAGE)
-        _cached_css = (package_files / "graph-viewer.css").read_text(encoding="utf-8")
-    return _cached_css
+    package_files = importlib.resources.files(_ASSET_PACKAGE)
+    return (package_files / "graph-viewer.css").read_text(encoding="utf-8")

--- a/pipelex/kit/configs/inference/backends/google.toml
+++ b/pipelex/kit/configs/inference/backends/google.toml
@@ -62,12 +62,51 @@ max_prompt_images = 3000
 costs = { input = 2, output = 12.0 }
 thinking_mode = "adaptive"
 
-["gemini-3.0-flash-preview"]
+["gemini-3.0-flash"]
 model_id = "gemini-3-flash-preview"
 inputs = ["text", "images", "pdf"]
 outputs = ["text", "structured"]
 max_prompt_images = 3000
 costs = { input = 0.5, output = 3.0 }
+thinking_mode = "adaptive"
+
+# --- Gemini 3.1 Series ----------------------------------------
+["gemini-3.1-flash-lite"]
+model_id = "gemini-3.1-flash-lite-preview"
+inputs = ["text", "images", "pdf"]
+outputs = ["text", "structured"]
+max_prompt_images = 3000
+costs = { input = 0.25, output = 1.50 }
+thinking_mode = "adaptive"
+
+["gemini-3.1-pro"]
+model_id = "gemini-3.1-pro-preview"
+inputs = ["text", "images", "pdf"]
+outputs = ["text", "structured"]
+max_prompt_images = 3000
+costs = { input = 2, output = 12.0 }
+thinking_mode = "adaptive"
+
+# --- Latest Aliases (point to current generation, change over time) -----------
+["gemini-pro-latest"]
+inputs = ["text", "images", "pdf"]
+outputs = ["text", "structured"]
+max_prompt_images = 3000
+costs = { input = 1.25, output = 10.0 }
+thinking_mode = "adaptive"
+
+["gemini-flash-latest"]
+inputs = ["text", "images", "pdf"]
+outputs = ["text", "structured"]
+max_prompt_images = 3000
+costs = { input = 0.30, output = 2.50 }
+thinking_mode = "adaptive"
+
+["gemini-flash-lite-latest"]
+inputs = ["text", "images", "pdf"]
+outputs = ["text", "structured"]
+max_prompt_images = 3000
+costs = { input = 0.10, output = 0.40 }
 thinking_mode = "adaptive"
 
 ################################################################################

--- a/pipelex/kit/configs/inference/backends/pipelex_gateway_models.md
+++ b/pipelex/kit/configs/inference/backends/pipelex_gateway_models.md
@@ -85,6 +85,14 @@ For configuration details, see the [documentation](https://docs.pipelex.com/late
 <td style="text-align:center;background-color:rgba(76,175,80,0.15)">✅</td>
 </tr>
 <tr>
+<td>claude-4.7-opus</td>
+<td style="text-align:center;background-color:rgba(33,150,243,0.15)">✅</td>
+<td style="text-align:center;background-color:rgba(33,150,243,0.15)">✅</td>
+<td style="text-align:center;background-color:rgba(33,150,243,0.15)">✅</td>
+<td style="text-align:center;background-color:rgba(76,175,80,0.15)">✅</td>
+<td style="text-align:center;background-color:rgba(76,175,80,0.15)">✅</td>
+</tr>
+<tr>
 <td>deepseek-v3.2</td>
 <td style="text-align:center;background-color:rgba(33,150,243,0.15)">✅</td>
 <td style="text-align:center;background-color:rgba(33,150,243,0.15)">❌</td>
@@ -126,6 +134,38 @@ For configuration details, see the [documentation](https://docs.pipelex.com/late
 </tr>
 <tr>
 <td>gemini-3.0-pro</td>
+<td style="text-align:center;background-color:rgba(33,150,243,0.15)">✅</td>
+<td style="text-align:center;background-color:rgba(33,150,243,0.15)">✅</td>
+<td style="text-align:center;background-color:rgba(33,150,243,0.15)">✅</td>
+<td style="text-align:center;background-color:rgba(76,175,80,0.15)">✅</td>
+<td style="text-align:center;background-color:rgba(76,175,80,0.15)">✅</td>
+</tr>
+<tr>
+<td>gemini-3.1-flash-lite-preview</td>
+<td style="text-align:center;background-color:rgba(33,150,243,0.15)">✅</td>
+<td style="text-align:center;background-color:rgba(33,150,243,0.15)">✅</td>
+<td style="text-align:center;background-color:rgba(33,150,243,0.15)">✅</td>
+<td style="text-align:center;background-color:rgba(76,175,80,0.15)">✅</td>
+<td style="text-align:center;background-color:rgba(76,175,80,0.15)">✅</td>
+</tr>
+<tr>
+<td>gemini-flash-latest</td>
+<td style="text-align:center;background-color:rgba(33,150,243,0.15)">✅</td>
+<td style="text-align:center;background-color:rgba(33,150,243,0.15)">✅</td>
+<td style="text-align:center;background-color:rgba(33,150,243,0.15)">✅</td>
+<td style="text-align:center;background-color:rgba(76,175,80,0.15)">✅</td>
+<td style="text-align:center;background-color:rgba(76,175,80,0.15)">✅</td>
+</tr>
+<tr>
+<td>gemini-flash-lite-latest</td>
+<td style="text-align:center;background-color:rgba(33,150,243,0.15)">✅</td>
+<td style="text-align:center;background-color:rgba(33,150,243,0.15)">✅</td>
+<td style="text-align:center;background-color:rgba(33,150,243,0.15)">✅</td>
+<td style="text-align:center;background-color:rgba(76,175,80,0.15)">✅</td>
+<td style="text-align:center;background-color:rgba(76,175,80,0.15)">✅</td>
+</tr>
+<tr>
+<td>gemini-pro-latest</td>
 <td style="text-align:center;background-color:rgba(33,150,243,0.15)">✅</td>
 <td style="text-align:center;background-color:rgba(33,150,243,0.15)">✅</td>
 <td style="text-align:center;background-color:rgba(33,150,243,0.15)">✅</td>
@@ -536,6 +576,6 @@ For configuration details, see the [documentation](https://docs.pipelex.com/late
 
 
 > **AUTO-GENERATED FILE** - Do not edit manually.
-> Last updated: 2026-04-14T09:23:56Z
+> Last updated: 2026-04-17T12:23:17Z
 >
 > Run `pipelex-dev update-gateway-models` or `make ugm` to regenerate.

--- a/pipelex/kit/configs/inference/backends/pipelex_gateway_models_plain.md
+++ b/pipelex/kit/configs/inference/backends/pipelex_gateway_models_plain.md
@@ -31,6 +31,9 @@ For configuration details, see the [documentation](https://docs.pipelex.com/late
 - **claude-4.6-sonnet**
   - inputs: text, images, pdf
   - outputs: text, structured
+- **claude-4.7-opus**
+  - inputs: text, images, pdf
+  - outputs: text, structured
 - **deepseek-v3.2**
   - inputs: text
   - outputs: text, structured
@@ -47,6 +50,18 @@ For configuration details, see the [documentation](https://docs.pipelex.com/late
   - inputs: text, images, pdf
   - outputs: text, structured
 - **gemini-3.0-pro**
+  - inputs: text, images, pdf
+  - outputs: text, structured
+- **gemini-3.1-flash-lite-preview**
+  - inputs: text, images, pdf
+  - outputs: text, structured
+- **gemini-flash-latest**
+  - inputs: text, images, pdf
+  - outputs: text, structured
+- **gemini-flash-lite-latest**
+  - inputs: text, images, pdf
+  - outputs: text, structured
+- **gemini-pro-latest**
   - inputs: text, images, pdf
   - outputs: text, structured
 - **gpt-4.1**
@@ -199,6 +214,6 @@ For configuration details, see the [documentation](https://docs.pipelex.com/late
 
 
 > **AUTO-GENERATED FILE** - Do not edit manually.
-> Last updated: 2026-04-14T09:23:56Z
+> Last updated: 2026-04-17T12:23:17Z
 >
 > Run `pipelex-dev update-gateway-models` or `make ugm` to regenerate.

--- a/pipelex/kit/configs/inference/deck/1_llm_deck.toml
+++ b/pipelex/kit/configs/inference/deck/1_llm_deck.toml
@@ -29,20 +29,20 @@ for_object = "@default-general"
 [llm.aliases]
 best-gpt = "gpt-5.2"
 best-claude = "claude-4.7-opus"
-best-gemini = "gemini-3.0-pro"
+best-gemini = "gemini-pro-latest"
 best-mistral = "mistral-large"
 
 # Default aliases (first choice from waterfalls)
 default-general = "claude-4.6-sonnet"
-default-premium = "claude-4.6-opus"
-default-premium-vision = "claude-4.6-opus"
-default-premium-structured = "claude-4.6-opus"
-default-large-context-code = "gemini-3.0-pro"
-default-large-context-text = "gemini-2.5-flash"
+default-premium = "claude-4.7-opus"
+default-premium-vision = "claude-4.7-opus"
+default-premium-structured = "claude-4.7-opus"
+default-large-context-code = "gemini-pro-latest"
+default-large-context-text = "gemini-flash-latest"
 default-small = "gpt-4o-mini"
 default-small-structured = "gpt-4o-mini"
-default-small-vision = "gemini-3.0-flash-preview"
-default-small-creative = "gemini-3.0-flash-preview"
+default-small-vision = "gemini-flash-latest"
+default-small-creative = "gemini-flash-latest"
 
 ####################################################################################################
 # LLM Presets
@@ -58,7 +58,7 @@ writing-creative-cheap = { model = "@default-small-creative", temperature = 0.9,
 
 # Retrieval
 retrieval = { model = "@default-large-context-text", temperature = 0.1, description = "Data retrieval from large text corpora" }
-retrieval-cheap = { model = "gemini-2.5-flash-lite", temperature = 0.1, description = "Cheap data retrieval from large text corpora" }
+retrieval-cheap = { model = "gemini-flash-lite-latest", temperature = 0.1, description = "Cheap data retrieval from large text corpora" }
 retrieval-premium = { model = "claude-4.7-opus", temperature = 0.1, description = "Premium data retrieval with highest accuracy" }
 
 # Engineering

--- a/pipelex/pipelex.toml
+++ b/pipelex/pipelex.toml
@@ -169,7 +169,7 @@ max = "max"
 
 [cogt.llm_config.google_config.effort_to_level_map]
 none = "disabled"
-minimal = "low"
+minimal = "minimal"
 low = "low"
 medium = "medium"
 high = "high"

--- a/pipelex/plugins/google/google_config.py
+++ b/pipelex/plugins/google/google_config.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
 
 
 class GoogleThinkingLevel(StrEnum):
+    MINIMAL = "minimal"
     LOW = "low"
     MEDIUM = "medium"
     HIGH = "high"
@@ -42,6 +43,8 @@ class GoogleConfig(ConfigModel):
             return None
         google_level = GoogleThinkingLevel(level_str)
         match google_level:
+            case GoogleThinkingLevel.MINIMAL:
+                return genai_types.ThinkingLevel.MINIMAL
             case GoogleThinkingLevel.LOW:
                 return genai_types.ThinkingLevel.LOW
             case GoogleThinkingLevel.MEDIUM:

--- a/tests/unit/pipelex/cogt/llm/test_llm_config_reasoning.py
+++ b/tests/unit/pipelex/cogt/llm/test_llm_config_reasoning.py
@@ -31,7 +31,7 @@ _DEFAULT_ANTHROPIC_LEVEL_MAP: dict[str, str] = {
 
 _DEFAULT_GOOGLE_LEVEL_MAP: dict[str, str] = {
     "none": "disabled",
-    "minimal": "low",
+    "minimal": "minimal",
     "low": "low",
     "medium": "medium",
     "high": "high",

--- a/tests/unit/pipelex/plugins/google/test_google_reasoning.py
+++ b/tests/unit/pipelex/plugins/google/test_google_reasoning.py
@@ -10,7 +10,7 @@ from pipelex.plugins.google.google_llm_worker import GoogleLLMWorker
 
 _GOOGLE_LEVEL_MAP: dict[str, str] = {
     "none": "disabled",
-    "minimal": "low",
+    "minimal": "minimal",
     "low": "low",
     "medium": "medium",
     "high": "high",
@@ -87,7 +87,7 @@ class TestGoogleReasoning:
     @pytest.mark.parametrize(
         ("effort", "expected_level"),
         [
-            (ReasoningEffort.MINIMAL, genai_types.ThinkingLevel.LOW),
+            (ReasoningEffort.MINIMAL, genai_types.ThinkingLevel.MINIMAL),
             (ReasoningEffort.LOW, genai_types.ThinkingLevel.LOW),
             (ReasoningEffort.MEDIUM, genai_types.ThinkingLevel.MEDIUM),
             (ReasoningEffort.HIGH, genai_types.ThinkingLevel.HIGH),


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds Gemini 3.1 models and “latest” aliases for Google, promotes `claude-4.7-opus` to default premium, and correctly maps Google’s MINIMAL reasoning level. Also simplifies ReactFlow asset caching and improves error messages when a local model deck is stale.

- **New Features**
  - Added `gemini-3.1-flash-lite` and `gemini-3.1-pro` to Google backend configs and test profiles.
  - Introduced `gemini-pro-latest`, `gemini-flash-latest`, and `gemini-flash-lite-latest` aliases; switched LLM deck defaults to use them (e.g., `best-gemini = gemini-pro-latest`, small vision/creative now `gemini-flash-latest`, cheap retrieval uses `gemini-flash-lite-latest`).
  - Promoted `claude-4.7-opus` as `best-claude` and as default for premium, premium-vision, and premium-structured.
  - Mapped `ReasoningEffort.MINIMAL` to Google’s `ThinkingLevel.MINIMAL`; enum and default map updated; tests and docs updated.

- **Refactors**
  - Simplified ReactFlow standalone asset caching with `functools.cache` and improved ModelNotFoundError guidance for stale local decks (`pipelex init inference` hint).
  - Renamed `gemini-3.0-flash-preview` to `gemini-3.0-flash`; regenerated gateway model docs.

<sup>Written for commit 0891ac9df93de3736c841d51dec97d02e25088a5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

