### PR TITLE
llm: omit image collection names in prompt placeholders

### DIFF
--- a/pipelex/core/stuffs/image_field_search.py
+++ b/pipelex/core/stuffs/image_field_search.py
@@ -54,12 +54,13 @@ def search_for_nested_image_fields(
             # Get the corresponding field type with full generic info
             current_field_type = potential_field_types[idx]
 
-            # Check if it's a list or tuple generic type (e.g., list[ImageContent], tuple[ImageContent, ...])
-            if hasattr(field_specific_type, "__origin__") and field_specific_type.__origin__ in {list, tuple}:  # type: ignore[union-attr]
-                # Check if this container or its nested contents have images
+            # Check if it's a generic container type (list/tuple/dict).
+            # Example: list[ImageContent], tuple[ImageContent, ...], dict[str, ImageContent].
+            if hasattr(field_specific_type, "__origin__") and field_specific_type.__origin__ in {list, tuple, dict}:  # type: ignore[union-attr]
+                # Check if this container or its nested contents have images.
                 if check_generic_container_for_images(field_specific_type):
                     paths.append(field_path)
-                continue  # Move to next field after handling list/tuple
+                continue  # Move to next field after handling generic containers
 
             # Skip if field type is not a class
             if not isinstance(field_specific_type, type):
@@ -129,10 +130,11 @@ def search_for_nested_image_fields(
 def check_generic_container_for_images(container_type: Any) -> bool:
     """Recursively check if a generic container type contains images at any depth.
 
-    Handles nested generics like list[tuple[list[MediaCollection]]] with arbitrary depth.
+    Handles nested generics like list[tuple[list[MediaCollection]]] or
+    dict[str, list[ImageContent]] with arbitrary depth.
 
     Args:
-        container_type: A generic type like list[...], tuple[...]
+        container_type: A generic type like list[...], tuple[...], dict[..., ...]
 
     Returns:
         True if the container or its nested contents contain ImageContent
@@ -143,8 +145,8 @@ def check_generic_container_for_images(container_type: Any) -> bool:
     # Get the args (item types) from the generic
     container_args = getattr(container_type, "__args__", ())
     for arg_type in container_args:
-        # Check if arg_type is itself a generic (nested list/tuple) - recurse!
-        if hasattr(arg_type, "__origin__") and arg_type.__origin__ in {list, tuple}:  # type: ignore[union-attr]
+        # Check if arg_type is itself a generic container - recurse!
+        if hasattr(arg_type, "__origin__") and arg_type.__origin__ in {list, tuple, dict}:  # type: ignore[union-attr]
             if check_generic_container_for_images(arg_type):
                 return True
         # Check if it's a regular type

--- a/pipelex/core/stuffs/structured_content.py
+++ b/pipelex/core/stuffs/structured_content.py
@@ -8,6 +8,8 @@ from rich.table import Table
 from typing_extensions import override
 
 from pipelex.cogt.templating.text_format import TextFormat
+from pipelex.core.stuffs.image_content import ImageContent
+from pipelex.core.stuffs.list_content import ListContent
 from pipelex.core.stuffs.stuff_content import StuffContent
 from pipelex.tools.jinja2.image_registry import ImageRegistry
 from pipelex.tools.jinja2.image_renderable import ImageRenderable
@@ -143,7 +145,10 @@ class StructuredContent(StuffContent):
                 continue
             rendered = self._render_value_with_images(field_value, registry, text_format)
             if rendered:
-                parts.append(f"{field_name}: {rendered}")
+                if self._is_image_collection_value(field_value):
+                    parts.append(rendered)
+                else:
+                    parts.append(f"{field_name}: {rendered}")
         return "\n".join(parts)
 
     def _render_value_with_images(
@@ -177,14 +182,50 @@ class StructuredContent(StuffContent):
         if isinstance(value, dict):
             dict_parts: list[str] = []
             dict_value = cast("dict[str, Any]", value)
+            hide_keys = self._is_image_collection_value(value)
             for key, val in dict_value.items():
                 rendered = self._render_value_with_images(val, registry, text_format)
                 if rendered:
-                    dict_parts.append(f"{key}: {rendered}")
+                    if hide_keys:
+                        dict_parts.append(rendered)
+                    else:
+                        dict_parts.append(f"{key}: {rendered}")
             return "\n".join(dict_parts)
         if isinstance(value, StuffContent):
             return value.rendered_for_prompt(text_format)
         return str(value)
+
+    def _is_image_collection_value(self, value: Any) -> bool:
+        """Return True for image collections where names should be omitted."""
+        if isinstance(value, (list, tuple)):
+            sequence = cast("list[Any]", value)
+            return bool(sequence) and all(self._is_image_only_value(item) for item in sequence)
+        if isinstance(value, dict):
+            dict_value = cast("dict[str, Any]", value)
+            return bool(dict_value) and all(self._is_image_only_value(item) for item in dict_value.values())
+        if isinstance(value, ListContent):
+            list_content = cast("ListContent[Any]", value)
+            items = list_content.items
+            return bool(items) and all(self._is_image_only_value(item) for item in items)
+        return False
+
+    def _is_image_only_value(self, value: Any) -> bool:
+        """Return True when a value is an image or nested image-only structure."""
+        if value is None:
+            return False
+        if isinstance(value, ImageContent):
+            return True
+        if isinstance(value, (list, tuple)):
+            sequence = cast("list[Any]", value)
+            return bool(sequence) and all(self._is_image_only_value(item) for item in sequence)
+        if isinstance(value, dict):
+            dict_value = cast("dict[str, Any]", value)
+            return bool(dict_value) and all(self._is_image_only_value(item) for item in dict_value.values())
+        if isinstance(value, ListContent):
+            list_content = cast("ListContent[Any]", value)
+            items = list_content.items
+            return bool(items) and all(self._is_image_only_value(item) for item in items)
+        return False
 
     # -------------------------------------------------------------------------
     # Pretty printing

--- a/tests/integration/pipelex/pipes/llm_prompt_inputs/test_prompt_image_extraction.py
+++ b/tests/integration/pipelex/pipes/llm_prompt_inputs/test_prompt_image_extraction.py
@@ -146,6 +146,7 @@ class TestPromptImageExtraction:
         assert llm_prompt.user_text is not None
         assert "[Image 1]" in llm_prompt.user_text
         assert "[Image 2]" in llm_prompt.user_text
+        assert "page_view: [Image 2]" in llm_prompt.user_text
 
         # Images should be extracted to user_images
         assert llm_prompt.user_images is not None

--- a/tests/unit/pipelex/core/concepts/data.py
+++ b/tests/unit/pipelex/core/concepts/data.py
@@ -71,6 +71,13 @@ class PersonWithImageTuple(StructuredContent):
     before_after: tuple[ImageContent, ImageContent]
 
 
+class GalleryWithImageDict(StructuredContent):
+    """A gallery with a dict of images."""
+
+    title: TextContent
+    photos_by_role: dict[str, ImageContent]
+
+
 class PhotoAlbumItem(StructuredContent):
     """An item in a photo album with nested image."""
 
@@ -164,6 +171,8 @@ class TestData:
         ("GalleryWithImageList", ["photos"]),
         # Tuple of images
         ("PersonWithImageTuple", ["before_after"]),
+        # Dict of images
+        ("GalleryWithImageDict", ["photos_by_role"]),
         # List with nested images in items
         ("PhotoAlbumWithNestedImages", ["album_items"]),
         # Complex deeply nested structure

--- a/tests/unit/pipelex/core/concepts/test_concept_find_image_field_paths.py
+++ b/tests/unit/pipelex/core/concepts/test_concept_find_image_field_paths.py
@@ -48,6 +48,7 @@ def register_test_concepts(load_test_library: Callable[[list[Path]], None]):
         ("PersonWithOptionalImage", "A person with optional image", "PersonWithOptionalImage", None),
         ("GalleryWithImageList", "A gallery with a list of images", "GalleryWithImageList", None),
         ("PersonWithImageTuple", "A person with a tuple of images", "PersonWithImageTuple", None),
+        ("GalleryWithImageDict", "A gallery with a dict of images", "GalleryWithImageDict", None),
         ("PhotoAlbumItem", "An item in a photo album", "PhotoAlbumItem", None),
         ("PhotoAlbumWithNestedImages", "A photo album with nested images in list items", "PhotoAlbumWithNestedImages", None),
         ("MediaFrame", "A frame containing an image", "MediaFrame", None),

--- a/tests/unit/pipelex/core/stuffs/test_structured_content_render_with_images.py
+++ b/tests/unit/pipelex/core/stuffs/test_structured_content_render_with_images.py
@@ -33,6 +33,13 @@ class CustomStructuredWithDict(StructuredContent):
     image_map: dict[str, ImageContent]
 
 
+class CustomStructuredWithMixedDict(StructuredContent):
+    """Test class with dict mixing image and non-image values."""
+
+    title: str
+    mixed_map: dict[str, ImageContent | str]
+
+
 class CustomStructuredWithNestedList(StructuredContent):
     """Test class with nested list structure."""
 
@@ -40,12 +47,21 @@ class CustomStructuredWithNestedList(StructuredContent):
     image_groups: list[list[ImageContent]]
 
 
+class CustomStructuredWithTuple(StructuredContent):
+    """Test class with tuple of images."""
+
+    title: str
+    image_tuple: tuple[ImageContent, ...]
+
+
 class TestData:
     """Expected values for render_with_images tests."""
 
-    EXPECTED_PLAIN_LIST = "title: Test Document\nimages: [Image 1]\n[Image 2]\n[Image 3]"
-    EXPECTED_DICT = "title: Gallery\nimage_map: cover: [Image 1]\nbackground: [Image 2]"
-    EXPECTED_NESTED_LIST = "title: Nested Gallery\nimage_groups: [Image 1]\n[Image 2]\n[Image 3]"
+    EXPECTED_PLAIN_LIST = "title: Test Document\n[Image 1]\n[Image 2]\n[Image 3]"
+    EXPECTED_DICT = "title: Gallery\n[Image 1]\n[Image 2]"
+    EXPECTED_MIXED_DICT = "title: Mixed Gallery\nmixed_map: cover: [Image 1]\nnote: Keep this context"
+    EXPECTED_NESTED_LIST = "title: Nested Gallery\n[Image 1]\n[Image 2]\n[Image 3]"
+    EXPECTED_TUPLE = "title: Tuple Gallery\n[Image 1]\n[Image 2]"
     EXPECTED_IMAGE_RENDERABLE = "text_and_images: Some document text\n[Image 1]\npage_view: [Image 2]"
     EXPECTED_PAGE_CONTENT_ALL = "text_and_images: Page content\n[Image 1]\n[Image 2]\npage_view: [Image 3]"
     EXPECTED_EMPTY_LIST = "title: Empty Gallery"
@@ -111,6 +127,38 @@ class TestStructuredContentRenderWithImages:
 
         assert result == TestData.EXPECTED_NESTED_LIST
         assert len(registry.images) == 3
+
+    def test_mixed_dict_keeps_keys_for_semantic_context(self) -> None:
+        """Test that mixed dict keeps keys, including image key names."""
+        content = CustomStructuredWithMixedDict(
+            title="Mixed Gallery",
+            mixed_map={
+                "cover": ImageContent(url=URLs.png_example_1),
+                "note": "Keep this context",
+            },
+        )
+        registry = ImageRegistry()
+
+        result = content.render_with_images(registry, TextFormat.PLAIN)
+
+        assert result == TestData.EXPECTED_MIXED_DICT
+        assert len(registry.images) == 1
+
+    def test_tuple_of_images_extracts_all(self) -> None:
+        """Test that tuple containing ImageContent is treated as image collection."""
+        content = CustomStructuredWithTuple(
+            title="Tuple Gallery",
+            image_tuple=(
+                ImageContent(url=URLs.png_example_1),
+                ImageContent(url=URLs.png_example_2),
+            ),
+        )
+        registry = ImageRegistry()
+
+        result = content.render_with_images(registry, TextFormat.PLAIN)
+
+        assert result == TestData.EXPECTED_TUPLE
+        assert len(registry.images) == 2
 
     def test_image_renderable_field_delegates_properly(self) -> None:
         """Test that ImageRenderable fields (like TextAndImagesContent) work correctly."""


### PR DESCRIPTION
## Summary
This PR addresses #521 by omitting collection names when rendering image collections into prompt placeholders.

## What changed
- Updated `StructuredContent.render_with_images()` behavior:
  - Omit field/key names only for image collections (lists/tuples/dicts of images).
  - Keep semantic keys for mixed-content dicts.
  - Keep non-collection image field labels (e.g. `page_view`) unchanged.
- Added regression tests for:
  - Plain image list rendering without collection name
  - Dict image collection rendering without keys
  - Tuple image collection behavior
  - Mixed dict behavior preserving semantic keys
  - Prompt extraction expectation for nested `with_images`

## Validation
- `pytest tests/unit/pipelex/core/stuffs/test_structured_content_render_with_images.py`
- `pytest tests/integration/pipelex/pipes/llm_prompt_inputs/test_prompt_image_extraction.py --disable-inference`
- `ruff check` on changed files
- `pyright` on changed files

Refs #521

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates prompt rendering to omit names for image-only collections (lists, tuples, dicts) and keep labels for single-image fields, reducing noise and aligning with image extraction (addresses #521). Also extends nested image discovery to detect dict-based image collections.

- **Bug Fixes**
  - Updated `StructuredContent.render_with_images()` to hide names for image-only collections; preserve names for mixed dicts and non-collection fields.
  - Improved image-only detection across nested sequences, dicts, and `ListContent` via `_is_image_collection_value()` and `_is_image_only_value()`.
  - Extended nested image discovery to include dict generics in `search_for_nested_image_fields()`/`check_generic_container_for_images()`; added tests for dict containers, tuples, nested lists, mixed dicts, and label preservation in prompt extraction.

<sup>Written for commit c8a3732277573c67aa50a924d9a740b02b9d0d98. Summary will update on new commits. <a href="https://cubic.dev/pr/Pipelex/pipelex/pull/916?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

