### PR TITLE
Release v0.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- **`RunEnvironment` env var renamed from `ENVIRONMENT` to `PIPELEX_ENV`.** The variable that selects the environment-specific `pipelex_<env>.toml` overlay (and is stamped on OTel spans as `deployment.environment`) is now namespaced to avoid collisions with unrelated `ENVIRONMENT` variables already set in deployment environments. Update any shell, CI, or container config that exported `ENVIRONMENT=...` to export `PIPELEX_ENV=...` instead.
+
 ## [v0.26.4] - 2026-05-06
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [v0.27.0] - 2026-05-07
 
 ### Changed
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -106,9 +106,6 @@ Set it the way you set any other env var — for example, in your shell, your `.
 export PIPELEX_ENV=staging
 ```
 
-!!! warning "Renamed in a recent release"
-    This variable used to be called `ENVIRONMENT`. It was renamed to `PIPELEX_ENV` to avoid colliding with unrelated `ENVIRONMENT` variables that some deployment platforms set automatically. Update any shell, CI, or container config that exported `ENVIRONMENT=...` to export `PIPELEX_ENV=...` instead.
-
 ### Best Practices for Overrides
 
 1. Use the base `pipelex.toml` for default settings

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -36,7 +36,7 @@ The main project configuration files are:
 In addition to `.pipelex/pipelex.toml`, Pipelex can apply override files at the **project root** (not in `.pipelex/`) for machine- and environment-specific settings:
 
 1. `pipelex_local.toml`
