### PR TITLE
feat: add --traceback flag for full CLI stack traces

### DIFF
--- a/pipelex/cli/_cli.py
+++ b/pipelex/cli/_cli.py
@@ -63,18 +63,24 @@ class PipelexCLI(TyperGroup):
         parent: Context | None = None,
         **extra: object,
     ) -> Context:
-        """Intercept --no-logo from args before Click/Typer processes them.
+        """Intercept global flags from args before Click/Typer processes them.
 
-        This allows --no-logo to be placed anywhere in the command line
-        (before or after subcommands) while keeping the CLI architecture clean.
+        This allows --no-logo and --traceback to be placed anywhere in the
+        command line (before or after subcommands) while keeping the CLI
+        architecture clean.
         """
         no_logo = "--no-logo" in args
         if no_logo:
             args = [arg for arg in args if arg != "--no-logo"]
 
+        traceback = "--traceback" in args
+        if traceback:
+            args = [arg for arg in args if arg != "--traceback"]
+
         ctx = super().make_context(info_name, args, parent, **extra)
         ctx.ensure_object(dict)
         ctx.obj["no_logo"] = no_logo
+        ctx.obj["traceback"] = traceback
         return ctx
 
 

--- a/pipelex/cli/commands/run/_run_core.py
+++ b/pipelex/cli/commands/run/_run_core.py
@@ -15,6 +15,7 @@ from pipelex.cli.error_handlers import (
     ErrorContext,
     handle_model_availability_error,
     handle_model_choice_error,
+    print_traceback_if_requested,
 )
 from pipelex.config import get_config
 from pipelex.core.interpreter.exceptions import MthdsDecodeError, PipelexInterpreterError
@@ -307,6 +308,7 @@ def execute_run(
 
     except PipelexError as exc:
         console = get_console()
+        print_traceback_if_requested(console)
         console.print("\n[bold red]Failed to execute pipeline[/bold red]\n")
         console.print(f"  {exc.message}\n")
         raise typer.Exit(1) from exc

--- a/pipelex/cli/error_handlers.py
+++ b/pipelex/cli/error_handlers.py
@@ -1,9 +1,11 @@
 from pathlib import Path
 from typing import NoReturn
 
+import click
 import typer
 from rich.console import Console
 from rich.markup import escape
+from rich.traceback import Traceback
 
 from pipelex.cogt.exceptions import GatewayUnknownModelError, ModelDeckPresetValidatonError
 from pipelex.core.pipes.exceptions import PipeOperatorModelChoiceError
@@ -41,6 +43,26 @@ class ErrorContext(StrEnum):
     VALIDATION_BEFORE_BUILD_INPUTS = "Pre-validation (build inputs)"
     VALIDATION_BEFORE_BUILD_OUTPUT = "Pre-validation (build output)"
     KIT = "Kit operation"
+
+
+def is_traceback_requested() -> bool:
+    """Check whether the --traceback global flag was passed on the CLI invocation."""
+    try:
+        ctx = click.get_current_context(silent=True)
+    except RuntimeError:
+        return False
+    if ctx is None:
+        return False
+    obj = ctx.find_root().obj
+    if obj is None:
+        return False
+    return bool(obj.get("traceback", False))
+
+
+def print_traceback_if_requested(console: Console) -> None:
+    """Print a Rich traceback of the current exception when --traceback is active."""
+    if is_traceback_requested():
+        console.print(Traceback())
 
 
 def display_error_panel(
@@ -89,12 +111,14 @@ def handle_model_choice_error(exc: PipeOperatorModelChoiceError, context: ErrorC
         exc: The model choice error exception
         context: Context for the error message
     """
