### PR TITLE
Fix/cubic remarks 0.25.1

### DIFF
--- a/.pipelex/inference/deck/.kit_manifest.json
+++ b/.pipelex/inference/deck/.kit_manifest.json
@@ -5,5 +5,5 @@
     "3_extract_deck.toml": "560a40bd3254b1be011cfb35340fef6c40d70136e5ddce33a961899f92fd70ba",
     "4_search_deck.toml": "08e3bd1bee0f9f8ed0ffc735a932705392d0ecfbdeefce64c9815d4b2d8d7e22"
   },
-  "kit_version": "0.25.0"
+  "kit_version": "0.25.1"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- **Managed-deck detection no longer misclassifies user TOMLs.** `_is_managed_deck_filename` previously treated any non-`x_custom_*.toml` as kit-managed, so a user file like `my_overrides.toml` dropped into the deck dir would have been reported (and on `pipelex update` overwritten) as if it were a kit file. Now requires the numbered `^\d+_.*\.toml$` prefix that the kit actually ships.
+- **`PipeLLM` output structure prompt used the unresolved concept ref.** When `is_structure_prompt_enabled`, `get_output_structure_prompt` was called with `pipe_run_params.dynamic_output_concept_ref or output_stuff_spec.concept.concept_ref`. The first form can be a bare code (no domain), which broke downstream concept resolution. Now passes the already-resolved `output_stuff_spec.concept.concept_ref` directly.
+- **`PIPELEX_NO_DECK_NOTICE` suppression was too lax.** Any non-empty value silenced the deck-staleness notice — including `PIPELEX_NO_DECK_NOTICE=0`, which users might reasonably expect to *enable* the notice. Now requires the documented `PIPELEX_NO_DECK_NOTICE=1`.
+- **Shipped `.kit_manifest.json` carried `kit_version: "0.25.0"`** for the 0.25.1 release, which would have triggered false stale-detection on fresh installs. Bumped to `0.25.1` and re-synced into `pipelex/kit/configs/`.
+
+### Documentation
+
+- **`docs/tools/cli/update.md` no longer claims the deck advisory fires on every CLI invocation.** Clarified that it is suppressed for `login`, `init`, `doctor`, `update`, and `which`.
+
 ## [v0.25.1] - 2026-04-29
 
 ### Added

--- a/docs/tools/cli/update.md
+++ b/docs/tools/cli/update.md
@@ -15,7 +15,7 @@ When a new `pipelex` release ships changes to the model deck — new models, new
 
 ## When to run it
 
