### PR TITLE
Release v0.26.4

### DIFF
--- a/.badges/tests.json
+++ b/.badges/tests.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "label": "tests",
-  "message": "4901",
+  "message": "4902",
   "color": "blue",
   "cacheSeconds": 300
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [v0.26.4] - 2026-05-06
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- **Temporal storage delivery no longer fails when `working_memory_raw` contains rehydrated Pydantic instances.** `WorkingMemory.dump_for_temporal()` embeds `__class__`/`__module__` markers on `ListContent` items so the receiving workflow can hydrate them. Kajson's Temporal data converter then eagerly rebuilds those dicts back into `BaseModel` instances (e.g. `PageContent` from `Page[]` outputs) on the activity worker that runs delivery — even though `working_memory_raw` is typed as `dict[str, Any]`. `clean_json_content()` previously walked only dicts/lists/scalars and let `BaseModel` instances reach `json.dumps`, which raised `TypeError: Object of type PageContent is not JSON serializable` and aborted `act_deliver`. `clean_json_content` now reduces any `BaseModel` it encounters via `model_dump(serialize_as_any=True)` (the canonical `smart_dump` path) before continuing the recursive walk.
+
 ## [v0.26.3] - 2026-05-06
 
 ### Fixed

--- a/pipelex/tools/misc/json_utils.py
+++ b/pipelex/tools/misc/json_utils.py
@@ -33,6 +33,7 @@ def clean_json_content(content: Any) -> Any:
     Removes kajson metadata fields (``__class__``, ``__module__``) and converts
     non-JSON-native types to their JSON-safe equivalents:
 
+    - ``BaseModel`` -> ``model_dump(serialize_as_any=True)`` (then cleaned recursively)
     - ``datetime.datetime`` / ``datetime.date`` / ``datetime.time`` -> ISO-format string
     - ``Enum`` -> its ``.value``
     - ``Decimal`` -> ``float``
@@ -44,6 +45,12 @@ def clean_json_content(content: Any) -> Any:
     Returns:
         A cleaned copy of *content* that ``json.dumps`` can serialize directly.
     """
+    if isinstance(content, BaseModel):
+        # Pydantic models can land inside otherwise plain dicts when kajson's
+        # Temporal data converter eagerly rehydrates `__class__` markers on the
+        # receiving worker. Reduce them to dicts via the canonical smart_dump
+        # path (model_dump(serialize_as_any=True)) before continuing the walk.
+        return clean_json_content(content.model_dump(serialize_as_any=True))
     if isinstance(content, dict):
         cleaned: dict[str, Any] = {}
         content_dict = cast("dict[str, Any]", content)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pipelex"
-version = "0.26.3"
+version = "0.26.4"
 description = "Execute composable AI methods declared in the MTHDS open standard"
 authors = [{ name = "Evotis S.A.S.", email = "oss@pipelex.com" }]
 maintainers = [{ name = "Pipelex staff", email = "oss@pipelex.com" }]

--- a/tests/unit/pipelex/pipe_run/test_delivery_executor.py
+++ b/tests/unit/pipelex/pipe_run/test_delivery_executor.py
@@ -251,6 +251,55 @@ class TestDeliveryExecutor:
         json_text = files["main_stuff.json"].data.decode("utf-8")
         assert "</pre><script>alert(1)</script><pre>" in json_text
 
+    async def test_generate_result_files_with_pydantic_instances_in_raw(self, mocker: MockerFixture) -> None:
+        """working_memory_raw can contain hydrated Pydantic instances after Temporal transit.
+
+        When `dump_for_temporal()` runs in a child workflow, it embeds `__class__` metadata
+        on ListContent items so the parent can reconstruct them. Kajson's Temporal data
+        converter then eagerly rehydrates those dicts back into BaseModel instances on the
+        activity worker that runs delivery — even though the typed slot is `dict[str, Any]`.
+
+        `clean_json_dumps()` does not know how to serialize a Pydantic BaseModel, so the
+        delivery activity blows up with `TypeError: Object of type PageContent is not JSON
+        serializable`. This test pins that scenario.
+        """
+        from pipelex.core.stuffs.image_content import ImageContent  # noqa: PLC0415
+        from pipelex.core.stuffs.page_content import PageContent  # noqa: PLC0415
+        from pipelex.core.stuffs.text_and_images_content import TextAndImagesContent  # noqa: PLC0415
+        from pipelex.core.stuffs.text_content import TextContent  # noqa: PLC0415
+
+        page = PageContent(
+            text_and_images=TextAndImagesContent(
+                text=TextContent(text="Page 1 contents"),
+                images=[ImageContent(url="https://example.com/img.png")],
+            ),
+        )
+
+        mock_output = mocker.MagicMock()
+        mock_output.working_memory_raw = {
+            "root": {
+                "cv_pages": {
+                    "stuff_code": "cv_pages",
+                    "stuff_name": "cv_pages",
+                    "concept": {
+                        "code": "Page",
+                        "domain_code": "native",
+                        "description": "A page",
+                        "structure_class_name": "PageContent",
+                    },
+                    "content": [page],
+                }
+            },
+            "aliases": {},
+        }
+        mock_output.graph_spec = None
+
+        files = await DeliveryExecutor().generate_result_files(mock_output)
+
+        json_text = files["working_memory.json"].data.decode("utf-8")
+        assert "Page 1 contents" in json_text
+        assert "https://example.com/img.png" in json_text
+
     async def test_webhook_failure_raises(self, mocker: MockerFixture) -> None:
         import httpx  # noqa: PLC0415
 

--- a/uv.lock
+++ b/uv.lock
@@ -3644,7 +3644,7 @@ wheels = [
 
 [[package]]
 name = "pipelex"
-version = "0.26.3"
+version = "0.26.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Release v0.26.4

Bumps version from `0.26.3` to `0.26.4`.

### Changelog

#### Fixed

- **Temporal storage delivery no longer fails when `working_memory_raw` contains rehydrated Pydantic instances.** `WorkingMemory.dump_for_temporal()` embeds `__class__`/`__module__` markers on `ListContent` items so the receiving workflow can hydrate them. Kajson's Temporal data converter then eagerly rebuilds those dicts back into `BaseModel` instances (e.g. `PageContent` from `Page[]` outputs) on the activity worker that runs delivery — even though `working_memory_raw` is typed as `dict[str, Any]`. `clean_json_content()` previously walked only dicts/lists/scalars and let `BaseModel` instances reach `json.dumps`, which raised `TypeError: Object of type PageContent is not JSON serializable` and aborted `act_deliver`. `clean_json_content` now reduces any `BaseModel` it encounters via `model_dump(serialize_as_any=True)` (the canonical `smart_dump` path) before continuing the recursive walk.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash in Temporal delivery when `working_memory_raw` includes rehydrated Pydantic models by serializing them to JSON-safe dicts. Bumps version to `0.26.4`.

- **Bug Fixes**
  - `clean_json_content` now converts any `BaseModel` via `model_dump(serialize_as_any=True)` before recursion to avoid `TypeError` during `json.dumps`.
  - Added a unit test that includes `PageContent` in `working_memory_raw` and verifies the JSON output in delivery.

<sup>Written for commit dbe4a50cd76df4b3c075c498253de82c9844d997. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