+    console = get_console()
+    print_traceback_if_requested(console)
     report = exc.to_error_report()
     tip = report.user_action_detail() or (
         f"Check your model configuration in .pipelex/inference/ or specify a different model in the '{exc.pipe_code}' pipe."
     )
     display_error_panel(
-        get_console(),
+        console,
         title=f"{context} failed because of a model choice could not be interpreted correctly",
         fields=[
             ("Pipe", f"[yellow]'{escape(exc.pipe_code)}'[/yellow] [dim]({escape(exc.pipe_type)})[/dim]"),
@@ -118,6 +142,8 @@ def handle_model_availability_error(exc: PipeOperatorModelAvailabilityError, con
         exc: The model availability error exception
         context: Context for the error message
     """
+    console = get_console()
+    print_traceback_if_requested(console)
     report = exc.to_error_report()
     fields: list[tuple[str, str]] = [
         ("Pipe", f"[yellow]'{escape(exc.pipe_code)}'[/yellow] [dim]({escape(exc.pipe_type)})[/dim]"),
@@ -133,7 +159,7 @@ def handle_model_availability_error(exc: PipeOperatorModelAvailabilityError, con
         f"Check your model configuration in .pipelex/inference/ or specify a different model in the '{exc.pipe_code}' pipe."
     )
     display_error_panel(
-        get_console(),
+        console,
         title=f"{context} failed because a model wasn't available",
         fields=fields,
         error_message=escape(str(exc)),
@@ -153,6 +179,8 @@ def handle_model_deck_preset_error(exc: ModelDeckPresetValidatonError, context: 
         exc: The model deck preset validation error exception
         context: Context for the error message
     """
+    console = get_console()
+    print_traceback_if_requested(console)
     report = exc.to_error_report()
     model_handle = exc.model_handle or ""
     fields: list[tuple[str, str]] = [
@@ -186,7 +214,7 @@ def handle_model_deck_preset_error(exc: ModelDeckPresetValidatonError, context: 
         tip = "\n".join(tip_lines)
 
     display_error_panel(
-        get_console(),
+        console,
         title=f"{context} failed due to model deck preset validation error",
         fields=fields,
         error_message=escape(exc.message),
@@ -280,6 +308,7 @@ def handle_validate_bundle_error(exc: ValidateBundleError, bundle_path: Path | N
     """
     report = exc.to_error_report()
     console = get_console()
+    print_traceback_if_requested(console)
     console.print("\n[bold red]❌ Bundle validation failed[/bold red]\n")
 
     if bundle_path:
@@ -306,6 +335,7 @@ def handle_inference_setup_required_error(exc: InferenceSetupRequiredError) -> N
         exc: The inference setup required error exception
     """
     console = get_console()
+    print_traceback_if_requested(console)
     console.print("\n[bold yellow]⚠ First-time inference setup required[/bold yellow]\n")
 
     console.print(
@@ -332,6 +362,7 @@ def handle_telemetry_config_validation_error(exc: TelemetryConfigValidationError
         exc: The telemetry config validation error exception
     """
     console = get_console()
+    print_traceback_if_requested(console)
     console.print("\n[bold red]❌ Telemetry configuration format has changed[/bold red]\n")
 
     console.print(
@@ -361,6 +392,7 @@ def handle_gateway_terms_not_accepted_error(exc: GatewayTermsNotAcceptedError) -
         exc: The gateway terms not accepted error exception
     """
     console = get_console()
+    print_traceback_if_requested(console)
     console.print("\n[bold red]❌ Pipelex Gateway terms not accepted[/bold red]\n")
 
     console.print("[bold yellow]⚠ Action Required:[/bold yellow] Pipelex Gateway is enabled but you haven't accepted\nthe terms of service yet.\n")
@@ -387,6 +419,7 @@ def handle_gateway_api_key_missing_error(exc: GatewayApiKeyMissingError) -> NoRe
         exc: The gateway API key missing error exception
     """
     console = get_console()
+    print_traceback_if_requested(console)
     console.print("\n[bold red]❌ Pipelex Gateway API key not set[/bold red]\n")
 
     console.print("[bold yellow]⚠ Action Required:[/bold yellow] Pipelex Gateway is enabled but the API key\nenvironment variable is not set.\n")
@@ -416,6 +449,7 @@ def handle_gateway_do_not_track_conflict_error(exc: GatewayDoNotTrackConflictErr
         exc: The gateway do not track conflict error exception
     """
     console = get_console()
+    print_traceback_if_requested(console)
     console.print("\n[bold red]❌ Pipelex Gateway requires telemetry[/bold red]\n")
 
     console.print(
@@ -444,6 +478,7 @@ def handle_remote_config_validation_error(exc: RemoteConfigValidationError) -> N
         exc: The remote config validation error exception
     """
     console = get_console()
+    print_traceback_if_requested(console)
     console.print("\n[bold red]❌ Pipelex Gateway configuration is invalid[/bold red]\n")
 
     console.print(
@@ -480,6 +515,7 @@ def handle_remote_config_unavailable_error(exc: RemoteConfigUnavailableError) ->
         exc: The remote config unavailable error exception
     """
     console = get_console()
+    print_traceback_if_requested(console)
     console.print("\n[bold red]❌ Pipelex Gateway is unreachable and no cached config is available[/bold red]\n")
 
     console.print(
@@ -513,6 +549,7 @@ def handle_gateway_unknown_model_error(exc: GatewayUnknownModelError) -> NoRetur
         exc: The gateway unknown model error exception
     """
     console = get_console()
+    print_traceback_if_requested(console)
     console.print("\n[bold red]❌ Unknown gateway model handle[/bold red]\n")
 
     console.print(f"[bold cyan]Model handle:[/bold cyan] [yellow]'{escape(exc.model_name)}'[/yellow]")

--- a/tests/unit/pipelex/cli/test_traceback_flag.py
+++ b/tests/unit/pipelex/cli/test_traceback_flag.py
@@ -1,0 +1,142 @@
+"""Tests for the --traceback global CLI flag.
+
+Verifies that:
+- Without --traceback, error handlers do NOT print a Rich traceback.
+- With --traceback, error handlers print a Rich traceback before the nice panel.
+- The flag is correctly intercepted by PipelexCLI.make_context.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import click
+import pytest
+import typer
+from rich.traceback import Traceback
+
+from pipelex.cli._cli import PipelexCLI  # noqa: PLC2701
+from pipelex.cli.error_handlers import (
+    handle_inference_setup_required_error,
+    is_traceback_requested,
+    print_traceback_if_requested,
+)
+from pipelex.system.pipelex_service.exceptions import InferenceSetupRequiredError
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+
+class TestIsTracebackRequested:
+    """Unit tests for is_traceback_requested()."""
+
+    def test_returns_false_when_no_click_context(self) -> None:
+        """Outside a Click context, should return False."""
+        assert is_traceback_requested() is False
+
+    def test_returns_false_when_flag_not_set(self) -> None:
+        """When ctx.obj has no 'traceback' key, should return False."""
+        ctx = click.Context(click.Command("test"), obj={})
+        with ctx:
+            assert is_traceback_requested() is False
+
+    def test_returns_true_when_flag_set(self) -> None:
+        """When ctx.obj['traceback'] is True, should return True."""
+        ctx = click.Context(click.Command("test"), obj={"traceback": True})
+        with ctx:
+            assert is_traceback_requested() is True
+
+    def test_returns_false_when_flag_explicitly_false(self) -> None:
+        """When ctx.obj['traceback'] is False, should return False."""
+        ctx = click.Context(click.Command("test"), obj={"traceback": False})
+        with ctx:
+            assert is_traceback_requested() is False
+
+
+class TestPrintTracebackIfRequested:
+    """Unit tests for print_traceback_if_requested()."""
+
+    def test_does_not_print_when_flag_not_set(self) -> None:
+        """When --traceback is not active, console.print should not be called."""
+        console = MagicMock()
+        ctx = click.Context(click.Command("test"), obj={"traceback": False})
+        with ctx:
+            print_traceback_if_requested(console)
+        console.print.assert_not_called()
+
+    def test_prints_traceback_when_flag_set(self) -> None:
+        """When --traceback is active, console.print should be called with a Traceback."""
+        console = MagicMock()
+        ctx = click.Context(click.Command("test"), obj={"traceback": True})
+        with ctx:
+            try:
+                msg = "test error"
+                raise ValueError(msg)
+            except ValueError:
+                print_traceback_if_requested(console)
+        console.print.assert_called_once()
+        arg = console.print.call_args[0][0]
+        assert isinstance(arg, Traceback)
+
+
+class TestTracebackFlagInErrorHandlers:
+    """Integration: error handlers respect the --traceback flag."""
+
+    def test_handler_prints_traceback_when_flag_active(self, mocker: MockerFixture) -> None:
+        """handle_inference_setup_required_error prints traceback when --traceback is set."""
+        mock_console = MagicMock()
+        mocker.patch("pipelex.cli.error_handlers.get_console", return_value=mock_console)
+
+        exc = InferenceSetupRequiredError()
+        ctx = click.Context(click.Command("test"), obj={"traceback": True})
+        with ctx:
+            try:
+                raise exc
+            except InferenceSetupRequiredError:
+                with pytest.raises(typer.Exit):
+                    handle_inference_setup_required_error(exc)
+
+        # The first call to console.print should be the Traceback
+        first_call_arg = mock_console.print.call_args_list[0][0][0]
+        assert isinstance(first_call_arg, Traceback)
+
+    def test_handler_does_not_print_traceback_when_flag_absent(self, mocker: MockerFixture) -> None:
+        """handle_inference_setup_required_error does NOT print traceback without --traceback."""
+        mock_console = MagicMock()
+        mocker.patch("pipelex.cli.error_handlers.get_console", return_value=mock_console)
+
+        exc = InferenceSetupRequiredError()
+        ctx = click.Context(click.Command("test"), obj={"traceback": False})
+        with ctx:
+            try:
+                raise exc
+            except InferenceSetupRequiredError:
+                with pytest.raises(typer.Exit):
+                    handle_inference_setup_required_error(exc)
+
+        # No call should have a Traceback argument
+        for call in mock_console.print.call_args_list:
+            args = call[0]
+            for arg in args:
+                assert not isinstance(arg, Traceback)
+
+
+class TestPipelexCLIMakeContext:
+    """Test that PipelexCLI.make_context intercepts --traceback."""
+
+    def test_traceback_flag_intercepted(self) -> None:
+        """--traceback should be removed from args and stored in ctx.obj."""
+        group = PipelexCLI(name="pipelex")
+        group.add_command(click.Command("dummy"))
+
+        ctx = group.make_context("pipelex", ["--traceback", "dummy"])
+        assert ctx.obj["traceback"] is True
+
+    def test_no_traceback_flag(self) -> None:
+        """Without --traceback, ctx.obj['traceback'] should be False."""
+        group = PipelexCLI(name="pipelex")
+        group.add_command(click.Command("dummy"))
+
+        ctx = group.make_context("pipelex", ["dummy"])
+        assert ctx.obj["traceback"] is False


### PR DESCRIPTION
Closes #437

## What

Adds a global \`--traceback\` flag to the \`pipelex\` CLI that prints a Rich-formatted stack trace before the friendly error panel, for any of the structured \`handle_*\` errors and the \`PipelexError\` branch in \`run\` execution.

Usage:

```
pipelex --traceback run my-pipe ...
pipelex run --traceback my-pipe ...   # position-agnostic
```

## Why

Issue #437: when a pipeline fails, the friendly panel hides the actual Python stack and forces users to re-run with extra debug glue. An opt-in flag keeps the default output clean while giving an easy escape hatch.

## How

- Intercepted at the \`PipelexCLI.make_context\` level (same pattern as \`--no-logo\`) so it works before or after subcommands. Stored on \`ctx.obj[\"traceback\"]\`.
- New helpers \`is_traceback_requested()\` / \`print_traceback_if_requested()\` in \`pipelex/cli/error_handlers.py\`.
- All 12 \`handle_*\` functions and the \`PipelexError\` branch in \`_run_core.py\` call the helper before rendering the panel.

## Scope decisions (open to feedback)

- \`--traceback\` is intercepted in \`make_context\`, so it doesn't show up in \`pipelex --help\`. Kept consistent with the existing \`--no-logo\` flag. Happy to migrate both to a typer callback if you'd prefer them surfaced in help.
- Not added to \`pipelex-agent\` / \`pipelex-dev\`: the agent CLI uses stdout for a structured JSON channel, and a Rich traceback would pollute it. Easy to add if you want it.
- The generic \`except Exception\` branch in \`_run_core.py\` already prints an unconditional traceback via \`console.print_exception\`, so the flag intentionally only affects branches with a friendly panel.

## Tests

10 new tests in \`tests/unit/pipelex/cli/test_traceback_flag.py\`:

- \`is_traceback_requested()\` across the 4 context states
- \`print_traceback_if_requested()\` with/without flag, asserting the Rich \`Traceback\` object reaches \`console.print\`
- Integration on \`handle_inference_setup_required_error\` for both flag states
- \`PipelexCLI.make_context\` interception (flag stripped from args, stored on \`ctx.obj\`)

## Verification

- \`make agent-check\` (ruff + pyright + mypy + plxt): clean
- \`make agent-test\`: green for the new tests; pre-existing 9 Windows path failures in \`tests/unit/pipelex/cli/\` are unrelated.

## Note

@airestful expressed interest 6 months ago but hasn't been assigned. Happy to defer if they'd like to pick it up.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a global `--traceback` flag to the `pipelex` CLI that prints a Rich stack trace before the friendly error panel, making failures easier to debug while keeping default output clean. Works from any position in the command. Addresses #437.

- New Features
  - Intercepted in `PipelexCLI.make_context` (position-agnostic) and stored as `ctx.obj["traceback"]`.
  - All CLI `handle_*` errors and the `PipelexError` path in `run/_run_core.py` print a Rich traceback when the flag is set.
  - Hidden from `--help` (same as `--no-logo`); not added to `pipelex-agent` or `pipelex-dev`; generic `Exception` behavior unchanged.
  - Added 10 unit tests covering flag interception and traceback output.

<sup>Written for commit dbbd0f7fdbfb9272344b89f0235e2c2285307ffd. Summary will update on new commits. <a href="https://cubic.dev/pr/Pipelex/pipelex/pull/936?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

