### PR TITLE
Release v0.25.1

### DIFF
--- a/.badges/tests.json
+++ b/.badges/tests.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "label": "tests",
-  "message": "4138",
+  "message": "4192",
   "color": "blue",
   "cacheSeconds": 300
 }

--- a/.badges/tests.json
+++ b/.badges/tests.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "label": "tests",
-  "message": "4192",
+  "message": "4193",
   "color": "blue",
   "cacheSeconds": 300
 }

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -5,7 +5,7 @@ on:
     types: [closed]
     branches:
       - main
-      - 'pre-release/v*'
+      - "pre-release/v*"
 
 jobs:
   build:
@@ -93,19 +93,19 @@ jobs:
         run: |
           VERSION="${{ env.VERSION }}"
           echo "Extracting changelog for version v$VERSION"
-          
+
           # Find the start of the current version section
           START_LINE=$(grep -n "## \[v$VERSION\] - " CHANGELOG.md | cut -d: -f1)
-          
+
           if [ -z "$START_LINE" ]; then
             echo "Warning: No changelog entry found for version v$VERSION"
             echo "CHANGELOG_NOTES=" >> $GITHUB_ENV
             exit 0
           fi
-          
+
           # Find the start of the next version section (previous version)
           NEXT_VERSION_LINE=$(tail -n +$((START_LINE + 1)) CHANGELOG.md | grep -n "^## \[v.*\] - " | head -1 | cut -d: -f1)
-          
+
           if [ -z "$NEXT_VERSION_LINE" ]; then
             # No next version found, extract from current version till end of file
             CHANGELOG_CONTENT=$(tail -n +$START_LINE CHANGELOG.md)
@@ -114,15 +114,15 @@ jobs:
             END_LINE=$((START_LINE + NEXT_VERSION_LINE - 1))
             CHANGELOG_CONTENT=$(sed -n "$START_LINE,$((END_LINE - 1))p" CHANGELOG.md)
           fi
-          
+
           # Clean up the content but preserve the blank line after the header
           # First, get the header line and add a blank line after it
           HEADER_LINE=$(echo "$CHANGELOG_CONTENT" | head -1)
           CONTENT_LINES=$(echo "$CHANGELOG_CONTENT" | tail -n +2 | sed '/^$/d' | sed 's/^[[:space:]]*//' | sed 's/[[:space:]]*$//')
-          
+
           # Combine header + blank line + content
           CHANGELOG_CONTENT=$(printf "%s\n\n%s" "$HEADER_LINE" "$CONTENT_LINES")
-          
+
           # Escape for GitHub Actions
           echo "CHANGELOG_NOTES<<EOF" >> $GITHUB_ENV
           echo "$CHANGELOG_CONTENT" >> $GITHUB_ENV

--- a/.pipelex/inference/deck/.kit_manifest.json
+++ b/.pipelex/inference/deck/.kit_manifest.json
@@ -1,0 +1,9 @@
+{
+  "files": {
+    "1_llm_deck.toml": "eb093712da6f4426ccade800c55aa3fbf64862917ec4e46c141eceb80e4ac1e8",
+    "2_img_gen_deck.toml": "63b1397f0427aada890096c7d430313f287fd613248aa1f3ab4b9e09a7f19402",
+    "3_extract_deck.toml": "560a40bd3254b1be011cfb35340fef6c40d70136e5ddce33a961899f92fd70ba",
+    "4_search_deck.toml": "08e3bd1bee0f9f8ed0ffc735a932705392d0ecfbdeefce64c9815d4b2d8d7e22"
+  },
+  "kit_version": "0.25.0"
+}

--- a/.pipelex/inference/deck/1_llm_deck.toml
+++ b/.pipelex/inference/deck/1_llm_deck.toml
@@ -4,6 +4,11 @@
 #
 # This file defines model defaults, aliases, and presets for LLMs
 #
+# Managed by `pipelex update`. To customize without conflict, edit
+# x_custom_llm_deck.toml in this directory — pipelex never tracks or
+# overwrites x_custom_* files. Local edits to this file are backed up
+# to <file>.bak.<timestamp> on update but will not survive future runs.
+#
 # Model Reference Syntax:
 # - Preset:    $preset_name or preset:preset_name
 # - Alias:     @alias_name or alias:alias_name

--- a/.pipelex/inference/deck/2_img_gen_deck.toml
+++ b/.pipelex/inference/deck/2_img_gen_deck.toml
@@ -4,6 +4,11 @@
 #
 # This file defines model aliases and presets for image generation models
 #
+# Managed by `pipelex update`. To customize without conflict, create an
+# x_custom_*.toml file in this directory — pipelex never tracks or
+# overwrites x_custom_* files. Local edits to this file are backed up
+# to <file>.bak.<timestamp> on update but will not survive future runs.
+#
 # Model Reference Syntax:
 # - Preset:    $preset_name or preset:preset_name
 # - Alias:     @alias_name or alias:alias_name

--- a/.pipelex/inference/deck/3_extract_deck.toml
+++ b/.pipelex/inference/deck/3_extract_deck.toml
@@ -5,6 +5,11 @@
 # This file defines model aliases and presets for Document extraction models, including
 # extraction of text and images from documents and OCR and text extraction from images.
 #
+# Managed by `pipelex update`. To customize without conflict, edit
+# x_custom_extract_deck.toml in this directory — pipelex never tracks or
+# overwrites x_custom_* files. Local edits to this file are backed up
+# to <file>.bak.<timestamp> on update but will not survive future runs.
+#
 # Model Reference Syntax:
 # - Preset:    $preset_name or preset:preset_name
 # - Alias:     @alias_name or alias:alias_name

--- a/.pipelex/inference/deck/4_search_deck.toml
+++ b/.pipelex/inference/deck/4_search_deck.toml
@@ -5,6 +5,11 @@
 # This file defines model aliases and presets for Search models, including
 # web search providers like Linkup.
 #
+# Managed by `pipelex update`. To customize without conflict, create an
+# x_custom_*.toml file in this directory — pipelex never tracks or
+# overwrites x_custom_* files. Local edits to this file are backed up
+# to <file>.bak.<timestamp> on update but will not survive future runs.
+#
 # Model Reference Syntax:
 # - Preset:    $preset_name or preset:preset_name
 # - Alias:     @alias_name or alias:alias_name

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,16 @@
 
 ### Added
 
+- **`pipelex update` command + model-deck staleness detection.** New top-level command refreshes the installed model deck (`~/.pipelex/inference/deck/`) to match the kit shipped with the running pipelex version. Tracks per-file SHA-256 hashes plus the kit version in a `.kit_manifest.json` written next to the deck files. Supports `--dry-run`, `--yes` (non-interactive), `--no-backup` (skip `.bak` files for locally-modified deck files), and `--local` (project-local deck instead of global).
+- **Boot-time deck staleness warn.** Every `pipelex` CLI invocation prints a one-line yellow advisory when the installed deck's recorded kit version is older than the running pipelex (or when no manifest exists yet). Cost is one file read + one string compare. Suppress with `PIPELEX_NO_DECK_NOTICE=1`. Skipped automatically for `pipelex login`, `init`, `doctor`, `update`, and `which`.
+- **`pipelex doctor` deck section.** Reports per-file deck status (`up_to_date`, `kit_added`, `kit_removed`, `clean_behind`, `locally_modified`) and offers `pipelex update` as an auto-fix under `--fix`.
+- **Manifest written by `pipelex init`.** Fresh installs land with a current `.kit_manifest.json` so future updates can detect drift cleanly.
 - **`--dynamic-output-concept` / `-O` flag on `pipelex run`.** All three subcommands (`run bundle`, `run pipe`, `run method`) accept a concept ref (e.g. `document_qa.ReferenceCount`) used to resolve a pipe whose output is declared as `Dynamic`. Threaded through `_run_core.execute_run` to `PipelexRunner.execute_pipeline(dynamic_output_concept_ref=...)`. Until now, Dynamic-output pipes were only callable from the Python runner.
-
 - **Line-length-safe wrapping in the structures generator.** `pipelex build structures` now wraps long descriptions so every emitted line stays under the 150-char ruff limit. Long class docstrings become a multi-line triple-quoted block; long Field descriptions become a parenthesized implicit-string-concatenation block (`description=("first chunk " "second chunk")`). Short descriptions still emit the compact single-line form. New unit tests in `tests/unit/pipelex/core/concepts/structure_generation/test_structure_generator_wrapping.py` cover both lengths and the combined long-everything case. Previously, descriptions above ~140 chars produced files that failed `ruff check` with E501.
+
+### Changed
+
+- **Numbered deck files (`N_*_deck.toml`) are pipelex-managed.** Each file now carries a header banner explaining that customizations belong in `x_custom_*.toml` (which pipelex never tracks or overwrites). Local edits to numbered files are preserved with a timestamped `.bak.<UTC-timestamp>` backup on `pipelex update` but will not survive future updates.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [v0.25.1] - 2026-04-29
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- **`--dynamic-output-concept` / `-O` flag on `pipelex run`.** All three subcommands (`run bundle`, `run pipe`, `run method`) accept a concept ref (e.g. `document_qa.ReferenceCount`) used to resolve a pipe whose output is declared as `Dynamic`. Threaded through `_run_core.execute_run` to `PipelexRunner.execute_pipeline(dynamic_output_concept_ref=...)`. Until now, Dynamic-output pipes were only callable from the Python runner.
+
+- **Line-length-safe wrapping in the structures generator.** `pipelex build structures` now wraps long descriptions so every emitted line stays under the 150-char ruff limit. Long class docstrings become a multi-line triple-quoted block; long Field descriptions become a parenthesized implicit-string-concatenation block (`description=("first chunk " "second chunk")`). Short descriptions still emit the compact single-line form. New unit tests in `tests/unit/pipelex/core/concepts/structure_generation/test_structure_generator_wrapping.py` cover both lengths and the combined long-everything case. Previously, descriptions above ~140 chars produced files that failed `ruff check` with E501.
+
+### Fixed
+
+- **`PipeLLM` Dynamic-output detection compared the wrong fields.** `pipe_llm.py` checked `self.output.concept.code == "native.Dynamic"`, but `concept.code` is the bare code (`"Dynamic"`) not the qualified ref. The check never matched, so when a caller passed `dynamic_output_concept_ref` for a `Dynamic`-output pipe, the resolver branch was skipped silently: the output structure stayed `DynamicContent` (an empty `StuffContent` subclass), the LLM produced JSON shaped like the requested concept, and the result deserialized to `{}`. Detection now uses `concept.code == NativeConceptCode.DYNAMIC and concept.domain_code == SpecialDomain.NATIVE`.
+
+- **Dynamic-output concept resolution rejected qualified refs.** When the runtime override was supplied (e.g. `"document_qa.ReferenceCount"`), the previous code called `make_concept_ref_with_domain(domain_code=self.domain_code, concept_code=output_concept_ref)`, producing `"document_qa.document_qa.ReferenceCount"` and a missing-concept lookup. Now uses `make_concept_ref_with_domain_from_concept_ref_or_code`, which extracts the domain from the input when it's already qualified and falls back to the pipe's domain only for bare codes. Callers can pass either form.
+
 ## [v0.25.0] - 2026-04-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ From here, Pipelex handles model routing across 60+ models, structured output pa
 Paste this into Claude Code:
 
 ```
-Install mthds: run bash -c 'npm install -g mthds && mthds-agent bootstrap && claude plugin marketplace add mthds-ai/mthds-plugins && claude plugin install mthds@mthds-plugins'. Then tell me to restart Claude Code.
+Install mthds: run bash -c 'npm install -g mthds && mthds-agent bootstrap && claude plugin marketplace add mthds-ai/mthds-plugins && claude plugin install mthds@mthds-plugins'. Then tell me to /reload-plugins.
 ```
 
 ## With Codex
