### PR TITLE
Feature/new plugin readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ From here, Pipelex handles model routing across 60+ models, structured output pa
 Paste this into Claude Code:
 
 ```
-Install mthds: run bash -c 'npm install -g mthds && mthds-agent bootstrap && claude plugin marketplace add mthds-ai/mthds-plugins && claude plugin install mthds@mthds-plugins'. Then tell me to restart Claude Code.
+Install mthds: run bash -c 'npm install -g mthds && mthds-agent bootstrap && claude plugin marketplace add mthds-ai/mthds-plugins && claude plugin install mthds@mthds-plugins'. Then tell me to /reload-plugins.
 ```
 
 ## With Codex
@@ -71,7 +71,7 @@ Install mthds: run bash -c 'npm install -g mthds && mthds-agent bootstrap && cla
 Paste this into Codex:
 
 ```
-Install mthds: run bash -c 'npm install -g mthds && mthds-agent bootstrap && bash <(curl -fsSL https://raw.githubusercontent.com/mthds-ai/mthds-plugins/main/bin/install-codex.sh)'. Then tell me to run /plugins, search for MTHDS, and install it.
+Install mthds: run bash -c 'npm install -g mthds && mthds-agent bootstrap && mthds-agent codex install-hook && mthds-agent codex apply-config && codex plugin marketplace add mthds-ai/mthds-plugins'. Then tell me to restart Codex and run /plugins to install mthds.
 ```
 
 Install the [VS Code extension](https://go.pipelex.com/vscode) for `.mthds` syntax highlighting and flowchart visualization.

--- a/pipelex/builder/operations/pipe_ops.py
+++ b/pipelex/builder/operations/pipe_ops.py
@@ -30,6 +30,9 @@ _PIPE_CODE_ALIASES = ("pipe", "the_pipe_code", "code", "name", "pipe_name", "pip
 # Aliases that agents may use instead of "output". First found is promoted when canonical key is absent; extras are dropped.
 _OUTPUT_ALIASES = ("output_concept", "output_type")
 
+# Aliases that agents may use instead of "prompt". First found is promoted when canonical key is absent; extras are dropped.
+_PROMPT_ALIASES = ("prompt_template",)
+
 
 def _normalize_sub_pipe_dict(data: dict[str, Any]) -> None:
     """Normalize a step/branch dict: resolve pipe_code aliases and drop extraneous fields."""
@@ -45,6 +48,16 @@ def _normalize_pipe_code_aliases(data: dict[str, Any]) -> None:
         if alias in data:
             if "pipe_code" not in data:
                 data["pipe_code"] = data.pop(alias)
+            else:
+                data.pop(alias)
+
+
+def _normalize_prompt_aliases(data: dict[str, Any]) -> None:
+    """Convert any alias of ``prompt`` to the canonical field name, in-place."""
+    for alias in _PROMPT_ALIASES:
+        if alias in data:
+            if "prompt" not in data:
+                data["prompt"] = data.pop(alias)
             else:
                 data.pop(alias)
 
@@ -78,6 +91,9 @@ def parse_pipe_spec(pipe_type: str, spec_data: dict[str, Any]) -> PipeSpec:
 
     # Accept common aliases for "pipe_code" at the top level
     _normalize_pipe_code_aliases(spec_data)
+
+    # Accept common aliases for "prompt" (e.g. "prompt_template")
+    _normalize_prompt_aliases(spec_data)
 
     # Handle steps/branches conversion — normalize aliases and drop unknown fields.
     # Deep-copy nested dicts to avoid mutating caller's nested structures.

--- a/tests/unit/pipelex/builder/operations/test_parse_pipe_spec.py
+++ b/tests/unit/pipelex/builder/operations/test_parse_pipe_spec.py
@@ -113,6 +113,36 @@ class TestParsePipeSpec:
         result = parse_pipe_spec("PipeLLM", spec)
         assert result.output == "FirstAlias"
 
+    # -- prompt aliases ---------------------------------------------------
+
+    def test_prompt_template_alias_for_llm(self) -> None:
+        """`prompt_template` alone is promoted to `prompt` for PipeLLM."""
+        spec = {key: val for key, val in _BASE_LLM.items() if key != "prompt"}
+        spec["prompt_template"] = "Write about @text"
+        result = parse_pipe_spec("PipeLLM", spec)
+        assert isinstance(result, PipeLLMSpec)
+        assert result.prompt == "Write about @text"
+
+    def test_canonical_prompt_takes_precedence_over_alias(self) -> None:
+        """When both `prompt` and `prompt_template` are present, canonical wins and alias is dropped."""
+        spec = {**_BASE_LLM, "prompt_template": "alias_value"}
+        result = parse_pipe_spec("PipeLLM", spec)
+        assert isinstance(result, PipeLLMSpec)
+        assert result.prompt == _BASE_LLM["prompt"]
+
+    def test_prompt_template_alias_for_img_gen(self) -> None:
+        """`prompt_template` alias also works for PipeImgGen."""
+        spec: dict[str, Any] = {
+            "pipe_code": "my_img",
+            "description": "Generate image",
+            "inputs": {"prompt_text": "ImgGenPrompt"},
+            "output": "Image",
+            "prompt_template": "Generate: $prompt_text",
+        }
+        result = parse_pipe_spec("PipeImgGen", spec)
+        assert isinstance(result, PipeImgGenSpec)
+        assert result.prompt == "Generate: $prompt_text"
+
     # -- steps/branches 'pipe' → 'pipe_code' alias -----------------------
 
     def test_sequence_steps_canonical_pipe_code(self) -> None:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds support for `prompt_template` as an alias for `prompt` in PipeSpec parsing, and updates `mthds` install steps for Claude Code and Codex to match the new flow.

- **New Features**
  - Accept `prompt_template` and promote it to `prompt` when the canonical field is missing; drop the alias if both exist.
  - Applies to both PipeLLM and PipeImgGen, with unit tests added.

<sup>Written for commit a306dc0d073be33af7a7f4a3294f3bd5fbcb7411. Summary will update on new commits. <a href="https://cubic.dev/pr/Pipelex/pipelex/pull/843?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