-Pipelex prints a one-line yellow advisory at the top of every CLI invocation when it detects that the installed deck is older than the running package, or when no deck manifest is present yet:
+Pipelex prints a one-line yellow advisory on most CLI invocations when it detects that the installed deck is older than the running package, or when no deck manifest is present yet (it is suppressed for `login`, `init`, `doctor`, `update`, and `which`):
 
 ```text
 ⚠ Pipelex model deck may be out of date — run pipelex update to refresh

--- a/pipelex/cli/deck_notice.py
+++ b/pipelex/cli/deck_notice.py
@@ -18,10 +18,10 @@ DECK_NOTICE_SUPPRESS_ENV_VAR = "PIPELEX_NO_DECK_NOTICE"
 def warn_if_deck_stale() -> None:
     """Print a one-line yellow advisory when the installed deck appears to be out of date.
 
-    Suppressed entirely when ``PIPELEX_NO_DECK_NOTICE`` is set in the environment.
+    Suppressed entirely when ``PIPELEX_NO_DECK_NOTICE=1`` is set in the environment.
     Silent when no deck dir exists yet (init_check elsewhere already prompts the user to run init).
     """
-    if os.environ.get(DECK_NOTICE_SUPPRESS_ENV_VAR):
+    if os.environ.get(DECK_NOTICE_SUPPRESS_ENV_VAR) == "1":
         return
 
     deck_dir = config_manager.pipelex_config_dir / "inference" / "deck"

--- a/pipelex/cli/deck_notice.py
+++ b/pipelex/cli/deck_notice.py
@@ -24,7 +24,7 @@ def warn_if_deck_stale() -> None:
     if os.environ.get(DECK_NOTICE_SUPPRESS_ENV_VAR) == "1":
         return
 
-    deck_dir = config_manager.pipelex_config_dir / "inference" / "deck"
+    deck_dir = config_manager.model_decks_dir_path
     if not deck_dir.exists():
         return
 

--- a/pipelex/cogt/models/deck_manifest.py
+++ b/pipelex/cogt/models/deck_manifest.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 from pathlib import Path
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -94,16 +95,18 @@ def kit_deck_dir() -> Path:
     return Path(str(get_kit_configs_dir())) / "inference" / "deck"
 
 
-def _is_managed_deck_filename(filename: str) -> bool:
-    """True for files that pipelex manages (numbered ``*_deck.toml``).
+_MANAGED_DECK_FILENAME_PATTERN = re.compile(r"^\d+_.*\.toml$")
 
-    Excludes any ``x_custom_*.toml`` override (the user-owned escape hatch) and non-TOML files
-    (e.g. an accidental ``.DS_Store``). The ``x_custom_`` prefix is the agreed-upon namespace for
-    user overrides — pipelex never tracks or overwrites those.
+
+def _is_managed_deck_filename(filename: str) -> bool:
+    """True for files that pipelex manages (numbered ``<digits>_*.toml``, e.g. ``1_llm_deck.toml``).
+
+    Only files matching the numbered-prefix pattern are pipelex-managed; everything else
+    (``x_custom_*.toml`` overrides, user-authored TOMLs without the numbered prefix,
+    ``.DS_Store``, etc.) is left untouched. This guards against accidentally treating a
+    user file as kit-managed and overwriting it during ``pipelex update``.
     """
-    if not filename.endswith(".toml"):
-        return False
-    return not filename.startswith("x_custom_")
+    return _MANAGED_DECK_FILENAME_PATTERN.match(filename) is not None
 
 
 def list_managed_kit_files() -> dict[str, str]:

--- a/pipelex/cogt/models/deck_manifest.py
+++ b/pipelex/cogt/models/deck_manifest.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-import re
 from pathlib import Path
 
 from pydantic import BaseModel, ConfigDict, Field

--- a/pipelex/kit/configs/inference/deck/.kit_manifest.json
+++ b/pipelex/kit/configs/inference/deck/.kit_manifest.json
@@ -5,5 +5,5 @@
     "3_extract_deck.toml": "560a40bd3254b1be011cfb35340fef6c40d70136e5ddce33a961899f92fd70ba",
     "4_search_deck.toml": "08e3bd1bee0f9f8ed0ffc735a932705392d0ecfbdeefce64c9815d4b2d8d7e22"
   },
-  "kit_version": "0.25.0"
+  "kit_version": "0.25.1"
 }

--- a/pipelex/pipe_operators/llm/pipe_llm.py
+++ b/pipelex/pipe_operators/llm/pipe_llm.py
@@ -318,7 +318,7 @@ class PipeLLM(PipeOperator[PipeLLMOutput]):
             output_structure_prompt: str | None = None
             if get_config().cogt.llm_config.is_structure_prompt_enabled:
                 output_structure_prompt = await get_output_structure_prompt(
-                    concept_ref=pipe_run_params.dynamic_output_concept_ref or output_stuff_spec.concept.concept_ref,
+                    concept_ref=output_stuff_spec.concept.concept_ref,
                     is_with_preliminary_text=is_with_preliminary_text,
                 )
             llm_prompt_1_for_object = await self.llm_prompt_spec.make_llm_prompt(

--- a/tests/unit/pipelex/cogt/models/test_deck_manifest.py
+++ b/tests/unit/pipelex/cogt/models/test_deck_manifest.py
@@ -102,6 +102,23 @@ class TestDeckManifest:
         installed = list_managed_installed_files(deck_dir)
         assert set(installed.keys()) == {"1_llm_deck.toml"}
 
+    def test_list_managed_installed_files_ignores_non_numbered_user_tomls(self, tmp_path: Path) -> None:
+        """Only numbered ``<digits>_*.toml`` files are kit-managed. A user TOML without the
+        numbered prefix and without the ``x_custom_`` prefix must be left alone so it isn't
+        reported / overwritten as if it were a kit file.
+        """
+        deck_dir = tmp_path / "deck"
+        self._seed_installed(
+            deck_dir,
+            {
+                "1_llm_deck.toml": "managed",
+                "my_overrides.toml": "user-authored",
+                "notes.toml": "user-authored",
+            },
+        )
+        installed = list_managed_installed_files(deck_dir)
+        assert set(installed.keys()) == {"1_llm_deck.toml"}
+
     def test_list_managed_installed_files_missing_dir(self, tmp_path: Path) -> None:
         assert list_managed_installed_files(tmp_path / "absent") == {}
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Hardens deck management and generated-code formatting for v0.25.1: prevents user TOMLs from being overwritten, fixes structure prompt concept resolution, aligns deck resolution and banner with runtime, and syncs kit manifests/docs.

- **Bug Fixes**
  - Only numbered `<digits>_*.toml` files are treated as managed; user TOMLs like `my_overrides.toml` are ignored during `pipelex update` (tests added).
  - `PIPELEX_NO_DECK_NOTICE` now requires `=1` to suppress the banner; `=0` no longer disables it.
  - Structure prompt now uses the resolved `output_stuff_spec.concept.concept_ref` (fixes failures with bare codes).
  - `doctor`, `update`, and the deck notice resolve the deck directory like runtime does (fallback to `model_decks_dir_path` when project deck is absent).
  - Generated field descriptions are indented so `ruff format` preserves implicit string concatenation (new tests verify this).
  - Bundled `.kit_manifest.json` now declares `kit_version: "0.25.1"`; manifests synced into the kit and project `.pipelex/`.

- **Documentation**
  - Clarified that the deck advisory is suppressed for `login`, `init`, `doctor`, `update`, and `which`.
  - Added management notes to deck TOMLs explaining `x_custom_*.toml` usage.
  - Regenerated gateway models doc; `gpt-5.4*` and `gpt-5.5` now list pdf input support.

<sup>Written for commit 8d950424f2855e77ccca36db71ec900c5a344b80. Summary will update on new commits. <a href="https://cubic.dev/pr/Pipelex/pipelex/pull/848?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