@@ -71,7 +71,7 @@ Install mthds: run bash -c 'npm install -g mthds && mthds-agent bootstrap && cla
 Paste this into Codex:
 
 ```
-Install mthds: run bash -c 'npm install -g mthds && mthds-agent bootstrap && bash <(curl -fsSL https://raw.githubusercontent.com/mthds-ai/mthds-plugins/main/bin/install-codex.sh)'. Then tell me to run /plugins, search for MTHDS, and install it.
+Install mthds: run bash -c 'npm install -g mthds && mthds-agent bootstrap && mthds-agent codex install-hook && mthds-agent codex apply-config && codex plugin marketplace add mthds-ai/mthds-plugins'. Then tell me to restart Codex and run /plugins to install mthds.
 ```
 
 Install the [VS Code extension](https://go.pipelex.com/vscode) for `.mthds` syntax highlighting and flowchart visualization.

--- a/docs/configuration/config-technical/inference-backend-config.md
+++ b/docs/configuration/config-technical/inference-backend-config.md
@@ -83,6 +83,11 @@ All inference backend configurations are stored in the `.pipelex/inference/` dir
 
 Deck files are loaded in order by their numeric prefix (`1_`, `2_`, `3_`), with custom/override files (`x_` prefix) loaded last.
 
+!!! tip "Numbered files are pipelex-managed; overrides go in `x_custom_*.toml`"
+    The numbered deck files (`1_llm_deck.toml`...`4_search_deck.toml`) are refreshed by `pipelex update` when a new release ships an updated deck. Local edits to those files are preserved with a timestamped `.bak` backup but will not survive future updates.
+
+    To customize aliases, presets, or default choices without conflict, edit (or create) any file in this directory whose name starts with `x_custom_` — Pipelex never tracks or overwrites those. See [`pipelex update`](../../tools/cli/update.md) for the full workflow.
+
 ## Pipelex Gateway (Optional & Free)
 
 Pipelex Gateway is a unified inference backend that provides access to all major AI providers through a single API key. This is the **recommended approach for getting started quickly** with Pipelex and **unlocking its full power**—with many models already available and new ones being added constantly. Using Pipelex Gateway is **completely optional**.

--- a/docs/features/cli.md
+++ b/docs/features/cli.md
@@ -17,6 +17,7 @@ The `pipelex` CLI is the primary tool for working with Pipelex methods. It cover
 |---------|-------------|
 | **`pipelex login`** | Authenticate with Pipelex Gateway via the browser and save your API key |
 | **`pipelex init`** | Initialize configuration, backends, credentials, routing, and telemetry |
+| **`pipelex update`** | Refresh the model deck to match the installed pipelex version |
 | **`pipelex doctor`** | Check configuration health and suggest fixes |
 | **`pipelex build`** | AI-powered method generation from natural language requirements |
 | **`pipelex validate`** | Check pipeline syntax, structure, and run dry-run validation |

--- a/docs/tools/cli/index.md
+++ b/docs/tools/cli/index.md
@@ -14,6 +14,7 @@ The Pipelex CLI is organized into several command groups:
 | Command | Description |
 |---------|-------------|
 | [**init**](init.md) | Initialize Pipelex configuration |
+| [**update**](update.md) | Refresh the model deck to match the installed pipelex version |
 | [**validate**](validate.md) | Validate configuration and pipelines |
 | [**show**](show.md) | Inspect configuration, pipes, and AI models |
 | [**run**](run.md) | Execute pipelines |

--- a/docs/tools/cli/update.md
+++ b/docs/tools/cli/update.md
@@ -1,0 +1,99 @@
+---
+description: "Refresh the installed Pipelex model deck — keep `1_llm_deck.toml` and friends in sync with the kit shipped by your installed pipelex version, while preserving your `x_custom_*.toml` overrides."
+---
+
+# Update Command
+
+Refresh the installed model deck so it matches the kit shipped with your current `pipelex` version.
+
+```bash
+pipelex update [OPTIONS]
+pipelex update --local [OPTIONS]
+```
+
+When a new `pipelex` release ships changes to the model deck — new models, new aliases, retired entries — your previously installed deck under `~/.pipelex/inference/deck/` will fall behind. `pipelex update` brings it up to date without nuking your overrides.
+
+## When to run it
+
+Pipelex prints a one-line yellow advisory at the top of every CLI invocation when it detects that the installed deck is older than the running package, or when no deck manifest is present yet:
+
+```text
+⚠ Pipelex model deck may be out of date — run pipelex update to refresh
+```
+
+Run `pipelex update` to clear the warning. To silence it permanently for a session or environment:
+
+```bash
+export PIPELEX_NO_DECK_NOTICE=1
+```
+
+## What it does
+
+Pipelex tracks the deck install state in a small JSON manifest at `~/.pipelex/inference/deck/.kit_manifest.json` (or `.pipelex/inference/deck/.kit_manifest.json` for project-local installs). The manifest stores the kit version that produced the install and a SHA-256 of each managed deck file at install time.
+
+On `update`, Pipelex compares three states — what the kit ships, what is on disk, what the manifest recorded — and produces a per-file plan:
+
+| Status | Meaning | Action |
+|---|---|---|
+| `up-to-date` | Installed file matches the kit | none |
+| `new` | Kit ships a new managed file not yet installed | install from kit |
+| `behind` | Installed file unchanged from manifest, kit has newer content | overwrite from kit |
+| `locally modified` | Installed file was edited after install — kit version differs | back up + overwrite |
+| `removed upstream` | Kit no longer ships this file | back up + remove |
+
+Locally-modified files are preserved as `<file>.bak.<UTC-timestamp>` before the kit version is written in their place. Removed files get the same backup treatment before deletion. After the run, Pipelex writes a fresh manifest stamped with the new kit version.
+
+## Managed files vs. user overrides
+
+Pipelex draws a sharp line between deck files it owns and deck files you own.
+
+- **Managed (pipelex-owned)** — `1_llm_deck.toml`, `2_img_gen_deck.toml`, `3_extract_deck.toml`, `4_search_deck.toml`. These are refreshed by `pipelex update`. Local edits are preserved with a `.bak.<timestamp>` backup but will not survive future updates.
+- **User overrides** — any file in the deck directory whose name starts with `x_custom_` (e.g. `x_custom_llm_deck.toml`, `x_custom_extract_deck.toml`). Pipelex never tracks, hashes, copies, or removes these. Add new ones whenever you need to override aliases, presets, or default choices for a backend.
+
+The deck loader merges all `*.toml` files under the deck directory in alphabetical order via deep-merge, so your `x_custom_*.toml` always wins over the numbered defaults.
+
+## Options
+
+| Flag | Description |
+|---|---|
+| `--local` / `-l` | Update the project-local `.pipelex/` deck instead of the global `~/.pipelex/` |
+| `--yes` / `-y` | Apply updates non-interactively (skip the confirmation prompt) |
+| `--dry-run` | Show the plan without modifying any file |
+| `--no-backup` | Do not create `.bak` files for locally-modified deck files |
+
+## Examples
+
+```bash
+# Preview what would change
+pipelex update --dry-run
+
+# Interactive update of the global deck
+pipelex update
+
+# Non-interactive update — useful for CI or scripts
+pipelex update --yes
+
+# Project-local deck only
+pipelex update --local --yes
+
+# Skip the .bak backups (advanced — your edits will be lost permanently)
+pipelex update --yes --no-backup
+```
+
+## Migration: existing installs without a manifest
+
+If your deck was installed before the `update` command existed, there will be no `.kit_manifest.json` next to your deck files. The first `pipelex update` run reports each managed file as `locally modified` (no provenance proof) and asks before overwriting. Two ways to migrate cleanly:
+
+1. **Trust the kit** — run `pipelex update --yes` to take the upstream version of every managed file. Anything you want to keep can be moved into an `x_custom_*.toml` afterwards using the `.bak.<timestamp>` files as a reference.
+2. **Move overrides first** — copy any custom aliases, presets, or defaults from your numbered files into a new `x_custom_<area>_deck.toml`, then run `pipelex update --yes`. Your customizations will live in the file Pipelex never touches.
+
+After either path, subsequent updates land cleanly without prompting on the unchanged files.
+
+## Diagnostics
+
+`pipelex doctor` includes a **Model Deck** section that reports the same per-file status as `update`. Run `pipelex doctor --fix` to be offered an interactive `pipelex update` as part of the standard fix flow.
+
+## Related
+
+- [Init Commands](init.md) — first-time setup that materializes the deck and its manifest
+- [LLM Providers & Models Configuration](../../configuration/config-technical/inference-backend-config.md) — what the deck files actually configure

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -259,6 +259,7 @@ plugins:
         Reference:
         - tools/cli/index.md: "CLI Reference Overview"
         - tools/cli/init.md: "CLI Init"
+        - tools/cli/update.md: "CLI Update"
         - tools/cli/validate.md: "CLI Validate"
         - tools/cli/run.md: "CLI Run"
         - tools/cli/show.md: "CLI Show"
@@ -435,6 +436,7 @@ nav:
     - CLI Reference:
       - Overview: tools/cli/index.md
       - Init: tools/cli/init.md
+      - Update: tools/cli/update.md
       - Validate: tools/cli/validate.md
       - Run: tools/cli/run.md
       - Show: tools/cli/show.md

--- a/pipelex/builder/operations/pipe_ops.py
+++ b/pipelex/builder/operations/pipe_ops.py
@@ -30,6 +30,9 @@ _PIPE_CODE_ALIASES = ("pipe", "the_pipe_code", "code", "name", "pipe_name", "pip
 # Aliases that agents may use instead of "output". First found is promoted when canonical key is absent; extras are dropped.
 _OUTPUT_ALIASES = ("output_concept", "output_type")
 
+# Aliases that agents may use instead of "prompt". First found is promoted when canonical key is absent; extras are dropped.
+_PROMPT_ALIASES = ("prompt_template",)
+
 
 def _normalize_sub_pipe_dict(data: dict[str, Any]) -> None:
     """Normalize a step/branch dict: resolve pipe_code aliases and drop extraneous fields."""
@@ -45,6 +48,16 @@ def _normalize_pipe_code_aliases(data: dict[str, Any]) -> None:
         if alias in data:
             if "pipe_code" not in data:
                 data["pipe_code"] = data.pop(alias)
+            else:
+                data.pop(alias)
+
+
+def _normalize_prompt_aliases(data: dict[str, Any]) -> None:
+    """Convert any alias of ``prompt`` to the canonical field name, in-place."""
+    for alias in _PROMPT_ALIASES:
+        if alias in data:
+            if "prompt" not in data:
+                data["prompt"] = data.pop(alias)
             else:
                 data.pop(alias)
 
@@ -78,6 +91,9 @@ def parse_pipe_spec(pipe_type: str, spec_data: dict[str, Any]) -> PipeSpec:
 
     # Accept common aliases for "pipe_code" at the top level
     _normalize_pipe_code_aliases(spec_data)
+
+    # Accept common aliases for "prompt" (e.g. "prompt_template")
+    _normalize_prompt_aliases(spec_data)
 
     # Handle steps/branches conversion — normalize aliases and drop unknown fields.
     # Deep-copy nested dicts to avoid mutating caller's nested structures.

--- a/pipelex/cli/_cli.py
+++ b/pipelex/cli/_cli.py
@@ -14,8 +14,10 @@ from pipelex.cli.commands.init.ui.types import InitFocus
 from pipelex.cli.commands.login.command import login_cmd
 from pipelex.cli.commands.run.app import run_app
 from pipelex.cli.commands.show_cmd import show_app
+from pipelex.cli.commands.update_cmd import update_cmd
 from pipelex.cli.commands.validate.app import validate_app
 from pipelex.cli.commands.which_cmd import which_cmd
+from pipelex.cli.deck_notice import warn_if_deck_stale
 from pipelex.cli.readiness import check_readiness
 from pipelex.hub import get_console
 from pipelex.tools.misc.package_utils import get_package_version
@@ -27,7 +29,7 @@ class PipelexCLI(TyperGroup):
     @override
     def list_commands(self, ctx: Context) -> list[str]:
         # List the commands in the proper order because natural ordering doesn't work between Typer groups and commands
-        return ["login", "init", "doctor", "build", "validate", "run", "graph", "show", "which"]
+        return ["login", "init", "doctor", "update", "build", "validate", "run", "graph", "show", "which"]
 
     @override
     def get_command(self, ctx: Context, cmd_name: str) -> Command | None:
@@ -115,12 +117,15 @@ def app_callback(
                ░██                                     v[cyan]{package_version}[/cyan]
 """
         )
-    # Skip checks if no command is being run (e.g., just --help) or if running init/doctor command
-    if ctx.invoked_subcommand is None or ctx.invoked_subcommand in {"login", "init", "doctor"}:
+    # Skip checks if no command is being run (e.g., just --help) or if running setup/diagnostic commands
+    if ctx.invoked_subcommand is None or ctx.invoked_subcommand in {"login", "init", "doctor", "update", "which"}:
         return
 
     # Check system readiness (dependencies and venv for dev installs)
     check_readiness()
+
+    # Warn if the model deck has fallen behind the installed pipelex version
+    warn_if_deck_stale()
 
 
 @app.command(name="login", help="Log in to Pipelex Gateway via the browser and save your API key")
@@ -168,6 +173,24 @@ def doctor_command(
 ) -> None:
     """Check Pipelex configuration health."""
     doctor_cmd(fix=fix)
+
+
+@app.command(name="update", help="Update the model deck to match the installed pipelex version")
+def update_command(
+    local: Annotated[
+        bool,
+        typer.Option(
+            "--local",
+            "-l",
+            help="Force the project-local .pipelex/ deck. Default targets the resolved deck dir (project if .pipelex/ exists, else global)",
+        ),
+    ] = False,
+    yes: Annotated[bool, typer.Option("--yes", "-y", help="Apply updates without the interactive confirmation prompt")] = False,
+    dry_run: Annotated[bool, typer.Option("--dry-run", help="Show the planned actions without modifying any file")] = False,
+    no_backup: Annotated[bool, typer.Option("--no-backup", help="Skip .bak files when overwriting locally-modified deck files")] = False,
+) -> None:
+    """Refresh the installed deck to match the kit shipped with the running pipelex version."""
+    update_cmd(local=local, yes=yes, dry_run=dry_run, no_backup=no_backup)
 
 
 app.add_typer(

--- a/pipelex/cli/agent_cli/commands/init_cmd.py
+++ b/pipelex/cli/agent_cli/commands/init_cmd.py
@@ -15,6 +15,7 @@ from pipelex.cli.commands.init.config_files import init_config
 from pipelex.cli.commands.init.ui.backends_ui import get_backend_options_from_toml
 from pipelex.cogt.model_backends.backend import PipelexBackend
 from pipelex.cogt.model_routing.routing_profile import PipelexRoutingProfile
+from pipelex.cogt.models.deck_manifest import compute_kit_manifest, write_manifest
 from pipelex.kit.paths import get_kit_configs_dir
 from pipelex.system.configuration.config_loader import config_manager
 from pipelex.system.pipelex_service.pipelex_service_agreement import (
@@ -115,6 +116,8 @@ def _copy_inference_templates(target_dir: Path) -> None:
     for deck_file in os.listdir(template_deck_dir):
         if deck_file.endswith(".toml"):
             shutil.copy2(template_deck_dir / deck_file, target_deck_dir / deck_file)
+
+    write_manifest(target_deck_dir, compute_kit_manifest())
 
     # Copy routing_profiles.toml
     template_routing_path = template_inference_dir / "routing_profiles.toml"

--- a/pipelex/cli/commands/doctor_cmd.py
+++ b/pipelex/cli/commands/doctor_cmd.py
@@ -19,10 +19,12 @@ from pipelex.base_exceptions import PipelexConfigError
 from pipelex.cli.commands.init.command import init_cmd
 from pipelex.cli.commands.init.config_files import init_config
 from pipelex.cli.commands.init.ui.types import InitFocus
+from pipelex.cli.commands.update_cmd import update_cmd
 from pipelex.cogt.exceptions import InferenceBackendLibraryError
 from pipelex.cogt.model_backends.backend_credentials import BackendCredentialsErrorMsgFactory
 from pipelex.cogt.model_backends.backend_library import BackendCredentialsReport, InferenceBackendLibrary
 from pipelex.cogt.model_backends.gateway_config import GatewayConfig
+from pipelex.cogt.models.deck_manifest import DeckFileStatus, DeckSyncReport, compute_deck_sync_report, status_rich_label
 from pipelex.cogt.models.model_manager import ModelManager
 from pipelex.config import get_config
 from pipelex.core.validation import report_validation_error
@@ -409,6 +411,9 @@ def display_health_report(
     models_healthy: bool,
     models_message: str,
     backend_file_reports: dict[str, BackendFileReport],
+    deck_healthy: bool,
+    deck_message: str,
+    deck_report: DeckSyncReport,
     config_location: ConfigLocationInfo,
     fix_mode: bool = False,
 ) -> None:
@@ -426,10 +431,13 @@ def display_health_report(
         models_healthy: Whether models check passed
         models_message: Message about models status
         backend_file_reports: Dict of backend file validation reports
+        deck_healthy: Whether the model deck is in sync with the kit shipped by this pipelex version
+        deck_message: Summary message about deck sync status
+        deck_report: Per-file sync status report (used to render the per-file detail when not healthy)
         config_location: Resolved configuration location information
         fix_mode: Whether we're in interactive fix mode (--fix flag)
     """
-    all_healthy = config_healthy and telemetry_healthy and backends_healthy and models_healthy
+    all_healthy = config_healthy and telemetry_healthy and backends_healthy and models_healthy and deck_healthy
 
     # Overall status panel
     if all_healthy:
@@ -530,6 +538,20 @@ def display_health_report(
                         console.print(f"    [dim]{error_lines[0][:100]}[/dim]")
     console.print()
 
+    # Model Deck section
+    console.print("[bold]Model Deck[/bold]")
+    if deck_healthy:
+        console.print(f"  [green]✓[/green] {deck_message}")
+    else:
+        console.print(f"  [yellow]⚠[/yellow]  {deck_message}")
+        # Per-file detail when there are pending actions
+        actionable_statuses = {name: status for name, status in deck_report.files.items() if status != DeckFileStatus.UP_TO_DATE}
+        if actionable_statuses:
+            for filename in sorted(actionable_statuses):
+                status = actionable_statuses[filename]
+                console.print(f"    [dim]{filename}[/dim] — {status_rich_label(status)}")
+    console.print()
+
     # Recommended actions
     if not all_healthy:
         # Check what can be auto-fixed
@@ -555,12 +577,14 @@ def display_health_report(
                 has_custom_backend_issues = any(not report.has_kit_template for report in invalid_backends.values())
 
         # Determine if we have any recommendations to show
+        has_deck_drift = not deck_healthy
         has_recommendations = (
             can_auto_fix_config
             or can_auto_fix_telemetry
             or has_telemetry_validation_error
             or (not backends_healthy and backend_credential_reports)
             or has_backend_file_issues
+            or has_deck_drift
         )
 
         if has_recommendations:
@@ -575,6 +599,9 @@ def display_health_report(
             if has_telemetry_validation_error and "pipelex init telemetry" not in telemetry_message:
                 console.print(f"  • Fix validation errors in [cyan]{config_location.config_dir}/telemetry.toml[/cyan]")
                 console.print("    or run [cyan]pipelex init telemetry[/cyan] to regenerate")
+
+            if has_deck_drift:
+                console.print("  • Run [cyan]pipelex update[/cyan] to refresh the model deck from the current kit")
 
             # Backend file issues
             if can_auto_fix_backends:
@@ -629,6 +656,39 @@ def display_health_report(
             console.print("  [cyan]https://docs.pipelex.com[/cyan] - Documentation")
             console.print("  [cyan]https://go.pipelex.com/discord[/cyan] - Discord Community")
             console.print()
+
+
+def check_deck_sync(config_dir: Path | None = None) -> tuple[bool, DeckSyncReport, str]:
+    """Check whether the installed model deck is in sync with the kit shipped by this pipelex version.
+
+    Args:
+        config_dir: Explicit config directory override. If None, uses layered resolution.
+
+    Returns:
+        Tuple of (is_healthy, sync_report, summary_message)
+    """
+    effective_config_dir = config_dir or config_manager.pipelex_config_dir
+    deck_dir = Path(effective_config_dir) / "inference" / "deck"
+
+    if not deck_dir.exists():
+        # Match the existing doctor pattern: surface as healthy when the area isn't initialized,
+        # since the missing-init advisory is handled by the config_files / backends checks above.
+        return True, DeckSyncReport(kit_version="", installed_kit_version=None, manifest_present=False, files={}), "Deck directory not present"
+
+    report = compute_deck_sync_report(deck_dir)
+    if report.is_clean():
+        return True, report, f"Deck is up to date with pipelex {report.kit_version}"
+
+    actionable = [name for name, status in report.files.items() if status.needs_action]
+    if not report.manifest_present:
+        return False, report, "Deck manifest missing — run `pipelex update` to materialize a baseline"
+    if report.installed_kit_version != report.kit_version:
+        return (
+            False,
+            report,
+            f"Deck installed for pipelex {report.installed_kit_version}, current is {report.kit_version} ({len(actionable)} file(s) need action)",
+        )
+    return False, report, f"{len(actionable)} deck file(s) need action"
 
 
 def check_models(config_dir: Path | None = None) -> tuple[bool, str, dict[str, BackendFileReport]]:
@@ -748,6 +808,7 @@ def do_doctor_cmd(
     telemetry_healthy, telemetry_message = check_telemetry_config()
     backends_healthy, backend_credential_reports, backends_message = check_backend_credentials()
     models_healthy, models_message, backend_file_reports = check_models()
+    deck_healthy, deck_report, deck_message = check_deck_sync()
 
     # Display report
     display_health_report(
@@ -762,11 +823,14 @@ def do_doctor_cmd(
         models_healthy=models_healthy,
         models_message=models_message,
         backend_file_reports=backend_file_reports,
+        deck_healthy=deck_healthy,
+        deck_message=deck_message,
+        deck_report=deck_report,
         config_location=config_location,
         fix_mode=fix,
     )
 
-    all_healthy = config_healthy and telemetry_healthy and backends_healthy and models_healthy
+    all_healthy = config_healthy and telemetry_healthy and backends_healthy and models_healthy and deck_healthy
 
     # Exit code: 0 if healthy, 1 if issues found
     if all_healthy:
@@ -789,7 +853,9 @@ def do_doctor_cmd(
         fixable_backends = [(name, report) for name, report in invalid_backends if report.has_kit_template]
         can_fix_backends = len(fixable_backends) > 0
 
-    has_auto_fixable_issues = can_fix_config or can_fix_telemetry or can_fix_backends
+    can_fix_deck = not deck_healthy and deck_report.kit_version != ""
+
+    has_auto_fixable_issues = can_fix_config or can_fix_telemetry or can_fix_backends or can_fix_deck
 
     # Determine what requires manual fixes (excludes auto-fixable issues)
     has_config_validation_error = not config_healthy and config_missing_count == 0
@@ -831,6 +897,17 @@ def do_doctor_cmd(
                     console.print("[green]✓[/green] Telemetry configured")
                 except Exception as exc:
                     console.print(f"[red]Failed to configure telemetry: {exc!s}[/red]")
+                console.print()
+
+        # Fix outdated model deck
+        if can_fix_deck:
+            if Confirm.ask("[bold]Update the model deck now?[/bold]", default=True):
+                try:
+                    console.print()
+                    update_cmd(yes=True)
+                    console.print("[green]✓[/green] Model deck updated")
+                except Exception as exc:
+                    console.print(f"[red]Failed to update deck: {exc!s}[/red]")
                 console.print()
 
         # Fix outdated backend files

--- a/pipelex/cli/commands/doctor_cmd.py
+++ b/pipelex/cli/commands/doctor_cmd.py
@@ -667,8 +667,10 @@ def check_deck_sync(config_dir: Path | None = None) -> tuple[bool, DeckSyncRepor
     Returns:
         Tuple of (is_healthy, sync_report, summary_message)
     """
-    effective_config_dir = config_dir or config_manager.pipelex_config_dir
-    deck_dir = Path(effective_config_dir) / "inference" / "deck"
+    # When no explicit config_dir is given, mirror runtime layered resolution so we report
+    # against the deck that's actually in use (project .pipelex/ wins when it ships a deck,
+    # otherwise we fall through to the global deck).
+    deck_dir = Path(config_dir) / "inference" / "deck" if config_dir is not None else config_manager.model_decks_dir_path
 
     if not deck_dir.exists():
         # Match the existing doctor pattern: surface as healthy when the area isn't initialized,

--- a/pipelex/cli/commands/init/command.py
+++ b/pipelex/cli/commands/init/command.py
@@ -27,6 +27,7 @@ from pipelex.cli.commands.init.ui.gateway_ui import (
 from pipelex.cli.commands.init.ui.general_ui import build_initialization_panel
 from pipelex.cli.commands.init.ui.types import InitFocus
 from pipelex.cogt.model_backends.backend import PipelexBackend
+from pipelex.cogt.models.deck_manifest import compute_kit_manifest, write_manifest
 from pipelex.hub import get_console
 from pipelex.kit.paths import get_kit_configs_dir
 from pipelex.system.configuration.config_loader import config_manager
@@ -253,6 +254,10 @@ def execute_initialization(
                     src_path = template_deck_dir / deck_file
                     dst_path = target_deck_dir / deck_file
                     shutil.copy2(src_path, dst_path)
+
+            # Stamp the deck manifest so future updates can detect drift and
+            # `pipelex update` knows the exact kit version this install came from.
+            write_manifest(target_deck_dir, compute_kit_manifest())
 
             # Reset routing_profiles.toml
             template_routing_path = template_inference_dir / "routing_profiles.toml"

--- a/pipelex/cli/commands/run/_run_core.py
+++ b/pipelex/cli/commands/run/_run_core.py
@@ -51,6 +51,7 @@ async def _execute_run(
     dry_run: bool,
     mock_inputs: bool,
     library_dir: list[str] | None,
+    dynamic_output_concept_ref: str | None = None,
 ) -> None:
     """Core async execution logic for running a pipe.
 
@@ -127,6 +128,7 @@ async def _execute_run(
             pipe_code=pipe_code,
             mthds_contents=[mthds_content] if mthds_content else None,
             inputs=pipeline_inputs,
+            dynamic_output_concept_ref=dynamic_output_concept_ref,
         )
         pipe_output = response.pipe_output
     except PipelineExecutionError as exc:
@@ -244,6 +246,7 @@ def execute_run(
     mock_inputs: bool,
     library_dir: list[str] | None,
     telemetry_command_label: str = COMMAND,
+    dynamic_output_concept_ref: str | None = None,
 ) -> None:
     """Synchronous entry point that wraps the async execution with Pipelex setup/teardown.
 
@@ -271,6 +274,7 @@ def execute_run(
                     dry_run=dry_run,
                     mock_inputs=mock_inputs,
                     library_dir=library_dir,
+                    dynamic_output_concept_ref=dynamic_output_concept_ref,
                 )
             )
 

--- a/pipelex/cli/commands/run/bundle_cmd.py
+++ b/pipelex/cli/commands/run/bundle_cmd.py
@@ -69,6 +69,14 @@ def run_bundle_cmd(
         list[str] | None,
         typer.Option("--library-dir", "-L", help="Directory to search for pipe definitions (.mthds files). Can be specified multiple times."),
     ] = None,
+    dynamic_output_concept_ref: Annotated[
+        str | None,
+        typer.Option(
+            "--dynamic-output-concept",
+            "-O",
+            help="Concept ref (e.g. 'document_qa.ReferenceCount') used to resolve a pipe whose output is declared as 'Dynamic'.",
+        ),
+    ] = None,
 ) -> None:
     """Run a pipeline from a bundle file (.mthds) or pipeline directory.
 
@@ -160,4 +168,5 @@ def run_bundle_cmd(
         mock_inputs=mock_inputs,
         library_dir=library_dir,
         telemetry_command_label=f"{COMMAND} bundle",
+        dynamic_output_concept_ref=dynamic_output_concept_ref,
     )

--- a/pipelex/cli/commands/run/method_cmd.py
+++ b/pipelex/cli/commands/run/method_cmd.py
@@ -68,6 +68,14 @@ def run_method_cmd(
         list[str] | None,
         typer.Option("--library-dir", "-L", help="Directory to search for pipe definitions (.mthds files). Can be specified multiple times."),
     ] = None,
+    dynamic_output_concept_ref: Annotated[
+        str | None,
+        typer.Option(
+            "--dynamic-output-concept",
+            "-O",
+            help="Concept ref (e.g. 'document_qa.ReferenceCount') used to resolve a pipe whose output is declared as 'Dynamic'.",
+        ),
+    ] = None,
 ) -> None:
     """Run an installed method by name.
 
@@ -130,4 +138,5 @@ def run_method_cmd(
         mock_inputs=mock_inputs,
         library_dir=effective_library_dir,
         telemetry_command_label=f"{COMMAND} method",
+        dynamic_output_concept_ref=dynamic_output_concept_ref,
     )

--- a/pipelex/cli/commands/run/pipe_cmd.py
+++ b/pipelex/cli/commands/run/pipe_cmd.py
@@ -65,6 +65,14 @@ def run_pipe_cmd(
         list[str] | None,
         typer.Option("--library-dir", "-L", help="Directory to search for pipe definitions (.mthds files). Can be specified multiple times."),
     ] = None,
+    dynamic_output_concept_ref: Annotated[
+        str | None,
+        typer.Option(
+            "--dynamic-output-concept",
+            "-O",
+            help="Concept ref (e.g. 'document_qa.ReferenceCount') used to resolve a pipe whose output is declared as 'Dynamic'.",
+        ),
+    ] = None,
 ) -> None:
     """Run a pipe by code.
 
@@ -125,4 +133,5 @@ def run_pipe_cmd(
         mock_inputs=mock_inputs,
         library_dir=library_dir,
         telemetry_command_label=f"{COMMAND} pipe",
+        dynamic_output_concept_ref=dynamic_output_concept_ref,
     )

--- a/pipelex/cli/commands/update_cmd.py
+++ b/pipelex/cli/commands/update_cmd.py
@@ -1,0 +1,186 @@
+"""``pipelex update`` — bring the installed model deck up to date with the kit-shipped templates.
+
+Numbered deck files are managed by pipelex. ``x_custom_*.toml`` files are user-owned and never
+touched. Locally-modified numbered files are backed up to ``<file>.bak.<UTC-timestamp>`` before
+being overwritten, unless ``--no-backup`` is passed.
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+from rich.markup import escape
+from rich.panel import Panel
+from rich.prompt import Confirm
+from rich.table import Table
+
+from pipelex.cogt.models.deck_manifest import (
+    DeckFileStatus,
+    DeckSyncReport,
+    compute_deck_sync_report,
+    compute_kit_manifest,
+    kit_deck_dir,
+    status_rich_label,
+    suggest_x_custom_filename,
+    write_manifest,
+)
+from pipelex.hub import get_console
+from pipelex.system.configuration.config_loader import config_manager
+
+
+def update_cmd(
+    local: bool = False,
+    yes: bool = False,
+    dry_run: bool = False,
+    no_backup: bool = False,
+) -> None:
+    """Apply pending model-deck updates from the running pipelex's kit.
+
+    Args:
+        local: Update the project-local ``.pipelex/`` instead of the resolved layered config dir.
+        yes: Skip the interactive confirmation.
+        dry_run: Print the planned actions without modifying any file.
+        no_backup: Do not create ``.bak`` files for locally-modified numbered deck files.
+    """
+    console = get_console()
+    deck_dir = _resolve_deck_dir(local=local)
+    if not deck_dir.exists():
+        console.print()
+        console.print(f"[red]✗[/red] No deck directory found at [cyan]{escape(str(deck_dir))}[/cyan].\nRun [cyan]pipelex init[/cyan] first.")
+        console.print()
+        sys.exit(1)
+
+    report = compute_deck_sync_report(deck_dir)
+    _print_status_table(report, deck_dir)
+
+    if report.is_clean():
+        console.print(_summary_panel("Model deck is up to date.", style="green"))
+        console.print()
+        return
+
+    if not report.manifest_present:
+        # Migration: surface what we found so the user can review before we materialize a baseline.
+        console.print(
+            "[dim]No deck manifest found — this looks like an existing install. Running [cyan]pipelex update[/cyan] "
+            "will install the latest deck content and write a baseline manifest.[/dim]"
+        )
+        console.print()
+
+    if dry_run:
+        console.print("[dim]Dry run — no changes written.[/dim]")
+        console.print()
+        return
+
+    if not yes and not Confirm.ask("[bold]Apply these updates?[/bold]", default=True):
+        console.print("[yellow]Update cancelled.[/yellow]")
+        console.print()
+        return
+
+    actions_applied = _apply_updates(deck_dir=deck_dir, report=report, no_backup=no_backup)
+    write_manifest(deck_dir, compute_kit_manifest())
+
+    console.print()
+    console.print(_summary_panel(f"Model deck updated ({actions_applied} file change(s) applied).", style="green"))
+    console.print()
+
+
+def _resolve_deck_dir(local: bool) -> Path:
+    """Pick the deck directory to operate on, mirroring the ``--local`` semantics of ``pipelex init``."""
+    if local:
+        project_root = config_manager.project_root
+        base = project_root / ".pipelex" if project_root is not None else Path.cwd() / ".pipelex"
+    else:
+        base = config_manager.pipelex_config_dir
+    return base / "inference" / "deck"
+
+
+def _print_status_table(report: DeckSyncReport, deck_dir: Path) -> None:
+    """Render the per-file sync status as a Rich table."""
+    table = Table(title="Pipelex Model Deck — Update Plan", show_lines=False)
+    table.add_column("File", style="cyan", no_wrap=True)
+    table.add_column("Status", style="bold")
+    table.add_column("Action")
+
+    for filename in sorted(report.files):
+        status = report.files[filename]
+        table.add_row(filename, status_rich_label(status), _action_description(status))
+
+    get_console().print()
+    get_console().print(f"Deck directory: [cyan]{escape(str(deck_dir))}[/cyan]")
+    installed_version_label = report.installed_kit_version or "(none)"
+    get_console().print(
+        f"Installed kit version: [cyan]{escape(installed_version_label)}[/cyan]   Kit version: [cyan]{escape(report.kit_version)}[/cyan]"
+    )
+    get_console().print()
+    get_console().print(table)
+    get_console().print()
+
+
+def _action_description(status: DeckFileStatus) -> str:
+    match status:
+        case DeckFileStatus.UP_TO_DATE:
+            return "—"
+        case DeckFileStatus.KIT_ADDED:
+            return "install from kit"
+        case DeckFileStatus.KIT_REMOVED:
+            return "back up + remove"
+        case DeckFileStatus.CLEAN_BEHIND:
+            return "overwrite from kit"
+        case DeckFileStatus.LOCALLY_MODIFIED:
+            return "back up + overwrite from kit"
+
+
+def _apply_updates(deck_dir: Path, report: DeckSyncReport, no_backup: bool) -> int:
+    """Apply the per-file actions described by ``report``. Returns the count of files changed."""
+    kit_dir = kit_deck_dir()
+    timestamp = datetime.now(tz=timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    actions_applied = 0
+
+    for filename in sorted(report.files):
+        status = report.files[filename]
+        installed_path = deck_dir / filename
+        kit_path = kit_dir / filename
+
+        match status:
+            case DeckFileStatus.UP_TO_DATE:
+                continue
+            case DeckFileStatus.KIT_ADDED:
+                deck_dir.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(kit_path, installed_path)
+                get_console().print(f"  [green]+[/green] installed [cyan]{escape(filename)}[/cyan]")
+                actions_applied += 1
+            case DeckFileStatus.CLEAN_BEHIND:
+                shutil.copy2(kit_path, installed_path)
+                get_console().print(f"  [yellow]↑[/yellow] updated [cyan]{escape(filename)}[/cyan]")
+                actions_applied += 1
+            case DeckFileStatus.LOCALLY_MODIFIED:
+                backup_note = ""
+                if not no_backup:
+                    backup_path = installed_path.with_name(f"{filename}.bak.{timestamp}")
+                    shutil.copy2(installed_path, backup_path)
+                    backup_note = f" (backed up to [dim]{escape(backup_path.name)}[/dim])"
+                shutil.copy2(kit_path, installed_path)
+                get_console().print(f"  [red]↑[/red] overwrote local edits in [cyan]{escape(filename)}[/cyan]{backup_note}")
+                suggested_override = suggest_x_custom_filename(filename)
+                get_console().print(
+                    f"    [dim]Tip: move custom aliases/presets into [cyan]{escape(suggested_override)}[/cyan] "
+                    "so future updates leave them in place.[/dim]"
+                )
+                actions_applied += 1
+            case DeckFileStatus.KIT_REMOVED:
+                backup_path = installed_path.with_name(f"{filename}.bak.{timestamp}")
+                shutil.copy2(installed_path, backup_path)
+                installed_path.unlink()
+                get_console().print(
+                    f"  [yellow]-[/yellow] removed [cyan]{escape(filename)}[/cyan] (backed up to [dim]{escape(backup_path.name)}[/dim])"
+                )
+                actions_applied += 1
+
+    return actions_applied
+
+
+def _summary_panel(message: str, *, style: str) -> Panel:
+    return Panel(message, border_style=style, padding=(1, 2))

--- a/pipelex/cli/commands/update_cmd.py
+++ b/pipelex/cli/commands/update_cmd.py
@@ -92,9 +92,10 @@ def _resolve_deck_dir(local: bool) -> Path:
     if local:
         project_root = config_manager.project_root
         base = project_root / ".pipelex" if project_root is not None else Path.cwd() / ".pipelex"
-    else:
-        base = config_manager.pipelex_config_dir
-    return base / "inference" / "deck"
+        return base / "inference" / "deck"
+    # Match runtime resolution: fall through to the global deck when the project .pipelex/
+    # does not contain inference/deck, so update targets the deck actually in use.
+    return config_manager.model_decks_dir_path
 
 
 def _print_status_table(report: DeckSyncReport, deck_dir: Path) -> None:

--- a/pipelex/cli/deck_notice.py
+++ b/pipelex/cli/deck_notice.py
@@ -1,0 +1,38 @@
+"""One-line boot-time warn shown when the installed model deck has fallen behind the kit.
+
+The warn is intentionally cheap (no hashing) so it can fire on every CLI invocation without slowing
+the boot path. ``pipelex update`` and ``pipelex doctor`` perform the deeper hash-based diff.
+"""
+
+from __future__ import annotations
+
+import os
+
+from pipelex.cogt.models.deck_manifest import is_deck_stale_fast
+from pipelex.hub import get_console
+from pipelex.system.configuration.config_loader import config_manager
+
+DECK_NOTICE_SUPPRESS_ENV_VAR = "PIPELEX_NO_DECK_NOTICE"
+
+
+def warn_if_deck_stale() -> None:
+    """Print a one-line yellow advisory when the installed deck appears to be out of date.
+
+    Suppressed entirely when ``PIPELEX_NO_DECK_NOTICE`` is set in the environment.
+    Silent when no deck dir exists yet (init_check elsewhere already prompts the user to run init).
+    """
+    if os.environ.get(DECK_NOTICE_SUPPRESS_ENV_VAR):
+        return
+
+    deck_dir = config_manager.pipelex_config_dir / "inference" / "deck"
+    if not deck_dir.exists():
+        return
+
+    if not is_deck_stale_fast(deck_dir):
+        return
+
+    get_console().print(
+        "[yellow]⚠[/yellow] [dim]Pipelex model deck may be out of date — run [cyan]pipelex update[/cyan] to refresh "
+        f"(set [cyan]{DECK_NOTICE_SUPPRESS_ENV_VAR}=1[/cyan] to silence)[/dim]",
+        highlight=False,
+    )

--- a/pipelex/cogt/models/deck_manifest.py
+++ b/pipelex/cogt/models/deck_manifest.py
@@ -1,0 +1,278 @@
+"""Model deck manifest: detect when an installed deck has drifted from the kit-shipped templates.
+
+The manifest pins, for one specific deck install, the kit version that produced it and the SHA-256 of
+each managed deck file at install/update time. It enables three independent signals:
+
+- Manifest's ``kit_version`` vs the running ``pipelex`` version → behind upstream.
+- Manifest's per-file hash vs the installed file's actual hash → user has locally edited a numbered file.
+- Kit content vs installed content → upstream changed.
+
+Numbered deck files (``1_llm_deck.toml``...``4_search_deck.toml``) are pipelex-managed.
+``x_custom_*.toml`` files are user-owned and never tracked.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from pipelex.kit.paths import get_kit_configs_dir
+from pipelex.tools.misc.file_utils import path_exists
+from pipelex.tools.misc.package_utils import get_package_version
+from pipelex.types import StrEnum
+
+MANIFEST_FILENAME = ".kit_manifest.json"
+
+
+class DeckFileStatus(StrEnum):
+    """Per-file sync status between the installed deck and the kit-shipped templates."""
+
+    UP_TO_DATE = "up_to_date"
+    KIT_ADDED = "kit_added"
+    KIT_REMOVED = "kit_removed"
+    CLEAN_BEHIND = "clean_behind"
+    LOCALLY_MODIFIED = "locally_modified"
+
+    @property
+    def needs_action(self) -> bool:
+        """True when an `update` run would touch this file."""
+        match self:
+            case DeckFileStatus.UP_TO_DATE:
+                return False
+            case DeckFileStatus.KIT_ADDED | DeckFileStatus.KIT_REMOVED | DeckFileStatus.CLEAN_BEHIND | DeckFileStatus.LOCALLY_MODIFIED:
+                return True
+
+
+class DeckManifest(BaseModel):
+    """Persisted record of the kit version and per-file hashes captured at install/update time."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    kit_version: str
+    files: dict[str, str] = Field(default_factory=dict)
+
+
+class DeckSyncReport(BaseModel):
+    """Result of comparing an installed deck dir to the currently shipping kit."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    kit_version: str
+    installed_kit_version: str | None
+    manifest_present: bool
+    files: dict[str, DeckFileStatus] = Field(default_factory=dict)
+
+    def is_clean(self) -> bool:
+        """True when no file needs any action and the manifest is in sync with the kit version."""
+        if not self.manifest_present:
+            return False
+        if self.installed_kit_version != self.kit_version:
+            return False
+        return all(status == DeckFileStatus.UP_TO_DATE for status in self.files.values())
+
+    def files_with_status(self, status: DeckFileStatus) -> list[str]:
+        return sorted(name for name, file_status in self.files.items() if file_status == status)
+
+
+def compute_sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def compute_file_sha256(path: Path) -> str:
+    return compute_sha256(path.read_bytes())
+
+
+def kit_deck_dir() -> Path:
+    """Return the kit's shipped deck directory as a real filesystem path.
+
+    Mirrors the conversion done in ``pipelex/cli/commands/init/command.py:228`` so we read the same
+    files that ``pipelex init`` copies.
+    """
+    return Path(str(get_kit_configs_dir())) / "inference" / "deck"
+
+
+def _is_managed_deck_filename(filename: str) -> bool:
+    """True for files that pipelex manages (numbered ``*_deck.toml``).
+
+    Excludes any ``x_custom_*.toml`` override (the user-owned escape hatch) and non-TOML files
+    (e.g. an accidental ``.DS_Store``). The ``x_custom_`` prefix is the agreed-upon namespace for
+    user overrides — pipelex never tracks or overwrites those.
+    """
+    if not filename.endswith(".toml"):
+        return False
+    return not filename.startswith("x_custom_")
+
+
+def list_managed_kit_files() -> dict[str, str]:
+    """Hash every managed deck file shipped in the current pipelex wheel."""
+    kit_dir = kit_deck_dir()
+    return {
+        entry.name: compute_file_sha256(entry) for entry in sorted(kit_dir.iterdir()) if entry.is_file() and _is_managed_deck_filename(entry.name)
+    }
+
+
+def list_managed_installed_files(deck_dir: Path) -> dict[str, str]:
+    """Hash every managed deck file present in the user's installed deck dir."""
+    if not deck_dir.is_dir():
+        return {}
+    return {
+        entry.name: compute_file_sha256(entry) for entry in sorted(deck_dir.iterdir()) if entry.is_file() and _is_managed_deck_filename(entry.name)
+    }
+
+
+def compute_kit_manifest() -> DeckManifest:
+    """Build the manifest that should be written after a fresh install or successful update."""
+    return DeckManifest(kit_version=get_package_version(), files=list_managed_kit_files())
+
+
+def manifest_path(deck_dir: Path) -> Path:
+    return deck_dir / MANIFEST_FILENAME
+
+
+def read_manifest(deck_dir: Path) -> DeckManifest | None:
+    """Return the persisted manifest, or ``None`` when absent or unreadable.
+
+    A corrupt manifest is treated as missing — the caller will warn the user and offer to rebuild it.
+    """
+    target = manifest_path(deck_dir)
+    if not path_exists(str(target)):
+        return None
+    try:
+        payload = json.loads(target.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    try:
+        return DeckManifest.model_validate(payload)
+    except ValueError:
+        return None
+
+
+def write_manifest(deck_dir: Path, manifest: DeckManifest) -> None:
+    """Persist the manifest, creating the deck directory if needed."""
+    deck_dir.mkdir(parents=True, exist_ok=True)
+    payload = manifest.model_dump()
+    target = manifest_path(deck_dir)
+    target.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def is_deck_stale_fast(deck_dir: Path) -> bool:
+    """Boot-path check: one file read, one string compare. No hashing.
+
+    Returns True (stale) when the manifest is missing or its ``kit_version`` is strictly older than
+    the running ``pipelex``. Two cases must NOT trigger the warn:
+
+    - exact match (incl. when one side carries a pre-release/build suffix and the other doesn't);
+    - downgrade (manifest newer than the installed package) — the user has presumably pinned
+      pipelex deliberately, and updating the deck backwards is rarely what they want.
+    """
+    manifest = read_manifest(deck_dir)
+    if manifest is None:
+        return True
+    return _is_manifest_older(manifest.kit_version, get_package_version())
+
+
+def _is_manifest_older(manifest_version: str, current_version: str) -> bool:
+    """True iff the manifest's recorded core version is strictly older than the installed package.
+
+    Compares semver cores (``X.Y.Z``) ignoring pre-release/build metadata so that an editable build
+    versioned ``0.25.0+localdev`` does not appear stale against a stable ``0.25.0`` manifest. Falls
+    back to literal string inequality on parse failure (rare, conservative).
+    """
+    manifest_parts = _try_parse_version(manifest_version)
+    current_parts = _try_parse_version(current_version)
+    if manifest_parts is None or current_parts is None:
+        return manifest_version != current_version
+    return manifest_parts < current_parts
+
+
+def _try_parse_version(version: str) -> tuple[int, ...] | None:
+    """Parse a SemVer-ish string's core into a comparable tuple. Returns ``None`` on any failure.
+
+    Strips both the pre-release suffix (``-rc1``) and the build metadata suffix (``+localbuild``).
+    """
+    core = version.split("+", 1)[0].split("-", 1)[0]
+    pieces = core.split(".")
+    try:
+        return tuple(int(piece) for piece in pieces)
+    except ValueError:
+        return None
+
+
+def status_rich_label(status: DeckFileStatus) -> str:
+    """Human-friendly Rich-markup label used by both the doctor report and the update plan table."""
+    match status:
+        case DeckFileStatus.UP_TO_DATE:
+            return "[green]up-to-date[/green]"
+        case DeckFileStatus.KIT_ADDED:
+            return "[green]new[/green]"
+        case DeckFileStatus.KIT_REMOVED:
+            return "[yellow]removed upstream[/yellow]"
+        case DeckFileStatus.CLEAN_BEHIND:
+            return "[yellow]behind[/yellow]"
+        case DeckFileStatus.LOCALLY_MODIFIED:
+            return "[red]locally modified[/red]"
+
+
+def suggest_x_custom_filename(numbered_filename: str) -> str:
+    """Suggest the right ``x_custom_*.toml`` companion for a numbered deck file.
+
+    Example: ``2_img_gen_deck.toml`` → ``x_custom_img_gen_deck.toml``. The convention is to drop
+    the leading ``N_`` prefix and prepend ``x_custom_``.
+    """
+    head, _, tail = numbered_filename.partition("_")
+    if not tail or not head.isdigit():
+        return "x_custom_*.toml"
+    return f"x_custom_{tail}"
+
+
+def compute_deck_sync_report(deck_dir: Path) -> DeckSyncReport:
+    """Full per-file diff between the installed deck and the running pipelex's kit.
+
+    This walks every managed file in either side and assigns it a ``DeckFileStatus``. Cost is one
+    SHA-256 per file — only call from ``pipelex update`` and ``pipelex doctor``, never on the boot path.
+    """
+    kit_files = list_managed_kit_files()
+    installed_files = list_managed_installed_files(deck_dir)
+    manifest = read_manifest(deck_dir)
+    manifest_files: dict[str, str] = manifest.files if manifest is not None else {}
+
+    all_filenames = set(kit_files) | set(installed_files)
+    file_statuses: dict[str, DeckFileStatus] = {}
+    for filename in all_filenames:
+        kit_hash = kit_files.get(filename)
+        installed_hash = installed_files.get(filename)
+        manifest_hash = manifest_files.get(filename)
+
+        if kit_hash is not None and installed_hash is None:
+            file_statuses[filename] = DeckFileStatus.KIT_ADDED
+            continue
+        if kit_hash is None and installed_hash is not None:
+            file_statuses[filename] = DeckFileStatus.KIT_REMOVED
+            continue
+
+        # Both present from here on.
+        if manifest_hash is not None:
+            if manifest_hash != installed_hash:
+                file_statuses[filename] = DeckFileStatus.LOCALLY_MODIFIED
+            elif manifest_hash != kit_hash:
+                file_statuses[filename] = DeckFileStatus.CLEAN_BEHIND
+            else:
+                file_statuses[filename] = DeckFileStatus.UP_TO_DATE
+            continue
+
+        # No manifest entry — treat untouched files as up-to-date, divergent ones as locally modified
+        # (we have no provenance proof, so we err on preserving user content via the backup path).
+        if installed_hash == kit_hash:
+            file_statuses[filename] = DeckFileStatus.UP_TO_DATE
+        else:
+            file_statuses[filename] = DeckFileStatus.LOCALLY_MODIFIED
+
+    return DeckSyncReport(
+        kit_version=get_package_version(),
+        installed_kit_version=manifest.kit_version if manifest is not None else None,
+        manifest_present=manifest is not None,
+        files=file_statuses,
+    )

--- a/pipelex/core/concepts/concept_factory.py
+++ b/pipelex/core/concepts/concept_factory.py
@@ -214,9 +214,9 @@ class ConceptFactory:
         return f"{domain_code}.{concept_code}"
 
     @classmethod
-    def make_concept_ref_with_domain_from_concept_ref_or_code(cls, domain_code: str, concept_sring_or_code: str) -> str:
+    def make_concept_ref_with_domain_from_concept_ref_or_code(cls, domain_code: str, concept_ref_or_code: str) -> str:
         input_domain_and_code = cls.make_domain_and_concept_code_from_concept_ref_or_code(
-            concept_ref_or_code=concept_sring_or_code,
+            concept_ref_or_code=concept_ref_or_code,
             domain_code=domain_code,
         )
 

--- a/pipelex/core/concepts/structure_generation/generator.py
+++ b/pipelex/core/concepts/structure_generation/generator.py
@@ -1,4 +1,5 @@
 import ast
+import textwrap
 from datetime import datetime
 from enum import Enum
 from typing import Any, List, Literal, Optional
@@ -12,6 +13,11 @@ from pipelex.core.concepts.native.concept_native import NativeConceptCode
 from pipelex.core.concepts.structure_generation.exceptions import ConceptStructureGeneratorError, ConceptStructureValidationError, SyntaxErrorData
 from pipelex.core.stuffs.structured_content import StructuredContent
 from pipelex.core.stuffs.stuff_content import StuffContent
+
+# Target line length for emitted code (matches the project's ruff config).
+# Each emitted line stays under this so ruff E501 doesn't trigger on long descriptions.
+_MAX_LINE_LENGTH = 150
+_WRAP_WIDTH = 120  # conservative: leaves headroom for indentation and syntax overhead
 
 
 class ConceptClassInfo:
@@ -184,6 +190,42 @@ class StructureGenerator:
             return self._escape_string_for_python(value)
         return repr(value)
 
+    def _format_class_docstring(self, docstring: str, indent: str = "    ") -> str:
+        """Render a class docstring, wrapping it across multiple lines when the single-line
+        form would exceed _MAX_LINE_LENGTH.
+        """
+        single_line = f'{indent}"""{docstring}"""'
+        if len(single_line) <= _MAX_LINE_LENGTH:
+            return single_line
+        # Wrap the docstring text. The first wrapped line follows """, subsequent lines are
+        # plain indented text, and the closing """ sits on its own line.
+        wrap_width = _WRAP_WIDTH
+        wrapped_lines = textwrap.wrap(docstring, width=wrap_width, break_long_words=False, break_on_hyphens=False)
+        if not wrapped_lines:
+            return single_line
+        body = "\n".join(f"{indent}{line}" for line in wrapped_lines)
+        return f'{indent}"""\n{body}\n{indent}"""'
+
+    def _format_field_description(self, description: str) -> str:
+        """Render the `description=` argument for a Field call. For short values, emit a
+        single-line `description="..."`. For long values, emit a parenthesized
+        implicit-string-concatenation block so each emitted line stays under the line limit.
+        """
+        escaped = self._escape_string_for_python(description)
+        if len(escaped) <= _WRAP_WIDTH:
+            return f"description={escaped}"
+        chunks = textwrap.wrap(description, width=_WRAP_WIDTH, break_long_words=False, break_on_hyphens=False)
+        if len(chunks) <= 1:
+            return f"description={escaped}"
+        # Join trailing space on each chunk except the last so the concatenation reads
+        # naturally; textwrap dropped the original spaces.
+        chunk_literals: list[str] = []
+        for index, chunk in enumerate(chunks):
+            content = chunk if index == len(chunks) - 1 else f"{chunk} "
+            chunk_literals.append(self._escape_string_for_python(content))
+        body = "\n".join(chunk_literals)
+        return f"description=(\n{body}\n)"
+
     def _generate_class_source_code_from_blueprint(
         self,
         class_name: str,
@@ -222,7 +264,7 @@ class StructureGenerator:
 
         # Generate class header with docstring (use class name if no description provided)
         docstring = description or f"Generated {class_name} class"
-        class_header = f'class {class_name}({base_class}):\n    """{docstring}"""\n'
+        class_header = f"class {class_name}({base_class}):\n{self._format_class_docstring(docstring)}\n"
 
         # Generate fields
         field_definitions: list[str] = []
@@ -261,7 +303,7 @@ class StructureGenerator:
             python_type = f"Optional[{python_type}]"
 
         # Generate Field parameters
-        field_params = [f"description={self._escape_string_for_python(field_blueprint.description)}"]
+        field_params = [self._format_field_description(field_blueprint.description)]
 
         if field_blueprint.required:
             if field_blueprint.default_value is not None:
@@ -429,7 +471,7 @@ class StructureGenerator:
             python_type = f"Optional[{python_type}]"
 
         # Generate Field parameters
-        field_params = [f"description={self._escape_string_for_python(description)}"]
+        field_params = [self._format_field_description(description)]
 
         if required:
             if default_value is not None:

--- a/pipelex/core/concepts/structure_generation/generator.py
+++ b/pipelex/core/concepts/structure_generation/generator.py
@@ -219,12 +219,14 @@ class StructureGenerator:
             return f"description={escaped}"
         # Join trailing space on each chunk except the last so the concatenation reads
         # naturally; textwrap dropped the original spaces.
+        # Indent chunk literals (and the closing paren) so `ruff format` preserves the
+        # implicit-string-concat — un-indented chunks get collapsed back to a single line.
         chunk_literals: list[str] = []
         for index, chunk in enumerate(chunks):
             content = chunk if index == len(chunks) - 1 else f"{chunk} "
-            chunk_literals.append(self._escape_string_for_python(content))
+            chunk_literals.append(f"        {self._escape_string_for_python(content)}")
         body = "\n".join(chunk_literals)
-        return f"description=(\n{body}\n)"
+        return f"description=(\n{body}\n    )"
 
     def _generate_class_source_code_from_blueprint(
         self,

--- a/pipelex/core/pipes/inputs/input_stuff_specs_factory.py
+++ b/pipelex/core/pipes/inputs/input_stuff_specs_factory.py
@@ -83,7 +83,7 @@ class InputStuffSpecsFactory:
 
         concept_ref_with_domain = ConceptFactory.make_concept_ref_with_domain_from_concept_ref_or_code(
             domain_code=domain_code,
-            concept_sring_or_code=concept_ref_or_code,
+            concept_ref_or_code=concept_ref_or_code,
         )
 
         # Determine multiplicity

--- a/pipelex/kit/configs/inference/backends/pipelex_gateway_models_plain.md
+++ b/pipelex/kit/configs/inference/backends/pipelex_gateway_models_plain.md
@@ -116,19 +116,19 @@ For configuration details, see the [documentation](https://docs.pipelex.com/late
   - inputs: text, images, pdf
   - outputs: text, structured
 - **gpt-5.4**
-  - inputs: text, images
+  - inputs: text, images, pdf
   - outputs: text, structured
 - **gpt-5.4-mini**
-  - inputs: text, images
+  - inputs: text, images, pdf
   - outputs: text, structured
 - **gpt-5.4-nano**
-  - inputs: text, images
+  - inputs: text, images, pdf
   - outputs: text, structured
 - **gpt-5.4-pro**
-  - inputs: text, images
+  - inputs: text, images, pdf
   - outputs: text, structured
 - **gpt-5.5**
-  - inputs: text, images
+  - inputs: text, images, pdf
   - outputs: text, structured
 - **gpt-oss-120b**
   - inputs: text
@@ -223,6 +223,6 @@ For configuration details, see the [documentation](https://docs.pipelex.com/late
 
 
 > **AUTO-GENERATED FILE** - Do not edit manually.
-> Last updated: 2026-04-28T11:06:01Z
+> Last updated: 2026-04-28T12:50:14Z
 >
 > Run `pipelex-dev update-gateway-models` or `make ugm` to regenerate.

--- a/pipelex/kit/configs/inference/deck/.kit_manifest.json
+++ b/pipelex/kit/configs/inference/deck/.kit_manifest.json
@@ -1,0 +1,9 @@
+{
+  "files": {
+    "1_llm_deck.toml": "eb093712da6f4426ccade800c55aa3fbf64862917ec4e46c141eceb80e4ac1e8",
+    "2_img_gen_deck.toml": "63b1397f0427aada890096c7d430313f287fd613248aa1f3ab4b9e09a7f19402",
+    "3_extract_deck.toml": "560a40bd3254b1be011cfb35340fef6c40d70136e5ddce33a961899f92fd70ba",
+    "4_search_deck.toml": "08e3bd1bee0f9f8ed0ffc735a932705392d0ecfbdeefce64c9815d4b2d8d7e22"
+  },
+  "kit_version": "0.25.0"
+}

--- a/pipelex/kit/configs/inference/deck/1_llm_deck.toml
+++ b/pipelex/kit/configs/inference/deck/1_llm_deck.toml
@@ -4,6 +4,11 @@
 #
 # This file defines model defaults, aliases, and presets for LLMs
 #
+# Managed by `pipelex update`. To customize without conflict, edit
+# x_custom_llm_deck.toml in this directory — pipelex never tracks or
+# overwrites x_custom_* files. Local edits to this file are backed up
+# to <file>.bak.<timestamp> on update but will not survive future runs.
+#
 # Model Reference Syntax:
 # - Preset:    $preset_name or preset:preset_name
 # - Alias:     @alias_name or alias:alias_name

--- a/pipelex/kit/configs/inference/deck/2_img_gen_deck.toml
+++ b/pipelex/kit/configs/inference/deck/2_img_gen_deck.toml
@@ -4,6 +4,11 @@
 #
 # This file defines model aliases and presets for image generation models
 #
+# Managed by `pipelex update`. To customize without conflict, create an
+# x_custom_*.toml file in this directory — pipelex never tracks or
+# overwrites x_custom_* files. Local edits to this file are backed up
+# to <file>.bak.<timestamp> on update but will not survive future runs.
+#
 # Model Reference Syntax:
 # - Preset:    $preset_name or preset:preset_name
 # - Alias:     @alias_name or alias:alias_name

--- a/pipelex/kit/configs/inference/deck/3_extract_deck.toml
+++ b/pipelex/kit/configs/inference/deck/3_extract_deck.toml
@@ -5,6 +5,11 @@
 # This file defines model aliases and presets for Document extraction models, including
 # extraction of text and images from documents and OCR and text extraction from images.
 #
+# Managed by `pipelex update`. To customize without conflict, edit
+# x_custom_extract_deck.toml in this directory — pipelex never tracks or
+# overwrites x_custom_* files. Local edits to this file are backed up
+# to <file>.bak.<timestamp> on update but will not survive future runs.
+#
 # Model Reference Syntax:
 # - Preset:    $preset_name or preset:preset_name
 # - Alias:     @alias_name or alias:alias_name

--- a/pipelex/kit/configs/inference/deck/4_search_deck.toml
+++ b/pipelex/kit/configs/inference/deck/4_search_deck.toml
@@ -5,6 +5,11 @@
 # This file defines model aliases and presets for Search models, including
 # web search providers like Linkup.
 #
+# Managed by `pipelex update`. To customize without conflict, create an
+# x_custom_*.toml file in this directory — pipelex never tracks or
+# overwrites x_custom_* files. Local edits to this file are backed up
+# to <file>.bak.<timestamp> on update but will not survive future runs.
+#
 # Model Reference Syntax:
 # - Preset:    $preset_name or preset:preset_name
 # - Alias:     @alias_name or alias:alias_name

--- a/pipelex/pipe_operators/llm/pipe_llm.py
+++ b/pipelex/pipe_operators/llm/pipe_llm.py
@@ -23,6 +23,7 @@ from pipelex.core.pipes.exceptions import PipeValidationError, PipeValidationErr
 from pipelex.core.pipes.inputs.input_stuff_specs import InputStuffSpecs
 from pipelex.core.pipes.inputs.input_stuff_specs_factory import InputStuffSpecsFactory
 from pipelex.core.pipes.pipe_output import PipeOutput
+from pipelex.core.pipes.stuff_spec.stuff_spec import StuffSpec
 from pipelex.core.pipes.validation import is_input_used_by_variables, is_variable_satisfied_by_inputs
 from pipelex.core.pipes.variable_multiplicity import VariableMultiplicity
 from pipelex.core.stuffs.list_content import ListContent
@@ -152,6 +153,32 @@ class PipeLLM(PipeOperator[PipeLLMOutput]):
     def required_variables(self) -> set[str]:
         return {variable_name for variable_name in self.llm_prompt_spec.required_variables() if not variable_name.startswith("_")}
 
+    def resolve_dynamic_output_stuff_spec(self, pipe_run_params: PipeRunParams) -> StuffSpec:
+        """Return the `StuffSpec` to use for this run. When the pipe's declared output is
+        `native.Dynamic`, the actual concept is resolved from the run params (override
+        on `pipe_run_params.dynamic_output_concept_ref`, with a legacy fallback on
+        `pipe_run_params.params[DYNAMIC_OUTPUT_CONCEPT]`, defaulting to `native.Text`)
+        and returned in a copy of `self.output`. Otherwise returns `self.output` unchanged.
+
+        Pure: never mutates `self`. The same pipe instance can therefore be reused across
+        runs with different `dynamic_output_concept_ref` values without the first run's
+        choice sticking.
+        """
+        # TODO: DYNAMIC_OUTPUT_CONCEPT should not be a key in `params`; promote to an
+        # attribute on PipeRunParams and drop the params-key fallback.
+        if self.output.concept.code != NativeConceptCode.DYNAMIC or self.output.concept.domain_code != SpecialDomain.NATIVE:
+            return self.output
+        output_concept_ref = pipe_run_params.dynamic_output_concept_ref or pipe_run_params.params.get(PipeRunParamKey.DYNAMIC_OUTPUT_CONCEPT)
+        if not output_concept_ref:
+            output_concept_ref = SpecialDomain.NATIVE + "." + NativeConceptCode.TEXT
+        resolved_concept = get_required_concept(
+            concept_ref=ConceptFactory.make_concept_ref_with_domain_from_concept_ref_or_code(
+                domain_code=self.domain_code,
+                concept_ref_or_code=output_concept_ref,
+            ),
+        )
+        return self.output.model_copy(update={"concept": resolved_concept})
+
     @override
     async def _live_run_operator_pipe(
         self,
@@ -163,18 +190,7 @@ class PipeLLM(PipeOperator[PipeLLMOutput]):
     ) -> PipeLLMOutput:
         content_generator = content_generator or get_content_generator()
         # interpret / unwrap the arguments
-        output_stuff_spec = self.output
-        if self.output.concept.code == SpecialDomain.NATIVE + "." + NativeConceptCode.DYNAMIC:
-            # TODO: This DYNAMIC_OUTPUT_CONCEPT should not be a field in the params attribute of PipeRunParams.
-            # It should be an attribute of PipeRunParams.
-            output_concept_code = pipe_run_params.dynamic_output_concept_code or pipe_run_params.params.get(PipeRunParamKey.DYNAMIC_OUTPUT_CONCEPT)
-
-            if not output_concept_code:
-                output_concept_code = SpecialDomain.NATIVE + "." + NativeConceptCode.TEXT
-            else:
-                output_stuff_spec.concept = get_required_concept(
-                    concept_ref=ConceptFactory.make_concept_ref_with_domain(domain_code=self.domain_code, concept_code=output_concept_code),
-                )
+        output_stuff_spec = self.resolve_dynamic_output_stuff_spec(pipe_run_params=pipe_run_params)
 
         multiplicity_resolution = output_multiplicity_to_apply(
             base_multiplicity=self.output_multiplicity,
@@ -302,7 +318,7 @@ class PipeLLM(PipeOperator[PipeLLMOutput]):
             output_structure_prompt: str | None = None
             if get_config().cogt.llm_config.is_structure_prompt_enabled:
                 output_structure_prompt = await get_output_structure_prompt(
-                    concept_ref=pipe_run_params.dynamic_output_concept_code or output_stuff_spec.concept.concept_ref,
+                    concept_ref=pipe_run_params.dynamic_output_concept_ref or output_stuff_spec.concept.concept_ref,
                     is_with_preliminary_text=is_with_preliminary_text,
                 )
             llm_prompt_1_for_object = await self.llm_prompt_spec.make_llm_prompt(

--- a/pipelex/pipe_operators/pipe_operator.py
+++ b/pipelex/pipe_operators/pipe_operator.py
@@ -40,7 +40,10 @@ class PipeOperator(PipeAbstract, Generic[PipeOperatorOutputType]):
             )
 
             main_stuff = pipe_output.main_stuff
-            output_concept_code = self.output.concept.code
+            # Read the concept from main_stuff, not self.output: when the pipe declares
+            # `Dynamic` output, the runtime-resolved concept lives on main_stuff, while
+            # self.output.concept stays Dynamic across runs.
+            output_concept_code = main_stuff.concept.code
             output_concept_with_multiplicity = f"[bold green]{output_concept_code}[/bold green]"
             if main_stuff.is_list:
                 list_content: ListContent[StuffContent] = main_stuff.as_list_content()  # pyright: ignore[reportUnknownVariableType, reportUnknownMemberType]

--- a/pipelex/pipe_run/pipe_run_params.py
+++ b/pipelex/pipe_run/pipe_run_params.py
@@ -139,7 +139,7 @@ class PipeRunParams(BaseModel):
     final_stuff_code: str | None = None
     is_with_preliminary_text: bool | None = None
     output_multiplicity: VariableMultiplicity | None = None
-    dynamic_output_concept_code: str | None = None
+    dynamic_output_concept_ref: str | None = None
     batch_params: BatchParams | None = None
     params: dict[str, Any] = Field(default_factory=dict)
 

--- a/pipelex/pipe_run/pipe_run_params_factory.py
+++ b/pipelex/pipe_run/pipe_run_params_factory.py
@@ -12,7 +12,7 @@ class PipeRunParamsFactory:
         pipe_run_mode: PipeRunMode = PipeRunMode.LIVE,
         pipe_stack_limit: int | None = None,
         output_multiplicity: VariableMultiplicity | None = None,
-        dynamic_output_concept_code: str | None = None,
+        dynamic_output_concept_ref: str | None = None,
         batch_params: BatchParams | None = None,
         params: dict[str, Any] | None = None,
     ) -> PipeRunParams:
@@ -21,7 +21,7 @@ class PipeRunParamsFactory:
             run_mode=pipe_run_mode,
             pipe_stack_limit=pipe_stack_limit,
             output_multiplicity=output_multiplicity,
-            dynamic_output_concept_code=dynamic_output_concept_code,
+            dynamic_output_concept_ref=dynamic_output_concept_ref,
             batch_params=batch_params,
             params=params or {},
         )

--- a/pipelex/pipeline/pipeline_run_setup.py
+++ b/pipelex/pipeline/pipeline_run_setup.py
@@ -53,7 +53,7 @@ async def pipeline_run_setup(
     inputs: PipelineInputs | WorkingMemory | None = None,
     output_name: str | None = None,
     output_multiplicity: VariableMultiplicity | None = None,
-    dynamic_output_concept_code: str | None = None,
+    dynamic_output_concept_ref: str | None = None,
     pipe_run_mode: PipeRunMode | None = None,
     search_domain_codes: list[str] | None = None,
     user_id: str | None = None,
@@ -100,7 +100,7 @@ async def pipeline_run_setup(
         Name of the output slot to write to.
     output_multiplicity:
         Output multiplicity specification.
-    dynamic_output_concept_code:
+    dynamic_output_concept_ref:
         Override the dynamic output concept code.
     pipe_run_mode:
         Pipe run mode: ``PipeRunMode.LIVE`` or ``PipeRunMode.DRY``. If not specified,
@@ -283,7 +283,7 @@ async def pipeline_run_setup(
 
         pipe_run_params = PipeRunParamsFactory.make_run_params(
             output_multiplicity=output_multiplicity,
-            dynamic_output_concept_code=dynamic_output_concept_code,
+            dynamic_output_concept_ref=dynamic_output_concept_ref,
             pipe_run_mode=pipe_run_mode,
         )
 

--- a/pipelex/pipeline/pipeline_run_setup.py
+++ b/pipelex/pipeline/pipeline_run_setup.py
@@ -101,7 +101,7 @@ async def pipeline_run_setup(
     output_multiplicity:
         Output multiplicity specification.
     dynamic_output_concept_ref:
-        Override the dynamic output concept code.
+        Override the dynamic output concept ref.
     pipe_run_mode:
         Pipe run mode: ``PipeRunMode.LIVE`` or ``PipeRunMode.DRY``. If not specified,
         inferred from the environment variable ``PIPELEX_FORCE_DRY_RUN_MODE``. Defaults

--- a/pipelex/pipeline/runner.py
+++ b/pipelex/pipeline/runner.py
@@ -74,7 +74,7 @@ class PipelexRunner(RunnerProtocol["PipeOutput"]):
         inputs: PipelineInputs | WorkingMemoryAbstract[Any] | None = None,
         output_name: str | None = None,
         output_multiplicity: VariableMultiplicity | None = None,
-        dynamic_output_concept_code: str | None = None,
+        dynamic_output_concept_ref: str | None = None,
     ) -> PipelexPipelineExecuteResponse:
         """Execute a pipeline and wait for its completion.
 
@@ -102,7 +102,7 @@ class PipelexRunner(RunnerProtocol["PipeOutput"]):
             Name of the output slot to write to.
         output_multiplicity:
             Output multiplicity specification.
-        dynamic_output_concept_code:
+        dynamic_output_concept_ref:
             Override the dynamic output concept code.
 
         Returns:
@@ -139,7 +139,7 @@ class PipelexRunner(RunnerProtocol["PipeOutput"]):
                 inputs=pipelex_inputs,
                 output_name=output_name,
                 output_multiplicity=output_multiplicity,
-                dynamic_output_concept_code=dynamic_output_concept_code,
+                dynamic_output_concept_ref=dynamic_output_concept_ref,
                 pipe_run_mode=self.pipe_run_mode,
                 search_domain_codes=self.search_domain_codes,
                 user_id=self.user_id,
@@ -227,6 +227,6 @@ class PipelexRunner(RunnerProtocol["PipeOutput"]):
         inputs: PipelineInputs | WorkingMemoryAbstract[Any] | None = None,
         output_name: str | None = None,
         output_multiplicity: VariableMultiplicity | None = None,
-        dynamic_output_concept_code: str | None = None,
+        dynamic_output_concept_ref: str | None = None,
     ) -> PipelineStartResponse[PipeOutput]:
         raise NotImplementedError

--- a/pipelex/pipeline/runner.py
+++ b/pipelex/pipeline/runner.py
@@ -103,7 +103,7 @@ class PipelexRunner(RunnerProtocol["PipeOutput"]):
         output_multiplicity:
             Output multiplicity specification.
         dynamic_output_concept_ref:
-            Override the dynamic output concept code.
+            Override the dynamic output concept ref.
 
         Returns:
         -------

--- a/pipelex/system/configuration/config_loader.py
+++ b/pipelex/system/configuration/config_loader.py
@@ -159,6 +159,12 @@ class ConfigLoader:
 
         copy_directory_structure(src_dir=config_template_dir, dst_dir=global_dir)
 
+        # Stamp the deck manifest so the boot-time staleness check has a baseline.
+        # Imported lazily to avoid a circular import — config_loader is loaded very early.
+        from pipelex.cogt.models.deck_manifest import compute_kit_manifest, write_manifest  # noqa: PLC0415
+
+        write_manifest(global_dir / "inference" / "deck", compute_kit_manifest())
+
     def load_config(self) -> dict[str, Any]:
         """Load and merge configurations from pipelex and local config files.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "json2html>=1.3.0",
   "kajson==0.3.1",
   "markdown>=3.6",
-  "mthds>=0.2.0",
+  "mthds>=0.3.0",
   "networkx>=3.4.2",
   "openai>=1.108.1",
   "opentelemetry-api",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pipelex"
-version = "0.25.0"
+version = "0.25.1"
 description = "Execute composable AI methods declared in the MTHDS open standard"
 authors = [{ name = "Evotis S.A.S.", email = "oss@pipelex.com" }]
 maintainers = [{ name = "Pipelex staff", email = "oss@pipelex.com" }]

--- a/tests/unit/pipelex/builder/operations/test_parse_pipe_spec.py
+++ b/tests/unit/pipelex/builder/operations/test_parse_pipe_spec.py
@@ -113,6 +113,36 @@ class TestParsePipeSpec:
         result = parse_pipe_spec("PipeLLM", spec)
         assert result.output == "FirstAlias"
 
+    # -- prompt aliases ---------------------------------------------------
+
+    def test_prompt_template_alias_for_llm(self) -> None:
+        """`prompt_template` alone is promoted to `prompt` for PipeLLM."""
+        spec = {key: val for key, val in _BASE_LLM.items() if key != "prompt"}
+        spec["prompt_template"] = "Write about @text"
+        result = parse_pipe_spec("PipeLLM", spec)
+        assert isinstance(result, PipeLLMSpec)
+        assert result.prompt == "Write about @text"
+
+    def test_canonical_prompt_takes_precedence_over_alias(self) -> None:
+        """When both `prompt` and `prompt_template` are present, canonical wins and alias is dropped."""
+        spec = {**_BASE_LLM, "prompt_template": "alias_value"}
+        result = parse_pipe_spec("PipeLLM", spec)
+        assert isinstance(result, PipeLLMSpec)
+        assert result.prompt == _BASE_LLM["prompt"]
+
+    def test_prompt_template_alias_for_img_gen(self) -> None:
+        """`prompt_template` alias also works for PipeImgGen."""
+        spec: dict[str, Any] = {
+            "pipe_code": "my_img",
+            "description": "Generate image",
+            "inputs": {"prompt_text": "ImgGenPrompt"},
+            "output": "Image",
+            "prompt_template": "Generate: $prompt_text",
+        }
+        result = parse_pipe_spec("PipeImgGen", spec)
+        assert isinstance(result, PipeImgGenSpec)
+        assert result.prompt == "Generate: $prompt_text"
+
     # -- steps/branches 'pipe' → 'pipe_code' alias -----------------------
 
     def test_sequence_steps_canonical_pipe_code(self) -> None:

--- a/tests/unit/pipelex/cli/test_doctor_cmd.py
+++ b/tests/unit/pipelex/cli/test_doctor_cmd.py
@@ -16,6 +16,7 @@ from pipelex.cli.commands.doctor_cmd import (
     check_telemetry_config,
     do_doctor_cmd,
 )
+from pipelex.cogt.models.deck_manifest import DeckSyncReport
 from pipelex.system.configuration.config_loader import ConfigLoader
 from pipelex.system.telemetry.telemetry_config import TELEMETRY_CONFIG_FILE_NAME
 
@@ -50,6 +51,14 @@ class TestDoctorLayeredResolution:
             "pipelex.cli.commands.doctor_cmd.check_models",
             return_value=(True, "OK", {}),
         )
+        mock_check_deck = mocker.patch(
+            "pipelex.cli.commands.doctor_cmd.check_deck_sync",
+            return_value=(
+                True,
+                DeckSyncReport(kit_version="1.0.0", installed_kit_version="1.0.0", manifest_present=True, files={}),
+                "OK",
+            ),
+        )
         mocker.patch("pipelex.cli.commands.doctor_cmd.display_health_report")
 
         with pytest.raises(SystemExit) as exc_info:
@@ -61,6 +70,7 @@ class TestDoctorLayeredResolution:
         mock_check_telemetry.assert_called_once_with()
         mock_check_backends.assert_called_once_with()
         mock_check_models.assert_called_once_with()
+        mock_check_deck.assert_called_once_with()
 
     def test_telemetry_check_falls_back_to_global(self, mocker: MockerFixture, tmp_path: Path) -> None:
         """When project .pipelex/ exists but has no telemetry.toml, fall back to global ~/.pipelex/."""

--- a/tests/unit/pipelex/cli/test_update_cmd.py
+++ b/tests/unit/pipelex/cli/test_update_cmd.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+import pytest
+
+from pipelex.cli.commands import update_cmd as update_cmd_module
+from pipelex.cli.commands.update_cmd import update_cmd
+from pipelex.cogt.models import deck_manifest
+from pipelex.cogt.models.deck_manifest import (
+    MANIFEST_FILENAME,
+    DeckManifest,
+    is_deck_stale_fast,
+    write_manifest,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from pytest_mock import MockerFixture
+
+
+class TestUpdateCmd:
+    @staticmethod
+    def _seed_kit(mocker: MockerFixture, kit_dir: Path, files: dict[str, str]) -> None:
+        kit_dir.mkdir(parents=True, exist_ok=True)
+        for filename, content in files.items():
+            (kit_dir / filename).write_text(content, encoding="utf-8")
+        mocker.patch.object(deck_manifest, "kit_deck_dir", return_value=kit_dir)
+        mocker.patch.object(update_cmd_module, "kit_deck_dir", return_value=kit_dir)
+
+    @staticmethod
+    def _seed_installed(deck_dir: Path, files: dict[str, str]) -> None:
+        deck_dir.mkdir(parents=True, exist_ok=True)
+        for filename, content in files.items():
+            (deck_dir / filename).write_text(content, encoding="utf-8")
+
+    @staticmethod
+    def _patch_resolve_deck_dir(mocker: MockerFixture, deck_dir: Path) -> None:
+        mocker.patch.object(update_cmd_module, "_resolve_deck_dir", return_value=deck_dir)
+
+    @staticmethod
+    def _patch_version(mocker: MockerFixture, version: str) -> None:
+        mocker.patch.object(deck_manifest, "get_package_version", return_value=version)
+
+    @pytest.fixture
+    def kit_and_deck(self, mocker: MockerFixture, tmp_path: Path) -> tuple[Path, Path]:
+        """Materialize a kit with one numbered file and an installed deck dir mirroring it."""
+        kit_dir = tmp_path / "kit"
+        deck_dir = tmp_path / "deck"
+        contents = {"1_llm_deck.toml": "v1-content"}
+        self._seed_kit(mocker, kit_dir, contents)
+        self._seed_installed(deck_dir, contents)
+        self._patch_resolve_deck_dir(mocker, deck_dir)
+        self._patch_version(mocker, "1.0.0")
+        return kit_dir, deck_dir
+
+    def test_dry_run_makes_no_changes(self, mocker: MockerFixture, kit_and_deck: tuple[Path, Path]) -> None:
+        kit_dir, deck_dir = kit_and_deck
+        # Kit has moved on, but the install hasn't yet.
+        (kit_dir / "1_llm_deck.toml").write_text("v2-content", encoding="utf-8")
+        write_manifest(
+            deck_dir, DeckManifest(kit_version="1.0.0", files={"1_llm_deck.toml": deck_manifest.compute_file_sha256(deck_dir / "1_llm_deck.toml")})
+        )
+        self._patch_version(mocker, "1.1.0")
+
+        update_cmd(dry_run=True)
+
+        assert (deck_dir / "1_llm_deck.toml").read_text(encoding="utf-8") == "v1-content"
+
+    def test_clean_state_writes_baseline_manifest(self, kit_and_deck: tuple[Path, Path]) -> None:
+        _, deck_dir = kit_and_deck
+        # No manifest yet — migration baseline should be written.
+        assert not (deck_dir / MANIFEST_FILENAME).exists()
+
+        update_cmd(yes=True)
+
+        assert (deck_dir / MANIFEST_FILENAME).is_file()
+        assert is_deck_stale_fast(deck_dir) is False
+
+    def test_clean_behind_overwrites_without_backup(self, mocker: MockerFixture, kit_and_deck: tuple[Path, Path]) -> None:
+        kit_dir, deck_dir = kit_and_deck
+        write_manifest(
+            deck_dir, DeckManifest(kit_version="1.0.0", files={"1_llm_deck.toml": deck_manifest.compute_file_sha256(deck_dir / "1_llm_deck.toml")})
+        )
+        (kit_dir / "1_llm_deck.toml").write_text("v2-content", encoding="utf-8")
+        self._patch_version(mocker, "1.1.0")
+
+        update_cmd(yes=True)
+
+        assert (deck_dir / "1_llm_deck.toml").read_text(encoding="utf-8") == "v2-content"
+        assert not list(deck_dir.glob("*.bak.*"))
+        assert is_deck_stale_fast(deck_dir) is False
+
+    def test_locally_modified_creates_backup_and_overwrites(self, mocker: MockerFixture, kit_and_deck: tuple[Path, Path]) -> None:
+        kit_dir, deck_dir = kit_and_deck
+        write_manifest(
+            deck_dir, DeckManifest(kit_version="1.0.0", files={"1_llm_deck.toml": deck_manifest.compute_file_sha256(deck_dir / "1_llm_deck.toml")})
+        )
+        (deck_dir / "1_llm_deck.toml").write_text("user-edits", encoding="utf-8")
+        (kit_dir / "1_llm_deck.toml").write_text("v2-content", encoding="utf-8")
+        self._patch_version(mocker, "1.1.0")
+
+        update_cmd(yes=True)
+
+        backups = sorted(deck_dir.glob("1_llm_deck.toml.bak.*"))
+        assert len(backups) == 1
+        assert backups[0].read_text(encoding="utf-8") == "user-edits"
+        assert re.match(r"1_llm_deck\.toml\.bak\.\d{8}T\d{6}Z", backups[0].name) is not None
+        assert (deck_dir / "1_llm_deck.toml").read_text(encoding="utf-8") == "v2-content"
+
+    def test_no_backup_flag_skips_backup(self, mocker: MockerFixture, kit_and_deck: tuple[Path, Path]) -> None:
+        kit_dir, deck_dir = kit_and_deck
+        write_manifest(
+            deck_dir, DeckManifest(kit_version="1.0.0", files={"1_llm_deck.toml": deck_manifest.compute_file_sha256(deck_dir / "1_llm_deck.toml")})
+        )
+        (deck_dir / "1_llm_deck.toml").write_text("user-edits", encoding="utf-8")
+        (kit_dir / "1_llm_deck.toml").write_text("v2-content", encoding="utf-8")
+        self._patch_version(mocker, "1.1.0")
+
+        update_cmd(yes=True, no_backup=True)
+
+        assert not list(deck_dir.glob("*.bak.*"))
+        assert (deck_dir / "1_llm_deck.toml").read_text(encoding="utf-8") == "v2-content"
+
+    def test_kit_added_installs_new_file(self, mocker: MockerFixture, kit_and_deck: tuple[Path, Path]) -> None:
+        kit_dir, deck_dir = kit_and_deck
+        write_manifest(
+            deck_dir, DeckManifest(kit_version="1.0.0", files={"1_llm_deck.toml": deck_manifest.compute_file_sha256(deck_dir / "1_llm_deck.toml")})
+        )
+        (kit_dir / "5_new_deck.toml").write_text("brand-new", encoding="utf-8")
+        self._patch_version(mocker, "1.1.0")
+
+        update_cmd(yes=True)
+
+        assert (deck_dir / "5_new_deck.toml").read_text(encoding="utf-8") == "brand-new"
+
+    def test_kit_removed_backs_up_then_deletes(self, mocker: MockerFixture, kit_and_deck: tuple[Path, Path]) -> None:
+        _, deck_dir = kit_and_deck
+        (deck_dir / "9_retired_deck.toml").write_text("retired-content", encoding="utf-8")
+        write_manifest(
+            deck_dir,
+            DeckManifest(
+                kit_version="1.0.0",
+                files={
+                    "1_llm_deck.toml": deck_manifest.compute_file_sha256(deck_dir / "1_llm_deck.toml"),
+                    "9_retired_deck.toml": deck_manifest.compute_file_sha256(deck_dir / "9_retired_deck.toml"),
+                },
+            ),
+        )
+        self._patch_version(mocker, "1.1.0")
+
+        update_cmd(yes=True)
+
+        assert not (deck_dir / "9_retired_deck.toml").exists()
+        backups = sorted(deck_dir.glob("9_retired_deck.toml.bak.*"))
+        assert len(backups) == 1
+        assert backups[0].read_text(encoding="utf-8") == "retired-content"
+
+    def test_x_custom_files_are_left_alone(self, mocker: MockerFixture, kit_and_deck: tuple[Path, Path]) -> None:
+        kit_dir, deck_dir = kit_and_deck
+        (deck_dir / "x_custom_llm_deck.toml").write_text("user-overrides", encoding="utf-8")
+        (kit_dir / "1_llm_deck.toml").write_text("v2-content", encoding="utf-8")
+        self._patch_version(mocker, "1.1.0")
+
+        update_cmd(yes=True)
+
+        assert (deck_dir / "x_custom_llm_deck.toml").read_text(encoding="utf-8") == "user-overrides"
+
+    def test_yes_flag_skips_confirm(self, mocker: MockerFixture, kit_and_deck: tuple[Path, Path]) -> None:
+        kit_dir, deck_dir = kit_and_deck
+        write_manifest(
+            deck_dir, DeckManifest(kit_version="1.0.0", files={"1_llm_deck.toml": deck_manifest.compute_file_sha256(deck_dir / "1_llm_deck.toml")})
+        )
+        (kit_dir / "1_llm_deck.toml").write_text("v2-content", encoding="utf-8")
+        self._patch_version(mocker, "1.1.0")
+
+        confirm_spy = mocker.patch.object(update_cmd_module.Confirm, "ask")
+        update_cmd(yes=True)
+
+        confirm_spy.assert_not_called()
+
+    def test_missing_deck_dir_exits_with_error(self, mocker: MockerFixture, tmp_path: Path) -> None:
+        absent = tmp_path / "nope"
+        self._patch_resolve_deck_dir(mocker, absent)
+        with pytest.raises(SystemExit) as exit_info:
+            update_cmd(yes=True)
+        assert exit_info.value.code == 1

--- a/tests/unit/pipelex/cogt/models/test_deck_manifest.py
+++ b/tests/unit/pipelex/cogt/models/test_deck_manifest.py
@@ -1,0 +1,269 @@
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from pipelex.cogt.models import deck_manifest
+from pipelex.cogt.models.deck_manifest import (
+    MANIFEST_FILENAME,
+    DeckFileStatus,
+    DeckManifest,
+    compute_deck_sync_report,
+    compute_file_sha256,
+    compute_kit_manifest,
+    is_deck_stale_fast,
+    list_managed_installed_files,
+    list_managed_kit_files,
+    manifest_path,
+    read_manifest,
+    suggest_x_custom_filename,
+    write_manifest,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from pytest_mock import MockerFixture
+
+
+class TestDeckManifest:
+    @staticmethod
+    def _seed_kit(mocker: MockerFixture, kit_dir: Path, files: dict[str, str]) -> None:
+        kit_dir.mkdir(parents=True, exist_ok=True)
+        for filename, content in files.items():
+            (kit_dir / filename).write_text(content, encoding="utf-8")
+        mocker.patch.object(deck_manifest, "kit_deck_dir", return_value=kit_dir)
+
+    @staticmethod
+    def _seed_installed(deck_dir: Path, files: dict[str, str]) -> None:
+        deck_dir.mkdir(parents=True, exist_ok=True)
+        for filename, content in files.items():
+            (deck_dir / filename).write_text(content, encoding="utf-8")
+
+    def test_manifest_round_trip(self, tmp_path: Path) -> None:
+        manifest = DeckManifest(kit_version="1.2.3", files={"1_llm_deck.toml": "hash-a", "2_img_gen_deck.toml": "hash-b"})
+        deck_dir = tmp_path / "deck"
+        write_manifest(deck_dir, manifest)
+        assert manifest_path(deck_dir).is_file()
+
+        reloaded = read_manifest(deck_dir)
+        assert reloaded == manifest
+
+    def test_read_manifest_missing(self, tmp_path: Path) -> None:
+        assert read_manifest(tmp_path / "absent") is None
+
+    def test_read_manifest_corrupt(self, tmp_path: Path) -> None:
+        deck_dir = tmp_path / "deck"
+        deck_dir.mkdir()
+        (deck_dir / MANIFEST_FILENAME).write_text("not json {", encoding="utf-8")
+        assert read_manifest(deck_dir) is None
+
+    def test_read_manifest_invalid_schema(self, tmp_path: Path) -> None:
+        deck_dir = tmp_path / "deck"
+        deck_dir.mkdir()
+        (deck_dir / MANIFEST_FILENAME).write_text(json.dumps({"unexpected": "shape"}), encoding="utf-8")
+        assert read_manifest(deck_dir) is None
+
+    def test_compute_file_sha256_is_deterministic(self, tmp_path: Path) -> None:
+        target = tmp_path / "f.toml"
+        target.write_text("hello", encoding="utf-8")
+        first = compute_file_sha256(target)
+        second = compute_file_sha256(target)
+        assert first == second
+        assert len(first) == 64
+
+    def test_x_custom_files_excluded(self, mocker: MockerFixture, tmp_path: Path) -> None:
+        kit_dir = tmp_path / "kit"
+        self._seed_kit(
+            mocker,
+            kit_dir,
+            {
+                "1_llm_deck.toml": "managed",
+                "2_img_gen_deck.toml": "managed",
+                "x_custom_llm_deck.toml": "user-owned",
+                "x_custom_extract_deck.toml": "user-owned",
+                ".DS_Store": "junk",
+            },
+        )
+        kit_files = list_managed_kit_files()
+        assert set(kit_files.keys()) == {"1_llm_deck.toml", "2_img_gen_deck.toml"}
+
+    def test_list_managed_installed_files_filters_same_way(self, tmp_path: Path) -> None:
+        deck_dir = tmp_path / "deck"
+        self._seed_installed(
+            deck_dir,
+            {
+                "1_llm_deck.toml": "a",
+                "x_custom_llm_deck.toml": "b",
+            },
+        )
+        installed = list_managed_installed_files(deck_dir)
+        assert set(installed.keys()) == {"1_llm_deck.toml"}
+
+    def test_list_managed_installed_files_missing_dir(self, tmp_path: Path) -> None:
+        assert list_managed_installed_files(tmp_path / "absent") == {}
+
+    def test_compute_kit_manifest_stamps_version(self, mocker: MockerFixture, tmp_path: Path) -> None:
+        kit_dir = tmp_path / "kit"
+        self._seed_kit(mocker, kit_dir, {"1_llm_deck.toml": "content-a"})
+        mocker.patch.object(deck_manifest, "get_package_version", return_value="9.9.9")
+
+        manifest = compute_kit_manifest()
+        assert manifest.kit_version == "9.9.9"
+        assert "1_llm_deck.toml" in manifest.files
+
+    def test_sync_report_up_to_date(self, mocker: MockerFixture, tmp_path: Path) -> None:
+        kit_dir = tmp_path / "kit"
+        deck_dir = tmp_path / "deck"
+        contents = {"1_llm_deck.toml": "same-everywhere"}
+        self._seed_kit(mocker, kit_dir, contents)
+        self._seed_installed(deck_dir, contents)
+        mocker.patch.object(deck_manifest, "get_package_version", return_value="1.0.0")
+        write_manifest(deck_dir, compute_kit_manifest())
+
+        report = compute_deck_sync_report(deck_dir)
+        assert report.is_clean()
+        assert report.files["1_llm_deck.toml"] == DeckFileStatus.UP_TO_DATE
+
+    def test_sync_report_clean_behind(self, mocker: MockerFixture, tmp_path: Path) -> None:
+        kit_dir = tmp_path / "kit"
+        deck_dir = tmp_path / "deck"
+        self._seed_kit(mocker, kit_dir, {"1_llm_deck.toml": "old"})
+        self._seed_installed(deck_dir, {"1_llm_deck.toml": "old"})
+        mocker.patch.object(deck_manifest, "get_package_version", return_value="1.0.0")
+        write_manifest(deck_dir, compute_kit_manifest())
+
+        # Simulate a kit upgrade — the file content has moved on but the user has not edited theirs.
+        (kit_dir / "1_llm_deck.toml").write_text("new", encoding="utf-8")
+        mocker.patch.object(deck_manifest, "get_package_version", return_value="1.1.0")
+
+        report = compute_deck_sync_report(deck_dir)
+        assert report.files["1_llm_deck.toml"] == DeckFileStatus.CLEAN_BEHIND
+        assert not report.is_clean()
+        assert report.installed_kit_version == "1.0.0"
+
+    def test_sync_report_locally_modified(self, mocker: MockerFixture, tmp_path: Path) -> None:
+        kit_dir = tmp_path / "kit"
+        deck_dir = tmp_path / "deck"
+        self._seed_kit(mocker, kit_dir, {"1_llm_deck.toml": "kit-version"})
+        self._seed_installed(deck_dir, {"1_llm_deck.toml": "kit-version"})
+        mocker.patch.object(deck_manifest, "get_package_version", return_value="1.0.0")
+        write_manifest(deck_dir, compute_kit_manifest())
+
+        # User edits their installed file, kit unchanged.
+        (deck_dir / "1_llm_deck.toml").write_text("user-edited", encoding="utf-8")
+
+        report = compute_deck_sync_report(deck_dir)
+        assert report.files["1_llm_deck.toml"] == DeckFileStatus.LOCALLY_MODIFIED
+
+    def test_sync_report_kit_added(self, mocker: MockerFixture, tmp_path: Path) -> None:
+        kit_dir = tmp_path / "kit"
+        deck_dir = tmp_path / "deck"
+        self._seed_kit(mocker, kit_dir, {"1_llm_deck.toml": "a", "5_new_deck.toml": "fresh"})
+        self._seed_installed(deck_dir, {"1_llm_deck.toml": "a"})
+        mocker.patch.object(deck_manifest, "get_package_version", return_value="1.0.0")
+        # Manifest captures only the file that existed at install time.
+        write_manifest(deck_dir, DeckManifest(kit_version="1.0.0", files={"1_llm_deck.toml": compute_file_sha256(deck_dir / "1_llm_deck.toml")}))
+
+        report = compute_deck_sync_report(deck_dir)
+        assert report.files["5_new_deck.toml"] == DeckFileStatus.KIT_ADDED
+        assert report.files["1_llm_deck.toml"] == DeckFileStatus.UP_TO_DATE
+
+    def test_sync_report_kit_removed(self, mocker: MockerFixture, tmp_path: Path) -> None:
+        kit_dir = tmp_path / "kit"
+        deck_dir = tmp_path / "deck"
+        self._seed_kit(mocker, kit_dir, {"1_llm_deck.toml": "a"})
+        self._seed_installed(deck_dir, {"1_llm_deck.toml": "a", "9_retired_deck.toml": "old"})
+        mocker.patch.object(deck_manifest, "get_package_version", return_value="1.1.0")
+        write_manifest(
+            deck_dir,
+            DeckManifest(
+                kit_version="1.0.0",
+                files={
+                    "1_llm_deck.toml": compute_file_sha256(deck_dir / "1_llm_deck.toml"),
+                    "9_retired_deck.toml": compute_file_sha256(deck_dir / "9_retired_deck.toml"),
+                },
+            ),
+        )
+
+        report = compute_deck_sync_report(deck_dir)
+        assert report.files["9_retired_deck.toml"] == DeckFileStatus.KIT_REMOVED
+        assert report.files["1_llm_deck.toml"] == DeckFileStatus.UP_TO_DATE
+
+    def test_sync_report_no_manifest_treats_matching_files_as_up_to_date(self, mocker: MockerFixture, tmp_path: Path) -> None:
+        kit_dir = tmp_path / "kit"
+        deck_dir = tmp_path / "deck"
+        contents = {"1_llm_deck.toml": "identical"}
+        self._seed_kit(mocker, kit_dir, contents)
+        self._seed_installed(deck_dir, contents)
+        mocker.patch.object(deck_manifest, "get_package_version", return_value="1.0.0")
+
+        report = compute_deck_sync_report(deck_dir)
+        assert report.manifest_present is False
+        assert report.files["1_llm_deck.toml"] == DeckFileStatus.UP_TO_DATE
+        # No manifest means the report still cannot be considered "clean" — boot warn still fires.
+        assert not report.is_clean()
+
+    def test_sync_report_no_manifest_marks_drift_as_locally_modified(self, mocker: MockerFixture, tmp_path: Path) -> None:
+        kit_dir = tmp_path / "kit"
+        deck_dir = tmp_path / "deck"
+        self._seed_kit(mocker, kit_dir, {"1_llm_deck.toml": "kit"})
+        self._seed_installed(deck_dir, {"1_llm_deck.toml": "drift"})
+        mocker.patch.object(deck_manifest, "get_package_version", return_value="1.0.0")
+
+        report = compute_deck_sync_report(deck_dir)
+        assert report.manifest_present is False
+        assert report.files["1_llm_deck.toml"] == DeckFileStatus.LOCALLY_MODIFIED
+
+    @pytest.mark.parametrize(
+        ("manifest_version", "current_version", "expected_stale"),
+        [
+            ("1.0.0", "1.0.0", False),
+            ("1.0.0", "1.1.0", True),
+            ("1.0.0", "2.0.0", True),
+            # Downgrade: manifest newer than installed — no warn.
+            ("2.0.0", "1.5.0", False),
+            # Editable / dev builds carry build metadata; cores match, so not stale.
+            ("1.0.0", "1.0.0+localdev", False),
+            ("1.0.0+ci.42", "1.0.0", False),
+            # Pre-release suffixes are also ignored for the boot check.
+            ("1.0.0-rc1", "1.0.0", False),
+        ],
+    )
+    def test_is_deck_stale_fast(
+        self,
+        mocker: MockerFixture,
+        tmp_path: Path,
+        manifest_version: str,
+        current_version: str,
+        expected_stale: bool,
+    ) -> None:
+        deck_dir = tmp_path / "deck"
+        deck_dir.mkdir()
+        write_manifest(deck_dir, DeckManifest(kit_version=manifest_version, files={}))
+        mocker.patch.object(deck_manifest, "get_package_version", return_value=current_version)
+
+        assert is_deck_stale_fast(deck_dir) is expected_stale
+
+    def test_is_deck_stale_fast_missing_manifest(self, tmp_path: Path) -> None:
+        deck_dir = tmp_path / "deck"
+        deck_dir.mkdir()
+        # No manifest at all — should be treated as stale so the user gets the migration warn.
+        assert is_deck_stale_fast(deck_dir) is True
+
+    @pytest.mark.parametrize(
+        ("numbered_filename", "expected_override"),
+        [
+            ("1_llm_deck.toml", "x_custom_llm_deck.toml"),
+            ("2_img_gen_deck.toml", "x_custom_img_gen_deck.toml"),
+            ("3_extract_deck.toml", "x_custom_extract_deck.toml"),
+            ("4_search_deck.toml", "x_custom_search_deck.toml"),
+            # Unconventional names fall back to the generic suggestion.
+            ("not_numbered.toml", "x_custom_*.toml"),
+            ("5.toml", "x_custom_*.toml"),
+        ],
+    )
+    def test_suggest_x_custom_filename(self, numbered_filename: str, expected_override: str) -> None:
+        assert suggest_x_custom_filename(numbered_filename) == expected_override

--- a/tests/unit/pipelex/core/concepts/structure_generation/test_structure_generator_escaping.py
+++ b/tests/unit/pipelex/core/concepts/structure_generation/test_structure_generator_escaping.py
@@ -1,4 +1,3 @@
-# ruff: noqa: E501
 """Unit tests for string escaping in StructureGenerator.
 
 This module tests that field descriptions and default values containing special
@@ -516,7 +515,11 @@ from typing import Optional, List, Dict, Any, Literal
 class LongDesc(StructuredContent):
     """Generated LongDesc class"""
 
-    long_field: str = Field(..., description="This is a very long description that contains many words and also has some \\"quoted sections\\" that need to be properly escaped. It goes on and on with more details about the field, including examples like \\"example1\\", \\"example2\\", and \\"example3\\". The description continues with even more information to test the robustness of the escaping mechanism.")
+    long_field: str = Field(..., description=(
+"This is a very long description that contains many words and also has some \\"quoted sections\\" that need to be properly "
+"escaped. It goes on and on with more details about the field, including examples like \\"example1\\", \\"example2\\", and "
+"\\"example3\\". The description continues with even more information to test the robustness of the escaping mechanism."
+))
 '''
 
         assert generated_code == expected_code

--- a/tests/unit/pipelex/core/concepts/structure_generation/test_structure_generator_escaping.py
+++ b/tests/unit/pipelex/core/concepts/structure_generation/test_structure_generator_escaping.py
@@ -516,10 +516,10 @@ class LongDesc(StructuredContent):
     """Generated LongDesc class"""
 
     long_field: str = Field(..., description=(
-"This is a very long description that contains many words and also has some \\"quoted sections\\" that need to be properly "
-"escaped. It goes on and on with more details about the field, including examples like \\"example1\\", \\"example2\\", and "
-"\\"example3\\". The description continues with even more information to test the robustness of the escaping mechanism."
-))
+        "This is a very long description that contains many words and also has some \\"quoted sections\\" that need to be properly "
+        "escaped. It goes on and on with more details about the field, including examples like \\"example1\\", \\"example2\\", and "
+        "\\"example3\\". The description continues with even more information to test the robustness of the escaping mechanism."
+    ))
 '''
 
         assert generated_code == expected_code

--- a/tests/unit/pipelex/core/concepts/structure_generation/test_structure_generator_wrapping.py
+++ b/tests/unit/pipelex/core/concepts/structure_generation/test_structure_generator_wrapping.py
@@ -12,6 +12,12 @@ Generated structure files must stay under the project's ruff line-length limit
 For short descriptions, both fall back to the compact single-line form.
 """
 
+import shutil
+import subprocess  # noqa: S404
+from pathlib import Path
+
+import pytest
+
 from pipelex.core.concepts.concept_structure_blueprint import ConceptStructureBlueprint, ConceptStructureBlueprintFieldType
 from pipelex.core.concepts.structure_generation.generator import StructureGenerator
 
@@ -119,6 +125,57 @@ class TestStructureGeneratorWrapping:
             "answerable type just to be helpful",
         ]:
             assert fragment in code
+
+    def test_long_field_description_survives_ruff_format(self, tmp_path: Path):
+        """Generated multi-line description blocks must survive `ruff format` without
+        the chunks being collapsed back into a single line. Un-indented chunks under a
+        hanging-indent paren block get joined by ruff format, defeating the wrap.
+        """
+        ruff_bin = shutil.which("ruff")
+        if ruff_bin is None:
+            pytest.skip("ruff not on PATH")
+
+        long_description = (
+            "Whether a factual answer could in principle be derived from documents. False for counterfactual, opinion, "
+            "and out_of_scope questions. This field is the central gate that prevents synthesis from forcing a question "
+            "into an answerable type just to be helpful."
+        )
+        blueprint = {
+            "is_answerable_from_documents": ConceptStructureBlueprint(
+                description=long_description,
+                type=ConceptStructureBlueprintFieldType.BOOLEAN,
+                required=True,
+            ),
+        }
+        code, _ = StructureGenerator().generate_from_structure_blueprint(
+            class_name="QuestionAnalysis",
+            structure_blueprint=blueprint,
+        )
+
+        target = tmp_path / "generated.py"
+        target.write_text(code)
+        subprocess.run([ruff_bin, "format", str(target)], check=True, capture_output=True)  # noqa: S603
+        formatted = target.read_text()
+
+        # The implicit-string-concat must still be present after formatting — i.e. ruff
+        # didn't merge the chunks. We check by counting string literal lines inside the
+        # description block.
+        assert "description=(" in formatted
+        # At least two string-literal lines remain inside the description block.
+        in_block = False
+        literal_lines = 0
+        for line in formatted.splitlines():
+            stripped = line.strip()
+            if "description=(" in stripped:
+                in_block = True
+                continue
+            if in_block:
+                if stripped.startswith((")", "),")):
+                    break
+                if stripped.startswith('"'):
+                    literal_lines += 1
+        assert literal_lines >= 2, f"ruff format collapsed the description chunks; got {literal_lines} literal line(s)"
+        assert _max_line_length(formatted) <= _LINE_LIMIT
 
     def test_long_descriptions_in_long_class_produce_clean_output(self):
         """End-to-end: a class with a long docstring AND multiple long field descriptions

--- a/tests/unit/pipelex/core/concepts/structure_generation/test_structure_generator_wrapping.py
+++ b/tests/unit/pipelex/core/concepts/structure_generation/test_structure_generator_wrapping.py
@@ -12,8 +12,8 @@ Generated structure files must stay under the project's ruff line-length limit
 For short descriptions, both fall back to the compact single-line form.
 """
 
-import shutil
 import subprocess  # noqa: S404
+import sys
 from pathlib import Path
 
 import pytest
@@ -131,9 +131,10 @@ class TestStructureGeneratorWrapping:
         the chunks being collapsed back into a single line. Un-indented chunks under a
         hanging-indent paren block get joined by ruff format, defeating the wrap.
         """
-        ruff_bin = shutil.which("ruff")
-        if ruff_bin is None:
-            pytest.skip("ruff not on PATH")
+        try:
+            subprocess.run([sys.executable, "-m", "ruff", "--version"], check=True, capture_output=True)  # noqa: S603
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            pytest.skip("ruff not available in current interpreter")
 
         long_description = (
             "Whether a factual answer could in principle be derived from documents. False for counterfactual, opinion, "
@@ -154,7 +155,13 @@ class TestStructureGeneratorWrapping:
 
         target = tmp_path / "generated.py"
         target.write_text(code)
-        subprocess.run([ruff_bin, "format", str(target)], check=True, capture_output=True)  # noqa: S603
+        # Use --isolated so ruff ignores any pyproject.toml in the path above tmp_path,
+        # and run via the current interpreter to ensure we use the project's pinned ruff.
+        subprocess.run(  # noqa: S603
+            [sys.executable, "-m", "ruff", "format", "--isolated", str(target)],
+            check=True,
+            capture_output=True,
+        )
         formatted = target.read_text()
 
         # The implicit-string-concat must still be present after formatting — i.e. ruff

--- a/tests/unit/pipelex/core/concepts/structure_generation/test_structure_generator_wrapping.py
+++ b/tests/unit/pipelex/core/concepts/structure_generation/test_structure_generator_wrapping.py
@@ -1,0 +1,163 @@
+"""Unit tests for line-length wrapping in StructureGenerator.
+
+Generated structure files must stay under the project's ruff line-length limit
+(150 chars). The generator handles this in two places:
+
+- **Class docstrings**: emitted as a multi-line triple-quoted block when the
+  single-line form would exceed the limit.
+- **Field `description=` arguments**: emitted as a parenthesized
+  implicit-string-concatenation block when the inline `description="..."` would
+  exceed the limit.
+
+For short descriptions, both fall back to the compact single-line form.
+"""
+
+from pipelex.core.concepts.concept_structure_blueprint import ConceptStructureBlueprint, ConceptStructureBlueprintFieldType
+from pipelex.core.concepts.structure_generation.generator import StructureGenerator
+
+_LINE_LIMIT = 150
+
+
+def _max_line_length(code: str) -> int:
+    return max((len(line) for line in code.splitlines()), default=0)
+
+
+class TestStructureGeneratorWrapping:
+    def test_short_class_docstring_stays_single_line(self):
+        """A short class description fits on one line and is emitted compactly."""
+        blueprint = {
+            "name": ConceptStructureBlueprint(
+                description="Name",
+                type=ConceptStructureBlueprintFieldType.TEXT,
+                required=True,
+            ),
+        }
+        code, _ = StructureGenerator().generate_from_structure_blueprint(
+            class_name="Person",
+            structure_blueprint=blueprint,
+            description="A person.",
+        )
+        assert '"""A person."""' in code
+        assert _max_line_length(code) <= _LINE_LIMIT
+
+    def test_long_class_docstring_wraps_to_multiline(self):
+        """A long class description is split across multiple lines, each under the limit."""
+        long_description = (
+            "Specific output structure for this example's question — how many references in the report come from the "
+            "report's own research center. Demonstrates how to output a typed structure tailored to the question rather "
+            "than a free-form text answer."
+        )
+        blueprint = {
+            "count": ConceptStructureBlueprint(
+                description="Count",
+                type=ConceptStructureBlueprintFieldType.INTEGER,
+                required=True,
+            ),
+        }
+        code, _ = StructureGenerator().generate_from_structure_blueprint(
+            class_name="ReferenceCount",
+            structure_blueprint=blueprint,
+            description=long_description,
+        )
+
+        # Multi-line docstring form: opening """, body lines, closing """ on its own line.
+        assert '    """\n' in code
+        assert '\n    """' in code
+        # Every emitted line stays under the limit.
+        assert _max_line_length(code) <= _LINE_LIMIT
+        # The full description content is preserved across the wrapped lines.
+        # Fragments must fit within a single wrapped line (textwrap inserts \n at word boundaries).
+        for fragment in ["Specific output structure", "research center", "free-form text"]:
+            assert fragment in code
+
+    def test_short_field_description_stays_single_line(self):
+        """A short Field description uses the compact `description="..."` form."""
+        blueprint = {
+            "count": ConceptStructureBlueprint(
+                description="The number of references coming from the report's own research center.",
+                type=ConceptStructureBlueprintFieldType.INTEGER,
+                required=True,
+            ),
+        }
+        code, _ = StructureGenerator().generate_from_structure_blueprint(
+            class_name="ReferenceCount",
+            structure_blueprint=blueprint,
+        )
+        assert 'description="The number of references coming from the report\'s own research center."' in code
+        assert "description=(" not in code
+        assert _max_line_length(code) <= _LINE_LIMIT
+
+    def test_long_field_description_wraps_to_implicit_concat(self):
+        """A long Field description becomes a parenthesized implicit-string-concatenation block."""
+        long_description = (
+            "Whether a factual answer could in principle be derived from documents. False for counterfactual, opinion, "
+            "and out_of_scope questions. This field is the central gate that prevents synthesis from forcing a question "
+            "into an answerable type just to be helpful."
+        )
+        blueprint = {
+            "is_answerable_from_documents": ConceptStructureBlueprint(
+                description=long_description,
+                type=ConceptStructureBlueprintFieldType.BOOLEAN,
+                required=True,
+            ),
+        }
+        code, _ = StructureGenerator().generate_from_structure_blueprint(
+            class_name="QuestionAnalysis",
+            structure_blueprint=blueprint,
+        )
+
+        # Parenthesized implicit-concat form was used.
+        assert "description=(" in code
+        # Every emitted line stays under the limit.
+        assert _max_line_length(code) <= _LINE_LIMIT
+        # Each fragment of the original description appears in the generated code
+        # (each within a single chunk — fragments that span chunk boundaries would
+        # be interrupted by the literal `" "` between adjacent string literals).
+        for fragment in [
+            "Whether a factual answer",
+            "out_of_scope questions",
+            "answerable type just to be helpful",
+        ]:
+            assert fragment in code
+
+    def test_long_descriptions_in_long_class_produce_clean_output(self):
+        """End-to-end: a class with a long docstring AND multiple long field descriptions
+        still stays under the line limit on every emitted line.
+        """
+        long_class_doc = (
+            "Structured understanding of the user's question: its type, whether it is answerable from documents at all, "
+            "its decomposition into sub-questions, key entities to search for, alternative phrasings to boost retrieval "
+            "recall, and any ambiguities that may block a confident answer."
+        )
+        blueprint = {
+            "sub_questions": ConceptStructureBlueprint(
+                description=(
+                    "Decomposition of a compound question into independently-answerable sub-questions. For simple "
+                    "questions, a single-item list containing the original question."
+                ),
+                type=ConceptStructureBlueprintFieldType.LIST,
+                required=True,
+            ),
+            "reformulations": ConceptStructureBlueprint(
+                description=(
+                    "Alternative phrasings and synonyms for the question's key terms. Improves retrieval recall when "
+                    "documents use different vocabulary."
+                ),
+                type=ConceptStructureBlueprintFieldType.LIST,
+                required=True,
+            ),
+            "ambiguities": ConceptStructureBlueprint(
+                description=(
+                    "Aspects of the question that are ambiguous and may require clarification from the user. Empty "
+                    "list if the question is fully specified."
+                ),
+                type=ConceptStructureBlueprintFieldType.LIST,
+                required=False,
+            ),
+        }
+        code, _ = StructureGenerator().generate_from_structure_blueprint(
+            class_name="QuestionAnalysis",
+            structure_blueprint=blueprint,
+            description=long_class_doc,
+        )
+        assert _max_line_length(code) <= _LINE_LIMIT

--- a/tests/unit/pipelex/pipe_operators/pipe_llm/test_pipe_llm_dynamic_output.py
+++ b/tests/unit/pipelex/pipe_operators/pipe_llm/test_pipe_llm_dynamic_output.py
@@ -1,0 +1,155 @@
+"""Unit tests for `PipeLLM.resolve_dynamic_output_stuff_spec`.
+
+When a PipeLLM declares `output = "Dynamic"`, the actual output concept is supplied
+at run time via `pipe_run_params.dynamic_output_concept_ref` (or the legacy
+`params[DYNAMIC_OUTPUT_CONCEPT]` key). The resolver returns a fresh `StuffSpec` with
+the resolved concept, leaving `self.output` unchanged so the same pipe instance can
+be reused across runs with different overrides.
+
+Pinned behaviors:
+
+- explicit override (qualified ref or bare code) → returned StuffSpec carries that concept
+- no override → fallback `native.Text`
+- non-Dynamic output → returns `self.output` unchanged
+- `self.output.concept` is **never mutated** (regression guard for the cubic P1 bug
+  where the resolver mutated state, making the second run on the same instance
+  silently ignore a different `dynamic_output_concept_ref`)
+"""
+
+from typing import Callable
+
+from pipelex.core.concepts.native.concept_native import NativeConceptCode
+from pipelex.core.domains.domain import SpecialDomain
+from pipelex.core.pipes.pipe_factory import PipeFactory
+from pipelex.pipe_operators.llm.pipe_llm import PipeLLM
+from pipelex.pipe_operators.llm.pipe_llm_blueprint import PipeLLMBlueprint
+from pipelex.pipe_run.pipe_run_params import PipeRunParamKey
+from pipelex.pipe_run.pipe_run_params_factory import PipeRunParamsFactory
+
+
+def _make_pipe(domain_code: str, pipe_code: str, output: str) -> PipeLLM:
+    blueprint = PipeLLMBlueprint(
+        description="dynamic-output test pipe",
+        inputs={"user_text": "native.Text"},
+        output=output,
+        prompt="Process @user_text",
+    )
+    return PipeFactory[PipeLLM].make_from_blueprint(
+        domain_code=domain_code,
+        pipe_code=pipe_code,
+        blueprint=blueprint,
+    )
+
+
+class TestPipeLLMDynamicOutputResolution:
+    def test_fallback_to_native_text_when_no_override(
+        self,
+        load_empty_library: Callable[[], str],
+    ):
+        """Regression: when the run params provide no override, the resolver still
+        returns a StuffSpec carrying `native.Text` (previously, the fallback was
+        only assigned to a local variable, so downstream code ran with `Dynamic`
+        and the LLM's structured JSON deserialized to `{}`).
+        """
+        load_empty_library()
+        pipe_llm = _make_pipe(domain_code="test_domain", pipe_code="test_dyn_fallback", output="native.Dynamic")
+        params = PipeRunParamsFactory.make_run_params()  # no dynamic_output_concept_ref
+
+        resolved = pipe_llm.resolve_dynamic_output_stuff_spec(pipe_run_params=params)
+
+        assert resolved.concept.code == NativeConceptCode.TEXT
+        assert resolved.concept.domain_code == SpecialDomain.NATIVE
+        # self.output is untouched.
+        assert pipe_llm.output.concept.code == NativeConceptCode.DYNAMIC
+        assert pipe_llm.output.concept.domain_code == SpecialDomain.NATIVE
+
+    def test_override_with_qualified_native_ref(
+        self,
+        load_empty_library: Callable[[], str],
+    ):
+        load_empty_library()
+        pipe_llm = _make_pipe(domain_code="test_domain", pipe_code="test_dyn_qualified", output="native.Dynamic")
+        params = PipeRunParamsFactory.make_run_params(dynamic_output_concept_ref="native.Number")
+
+        resolved = pipe_llm.resolve_dynamic_output_stuff_spec(pipe_run_params=params)
+
+        assert resolved.concept.code == NativeConceptCode.NUMBER
+        assert resolved.concept.domain_code == SpecialDomain.NATIVE
+        assert pipe_llm.output.concept.code == NativeConceptCode.DYNAMIC
+
+    def test_override_with_bare_code_uses_pipe_domain(
+        self,
+        load_empty_library: Callable[[], str],
+    ):
+        """A bare concept code (no `domain.` prefix) is resolved against the pipe's own
+        domain — for native concepts that means `native.<Code>` is found in the library.
+        This guards against accidental double-prefixing (`test_domain.native.Number`).
+        """
+        load_empty_library()
+        pipe_llm = _make_pipe(domain_code="test_domain", pipe_code="test_dyn_bare", output="native.Dynamic")
+        params = PipeRunParamsFactory.make_run_params(dynamic_output_concept_ref="Number")
+
+        resolved = pipe_llm.resolve_dynamic_output_stuff_spec(pipe_run_params=params)
+
+        assert resolved.concept.code == NativeConceptCode.NUMBER
+        assert resolved.concept.domain_code == SpecialDomain.NATIVE
+
+    def test_legacy_params_key_override(
+        self,
+        load_empty_library: Callable[[], str],
+    ):
+        """Legacy callers set the override via `params[_dynamic_output_concept]` instead
+        of the dedicated field. The resolver must honor it as a fallback so existing
+        integrations keep working.
+        """
+        load_empty_library()
+        pipe_llm = _make_pipe(domain_code="test_domain", pipe_code="test_dyn_legacy", output="native.Dynamic")
+        params = PipeRunParamsFactory.make_run_params(params={PipeRunParamKey.DYNAMIC_OUTPUT_CONCEPT: "native.Number"})
+
+        resolved = pipe_llm.resolve_dynamic_output_stuff_spec(pipe_run_params=params)
+
+        assert resolved.concept.code == NativeConceptCode.NUMBER
+        assert resolved.concept.domain_code == SpecialDomain.NATIVE
+
+    def test_non_dynamic_output_is_unchanged(
+        self,
+        load_empty_library: Callable[[], str],
+    ):
+        load_empty_library()
+        pipe_llm = _make_pipe(domain_code="test_domain", pipe_code="test_dyn_non_dynamic", output="native.Text")
+        params = PipeRunParamsFactory.make_run_params(dynamic_output_concept_ref="native.Number")
+
+        resolved = pipe_llm.resolve_dynamic_output_stuff_spec(pipe_run_params=params)
+
+        # Non-Dynamic output: helper returns the static spec unchanged, ignoring the override.
+        assert resolved is pipe_llm.output
+        assert resolved.concept.code == NativeConceptCode.TEXT
+        assert resolved.concept.domain_code == SpecialDomain.NATIVE
+
+    def test_resolves_independently_across_invocations(
+        self,
+        load_empty_library: Callable[[], str],
+    ):
+        """Regression for the cubic P1: the same pipe instance must resolve a different
+        dynamic output concept on each call. The previous implementation mutated
+        `self.output.concept` on the first call, so the guard at the top of the helper
+        (which short-circuits when concept is no longer Dynamic) silently ignored every
+        subsequent override.
+        """
+        load_empty_library()
+        pipe_llm = _make_pipe(domain_code="test_domain", pipe_code="test_dyn_repeat", output="native.Dynamic")
+
+        first = pipe_llm.resolve_dynamic_output_stuff_spec(
+            pipe_run_params=PipeRunParamsFactory.make_run_params(dynamic_output_concept_ref="native.Number"),
+        )
+        assert first.concept.code == NativeConceptCode.NUMBER
+        # self.output stays Dynamic between runs.
+        assert pipe_llm.output.concept.code == NativeConceptCode.DYNAMIC
+
+        second = pipe_llm.resolve_dynamic_output_stuff_spec(
+            pipe_run_params=PipeRunParamsFactory.make_run_params(dynamic_output_concept_ref="native.Text"),
+        )
+        assert second.concept.code == NativeConceptCode.TEXT
+        # First call's resolution didn't leak into the second.
+        assert first.concept.code == NativeConceptCode.NUMBER
+        assert pipe_llm.output.concept.code == NativeConceptCode.DYNAMIC

--- a/uv.lock
+++ b/uv.lock
@@ -3496,7 +3496,7 @@ wheels = [
 
 [[package]]
 name = "pipelex"
-version = "0.25.0"
+version = "0.25.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },

--- a/uv.lock
+++ b/uv.lock
@@ -2480,7 +2480,7 @@ wheels = [
 
 [[package]]
 name = "mthds"
-version = "0.2.0"
+version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "backports-strenum", marker = "python_full_version < '3.11'" },
@@ -2491,9 +2491,9 @@ dependencies = [
     { name = "tomlkit" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/e8/69d60b665f10a28c5efede63ccf95bdf75954701023e38138dc97da5862a/mthds-0.2.0.tar.gz", hash = "sha256:95952b489e0a6336667086a3eddb0f761f81d4af29f32de28b4182b33d265fc9", size = 112564, upload-time = "2026-03-24T13:33:51.927Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/3c/eea615b49c011657246ff61371ca4a95ab3baa94d4b79541bd4b0f816ae5/mthds-0.3.0.tar.gz", hash = "sha256:de479f977b2ec3614b23bdb53ed3e28e2332a2f1653ee92e118c530fe3d5d820", size = 112693, upload-time = "2026-04-29T12:50:11.426Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/64/3fe70f33f0f9c6237336f368cf0a24d28fce60fc1d486f0df308b36d3beb/mthds-0.2.0-py3-none-any.whl", hash = "sha256:72f6765ef48caff24211c0fc3523f61a7118ae829bd54caf1b9eba7fb4e4f281", size = 49346, upload-time = "2026-03-24T13:33:50.479Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/86/1184f31583d3089baea9316853b329720cb786d8e01f38f303a17f1e3f4c/mthds-0.3.0-py3-none-any.whl", hash = "sha256:3f9822c23beb82607ec4bafcff99717fb6531eed8d19b86086dc9deb7825b06b", size = 49356, upload-time = "2026-04-29T12:50:09.734Z" },
 ]
 
 [[package]]
@@ -3645,7 +3645,7 @@ requires-dist = [
     { name = "mkdocs-meta-manager", marker = "extra == 'docs'", specifier = ">=1.1.0" },
     { name = "mkdocs-redirects", marker = "extra == 'docs'", specifier = "==1.2.2" },
     { name = "moto", extras = ["s3"], marker = "extra == 'dev'", specifier = ">=5.0.0" },
-    { name = "mthds", specifier = ">=0.2.0" },
+    { name = "mthds", specifier = ">=0.3.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = "==1.19.1" },
     { name = "networkx", specifier = ">=3.4.2" },
     { name = "openai", specifier = ">=1.108.1" },


### PR DESCRIPTION
## Release v0.25.1

Bumps version from `0.25.0` to `0.25.1`.

### Changelog

#### Added

- **`pipelex update` command + model-deck staleness detection.** New top-level command refreshes the installed model deck (`~/.pipelex/inference/deck/`) to match the kit shipped with the running pipelex version. Tracks per-file SHA-256 hashes plus the kit version in a `.kit_manifest.json` written next to the deck files. Supports `--dry-run`, `--yes` (non-interactive), `--no-backup` (skip `.bak` files for locally-modified deck files), and `--local` (project-local deck instead of global).
- **Boot-time deck staleness warn.** Every `pipelex` CLI invocation prints a one-line yellow advisory when the installed deck's recorded kit version is older than the running pipelex (or when no manifest exists yet). Cost is one file read + one string compare. Suppress with `PIPELEX_NO_DECK_NOTICE=1`. Skipped automatically for `pipelex login`, `init`, `doctor`, `update`, and `which`.
- **`pipelex doctor` deck section.** Reports per-file deck status (`up_to_date`, `kit_added`, `kit_removed`, `clean_behind`, `locally_modified`) and offers `pipelex update` as an auto-fix under `--fix`.
- **Manifest written by `pipelex init`.** Fresh installs land with a current `.kit_manifest.json` so future updates can detect drift cleanly.
- **`--dynamic-output-concept` / `-O` flag on `pipelex run`.** All three subcommands (`run bundle`, `run pipe`, `run method`) accept a concept ref (e.g. `document_qa.ReferenceCount`) used to resolve a pipe whose output is declared as `Dynamic`. Threaded through `_run_core.execute_run` to `PipelexRunner.execute_pipeline(dynamic_output_concept_ref=...)`. Until now, Dynamic-output pipes were only callable from the Python runner.
- **Line-length-safe wrapping in the structures generator.** `pipelex build structures` now wraps long descriptions so every emitted line stays under the 150-char ruff limit. Long class docstrings become a multi-line triple-quoted block; long Field descriptions become a parenthesized implicit-string-concatenation block (`description=("first chunk " "second chunk")`). Short descriptions still emit the compact single-line form. New unit tests in `tests/unit/pipelex/core/concepts/structure_generation/test_structure_generator_wrapping.py` cover both lengths and the combined long-everything case. Previously, descriptions above ~140 chars produced files that failed `ruff check` with E501.

#### Changed

- **Numbered deck files (`N_*_deck.toml`) are pipelex-managed.** Each file now carries a header banner explaining that customizations belong in `x_custom_*.toml` (which pipelex never tracks or overwrites). Local edits to numbered files are preserved with a timestamped `.bak.<UTC-timestamp>` backup on `pipelex update` but will not survive future updates.

#### Fixed

- **`PipeLLM` Dynamic-output detection compared the wrong fields.** `pipe_llm.py` checked `self.output.concept.code == "native.Dynamic"`, but `concept.code` is the bare code (`"Dynamic"`) not the qualified ref. The check never matched, so when a caller passed `dynamic_output_concept_ref` for a `Dynamic`-output pipe, the resolver branch was skipped silently: the output structure stayed `DynamicContent` (an empty `StuffContent` subclass), the LLM produced JSON shaped like the requested concept, and the result deserialized to `{}`. Detection now uses `concept.code == NativeConceptCode.DYNAMIC and concept.domain_code == SpecialDomain.NATIVE`.
- **Dynamic-output concept resolution rejected qualified refs.** When the runtime override was supplied (e.g. `"document_qa.ReferenceCount"`), the previous code called `make_concept_ref_with_domain(domain_code=self.domain_code, concept_code=output_concept_ref)`, producing `"document_qa.document_qa.ReferenceCount"` and a missing-concept lookup. Now uses `make_concept_ref_with_domain_from_concept_ref_or_code`, which extracts the domain from the input when it's already qualified and falls back to the pipe's domain only for bare codes. Callers can pass either form.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v0.25.1 adds manifest-based model deck management with `pipelex update`, improves CLI support for `Dynamic` outputs, and tightens structures codegen wrapping. It also bumps `mthds` to `0.3.0`.

- **New Features**
  - Model deck management: new `pipelex update` syncs numbered deck files with the shipped kit, preserves `x_custom_*`, writes `.kit_manifest.json`, backs up local edits, and supports `--dry-run`, `--yes`, `--no-backup`, `--local`. Boot-time stale-deck notice (suppress with `PIPELEX_NO_DECK_NOTICE=1`), `pipelex doctor` reports per-file status and can `--fix`, and both `pipelex init` and `pipelex-agent init` (plus global auto-bootstrap) now stamp a manifest; numbered deck files include a “pipelex-managed” banner.
  - `pipelex run` now accepts `--dynamic-output-concept` / `-O` to resolve `Dynamic` outputs across `run bundle`, `run pipe`, and `run method`.
  - Structures generator wraps long docstrings and field descriptions to stay under 150 chars.
  - PipeSpec parsing accepts `prompt_template` as an alias for `prompt`.
  - Docs: added CLI page for `update` and cross-links.

- **Bug Fixes**
  - Fixed `PipeLLM` `Dynamic` detection and concept override: correct domain-aware checks, accept qualified refs, avoid mutating `self.output`, and use the runtime-resolved concept for output logging.
  - Minor fixes in concept factory arg names and related tests to prevent regressions.

<sup>Written for commit 3e37abba95527861edb60383793352850b1f7ad8. Summary will update on new commits. <a href="https://cubic.dev/pr/Pipelex/pipelex/pull/847?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

