### PR TITLE
fix: remove dead TemplateSigilSyntaxError catches

### DIFF
--- a/pipelex/cogt/templating/template_blueprint.py
+++ b/pipelex/cogt/templating/template_blueprint.py
@@ -3,7 +3,6 @@ from typing import Any
 from pydantic import BaseModel, Field, model_validator
 
 from pipelex.cogt.templating.template_category import TemplateCategory
-from pipelex.cogt.templating.template_errors import TemplateSigilSyntaxError
 from pipelex.cogt.templating.template_preprocessor import preprocess_template
 from pipelex.cogt.templating.templating_style import TemplatingStyle
 from pipelex.tools.jinja2.jinja2_errors import Jinja2TemplateSyntaxError
@@ -21,11 +20,7 @@ class TemplateBlueprint(BaseModel):
 
     @model_validator(mode="after")
     def validate_template(self) -> "TemplateBlueprint":
-        try:
-            preprocessed = preprocess_template(self.template)
-        except TemplateSigilSyntaxError as exc:
-            msg = f"Template sigil error in TemplateBlueprint: {exc}"
-            raise ValueError(msg) from exc
+        preprocessed = preprocess_template(self.template)
         try:
             check_jinja2_parsing(template_source=preprocessed, template_category=self.category)
         except Jinja2TemplateSyntaxError as exc:

--- a/pipelex/pipe_operators/compose/construct_blueprint.py
+++ b/pipelex/pipe_operators/compose/construct_blueprint.py
@@ -13,7 +13,6 @@ from typing import Any, cast
 from pydantic import BaseModel, ConfigDict, SerializationInfo, SerializerFunctionWrapHandler, field_validator, model_serializer, model_validator
 
 from pipelex.cogt.templating.template_category import TemplateCategory
-from pipelex.cogt.templating.template_errors import TemplateSigilSyntaxError
 from pipelex.cogt.templating.template_preprocessor import preprocess_template
 from pipelex.pipe_operators.compose.exceptions import ConstructFieldBlueprintTypeError, ConstructFieldBlueprintValueError
 from pipelex.tools.jinja2.jinja2_errors import Jinja2DetectVariablesError
@@ -245,11 +244,7 @@ class ConstructBlueprint(BaseModel):
                 case ConstructFieldMethod.TEMPLATE:
                     if field_blueprint.template:
                         # Use the same approach as template mode: preprocess then detect variables
-                        try:
-                            preprocessed = preprocess_template(field_blueprint.template)
-                        except TemplateSigilSyntaxError as exc:
-                            msg = f"Template sigil error in construct template: {exc}"
-                            raise ValueError(msg) from exc
+                        preprocessed = preprocess_template(field_blueprint.template)
                         try:
                             template_vars = detect_jinja2_required_variables(
                                 template_category=TemplateCategory.BASIC,


### PR DESCRIPTION
## Summary

- Remove `try/except TemplateSigilSyntaxError` wrappers in `TemplateBlueprint.validate_template` and `ConstructBlueprint.get_required_variables` (TEMPLATE branch), plus their now-unused imports.
- Both sites call `preprocess_template(self.template)` without `declared_inputs`. Per `preprocess_template`'s contract (`pipelex/cogt/templating/template_preprocessor.py:198`), the validator — the only path that raises `TemplateSigilSyntaxError` — is skipped when `declared_inputs is None`. The catches were unreachable.
- The five other `preprocess_template(...)` call sites (`pipe_llm_blueprint.py` ×2, `pipe_compose_factory.py`, `pipe_compose_blueprint.py`, `pipe_search_blueprint.py`, `pipe_img_gen_blueprint.py`) all pass `declared_inputs=` and remain unchanged.
- Aligns with CLAUDE.md's rule against speculative `try/except`.

## Test plan

- [x] `make agent-check` clean (ruff + plxt + pyright + mypy)
- [x] No tests asserted on the removed `TemplateSigilSyntaxError → ValueError` conversion at these sites (verified by independent reviewer agent)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove unreachable `TemplateSigilSyntaxError` handling where `preprocess_template` is called without `declared_inputs`, since the sigil validator isn’t run in that path. This cleans up dead code and unused imports without changing behavior.

- **Refactors**
  - Removed `try/except TemplateSigilSyntaxError` in `TemplateBlueprint.validate_template` and `ConstructBlueprint.get_required_variables` (TEMPLATE branch).
  - Deleted unused `TemplateSigilSyntaxError` imports.
  - Other `preprocess_template(..., declared_inputs=...)` call sites remain unchanged.

<sup>Written for commit ba6eeda77b81459163a51271a85ed8457255412b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

