### PR TITLE
fix/environment name to pipelex_env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- **`RunEnvironment` env var renamed from `ENVIRONMENT` to `PIPELEX_ENV`.** The variable that selects the environment-specific `pipelex_<env>.toml` overlay (and is stamped on OTel spans as `deployment.environment`) is now namespaced to avoid collisions with unrelated `ENVIRONMENT` variables already set in deployment environments. Update any shell, CI, or container config that exported `ENVIRONMENT=...` to export `PIPELEX_ENV=...` instead.
+
 ## [v0.26.4] - 2026-05-06
 
 ### Fixed

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -106,9 +106,6 @@ Set it the way you set any other env var — for example, in your shell, your `.
 export PIPELEX_ENV=staging
 ```
 
-!!! warning "Renamed in a recent release"
-    This variable used to be called `ENVIRONMENT`. It was renamed to `PIPELEX_ENV` to avoid colliding with unrelated `ENVIRONMENT` variables that some deployment platforms set automatically. Update any shell, CI, or container config that exported `ENVIRONMENT=...` to export `PIPELEX_ENV=...` instead.
-
 ### Best Practices for Overrides
 
 1. Use the base `pipelex.toml` for default settings

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -36,7 +36,7 @@ The main project configuration files are:
 In addition to `.pipelex/pipelex.toml`, Pipelex can apply override files at the **project root** (not in `.pipelex/`) for machine- and environment-specific settings:
 
 1. `pipelex_local.toml`
-2. `pipelex_{environment}.toml` (example: `pipelex_dev.toml`)
+2. `pipelex_{environment}.toml` (example: `pipelex_dev.toml`) — selected by the `PIPELEX_ENV` environment variable (see [Selecting the environment](#selecting-the-environment))
 3. `pipelex_{run_mode}.toml` (example: `pipelex_normal.toml`; unit tests may use `tests/pipelex_unit_test.toml`)
 4. `pipelex_override.toml` (recommended to gitignore)
 
@@ -63,7 +63,7 @@ The exact loading sequence is:
 2. Your project's base configuration (`pipelex.toml` in your project root)
 3. Local overrides (`pipelex_local.toml`)
 4. Environment-specific overrides (`pipelex_{environment}.toml`)
-   - Example environments: dev, staging, prod -> based on the environment variable `ENV` in your .env file
+   - Example environments: `local`, `dev`, `staging`, `prod` — selected by the `PIPELEX_ENV` environment variable (see [Selecting the environment](#selecting-the-environment))
 5. Run mode overrides (`pipelex_{run_mode}.toml`)
    - Example run modes: normal, unit_test
 6. Final overrides (`pipelex_override.toml`) (recommended to put in .gitignore)
@@ -84,6 +84,30 @@ Each subsequent configuration file in this sequence can override settings from t
 - Final overrides: `pipelex_override.toml`
 
 NB: The run_mode unit_test is used for testing purposes.
+
+### Selecting the environment
+
+The `pipelex_{environment}.toml` overlay is picked at runtime from the `PIPELEX_ENV` environment variable.
+
+| Value     | Overlay file loaded   |
+| --------- | --------------------- |
+| `local`   | `pipelex_local.toml` *(also loaded as the local override layer; see above)* |
+| `dev`     | `pipelex_dev.toml`     |
+| `staging` | `pipelex_staging.toml` |
+| `prod`    | `pipelex_prod.toml`    |
+
+If `PIPELEX_ENV` is unset, Pipelex defaults to `dev`. Any other value raises an error at startup — the accepted values are defined by the `RunEnvironment` enum in `pipelex/system/runtime.py`.
+
+The selected environment is also stamped on OpenTelemetry spans as `deployment.environment`, so it doubles as the environment label for traces and metrics.
+
+Set it the way you set any other env var — for example, in your shell, your `.env` file, your CI configuration, or your container runtime:
+
+```bash
+export PIPELEX_ENV=staging
+```
+
+!!! warning "Renamed in a recent release"
+    This variable used to be called `ENVIRONMENT`. It was renamed to `PIPELEX_ENV` to avoid colliding with unrelated `ENVIRONMENT` variables that some deployment platforms set automatically. Update any shell, CI, or container config that exported `ENVIRONMENT=...` to export `PIPELEX_ENV=...` instead.
 
 ### Best Practices for Overrides
 

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -17,7 +17,7 @@ Pipelex uses a layered TOML configuration system that lets you define sensible d
 2. **Global overrides** — `~/.pipelex/pipelex.toml` for user-wide settings
 3. **Project overrides** — `{project_root}/.pipelex/pipelex.toml` for project-specific settings
 4. **Local overrides** — `pipelex_local.toml` (git-ignored) for machine-specific values
-5. **Environment / run-mode-specific** — `pipelex_dev.toml`, `pipelex_prod.toml`, `pipelex_testing.toml`, etc.
+5. **Environment / run-mode-specific** — `pipelex_dev.toml`, `pipelex_prod.toml`, `pipelex_testing.toml`, etc. The environment overlay is selected by the `PIPELEX_ENV` environment variable (accepted values: `local`, `dev`, `staging`, `prod`; defaults to `dev`).
 
 A final `pipelex_override.toml` file can be used for last-resort overrides.
 

--- a/pipelex/system/runtime.py
+++ b/pipelex/system/runtime.py
@@ -70,7 +70,7 @@ class RunEnvironment(StrEnum):
 
     @classmethod
     def get_from_env_var(cls) -> "RunEnvironment":
-        return RunEnvironment(get_optional_env("ENVIRONMENT") or RunEnvironment.DEV)
+        return RunEnvironment(get_optional_env("PIPELEX_ENV") or RunEnvironment.DEV)
 
 
 class ProblemReaction(StrEnum):


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Renamed the env var that selects the runtime environment from `ENVIRONMENT` to `PIPELEX_ENV` to avoid collisions. It now picks `pipelex_{environment}.toml` and sets `deployment.environment` on OTel spans.

- **Migration**
  - Replace any `ENVIRONMENT=<env>` exports with `PIPELEX_ENV=<env>` in shell, CI, and container configs.
  - Accepted values: `local`, `dev`, `staging`, `prod`; defaults to `dev` if unset. Any other value fails at startup.

<sup>Written for commit 5f4a52d8df9b7d4030e9f4dcad1ea1d5f0fb9bfc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

