### PR TITLE
fix/run-environment-rollback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@
 - **`PipeOutput.graph_assembly_error`**: optional `str` field set when the Temporal `act_assemble_graph` activity raises so consumers can distinguish "graph never produced" from "graph assembly failed". Previously the failure was logged as a warning and `graph_spec` silently stayed `None`.
 - **`pipe extract` web URL support** with full test coverage in `tests/integration/pipelex/pipes/pipe_operators/pipe_extract/`.
 - **`needs_inference` flag on CLI commands**: non-inference subcommands (e.g. `worker`, `doctor`) skip inference setup, shaving cold-start time.
-- **Environment-specific config**: `RunEnvironment` enum values updated to full names (`"development"`, `"production"`). Config loaded from `ENVIRONMENT` env var (was `ENV`).
+- **Environment-specific config**: `RunEnvironment` is now loaded from the `ENVIRONMENT` env var (was `ENV`). Accepted values: `local`, `dev`, `staging`, `prod`.
 
 ### Changed
 

--- a/pipelex/system/runtime.py
+++ b/pipelex/system/runtime.py
@@ -64,13 +64,13 @@ class WorkerMode(StrEnum):
 
 class RunEnvironment(StrEnum):
     LOCAL = "local"
-    DEVELOPMENT = "development"
+    DEV = "dev"
     STAGING = "staging"
-    PRODUCTION = "production"
+    PROD = "prod"
 
     @classmethod
     def get_from_env_var(cls) -> "RunEnvironment":
-        return RunEnvironment(get_optional_env("ENVIRONMENT") or RunEnvironment.DEVELOPMENT)
+        return RunEnvironment(get_optional_env("ENVIRONMENT") or RunEnvironment.DEV)
 
 
 class ProblemReaction(StrEnum):


### PR DESCRIPTION
### 🔗 Related Issues

### 📝 Description

### 🔄 Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🧹 Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update

### 🧪 Tests

### 📋 Checklist

- [ ] Linting / type-checking / unit tests pass locally with my changes
- [ ] I've added tests that prove my fix is effective or that my feature works
- [ ] My code follows the style guidelines of this project
- [ ] I've made corresponding changes to the documentation
- [ ] My changes generate no new warnings


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverted runtime environment identifiers to short names to avoid breaking existing deployments using `ENVIRONMENT`. Also updated the changelog to list accepted values.

- **Bug Fixes**
  - Switched `RunEnvironment` values back to `DEV`/`PROD` (from `development`/`production`), keeping `LOCAL` and `STAGING`.
  - `RunEnvironment.get_from_env_var()` now defaults to `RunEnvironment.DEV` if `ENVIRONMENT` is unset.
  - CHANGELOG clarifies `ENVIRONMENT` accepted values: `local`, `dev`, `staging`, `prod`.

<sup>Written for commit a3daa6318c4c15d8ac2ca53f0196d1ca610dc578. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

