### PR TITLE
chore(security): narrow Dependabot + add OpenSSF Scorecard

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,38 +1,18 @@
 version: 2
 updates:
-  # Python dependencies via uv/pip ecosystem
-  - package-ecosystem: "pip"
-    directory: "/"
-    # Target dev: merges to main trigger PyPI publish, so dep bumps must go through
-    # a proper versioned release (dev -> release/vX.Y.Z -> main), not a direct main merge.
-    target-branch: "dev"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-    open-pull-requests-limit: 10
-    groups:
-      dev-dependencies:
-        dependency-type: "development"
-        update-types:
-          - "minor"
-          - "patch"
-      runtime-minor-patch:
-        dependency-type: "production"
-        update-types:
-          - "minor"
-          - "patch"
-    # Runtime majors get individual PRs so breaking changes are reviewed separately.
-
-  # GitHub Actions — keeps SHA-pinned actions fresh.
+  # GitHub Actions only — keeps SHA-pinned actions fresh on a monthly cadence.
+  # Python dependencies are NOT tracked here by design: as a library, Pipelex
+  # does not benefit from routine version bumps. Security-driven updates still
+  # fire automatically via Dependabot alerts + security updates (repo settings),
+  # and `.github/workflows/dependency-review.yml` blocks PRs that introduce
+  # newly vulnerable deps. Major version bumps for runtime deps are made
+  # manually when they unlock features or fix real bugs.
   - package-ecosystem: "github-actions"
     directory: "/"
     target-branch: "dev"
     schedule:
-      interval: "weekly"
-      day: "monday"
-    open-pull-requests-limit: 5
+      interval: "monthly"
+    open-pull-requests-limit: 3
     groups:
-      actions-minor-patch:
-        update-types:
-          - "minor"
-          - "patch"
+      actions:
+        patterns: ["*"]

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,48 @@
+# OpenSSF Scorecard — grades security posture (branch protection, SAST, pinned deps,
+# token permissions, signed releases, etc.) and publishes findings to GitHub's code
+# scanning dashboard. See https://scorecard.dev for each check's definition.
+name: OSSF Scorecard
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: "0 3 * * 1" # Weekly, Mondays 03:00 UTC
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # upload SARIF results to code scanning
+      id-token: write        # publish results to OpenSSF (publish_results: true)
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@v2.4.1
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload results as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload results to code scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+
+### Security
+
+- **Dependabot narrowed to GitHub Actions only, monthly cadence**. Python dependency version-update PRs are disabled by design: as a library, Pipelex does not benefit from routine bumps — they create churn and occasionally break downstream projects. Security-driven updates still fire via Dependabot alerts + security updates (repo settings), and `dependency-review.yml` continues to block PRs introducing newly vulnerable deps. Major runtime deps are bumped manually when they unlock features or fix real bugs.
+- **OpenSSF Scorecard workflow added** (`.github/workflows/scorecard.yml`). Grades security posture across branch protection, pinned dependencies, token permissions, signed releases, and other checks. Runs weekly and on push to `main`, publishes results to the GitHub code scanning dashboard and the public OpenSSF registry so adopters can inspect the project's security grade at https://scorecard.dev.
+
 ## [v0.24.1] - 2026-04-22
 
 ### Security


### PR DESCRIPTION
## Summary

Shift to **security-alerts-driven** dependency hygiene — the library best practice. Stops the weekly noise (PRs #828–#836) while keeping the real protection (CVE alerts, security fix PRs, dependency-review gate).

### Changes

1. **`.github/dependabot.yml`** — narrowed:
   - **Before:** weekly Python + GHA bumps with groupings — generates 5–10 PRs/month, most reject-worthy for a library.
   - **After:** GHA-only, monthly, all actions grouped. Keeps SHA pins from going stale; zero noise on runtime deps.
   - Python version updates are now **manual, deliberate**. Security updates still fire automatically.

2. **`.github/workflows/scorecard.yml`** — OpenSSF Scorecard added:
   - Grades the repo across branch protection, pinned deps, token permissions, signed releases, SAST, etc.
   - Runs weekly + on push to `main`.
   - Publishes to the code scanning dashboard and to the public OpenSSF registry at https://scorecard.dev/viewer/?uri=github.com/Pipelex/pipelex once on `main`.

3. **`CHANGELOG.md`** — new `[Unreleased]` section documenting both.

### Why this is the library best practice

Top Python libraries (FastAPI, Pydantic, HTTPX, Django, Requests) all follow this pattern:
- Security alerts + security-fix PRs: **always on** (GitHub repo setting, not dependabot.yml)
- Dependency Review action in CI: **always on** (we have it)
- Routine version bumps: **off or very narrow** (GHA-only is typical)
- Lockfile committed + pyproject floors: **yes** (we have it)

Applications benefit from staying current because they run the deps. Libraries don't — downstream consumers pick their own versions. Routine bumps for a library create churn and occasionally break consumers.

### What we keep

- Dependabot alerts (Security tab notifications)
- Dependabot security updates (automatic PRs when a CVE has a fix — this is how we got the lxml alert)
- `dependency-review.yml` blocks PRs introducing moderate+ CVE deps
- SHA-pinned release-critical actions in `publish-pypi.yml`
- OIDC trusted publishing to PyPI
- Sigstore signing of releases

### Companion actions taken

- Closed PRs #829, #833, #834, #835, #836 (the risky/speculative bumps)
- Queued merge for PRs #828, #830, #831, #832 (reasonable GHA bumps with green CI)

## Test plan

- [ ] CI green on this PR (scorecard workflow itself only runs on main/schedule, so it won't fail this PR)
- [ ] After merge to `dev` and subsequent release to `main`: verify scorecard appears at https://scorecard.dev/viewer/?uri=github.com/Pipelex/pipelex
- [ ] Verify no new routine-bump PRs land over the next week

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Limit Dependabot to GitHub Actions (monthly, grouped) and add OpenSSF Scorecard to track and publish our security posture. Reduces routine bump noise for a library while keeping CVE-driven protections and visibility via code scanning and the OpenSSF registry.

- **Dependencies**
  - Dependabot now tracks only GitHub Actions on a monthly schedule, grouped.
  - Python version-bump PRs are disabled; security alerts and security update PRs stay on.
  - `dependency-review.yml` continues to block PRs adding vulnerable deps.

- **New Features**
  - Added OpenSSF Scorecard workflow (weekly and on `main`) that uploads SARIF to code scanning and publishes to the public registry: https://scorecard.dev/viewer/?uri=github.com/Pipelex/pipelex

<sup>Written for commit 7e63fb769e1d16267d8d4473ef95119e79d86fe7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

