### PR TITLE
fix: resolve NameError 'Any' for PipeLLM output refining native JSON concept

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- **`PipeLLM` outputting a concept that refines the native `JSON` concept no longer crashes with `NameError: name 'Any' is not defined`.** On a LIVE run, such a concept resolves to a structured-output model carrying a `dict[str, Any]` field inherited from `JSONContent`. `SchemaToModelFactory` generates that model as source with `from __future__ import annotations` (every annotation becomes a string) and then rebuilds each class to resolve the string annotations. The rebuild namespace was assembled from the exec'd user types plus a hand-listed `Literal`, but `typing.Any` is a special form, not a `type`, so it was filtered out — `model_rebuild` then raised `PydanticUndefinedAnnotation` evaluating `"dict[str, Any]"`. The rebuild namespace is now the exec namespace itself (minus `__builtins__`), so it carries exactly the names the generated source was written against and cannot drift as codegen emits other typing constructs. Fixed in `pipelex/cogt/content_generation/schema_to_model_factory.py`; covers both the sender path (`make_from_json_schema`) and the cross-process receiver path (`make_types_from_source`).
+
 ## [v0.28.0] - 2026-05-13
 
 ### Changed

--- a/pipelex/cogt/content_generation/schema_to_model_factory.py
+++ b/pipelex/cogt/content_generation/schema_to_model_factory.py
@@ -36,7 +36,7 @@ import threading
 from collections import OrderedDict
 from enum import Enum
 from pathlib import Path
-from typing import Any, ClassVar, Literal, cast
+from typing import Any, ClassVar, cast
 
 from pydantic import BaseModel, RootModel
 
@@ -268,7 +268,17 @@ class SchemaToModelFactory:
         # type annotations into strings. Rebuild every BaseModel so forward refs (including
         # references to generated Enum classes for choices fields, and Literal annotations
         # produced by `enum_field_as_literal=All`) resolve against the full type namespace.
-        rebuild_namespace: dict[str, Any] = {**all_user_types, "Literal": Literal}
+        #
+        # The rebuild namespace must carry every name the generated source was written
+        # against — not just the user-defined types. The exec namespace already holds
+        # exactly that: the generated `from typing import ...` / `from pydantic import ...`
+        # imports landed there alongside the user types. Reusing it (minus `__builtins__`)
+        # keeps the namespace correct even as codegen starts emitting other typing
+        # constructs. `all_user_types` alone is NOT enough: it filters the namespace to
+        # `type` instances, which drops typing special forms like `Any` (not a `type`),
+        # so a `dict[str, Any]` field — e.g. one inherited from `JSONContent` by a concept
+        # refining the native `JSON` concept — would fail with `NameError: name 'Any'`.
+        rebuild_namespace: dict[str, Any] = {key: value for key, value in namespace.items() if key != "__builtins__"}
         for candidate in all_user_types.values():
             if issubclass(candidate, BaseModel):
                 candidate.model_rebuild(_types_namespace=rebuild_namespace)

--- a/tests/e2e/pipelex/pipes/pipe_operators/pipe_llm/pipe_llm_json_concept.mthds
+++ b/tests/e2e/pipelex/pipes/pipe_operators/pipe_llm/pipe_llm_json_concept.mthds
@@ -1,0 +1,18 @@
+domain      = "pipe_llm_json_concept_e2e"
+description = "Test PipeLLM whose output concept refines the native JSON concept"
+
+[concept.VectorIndex]
+description = "An indexed collection of vectors organized as a free-form JSON object"
+refines     = "JSON"
+
+[pipe.build_index]
+type = "PipeLLM"
+description = "Organize text into a structured JSON index"
+inputs = { text = "Text" }
+output = "VectorIndex"
+prompt = """
+Organize the following text into a structured index. Produce a JSON object with
+top-level categories as keys and lists of related terms as values.
+
+@text
+"""