-2. `pipelex_{environment}.toml` (example: `pipelex_dev.toml`)
+2. `pipelex_{environment}.toml` (example: `pipelex_dev.toml`) — selected by the `PIPELEX_ENV` environment variable (see [Selecting the environment](#selecting-the-environment))
 3. `pipelex_{run_mode}.toml` (example: `pipelex_normal.toml`; unit tests may use `tests/pipelex_unit_test.toml`)
 4. `pipelex_override.toml` (recommended to gitignore)
 
@@ -63,7 +63,7 @@ The exact loading sequence is:
 2. Your project's base configuration (`pipelex.toml` in your project root)
 3. Local overrides (`pipelex_local.toml`)
 4. Environment-specific overrides (`pipelex_{environment}.toml`)
-   - Example environments: dev, staging, prod -> based on the environment variable `ENV` in your .env file
+   - Example environments: `local`, `dev`, `staging`, `prod` — selected by the `PIPELEX_ENV` environment variable (see [Selecting the environment](#selecting-the-environment))
 5. Run mode overrides (`pipelex_{run_mode}.toml`)
    - Example run modes: normal, unit_test
 6. Final overrides (`pipelex_override.toml`) (recommended to put in .gitignore)
@@ -84,6 +84,30 @@ Each subsequent configuration file in this sequence can override settings from t
 - Final overrides: `pipelex_override.toml`
 
 NB: The run_mode unit_test is used for testing purposes.
+
+### Selecting the environment
+
+The `pipelex_{environment}.toml` overlay is picked at runtime from the `PIPELEX_ENV` environment variable.
+
+| Value     | Overlay file loaded   |
+| --------- | --------------------- |
+| `local`   | `pipelex_local.toml` *(also loaded as the local override layer; see above)* |
+| `dev`     | `pipelex_dev.toml`     |
+| `staging` | `pipelex_staging.toml` |
+| `prod`    | `pipelex_prod.toml`    |
+
+If `PIPELEX_ENV` is unset, Pipelex defaults to `dev`. Any other value raises an error at startup — the accepted values are defined by the `RunEnvironment` enum in `pipelex/system/runtime.py`.
+
+The selected environment is also stamped on OpenTelemetry spans as `deployment.environment`, so it doubles as the environment label for traces and metrics.
+
+Set it the way you set any other env var — for example, in your shell, your `.env` file, your CI configuration, or your container runtime:
+
+```bash
+export PIPELEX_ENV=staging
+```
+
+!!! warning "Renamed in a recent release"
+    This variable used to be called `ENVIRONMENT`. It was renamed to `PIPELEX_ENV` to avoid colliding with unrelated `ENVIRONMENT` variables that some deployment platforms set automatically. Update any shell, CI, or container config that exported `ENVIRONMENT=...` to export `PIPELEX_ENV=...` instead.
 
 ### Best Practices for Overrides
 

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -17,7 +17,7 @@ Pipelex uses a layered TOML configuration system that lets you define sensible d
 2. **Global overrides** — `~/.pipelex/pipelex.toml` for user-wide settings
 3. **Project overrides** — `{project_root}/.pipelex/pipelex.toml` for project-specific settings
 4. **Local overrides** — `pipelex_local.toml` (git-ignored) for machine-specific values
-5. **Environment / run-mode-specific** — `pipelex_dev.toml`, `pipelex_prod.toml`, `pipelex_testing.toml`, etc.
+5. **Environment / run-mode-specific** — `pipelex_dev.toml`, `pipelex_prod.toml`, `pipelex_testing.toml`, etc. The environment overlay is selected by the `PIPELEX_ENV` environment variable (accepted values: `local`, `dev`, `staging`, `prod`; defaults to `dev`).
 
 A final `pipelex_override.toml` file can be used for last-resort overrides.
 

--- a/pipelex/system/runtime.py
+++ b/pipelex/system/runtime.py
@@ -5,6 +5,7 @@ from pipelex.types import StrEnum
 
 RUN_MODE_ENV_VAR_KEY = "RUN_MODE"
 CODEX_CLOUD_ENV_VAR_KEY = "CODEX_CLOUD"
+RUN_ENVIRONMENT_ENV_VAR_KEY = "PIPELEX_ENV"
 
 
 class IntegrationMode(StrEnum):
@@ -70,7 +71,7 @@ class RunEnvironment(StrEnum):
 
     @classmethod
     def get_from_env_var(cls) -> "RunEnvironment":
-        return RunEnvironment(get_optional_env("PIPELEX_ENV") or RunEnvironment.DEV)
+        return RunEnvironment(get_optional_env(RUN_ENVIRONMENT_ENV_VAR_KEY) or RunEnvironment.DEV)
 
 
 class ProblemReaction(StrEnum):

--- a/pipelex/system/runtime.py
+++ b/pipelex/system/runtime.py
@@ -70,7 +70,7 @@ class RunEnvironment(StrEnum):
 
     @classmethod
     def get_from_env_var(cls) -> "RunEnvironment":
-        return RunEnvironment(get_optional_env("ENVIRONMENT") or RunEnvironment.DEV)
+        return RunEnvironment(get_optional_env("PIPELEX_ENV") or RunEnvironment.DEV)
 
 
 class ProblemReaction(StrEnum):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pipelex"
-version = "0.26.4"
+version = "0.27.0"
 description = "Execute composable AI methods declared in the MTHDS open standard"
 authors = [{ name = "Evotis S.A.S.", email = "oss@pipelex.com" }]
 maintainers = [{ name = "Pipelex staff", email = "oss@pipelex.com" }]

--- a/uv.lock
+++ b/uv.lock
@@ -3644,7 +3644,7 @@ wheels = [
 
 [[package]]
 name = "pipelex"
-version = "0.26.4"
+version = "0.27.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Release v0.27.0

Bumps version from `0.26.4` to `0.27.0`.

### Changelog

#### Changed

- **`RunEnvironment` env var renamed from `ENVIRONMENT` to `PIPELEX_ENV`.** The variable that selects the environment-specific `pipelex_<env>.toml` overlay (and is stamped on OTel spans as `deployment.environment`) is now namespaced to avoid collisions with unrelated `ENVIRONMENT` variables already set in deployment environments. Update any shell, CI, or container config that exported `ENVIRONMENT=...` to export `PIPELEX_ENV=...` instead.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the environment selector from `ENVIRONMENT` to `PIPELEX_ENV` to avoid collisions. Code now reads the var via `RUN_ENVIRONMENT_ENV_VAR_KEY`, updated docs, and bumped `pipelex` to v0.27.0.

- **Migration**
  - Replace any `ENVIRONMENT=...` exports with `PIPELEX_ENV=...` in your shell, `.env`, CI, and container configs.
  - Allowed values: `local`, `dev`, `staging`, `prod` (defaults to `dev`; other values error).
  - This selects the `pipelex_{environment}.toml` overlay and sets `deployment.environment` on OTel spans.

<sup>Written for commit ed1fe29a32d832cad066c5944c8e323853922b8e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

