### PR TITLE
Release v0.26.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v0.26.1] - 2026-05-05
+
+### Changed
+
+- **Live-run graph output**: `pipelex run` now emits the assembled `GraphSpec` as `live_run_graph.json` alongside `live_run.json` and the ReactFlow HTML, so live runs produce the same machine-readable graph artifact as dry runs.
+
 ## [v0.26.0] - 2026-05-04
 
 ### Highlights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- **Live-run graph output**: `pipelex run` now emits the assembled `GraphSpec` as `live_run_graph.json` alongside `live_run.json` and the ReactFlow HTML, so live runs produce the same machine-readable graph artifact as dry runs.
+- **Live-run graph output**: `pipelex-agent run` now emits the assembled `GraphSpec` as `live_run_graph.json` alongside `live_run.json` and the ReactFlow HTML.
 
 ## [v0.26.0] - 2026-05-04
 

--- a/pipelex/cli/agent_cli/commands/run/_run_core.py
+++ b/pipelex/cli/agent_cli/commands/run/_run_core.py
@@ -114,7 +114,7 @@ async def run_pipeline_core(
                 ),
                 "graphs_inclusion": graph_config.graphs_inclusion.model_copy(
                     update={
-                        "graphspec_json": False,
+                        "graphspec_json": True,
                         "mermaidflow_html": False,
                         "reactflow_html": True,
                     }
@@ -137,6 +137,13 @@ async def run_pipeline_core(
             final_path = reactflow_path.parent / graph_filename
             shutil.move(str(reactflow_path), str(final_path))
             side_effects["graph_files"] = {"graph_html": str(final_path)}
+
+        # On live runs only, rename graphspec.json to live_run_graph.json
+        graphspec_path = saved_files.get("graphspec_json")
+        if graphspec_path and not dry_run:
+            final_graphspec_path = graphspec_path.parent / "live_run_graph.json"
+            shutil.move(str(graphspec_path), str(final_graphspec_path))
+            side_effects.setdefault("graph_files", {})["graph_spec"] = str(final_graphspec_path)
 
     # Save output JSON (includes side-effect paths for on-disk reference)
     output_filename = "dry_run.json" if dry_run else "live_run.json"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pipelex"
-version = "0.26.0"
+version = "0.26.1"
 description = "Execute composable AI methods declared in the MTHDS open standard"
 authors = [{ name = "Evotis S.A.S.", email = "oss@pipelex.com" }]
 maintainers = [{ name = "Pipelex staff", email = "oss@pipelex.com" }]

--- a/uv.lock
+++ b/uv.lock
@@ -3630,7 +3630,7 @@ wheels = [
 
 [[package]]
 name = "pipelex"
-version = "0.26.0"
+version = "0.26.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Release v0.26.1

Bumps version from `0.26.0` to `0.26.1`.

### Changelog

#### Changed

- **Live-run graph output**: `pipelex run` now emits the assembled `GraphSpec` as `live_run_graph.json` alongside `live_run.json` and the ReactFlow HTML, so live runs produce the same machine-readable graph artifact as dry runs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`pipelex-agent run` now writes the assembled GraphSpec to live_run_graph.json during live runs, alongside live_run.json and the ReactFlow HTML, matching dry-run artifacts. Bumps `pipelex` to v0.26.1.

<sup>Written for commit 37ef6214e2bf02322e905ec1d7797592f7cd521f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