--- a/tests/e2e/pipelex/pipes/pipe_operators/pipe_llm/test_pipe_llm_json_concept.py
+++ b/tests/e2e/pipelex/pipes/pipe_operators/pipe_llm/test_pipe_llm_json_concept.py
@@ -1,0 +1,51 @@
+"""E2E test for PipeLLM whose output concept refines the native JSON concept.
+
+Regression coverage for `NameError: name 'Any' is not defined`: a `PipeLLM` whose
+`output` is a concept that `refines = "JSON"` resolves to a structured-output model
+carrying an `Any`-typed field (inherited from `JSONContent`). On a LIVE run, that
+model is generated as source with `from __future__ import annotations` and rebuilt;
+if the rebuild namespace lacks `Any`, the run crashes. DRY runs do not build the
+structured-output model, so only the LIVE variant exercises the regression.
+"""
+
+import pytest
+
+from pipelex import pretty_print
+from pipelex.core.stuffs.json_content import JSONContent
+from pipelex.core.stuffs.text_content import TextContent
+from pipelex.pipe_run.pipe_run_mode import PipeRunMode
+from pipelex.pipeline.runner import PipelexRunner
+
+
+@pytest.mark.llm
+@pytest.mark.inference
+@pytest.mark.dry_runnable
+@pytest.mark.asyncio
+class TestPipeLLMJsonConcept:
+    async def test_build_index(self, pipe_run_mode: PipeRunMode) -> None:
+        """A PipeLLM outputting a bare `refines = "JSON"` concept must build and
+        rebuild its structured-output model without raising.
+        """
+        pipeline_response = await PipelexRunner(
+            library_dirs=["tests/e2e/pipelex/pipes/pipe_operators"], pipe_run_mode=pipe_run_mode
+        ).execute_pipeline(
+            pipe_code="build_index",
+            inputs={
+                "text": TextContent(
+                    text="Vectors, embeddings, and cosine similarity power semantic search and retrieval.",
+                ),
+            },
+        )
+
+        assert pipeline_response.pipe_output is not None
+        assert pipeline_response.pipe_output.working_memory is not None
+        assert pipeline_response.pipe_output.main_stuff is not None
+
+        json_content = pipeline_response.pipe_output.main_stuff_as(content_type=JSONContent)
+        assert isinstance(json_content.json_obj, dict)
+
+        pretty_print(json_content.json_obj, title="Vector index")
+
+        # In live mode, the LLM must have populated the free-form JSON object.
+        if pipe_run_mode.is_live:
+            assert len(json_content.json_obj) > 0, f"Expected a non-empty JSON index, got {json_content.json_obj}"

--- a/tests/unit/pipelex/cogt/content_generation/test_schema_to_model.py
+++ b/tests/unit/pipelex/cogt/content_generation/test_schema_to_model.py
@@ -28,6 +28,20 @@ class ModelWithLiteralChoices(BaseModel):
     recommendation: Literal["Strong Match", "Good Match", "Partial Match", "Poor Match"]
 
 
+class ModelWithJsonObject(BaseModel):
+    """A model with a free-form JSON object field typed ``dict[str, Any]``.
+
+    Mirrors ``JSONContent``, the native content class that a concept refining the
+    native ``JSON`` concept resolves to. The ``Any`` in ``dict[str, Any]`` is what
+    breaks forward-reference resolution: datamodel-code-generator emits
+    ``from __future__ import annotations``, turning the field annotation into the
+    string ``"dict[str, Any]"``. If the rebuild namespace does not carry ``Any``,
+    ``model_rebuild`` raises ``NameError: name 'Any' is not defined``.
+    """
+
+    json_obj: dict[str, Any] = Field(description="The JSON object")
+
+
 class Address(BaseModel):
     street: str
     city: str
@@ -89,6 +103,56 @@ class TestSchemaToModel:
             "Partial Match",
             "Poor Match",
         }, f"Literal args drifted during round-trip: {get_args(annotation)!r}"
