### PR TITLE
Release v0.25.2

### DIFF
--- a/.badges/tests.json
+++ b/.badges/tests.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "label": "tests",
-  "message": "4193",
+  "message": "4194",
   "color": "blue",
   "cacheSeconds": 300
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v0.25.2] - 2026-04-30
+
+### Fixed
+
+- **`pipelex update` no longer flags user-added deck files for removal.** The "managed file" filter accepted any `.toml` not prefixed with `x_custom_`, so project-local additions like `pipelex-cookbook`'s `cookbook.toml` were reported as "removed upstream" with action "back up + remove". The filter now matches the documented numbered convention only (`<digits>_*.toml`); any other filename — `cookbook.toml`, `x_custom_*.toml`, etc. — is invisible to the update planner.
+
 ## [v0.25.1] - 2026-04-29
 
 ### Added

--- a/pipelex/cogt/models/deck_manifest.py
+++ b/pipelex/cogt/models/deck_manifest.py
@@ -7,8 +7,9 @@ each managed deck file at install/update time. It enables three independent sign
 - Manifest's per-file hash vs the installed file's actual hash → user has locally edited a numbered file.
 - Kit content vs installed content → upstream changed.
 
-Numbered deck files (``1_llm_deck.toml``...``4_search_deck.toml``) are pipelex-managed.
-``x_custom_*.toml`` files are user-owned and never tracked.
+Numbered deck files (``<digits>_*.toml``, e.g. ``1_llm_deck.toml``) are pipelex-managed. Anything
+else is left alone — including ``x_custom_*.toml`` overrides (the recommended escape hatch) and
+any other project-local additions (e.g. a cookbook's preset file).
 """
 
 from __future__ import annotations
@@ -95,15 +96,16 @@ def kit_deck_dir() -> Path:
 
 
 def _is_managed_deck_filename(filename: str) -> bool:
-    """True for files that pipelex manages (numbered ``*_deck.toml``).
+    """True for files that follow the pipelex-managed numbered convention.
 
-    Excludes any ``x_custom_*.toml`` override (the user-owned escape hatch) and non-TOML files
-    (e.g. an accidental ``.DS_Store``). The ``x_custom_`` prefix is the agreed-upon namespace for
-    user overrides — pipelex never tracks or overwrites those.
+    Only ``<digits>_*.toml`` filenames (e.g., ``1_llm_deck.toml``) are pipelex-managed.
+    Everything else is left untouched: ``x_custom_*.toml`` overrides, project-local additions
+    like ``cookbook.toml``, and non-TOML files (e.g. an accidental ``.DS_Store``).
     """
     if not filename.endswith(".toml"):
         return False
-    return not filename.startswith("x_custom_")
+    head, sep, _ = filename.partition("_")
+    return bool(sep) and head.isdigit()
 
 
 def list_managed_kit_files() -> dict[str, str]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pipelex"
-version = "0.25.1"
+version = "0.25.2"
 description = "Execute composable AI methods declared in the MTHDS open standard"
 authors = [{ name = "Evotis S.A.S.", email = "oss@pipelex.com" }]
 maintainers = [{ name = "Pipelex staff", email = "oss@pipelex.com" }]

--- a/tests/unit/pipelex/cogt/models/test_deck_manifest.py
+++ b/tests/unit/pipelex/cogt/models/test_deck_manifest.py
@@ -74,7 +74,7 @@ class TestDeckManifest:
         assert first == second
         assert len(first) == 64
 
-    def test_x_custom_files_excluded(self, mocker: MockerFixture, tmp_path: Path) -> None:
+    def test_managed_filter_only_admits_numbered_files(self, mocker: MockerFixture, tmp_path: Path) -> None:
         kit_dir = tmp_path / "kit"
         self._seed_kit(
             mocker,
@@ -84,6 +84,8 @@ class TestDeckManifest:
                 "2_img_gen_deck.toml": "managed",
                 "x_custom_llm_deck.toml": "user-owned",
                 "x_custom_extract_deck.toml": "user-owned",
+                "cookbook.toml": "user-owned",
+                "not_numbered.toml": "user-owned",
                 ".DS_Store": "junk",
             },
         )
@@ -97,6 +99,7 @@ class TestDeckManifest:
             {
                 "1_llm_deck.toml": "a",
                 "x_custom_llm_deck.toml": "b",
+                "cookbook.toml": "c",
             },
         )
         installed = list_managed_installed_files(deck_dir)
@@ -190,6 +193,18 @@ class TestDeckManifest:
 
         report = compute_deck_sync_report(deck_dir)
         assert report.files["9_retired_deck.toml"] == DeckFileStatus.KIT_REMOVED
+        assert report.files["1_llm_deck.toml"] == DeckFileStatus.UP_TO_DATE
+
+    def test_sync_report_ignores_user_added_files(self, mocker: MockerFixture, tmp_path: Path) -> None:
+        kit_dir = tmp_path / "kit"
+        deck_dir = tmp_path / "deck"
+        self._seed_kit(mocker, kit_dir, {"1_llm_deck.toml": "kit"})
+        self._seed_installed(deck_dir, {"1_llm_deck.toml": "kit", "cookbook.toml": "user-content"})
+        mocker.patch.object(deck_manifest, "get_package_version", return_value="1.0.0")
+        write_manifest(deck_dir, compute_kit_manifest())
+
+        report = compute_deck_sync_report(deck_dir)
+        assert "cookbook.toml" not in report.files
         assert report.files["1_llm_deck.toml"] == DeckFileStatus.UP_TO_DATE
 
     def test_sync_report_no_manifest_treats_matching_files_as_up_to_date(self, mocker: MockerFixture, tmp_path: Path) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -3496,7 +3496,7 @@ wheels = [
 
 [[package]]
 name = "pipelex"
-version = "0.25.1"
+version = "0.25.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Release v0.25.2

Bumps version from `0.25.1` to `0.25.2`.

### Changelog

### Fixed

- **`pipelex update` no longer flags user-added deck files for removal.** The "managed file" filter accepted any `.toml` not prefixed with `x_custom_`, so project-local additions like `pipelex-cookbook`'s `cookbook.toml` were reported as "removed upstream" with action "back up + remove". The filter now matches the documented numbered convention only (`<digits>_*.toml`); any other filename — `cookbook.toml`, `x_custom_*.toml`, etc. — is invisible to the update planner.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes managed-file detection so `pipelex update` only treats numbered `<digits>_*.toml` files as managed. User files like `cookbook.toml` and `x_custom_*.toml` are ignored, eliminating false “backup + remove” prompts.

<sup>Written for commit 9506e417647aa4fe843f1df0138143c80cef952e. Summary will update on new commits. <a href="https://cubic.dev/pr/Pipelex/pipelex/pull/849?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