+
+    def test_json_object_field_reconstructs_without_undefined_any(self) -> None:
+        """A schema with a ``dict[str, Any]`` field reconstructs without raising.
+
+        Bug repro: a ``PipeLLM`` whose output is a concept refining the native
+        ``JSON`` concept produces a structured-output model carrying an
+        ``Any``-typed field (inherited from ``JSONContent``). datamodel-code-generator
+        emits ``from __future__ import annotations``, so the field annotation becomes
+        the string ``"dict[str, Any]"``. If ``model_rebuild`` runs against a namespace
+        that lacks ``Any``, it raises ``PydanticUndefinedAnnotation: name 'Any' is
+        not defined``. The rebuild namespace must carry the typing names the generated
+        source was written against.
+        """
+        schema = ModelWithJsonObject.model_json_schema()
+        unique_title = f"JsonObjectRepro_{uuid.uuid4().hex}"
+        schema["title"] = unique_title
+
+        result_class = SchemaToModelFactory.make_from_json_schema(schema, unique_title)
+
+        source = getattr(result_class, "__kajson_class_source__", "")
+        assert "from __future__ import annotations" in source, (
+            f"Expected datamodel-code-generator to emit future annotations (so the regression target is meaningful). Source:\n{source}"
+        )
+        assert "json_obj" in result_class.model_fields
+        instance = result_class(json_obj={"category": "vectors", "count": 3})
+        assert instance.json_obj == {"category": "vectors", "count": 3}  # type: ignore[attr-defined]
+
+    def test_make_types_from_source_resolves_any_annotation(self) -> None:
+        """The receiver path (``make_types_from_source``) rebuilds a model whose
+        string annotation references ``Any`` without raising.
+
+        This is the cross-process path: a ``__kajson_class_source__`` payload carrying
+        ``from __future__ import annotations`` plus a ``dict[str, Any]`` field must
+        rebuild against a namespace that includes ``Any``.
+        """
+        source = (
+            "from __future__ import annotations\n"
+            "from typing import Any\n"
+            "from pydantic import BaseModel, Field\n"
+            "\n\n"
+            "class JsonHolder(BaseModel):\n"
+            "    json_obj: dict[str, Any] = Field(..., description='The JSON object')\n"
+        )
+
+        types = SchemaToModelFactory.make_types_from_source(source)
+
+        json_holder = types["JsonHolder"]
+        assert issubclass(json_holder, BaseModel)
+        instance = json_holder(json_obj={"k": "v"})
+        assert instance.json_obj == {"k": "v"}  # type: ignore[attr-defined]
 
     def test_simple_model_reconstruction(self) -> None:
         """A simple model can be reconstructed from its JSON schema."""


### PR DESCRIPTION
## Summary

A `PipeLLM` whose `output` is a concept that `refines = "JSON"` crashed at pipe-execution time on LIVE runs with `PydanticUndefinedAnnotation: name 'Any' is not defined`.

Such a concept resolves to a structured-output model carrying a `dict[str, Any]` field inherited from `JSONContent`. `SchemaToModelFactory` generates that model as source with `from __future__ import annotations` (every annotation becomes a string), then rebuilds each class to resolve the string annotations. The rebuild namespace was assembled from the exec'd user types plus a hand-listed `Literal` — but `typing.Any` is a special form, not a `type`, so it was filtered out, and `model_rebuild` raised when evaluating `"dict[str, Any]"`.

## Fix

`_exec_source_to_types` now builds `rebuild_namespace` from the exec namespace itself (minus `__builtins__`) instead of `{**all_user_types, "Literal": Literal}`. The exec namespace already holds exactly the names the generated source imported (`Any`, `Literal`, `BaseModel`, ...), so the namespace cannot drift as codegen emits other typing constructs. Fixes both the sender path (`make_from_json_schema`) and the cross-process receiver path (`make_types_from_source`).

## Tests

- **Unit** (`test_schema_to_model.py`): a `dict[str, Any]` schema reconstructs without raising (sender path); a `__kajson_class_source__`-style payload with `from __future__ import annotations` + `Any` rebuilds without raising (receiver path). Both fail before the fix.
- **E2E**: new `pipe_llm_json_concept.mthds` bundle + test — a `PipeLLM` outputting a bare `refines = "JSON"` concept. Verified red→green on the LIVE path (`git stash` the fix → live run crashes with `name 'Any' is not defined`; restore → passes).
- `make agent-check` clean; cogt unit+integration, pipe_llm e2e, and temporal data_converter suites all green.

## Note on the second site

The originating brief flagged `library_manager._rebuild_models_with_forward_refs` as having the same defect. Investigation showed it is **not** triggered by this bug: a JSON-refining concept's generated structure class is already `__pydantic_complete__ == True`, so its `model_rebuild` is a no-op. No speculative fix was applied there. (That site does carry an unrelated `except Exception` worth cleaning up in a follow-up.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash in `PipeLLM` when the output concept refines native `JSON` by ensuring `Any` resolves during model rebuilds on LIVE runs. We now use the exec namespace for rebuilding generated models, preventing `PydanticUndefinedAnnotation`/`NameError`.

- **Bug Fixes**
  - In `SchemaToModelFactory._exec_source_to_types`, use the exec namespace (minus `__builtins__`) as the `_types_namespace` for `model_rebuild`, so names imported by the generated source (`Any`, `Literal`, `BaseModel`, etc.) are available. Covers both `make_from_json_schema` and `make_types_from_source`. Regression tests added (unit and LIVE E2E) for `dict[str, Any]` and a `PipeLLM` output concept that `refines = "JSON"`.

<sup>Written for commit 9128db8306f8a771eb16d15a7f86b0ffe10447c2. Summary will update on new commits. <a href="https://cubic.dev/pr/Pipelex/pipelex/pull/902?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

