### PR TITLE
Release v0.30.1

### DIFF
--- a/.badges/tests.json
+++ b/.badges/tests.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "label": "tests",
-  "message": "6111",
+  "message": "6112",
   "color": "blue",
   "cacheSeconds": 300
 }

--- a/.badges/tests.json
+++ b/.badges/tests.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "label": "tests",
-  "message": "6112",
+  "message": "6114",
   "color": "blue",
   "cacheSeconds": 300
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [v0.30.1] - 2026-05-25
+
+### Fixed
+
+- **`pipelex-agent` now silences all pipelex logs on stderr regardless of user TOML.** The agent CLI is machine-consumed: stdout is reserved for the structured success envelope (JSON / markdown) and stderr for the structured error envelope. Free-floating `log.*` calls — even a single `log.debug` from `telemetry_factory.py` or a `log.warning` from `validation_error_categorizer.py` — would corrupt the stderr channel for downstream parsers (`mthds-js`'s `PipelexRunner` doing `JSON.parse(stderr)` on the validate hook). `make_pipelex_for_agent_cli` now injects `config_overrides` into `Pipelex.make()` that pin `default_log_level = OFF` and `package_log_levels.pipelex = OFF` from the very first `log.configure` call — so a user setting `[pipelex.log_config.package_log_levels] pipelex = "DEBUG"` in `~/.pipelex/pipelex.toml` can no longer leak DEBUG/INFO/WARNING lines onto the agent CLI's stderr channel. The DEBUG log line in `telemetry_factory.py:77` itself is unchanged — it's still useful diagnostic info for the human `pipelex` CLI.
+
+### Changed
+
+- **`pipelex-agent` no longer accepts `--log-level`.** Log suppression is unconditional by design — there is no verbosity setting on the agent CLI. The `log_level` parameter is removed from `make_pipelex_for_agent_cli()` and `apply_agent_cli_output_discipline()`, and the corresponding `ctx.obj["log_level"]` plumbing is gone from every caller. For verbose debugging, use the human `pipelex` CLI, which honors the user's TOML log config.
+
+- **`pipelex/cli/commands/doctor_cmd.py::setup_doctor_runtime` now `deep_update`s `log_config_overrides` into the loaded config** (was a flat-merge that silently replaced nested dicts like `package_log_levels`). With the flat merge, pinning `package_log_levels.pipelex = OFF` for the agent doctor path would have wiped out all the third-party package levels (`anthropic`, `asyncio`, `botocore`, ...) shipped in the default config. The deep merge preserves them.
+
+- **Removed `ctx: typer.Context` from 8 agent CLI commands that no longer used it.** `validate/{pipe,bundle,method}_cmd.py`, `inputs/{pipe,bundle,method}_cmd.py`, `models_cmd.py`, `check_model_cmd.py` had `ctx.obj["log_level"]` as their only ctx usage; with `--log-level` gone, the parameter became dead weight. The `run/` commands keep `ctx` because they still read `ctx.obj["runner"]`. Test callers (and the now-unused `agent_ctx` conftest fixture) updated to match.
+
 ## [v0.30.0] - 2026-05-25
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Changelog
 
-## [v0.30.1] - 2026-05-25
+## [v0.30.1] - 2026-05-26
 
 ### Fixed
 
-- **`pipelex-agent` now silences all pipelex logs on stderr regardless of user TOML.** The agent CLI is machine-consumed: stdout is reserved for the structured success envelope (JSON / markdown) and stderr for the structured error envelope. Free-floating `log.*` calls — even a single `log.debug` from `telemetry_factory.py` or a `log.warning` from `validation_error_categorizer.py` — would corrupt the stderr channel for downstream parsers (`mthds-js`'s `PipelexRunner` doing `JSON.parse(stderr)` on the validate hook). `make_pipelex_for_agent_cli` now injects `config_overrides` into `Pipelex.make()` that pin `default_log_level = OFF` and `package_log_levels.pipelex = OFF` from the very first `log.configure` call — so a user setting `[pipelex.log_config.package_log_levels] pipelex = "DEBUG"` in `~/.pipelex/pipelex.toml` can no longer leak DEBUG/INFO/WARNING lines onto the agent CLI's stderr channel. The DEBUG log line in `telemetry_factory.py:77` itself is unchanged — it's still useful diagnostic info for the human `pipelex` CLI.
+- **`pipelex-agent` now silences every Python logger on stderr regardless of user TOML.** The agent CLI is machine-consumed: stdout is reserved for the structured success envelope (JSON / markdown) and stderr for the structured error envelope. Free-floating `log.*` calls — a `log.debug` from `telemetry_factory.py`, a `log.warning` from `validation_error_categorizer.py`, or an INFO/WARNING line from any third-party dep (`anthropic`, `httpx`, `botocore`, `openai`, anything a transitive dep configures) — would corrupt the stderr channel for downstream parsers (`mthds-js`'s `PipelexRunner` doing `JSON.parse(stderr)` on the validate hook). Two layers, defense-in-depth:
+  - **Layer 1 — pin pipelex's own logs off via config.** `make_pipelex_for_agent_cli` injects `config_overrides` into `Pipelex.make()` that pin `default_log_level = OFF` and `package_log_levels.pipelex = OFF` from the very first `log.configure` call. A user setting `[pipelex.log_config.package_log_levels] pipelex = "DEBUG"` in `~/.pipelex/pipelex.toml` can no longer leak its own DEBUG/INFO/WARNING lines.
+  - **Layer 2 — process-global cutoff that covers every logger.** New `silence_logging_for_agent_cli()` calls `logging.disable(sys.maxsize)` — a process-global threshold checked inside `Logger.isEnabledFor` BEFORE any per-logger level. No record gets created for any logger at any level (including custom levels above `CRITICAL`), regardless of which package emits or what level the user configured. Wired into the Typer `app_callback` so every subcommand — including `init` and `accept-gateway-terms`, which bypass `make_pipelex_for_agent_cli` — silences logging before any command body runs; idempotent per-call invocations remain inside `make_pipelex_for_agent_cli` and `agent_doctor_cmd` as belt-and-braces for direct library callers.
+
+  A new e2e regression test pins the contract by setting `anthropic`, `httpx`, `botocore`, `openai` to `DEBUG` in the user TOML and asserting both stdout and stderr stay clean.
 
 ### Changed
 

--- a/TODOS.md
+++ b/TODOS.md
@@ -87,23 +87,23 @@ Production-code changes are done. Test-only work remains.
 
 ## Phase 3 — Test/helper robustness (independent improvements)
 
-- [ ] **Step 3.1 (fixes #13)** — In `tests/e2e/agent_cli/test_stdout_is_clean_json.py::test_models_json_stdout_and_stderr_stay_clean_under_third_party_logger_enabled`, replace the `assert result.stderr == ""` with: stderr must be either empty OR parse as a structured error envelope (a dict with `error` field). This catches log-line leaks (which would not be valid JSON) while tolerating environmental noise like ResourceWarnings. Helper: try `json.loads(result.stderr)` and accept either parse-success-with-envelope-shape or empty.
-- [ ] **Step 3.2 (fixes #7, #8, #15)** — Rewrite `_set_package_log_level` in `tests/e2e/agent_cli/test_stdout_is_clean_json.py` using `tomlkit` (already a project dep — see `init_cmd.py`'s usage). Pseudo:
+- [x] **Step 3.1 (fixes #13)** — In `tests/e2e/agent_cli/test_stdout_is_clean_json.py::test_models_json_stdout_and_stderr_stay_clean_under_third_party_logger_enabled`, replace the `assert result.stderr == ""` with: stderr must be either empty OR parse as a structured error envelope (a dict with `error` field). This catches log-line leaks (which would not be valid JSON) while tolerating environmental noise like ResourceWarnings. Helper: try `json.loads(result.stderr)` and accept either parse-success-with-envelope-shape or empty. **Done:** added `_assert_stderr_is_clean_or_structured_envelope` helper; the test now calls it in place of the strict empty-string assertion.
+- [x] **Step 3.2 (fixes #7, #8, #15)** — Rewrite `_set_package_log_level` in `tests/e2e/agent_cli/test_stdout_is_clean_json.py` using `tomlkit` (already a project dep — see `init_cmd.py`'s usage). Pseudo:
   ```python
   import tomlkit
   doc = tomlkit.parse(pipelex_toml_path.read_text())
   doc["pipelex"]["log_config"]["package_log_levels"][package_name] = level
   pipelex_toml_path.write_text(tomlkit.dumps(doc))
   ```
-  This eliminates all three line-based-rewriter edges (duplicate section, no-space matcher, no-trailing-newline) in one pass. Keep the `_set_pipelex_package_log_level_to_debug` compat shim so the original two callers don't change.
-- [ ] **Step 3.3** — Sanity check: read the rewritten test file to confirm the section path `["pipelex"]["log_config"]["package_log_levels"]` exists in the kit's `pipelex.toml` (it does, line 177 — `[pipelex.log_config.package_log_levels]`).
+  This eliminates all three line-based-rewriter edges (duplicate section, no-space matcher, no-trailing-newline) in one pass. Keep the `_set_pipelex_package_log_level_to_debug` compat shim so the original two callers don't change. **Done:** used the project's `load_toml_with_tomlkit` + `save_toml_to_path` helpers from `pipelex.tools.misc.toml_utils` (proper type stubs, same pair `init_cmd` uses) instead of raw tomlkit — pyright was unhappy with the raw `tomlkit.dumps` overload. Compat shim preserved.
+- [x] **Step 3.3** — Sanity check: read the rewritten test file to confirm the section path `["pipelex"]["log_config"]["package_log_levels"]` exists in the kit's `pipelex.toml` (it does, line 177 — `[pipelex.log_config.package_log_levels]`). **Confirmed via grep on both `pipelex/pipelex.toml:98` and `pipelex/kit/configs/pipelex.toml:177`.**
 
 ### ✅ CHECKPOINT 3 — final verification
 
-- [ ] Run `make agent-check`. Must be clean.
-- [ ] Run targeted: `.venv/bin/pytest -n auto -m "(dry_runnable or not (inference or llm or img_gen or extract or search)) and not pipelex_api" -o log_level=WARNING --tb=short -q tests/unit/pipelex/cli/ tests/unit/pipelex/tools/ tests/integration/pipelex/cli/ tests/e2e/agent_cli/`. All pass.
-- [ ] Run `make tb`. Pass.
-- [ ] Skim `git diff HEAD --stat` — the diff should now cover: `_agent_cli.py` (new silence wire), `agent_cli_factory.py` (sys.maxsize), `test_agent_cli_factory.py` (fixture), `test_agent_cli_factory_suppression.py` + `test_agent_cli_output_discipline.py` (per-logger restore), `test_stdout_is_clean_json.py` (relaxed assertion + tomlkit rewrite).
+- [x] Run `make agent-check`. Must be clean. **Result:** 0 pyright errors, mypy success on 1893 files.
+- [x] Run targeted: `.venv/bin/pytest -n auto -m "(dry_runnable or not (inference or llm or img_gen or extract or search)) and not pipelex_api" -o log_level=WARNING --tb=short -q tests/unit/pipelex/cli/ tests/unit/pipelex/tools/ tests/integration/pipelex/cli/ tests/e2e/agent_cli/`. All pass. **Result:** 1541 passed, 1 skipped (pre-existing `test_toml_utils.py:61` skip — unrelated) in 33.33s.
+- [x] Run `make tb`. Pass. **Result:** 2 passed, 6708 deselected in 6.13s.
+- [x] Skim `git diff HEAD --stat` — the diff should now cover: `_agent_cli.py` (new silence wire), `agent_cli_factory.py` (sys.maxsize), `test_agent_cli_factory.py` (fixture), `test_agent_cli_factory_suppression.py` + `test_agent_cli_output_discipline.py` (per-logger restore), `test_stdout_is_clean_json.py` (relaxed assertion + tomlkit rewrite). **Note:** Phase 1 (commit `d98eb0e2`) and Phase 2 (commit `9563915f`) are already landed on the branch, so `git diff HEAD --stat` now shows only the Phase 3 file (`test_stdout_is_clean_json.py`) plus `TODOS.md`. The cumulative range vs `main`/release base covers every file listed.
 
 ---
 
@@ -122,7 +122,7 @@ The `/code-review` surfaced 15 findings; these 9 were explicitly skipped after t
 
 When all phases are checked off:
 
-- [ ] `git diff HEAD --stat` shows the expected files (see Checkpoint 3 list).
-- [ ] All three e2e tests in `test_stdout_is_clean_json.py` pass.
-- [ ] No regression in `make agent-test` (full suite — run before commit per CLAUDE.md release/commit conventions).
-- [ ] Decide whether this work folds into the existing `release/v0.30.1` branch or warrants a follow-up release entry in CHANGELOG. (Note: per memory `feedback_no_unreleased_header.md`, use `[Unreleased]` on work branches — replace with versioned entry only at release time. The current branch is already named `release/v0.30.1` so check with user before bumping.)
+- [x] `git diff HEAD --stat` shows the expected files (see Checkpoint 3 list). **Cumulative diff across the 3 commits on this branch since `Release v0.30.1` (6902952c): `_agent_cli.py`, `agent_cli_factory.py`, `doctor_cmd.py`, `test_stdout_is_clean_json.py`, `test_agent_cli_factory.py`, `test_agent_cli_factory_init_overrides.py`, `test_agent_cli_factory_suppression.py`, `test_agent_cli_output_discipline.py`, `test_agent_doctor_cmd.py`, `TODOS.md`, `CHANGELOG.md`.**
+- [x] All three e2e tests in `test_stdout_is_clean_json.py` pass. **Result:** 3 passed in 3.73s.
+- [x] No regression in `make agent-test` (full suite — run before commit per CLAUDE.md release/commit conventions). **Result:** "All tests passed." — full suite clean.
+- [x] Decide whether this work folds into the existing `release/v0.30.1` branch or warrants a follow-up release entry in CHANGELOG. **Decision (user-confirmed):** fold into the existing v0.30.1 CHANGELOG entry. v0.30.1 is not yet tagged (only v0.30.0 exists), so the entry was still safely editable. Appended a second `### Fixed` bullet covering the Phase 1-3 work (process-global `logging.disable(sys.maxsize)`, `app_callback` wiring, third-party-logger leak regression test) and bumped the v0.30.1 date from 2026-05-25 → 2026-05-26.

--- a/TODOS.md
+++ b/TODOS.md
@@ -66,20 +66,20 @@ The structural change is invasive enough that a regression here would mask every
 
 Three small fixes, tightly related. Land together.
 
-- [ ] **Step 2.1 (fixes #9)** — In `pipelex/cli/agent_cli/commands/agent_cli_factory.py`, change `silence_logging_for_agent_cli` to call `logging.disable(sys.maxsize)` instead of `logging.disable(LOGGING_LEVEL_OFF)`. Add `import sys` if missing. Keep `LOGGING_LEVEL_OFF` import only if still used elsewhere in the file. Update the docstring's "blocks DEBUG through CRITICAL" line to "blocks every record at every level (including custom levels above CRITICAL)".
-- [ ] **Step 2.2 (fixes #9 tests)** — Update assertions in `tests/unit/pipelex/cli/test_agent_cli_factory_init_overrides.py:85` and `tests/unit/pipelex/cli/test_agent_cli_output_discipline.py` that compare `logging.root.manager.disable` to `LOGGING_LEVEL_OFF`. Change to compare to `sys.maxsize`. Update imports.
-- [ ] **Step 2.3 (fixes #3)** — In `tests/unit/pipelex/cli/test_agent_cli_factory.py:31-39`, extend the autouse `_restore_globals` fixture to save/restore `logging.root.manager.disable` alongside `PrettyPrinter.mode` and `root_logger.level`. Follow the pattern from `test_agent_cli_factory_init_overrides.py`.
-- [ ] **Step 2.4 (fixes #11)** — In `tests/unit/pipelex/cli/test_agent_cli_factory_suppression.py:22-30` AND `tests/unit/pipelex/cli/test_agent_cli_output_discipline.py:32-40`, extend the autouse fixture to snapshot and restore the `.level` attribute of every logger the tests arm. Targets to cover:
-  - In `test_agent_cli_factory_suppression.py`: `pipelex`, `anthropic`, `httpx`, `some.unknown.transitive.dep`.
-  - In `test_agent_cli_output_discipline.py`: `anthropic`, `httpx`, `some.transitive.dep.we.never.heard.of`, AND the loggers derived from `_THIRD_PARTY_PACKAGES` via `package_name.replace("-", ".")`.
+- [x] **Step 2.1 (fixes #9)** — In `pipelex/cli/agent_cli/commands/agent_cli_factory.py`, change `silence_logging_for_agent_cli` to call `logging.disable(sys.maxsize)` instead of `logging.disable(LOGGING_LEVEL_OFF)`. Add `import sys` if missing. Keep `LOGGING_LEVEL_OFF` import only if still used elsewhere in the file. Update the docstring's "blocks DEBUG through CRITICAL" line to "blocks every record at every level (including custom levels above CRITICAL)". **Done:** added `import sys`, removed `LOGGING_LEVEL_OFF` import (no other uses in file), updated docstring + the comment block at lines 32-49 that also referenced the old constant.
+- [x] **Step 2.2 (fixes #9 tests)** — Update assertions in `tests/unit/pipelex/cli/test_agent_cli_factory_init_overrides.py:85` and `tests/unit/pipelex/cli/test_agent_cli_output_discipline.py` that compare `logging.root.manager.disable` to `LOGGING_LEVEL_OFF`. Change to compare to `sys.maxsize`. Update imports. **Done:** swapped both assertions and import statements; updated module/test docstrings.
+- [x] **Step 2.3 (fixes #3)** — In `tests/unit/pipelex/cli/test_agent_cli_factory.py:31-39`, extend the autouse `_restore_globals` fixture to save/restore `logging.root.manager.disable` alongside `PrettyPrinter.mode` and `root_logger.level`. Follow the pattern from `test_agent_cli_factory_init_overrides.py`. **Done.**
+- [x] **Step 2.4 (fixes #11)** — In `tests/unit/pipelex/cli/test_agent_cli_factory_suppression.py:22-30` AND `tests/unit/pipelex/cli/test_agent_cli_output_discipline.py:32-40`, extend the autouse fixture to snapshot and restore the `.level` attribute of every logger the tests arm. Targets to cover:
+  - In `test_agent_cli_factory_suppression.py`: `pipelex`, `anthropic`, `httpx`, `some.unknown.transitive.dep`. **Done** (via module-level `_ARMED_LOGGER_NAMES` tuple consumed by the fixture).
+  - In `test_agent_cli_output_discipline.py`: `anthropic`, `httpx`, `some.transitive.dep.we.never.heard.of`. **Done** (same pattern). Note: the TODOS step also mentioned `_THIRD_PARTY_PACKAGES` — that symbol does not exist anywhere in `pipelex/` or `tests/` (grep confirms), so it was a stale reference from the abandoned enumeration approach. The actual loggers armed by the test body are the three listed; nothing more to restore.
 
 ### ✅ CHECKPOINT 2 — verify before continuing
 
 Production-code changes are done. Test-only work remains.
 
-- [ ] Run `make agent-check`. Must be clean.
-- [ ] Run targeted: `.venv/bin/pytest -n auto -m "(dry_runnable or not (inference or llm or img_gen or extract or search)) and not pipelex_api" -o log_level=WARNING --tb=short -q tests/unit/pipelex/cli/ tests/unit/pipelex/tools/test_log_config.py tests/e2e/agent_cli/`. Must pass.
-- [ ] Run `make tb` (boot test) — sanity check on config loading.
+- [x] Run `make agent-check`. Must be clean. **Result:** 0 pyright errors, mypy success on 1893 files.
+- [x] Run targeted: `.venv/bin/pytest -n auto -m "(dry_runnable or not (inference or llm or img_gen or extract or search)) and not pipelex_api" -o log_level=WARNING --tb=short -q tests/unit/pipelex/cli/ tests/unit/pipelex/tools/test_log_config.py tests/e2e/agent_cli/`. Must pass. **Result:** 366 passed in 43.36s.
+- [x] Run `make tb` (boot test) — sanity check on config loading. **Result:** 2 passed, 6708 deselected in 5.67s.
 
 **Cold-start handoff at this checkpoint:** next agent reads this TODOS.md, runs `git diff HEAD --stat` to see what's staged. Phase 3 is test-only and can land in a fresh session safely. If anything in Phase 2 broke, the most likely culprits are: (a) the `sys.maxsize` swap left a dangling `LOGGING_LEVEL_OFF` import; (b) the fixture extension overlooked one of the logger names. Re-grep the test files for `setLevel(` calls and verify each target is in the restore loop.
 

--- a/TODOS.md
+++ b/TODOS.md
@@ -1,49 +1,128 @@
-# TODOS
+# Agent CLI logging-discipline hardening — TODOS
 
-No open work items. This branch (`refactor/ECR`, branched from `feature/Temporal-merge-3` via `feature/Error-handling-2`) is the Extract / Classify / Render decomposition — the final sweep of the error-handling overhaul. What follows is a guide for reviewing it.
+## Context (read this first on a cold start)
 
-## Reviewing this branch
+**Branch:** `release/v0.30.1`
+**Working dir:** `/Users/lchoquel/repos/Pipelex/pipelex`
 
-The current-state reference is **`wip/error-handling/`**. Start with [`wip/error-handling/README.md`](wip/error-handling/README.md): its status table and suggested read order map every track to its doc and say what landed vs. what is still only proposed. For the shipped, user-facing version of the same material, see [`docs/under-the-hood/error-model.md`](docs/under-the-hood/error-model.md) — including its "The Uniform Shape — Extract / Classify / Render" section.
+### What this work is about
 
-This branch is scoped to the ECR refactor. The single most relevant doc is:
+A reviewer flagged a real bug at `pipelex/cli/agent_cli/commands/agent_cli_factory.py:75` (pre-fix line number): the agent CLI's `package_log_levels` override only pinned `pipelex = OFF`, but `deep_update` deep-merges it into the user config. Third-party loggers (anthropic, httpx, botocore, openai, ...) configured at INFO/WARNING in `pipelex/pipelex.toml` kept emitting through the root's `RichHandler` (now pointing at stderr) — corrupting the JSON error envelope that downstream parsers (e.g. `mthds-js`'s `PipelexRunner`) expect.
 
-- [`wip/error-handling/track-extract-classify-render.md`](wip/error-handling/track-extract-classify-render.md) — what the post-refactor code looks like, plus the design motivation that led to it.
-- [`wip/error-handling/archive-extract-classify-render.md`](wip/error-handling/archive-extract-classify-render.md) — checkpoint history and the key deviations from the original design (e.g. why Classify + Render live in their own modules, why `is_quota_exhaustion` is checked early, why Azure ImgGen keeps two `AMBIGUOUS` branches).
+### What's been done in the current session
 
-The rest of the error-handling tracks are unchanged on this branch but provide context:
+First pass tried to enumerate every third-party logger (brittle list). User pushed back: "Listing feels like an uphill battle — do we control enough of the logging config to just cut off all logs to stdout and stderr regardless of what package sends them?"
 
-1. [`architecture.md`](wip/error-handling/architecture.md) — layer model, exception hierarchy, `ErrorReport` shape. Read first; every track refers back to it.
-2. [`track-metadata-model.md`](wip/error-handling/track-metadata-model.md) — the data contract: `error_category`, `error_domain`, `user_action`, `ProviderErrorMetadata` (the type now aliased as `SDKErrorEnvelope` in ECR signatures). Key files: `pipelex/base_exceptions.py`, `pipelex/cogt/exceptions.py`.
-3. [`track-worker-classification.md`](wip/error-handling/track-worker-classification.md) — the per-worker classification sweep that ECR consolidates. Key files: `pipelex/plugins/*/*_worker.py`.
-4. [`track-retry-and-resilience.md`](wip/error-handling/track-retry-and-resilience.md) — explicit transport retry, removal of the `PipeRouter` retry loop, bounded `PipeBatch` fan-out.
-5. [`track-cli-delivery.md`](wip/error-handling/track-cli-delivery.md) — markdown/JSON agent-CLI delivery, `error_domain` → HTTP-status mapping.
-6. [`track-temporal-integration.md`](wip/error-handling/track-temporal-integration.md) — `ErrorReport` carried across the activity → workflow → submitter boundary.
-7. [`track-testing.md`](wip/error-handling/track-testing.md) — cross-cutting; verifies the rest.
+Second pass landed the correct fix: `logging.disable(LOGGING_LEVEL_OFF)` as a process-global cutoff called at the start of `make_pipelex_for_agent_cli` and `agent_doctor_cmd`. Records get filtered in `Logger.isEnabledFor` BEFORE any per-logger level check — no list to maintain.
 
-## Where the changes are
+Files modified in this session (staged, not committed):
 
-Production code:
+- `pipelex/cli/agent_cli/commands/agent_cli_factory.py` — added `silence_logging_for_agent_cli()`; simplified `apply_agent_cli_output_discipline()`; simplified `AGENT_CLI_STDERR_LOG_FIELDS` back to `{pipelex: OFF}`
+- `pipelex/cli/agent_cli/commands/doctor_cmd.py` — wired `silence_logging_for_agent_cli` at top of `agent_doctor_cmd`
+- `tests/e2e/agent_cli/test_stdout_is_clean_json.py` — added the third-party-logger leak regression test; refactored `_set_package_log_level` helper
+- `tests/unit/pipelex/cli/test_agent_cli_factory_init_overrides.py` — updated for the new design
+- `tests/unit/pipelex/cli/test_agent_cli_factory_suppression.py` — replaced per-logger level assertion with `isEnabledFor` checks
+- `tests/unit/pipelex/cli/test_agent_cli_output_discipline.py` — renamed test class, added `silence_logging_for_agent_cli` regression
+- `tests/unit/pipelex/cli/test_agent_doctor_cmd.py` — stubbed `silence_logging_for_agent_cli` in the bootstrap fixture
 
-- `pipelex/cogt/inference/error_classify.py`, `error_render.py`, `provider_name.py` — new modules. Classify is one pure, provider-blind function; Render picks the `CogtError` subclass from `InferenceErrorFamily` + the `is_model_not_found` flag.
-- `pipelex/cogt/inference/error_classification.py` — `ProviderErrorMetadata` gains `message` + three `@property` accessors (`is_quota_exhaustion`, `is_content_policy_violation`, `is_network_error`). 12 `extract_*_metadata` functions updated to populate `message`. `_AWS_ERROR_CODE_TO_STATUS` map added for Bedrock.
-- 6 LLM workers (`anthropic`, `openai_completions`, `openai_responses`, `mistral`, `google`, `bedrock`) — every `except` block collapsed to `extract → classify → raise render(...) from exc`.
-- 7 img-gen workers (`openai`, `openai_completions_img_gen`, `fal`, `huggingface`, `google_img_gen`, `gateway_img_gen`, `azure_rest`) — same migration. Azure keeps two worker-specific `AMBIGUOUS` branches; see the key deviations in the archive.
-- 7 extract + search workers (`mistral`, `linkup` x2, `gateway` x2, `docling`, `pypdfium2`) — same migration. Mistral + gateway-search now specialize HTTP 404 to `ExtractModelNotFoundError` / `SearchModelNotFoundError`.
-- Deleted: 4 per-provider `*_error_classification.py` files (+ matching tests), `AnthropicCredentialsError`, `GatewayFactory.classify_error_category` / `make_user_action_from_portkey_error` / `make_error_summary_from_portkey_error`, and every inline `_classify_*_error` / `_raise_categorized_*` instance method that the workers used to carry.
+State: `make agent-check` clean. Targeted unit/integration/e2e tests pass (1541 pass / 1 skip).
 
-Tests:
+### Why we have more TODOs
 
-- `tests/unit/pipelex/cogt/inference/test_classify_inference_error.py` — provider-blind parity matrix (synthesized envelopes → expected category + user-action kind).
-- `tests/unit/pipelex/cogt/inference/test_render_inference_error.py` — render correctness against synthetic envelopes + classifications.
-- `tests/unit/pipelex/cogt/inference/test_provider_classification_parity.py` — meta-test that walks every `ProviderName` against the extract-fn registry and the worker-family map, so adding a new provider without wiring it fails fast.
-- Per-worker classification tests were updated to the new three-line shape; most categorization assertions have moved to the parity matrix.
+A `/code-review` pass found 15 findings. After triage with the user, 6 actionable items remain (rest are skipped or made moot by the structural fix). Decisions are baked into the steps below.
 
-## What is intentionally left open
+### Key references
 
-So these are not flagged as missing during review:
+- The source-of-truth docstring for the cutoff is `pipelex/cli/agent_cli/commands/agent_cli_factory.py:95` (`silence_logging_for_agent_cli`).
+- The comment block at `pipelex/cli/agent_cli/commands/agent_cli_factory.py:32-83` explains why the listing approach was abandoned and how the four knobs in `AGENT_CLI_STDERR_LOG_FIELDS` relate to the global cutoff.
+- The e2e regression test for the original third-party leak: `tests/e2e/agent_cli/test_stdout_is_clean_json.py::test_models_json_stdout_and_stderr_stay_clean_under_third_party_logger_enabled`.
 
-- **Metadata-model long tail** — a few non-inference `PipelexError` subclasses still rely on the `agent_output.py` fallback dicts for `hint` / `error_domain` instead of class-level metadata. Pre-existing; see the Followups in [`track-metadata-model.md`](wip/error-handling/track-metadata-model.md). Out of scope for ECR.
-- Optional, non-blocking review notes from earlier error-handling sweeps (Temporal activity boundary, Phase 12 search workers) are collected in [`wip/error-handling/review-notes/`](wip/error-handling/review-notes/). Each entry is a deliberate non-fix recorded with a conditional trigger for when to revisit. None are ECR regressions; ECR has if anything reduced their surface by routing the same code paths through the shared parity matrix.
+---
 
-Completed plans are archived under `wip/error-handling/archive-*.md` — kept for their running notes, not authoritative for the current state. The ECR archive ([`archive-extract-classify-render.md`](wip/error-handling/archive-extract-classify-render.md)) is the new one this branch adds.
+## Phase 1 — Structural fix (the biggest change)
+
+Single architectural shift: every agent CLI command must traverse `app_callback` in `pipelex/cli/agent_cli/_agent_cli.py`. Wiring the silence call there guarantees every current AND future command is covered, even ones (like `init_cmd`, `accept_gateway_terms_cmd`) that bypass `make_pipelex_for_agent_cli`.
+
+- [ ] **Step 1.1** — Read `pipelex/cli/agent_cli/_agent_cli.py` to locate `app_callback` (around line 81 per the review). Confirm it's the typer choke point every command runs through, and that `set_agent_cli_error_format(CliOutputFormat.JSON)` already lives there.
+- [ ] **Step 1.2** — Add `silence_logging_for_agent_cli()` call at the top of `app_callback`, BEFORE `set_agent_cli_error_format`. Import the symbol from `pipelex.cli.agent_cli.commands.agent_cli_factory`.
+- [ ] **Step 1.3** — Decide: keep the existing per-call invocations in `make_pipelex_for_agent_cli:166` and `agent_doctor_cmd:134` OR remove them.
+  - **Decision recorded:** KEEP both. `silence_logging_for_agent_cli` is idempotent (calling `logging.disable` twice with the same value is a no-op). Keeping preserves defense for direct library callers of `make_pipelex_for_agent_cli` and avoids breaking the unit tests that mock `Pipelex.make` and call the factory directly (they assert `logging.root.manager.disable == LOGGING_LEVEL_OFF` after the call).
+- [ ] **Step 1.4** — Update docstrings: `silence_logging_for_agent_cli`'s docstring says "Must be called at the very start of every agent CLI entry point (`make_pipelex_for_agent_cli`, `agent_doctor_cmd`)" — rewrite to reflect that `app_callback` is now the primary armor and the per-call invocations are belt-and-braces.
+
+### ✅ CHECKPOINT 1 — verify before continuing
+
+The structural change is invasive enough that a regression here would mask everything else. STOP here and:
+
+- [ ] Run `make agent-check` — must be clean.
+- [ ] Run the unit suite for cli/: `.venv/bin/pytest -n auto -m "(dry_runnable or not (inference or llm or img_gen or extract or search)) and not pipelex_api" -o log_level=WARNING --tb=short -q tests/unit/pipelex/cli/`. Must pass.
+- [ ] Run the e2e: `.venv/bin/pytest --tb=short -q tests/e2e/agent_cli/test_stdout_is_clean_json.py`. Must pass — both the original three tests AND the new third-party-leak test.
+- [ ] Manually verify with a fresh shell that `pipelex-agent init --format json` produces a clean stderr in offline mode (no httpx INFO leaks).
+
+**Cold-start handoff at this checkpoint:** if the session ends here, the next agent should re-read this TODOS.md (especially the "Context" section above), then `git diff HEAD` to see what's staged. If Step 1.2 landed but the verify failed, the regression is most likely in `_agent_cli.py` — check that `app_callback` runs unconditionally for every command, not gated on some Typer flag. If verify passed, Phase 2 is independent and can start fresh.
+
+---
+
+## Phase 2 — Production-code hardening + test-fixture leak fix
+
+Three small fixes, tightly related. Land together.
+
+- [ ] **Step 2.1 (fixes #9)** — In `pipelex/cli/agent_cli/commands/agent_cli_factory.py`, change `silence_logging_for_agent_cli` to call `logging.disable(sys.maxsize)` instead of `logging.disable(LOGGING_LEVEL_OFF)`. Add `import sys` if missing. Keep `LOGGING_LEVEL_OFF` import only if still used elsewhere in the file. Update the docstring's "blocks DEBUG through CRITICAL" line to "blocks every record at every level (including custom levels above CRITICAL)".
+- [ ] **Step 2.2 (fixes #9 tests)** — Update assertions in `tests/unit/pipelex/cli/test_agent_cli_factory_init_overrides.py:85` and `tests/unit/pipelex/cli/test_agent_cli_output_discipline.py` that compare `logging.root.manager.disable` to `LOGGING_LEVEL_OFF`. Change to compare to `sys.maxsize`. Update imports.
+- [ ] **Step 2.3 (fixes #3)** — In `tests/unit/pipelex/cli/test_agent_cli_factory.py:31-39`, extend the autouse `_restore_globals` fixture to save/restore `logging.root.manager.disable` alongside `PrettyPrinter.mode` and `root_logger.level`. Follow the pattern from `test_agent_cli_factory_init_overrides.py`.
+- [ ] **Step 2.4 (fixes #11)** — In `tests/unit/pipelex/cli/test_agent_cli_factory_suppression.py:22-30` AND `tests/unit/pipelex/cli/test_agent_cli_output_discipline.py:32-40`, extend the autouse fixture to snapshot and restore the `.level` attribute of every logger the tests arm. Targets to cover:
+  - In `test_agent_cli_factory_suppression.py`: `pipelex`, `anthropic`, `httpx`, `some.unknown.transitive.dep`.
+  - In `test_agent_cli_output_discipline.py`: `anthropic`, `httpx`, `some.transitive.dep.we.never.heard.of`, AND the loggers derived from `_THIRD_PARTY_PACKAGES` via `package_name.replace("-", ".")`.
+
+### ✅ CHECKPOINT 2 — verify before continuing
+
+Production-code changes are done. Test-only work remains.
+
+- [ ] Run `make agent-check`. Must be clean.
+- [ ] Run targeted: `.venv/bin/pytest -n auto -m "(dry_runnable or not (inference or llm or img_gen or extract or search)) and not pipelex_api" -o log_level=WARNING --tb=short -q tests/unit/pipelex/cli/ tests/unit/pipelex/tools/test_log_config.py tests/e2e/agent_cli/`. Must pass.
+- [ ] Run `make tb` (boot test) — sanity check on config loading.
+
+**Cold-start handoff at this checkpoint:** next agent reads this TODOS.md, runs `git diff HEAD --stat` to see what's staged. Phase 3 is test-only and can land in a fresh session safely. If anything in Phase 2 broke, the most likely culprits are: (a) the `sys.maxsize` swap left a dangling `LOGGING_LEVEL_OFF` import; (b) the fixture extension overlooked one of the logger names. Re-grep the test files for `setLevel(` calls and verify each target is in the restore loop.
+
+---
+
+## Phase 3 — Test/helper robustness (independent improvements)
+
+- [ ] **Step 3.1 (fixes #13)** — In `tests/e2e/agent_cli/test_stdout_is_clean_json.py::test_models_json_stdout_and_stderr_stay_clean_under_third_party_logger_enabled`, replace the `assert result.stderr == ""` with: stderr must be either empty OR parse as a structured error envelope (a dict with `error` field). This catches log-line leaks (which would not be valid JSON) while tolerating environmental noise like ResourceWarnings. Helper: try `json.loads(result.stderr)` and accept either parse-success-with-envelope-shape or empty.
+- [ ] **Step 3.2 (fixes #7, #8, #15)** — Rewrite `_set_package_log_level` in `tests/e2e/agent_cli/test_stdout_is_clean_json.py` using `tomlkit` (already a project dep — see `init_cmd.py`'s usage). Pseudo:
+  ```python
+  import tomlkit
+  doc = tomlkit.parse(pipelex_toml_path.read_text())
+  doc["pipelex"]["log_config"]["package_log_levels"][package_name] = level
+  pipelex_toml_path.write_text(tomlkit.dumps(doc))
+  ```
+  This eliminates all three line-based-rewriter edges (duplicate section, no-space matcher, no-trailing-newline) in one pass. Keep the `_set_pipelex_package_log_level_to_debug` compat shim so the original two callers don't change.
+- [ ] **Step 3.3** — Sanity check: read the rewritten test file to confirm the section path `["pipelex"]["log_config"]["package_log_levels"]` exists in the kit's `pipelex.toml` (it does, line 177 — `[pipelex.log_config.package_log_levels]`).
+
+### ✅ CHECKPOINT 3 — final verification
+
+- [ ] Run `make agent-check`. Must be clean.
+- [ ] Run targeted: `.venv/bin/pytest -n auto -m "(dry_runnable or not (inference or llm or img_gen or extract or search)) and not pipelex_api" -o log_level=WARNING --tb=short -q tests/unit/pipelex/cli/ tests/unit/pipelex/tools/ tests/integration/pipelex/cli/ tests/e2e/agent_cli/`. All pass.
+- [ ] Run `make tb`. Pass.
+- [ ] Skim `git diff HEAD --stat` — the diff should now cover: `_agent_cli.py` (new silence wire), `agent_cli_factory.py` (sys.maxsize), `test_agent_cli_factory.py` (fixture), `test_agent_cli_factory_suppression.py` + `test_agent_cli_output_discipline.py` (per-logger restore), `test_stdout_is_clean_json.py` (relaxed assertion + tomlkit rewrite).
+
+---
+
+## Skipped findings (recorded so a future session doesn't re-litigate)
+
+The `/code-review` surfaced 15 findings; these 9 were explicitly skipped after triage:
+
+- **#4 + #5 (warnings module / print_to_stderr leaks)** — Skipped. `logging.disable` doesn't cover these channels (`warnings.warn` → `sys.stderr.write` directly; `print_to_stderr` in `remote_config_fetcher.py:82/219/259`). Doctor path has no `catch_warnings` wrapper, so `GatewayOverrideWarning` (UserWarning subclass) could leak there. Decision: no real-world report; defer until someone hits it. Phase 3 Step 3.1's relaxed e2e assertion absorbs the noise.
+- **#6 (process-global `logging.disable` leaks for in-process callers)** — Skipped. Documented one-shot CLI; embedded/in-process use isn't supported. Could add a docstring note but no functional change.
+- **#10 (apply_agent_cli_output_discipline lost the `pipelex = OFF` backstop)** — Skipped. With `silence_logging_for_agent_cli` in `app_callback` (Phase 1), every path that calls `apply_agent_cli_output_discipline` also has silence armed. Restoring the backstop would be cargo-cult.
+- **#14 (silence ordering in `agent_doctor_cmd`)** — Made moot by Phase 1. `app_callback` runs before any command body, so silence is armed before `set_agent_cli_error_format` runs in `agent_doctor_cmd`.
+
+---
+
+## End-to-end completion criteria
+
+When all phases are checked off:
+
+- [ ] `git diff HEAD --stat` shows the expected files (see Checkpoint 3 list).
+- [ ] All three e2e tests in `test_stdout_is_clean_json.py` pass.
+- [ ] No regression in `make agent-test` (full suite — run before commit per CLAUDE.md release/commit conventions).
+- [ ] Decide whether this work folds into the existing `release/v0.30.1` branch or warrants a follow-up release entry in CHANGELOG. (Note: per memory `feedback_no_unreleased_header.md`, use `[Unreleased]` on work branches — replace with versioned entry only at release time. The current branch is already named `release/v0.30.1` so check with user before bumping.)

--- a/TODOS.md
+++ b/TODOS.md
@@ -43,20 +43,20 @@ A `/code-review` pass found 15 findings. After triage with the user, 6 actionabl
 
 Single architectural shift: every agent CLI command must traverse `app_callback` in `pipelex/cli/agent_cli/_agent_cli.py`. Wiring the silence call there guarantees every current AND future command is covered, even ones (like `init_cmd`, `accept_gateway_terms_cmd`) that bypass `make_pipelex_for_agent_cli`.
 
-- [ ] **Step 1.1** — Read `pipelex/cli/agent_cli/_agent_cli.py` to locate `app_callback` (around line 81 per the review). Confirm it's the typer choke point every command runs through, and that `set_agent_cli_error_format(CliOutputFormat.JSON)` already lives there.
-- [ ] **Step 1.2** — Add `silence_logging_for_agent_cli()` call at the top of `app_callback`, BEFORE `set_agent_cli_error_format`. Import the symbol from `pipelex.cli.agent_cli.commands.agent_cli_factory`.
-- [ ] **Step 1.3** — Decide: keep the existing per-call invocations in `make_pipelex_for_agent_cli:166` and `agent_doctor_cmd:134` OR remove them.
+- [x] **Step 1.1** — Read `pipelex/cli/agent_cli/_agent_cli.py` to locate `app_callback` (around line 81 per the review). Confirm it's the typer choke point every command runs through, and that `set_agent_cli_error_format(CliOutputFormat.JSON)` already lives there.
+- [x] **Step 1.2** — Add `silence_logging_for_agent_cli()` call at the top of `app_callback`, BEFORE `set_agent_cli_error_format`. Import the symbol from `pipelex.cli.agent_cli.commands.agent_cli_factory`.
+- [x] **Step 1.3** — Decide: keep the existing per-call invocations in `make_pipelex_for_agent_cli:166` and `agent_doctor_cmd:134` OR remove them.
   - **Decision recorded:** KEEP both. `silence_logging_for_agent_cli` is idempotent (calling `logging.disable` twice with the same value is a no-op). Keeping preserves defense for direct library callers of `make_pipelex_for_agent_cli` and avoids breaking the unit tests that mock `Pipelex.make` and call the factory directly (they assert `logging.root.manager.disable == LOGGING_LEVEL_OFF` after the call).
-- [ ] **Step 1.4** — Update docstrings: `silence_logging_for_agent_cli`'s docstring says "Must be called at the very start of every agent CLI entry point (`make_pipelex_for_agent_cli`, `agent_doctor_cmd`)" — rewrite to reflect that `app_callback` is now the primary armor and the per-call invocations are belt-and-braces.
+- [x] **Step 1.4** — Update docstrings: `silence_logging_for_agent_cli`'s docstring says "Must be called at the very start of every agent CLI entry point (`make_pipelex_for_agent_cli`, `agent_doctor_cmd`)" — rewrite to reflect that `app_callback` is now the primary armor and the per-call invocations are belt-and-braces.
 
 ### ✅ CHECKPOINT 1 — verify before continuing
 
 The structural change is invasive enough that a regression here would mask everything else. STOP here and:
 
-- [ ] Run `make agent-check` — must be clean.
-- [ ] Run the unit suite for cli/: `.venv/bin/pytest -n auto -m "(dry_runnable or not (inference or llm or img_gen or extract or search)) and not pipelex_api" -o log_level=WARNING --tb=short -q tests/unit/pipelex/cli/`. Must pass.
-- [ ] Run the e2e: `.venv/bin/pytest --tb=short -q tests/e2e/agent_cli/test_stdout_is_clean_json.py`. Must pass — both the original three tests AND the new third-party-leak test.
-- [ ] Manually verify with a fresh shell that `pipelex-agent init --format json` produces a clean stderr in offline mode (no httpx INFO leaks).
+- [x] Run `make agent-check` — must be clean. **Result:** 0 pyright errors, mypy success on 1893 files.
+- [x] Run the unit suite for cli/: `.venv/bin/pytest -n auto -m "(dry_runnable or not (inference or llm or img_gen or extract or search)) and not pipelex_api" -o log_level=WARNING --tb=short -q tests/unit/pipelex/cli/`. Must pass. **Result:** 349 passed in 10.29s.
+- [x] Run the e2e: `.venv/bin/pytest --tb=short -q tests/e2e/agent_cli/test_stdout_is_clean_json.py`. Must pass — both the original three tests AND the new third-party-leak test. **Result:** 3 passed in 3.02s (incl. `test_models_json_stdout_and_stderr_stay_clean_under_third_party_logger_enabled`).
+- [x] Manually verify with a fresh shell that `pipelex-agent init --format json` produces a clean stderr in offline mode (no httpx INFO leaks). **Result:** stderr is exactly the structured `ArgumentError` envelope (no project root in `/tmp`); no log lines. Confirms `app_callback` runs and silences logging even on the `init`/`accept-gateway-terms` paths that bypass `make_pipelex_for_agent_cli` (verified by grep — neither cmd module calls `silence_logging_for_agent_cli` nor the factory).
 
 **Cold-start handoff at this checkpoint:** if the session ends here, the next agent should re-read this TODOS.md (especially the "Context" section above), then `git diff HEAD` to see what's staged. If Step 1.2 landed but the verify failed, the regression is most likely in `_agent_cli.py` — check that `app_callback` runs unconditionally for every command, not gated on some Typer flag. If verify passed, Phase 2 is independent and can start fresh.
 

--- a/pipelex/cli/agent_cli/_agent_cli.py
+++ b/pipelex/cli/agent_cli/_agent_cli.py
@@ -9,6 +9,7 @@ from typer.core import TyperGroup
 from typing_extensions import override
 
 from pipelex.cli.agent_cli.commands.accept_gateway_terms_cmd import agent_accept_gateway_terms_cmd
+from pipelex.cli.agent_cli.commands.agent_cli_factory import silence_logging_for_agent_cli
 from pipelex.cli.agent_cli.commands.agent_output import CliOutputFormat, agent_error, set_agent_cli_error_format
 from pipelex.cli.agent_cli.commands.check_model_cmd import agent_check_model_cmd
 from pipelex.cli.agent_cli.commands.concept_cmd import concept_cmd
@@ -99,10 +100,20 @@ def app_callback(
 
     Note: there is no ``--log-level`` flag. ``pipelex-agent`` is machine-consumed:
     stdout is reserved for the success envelope and stderr for the error envelope.
-    Free-floating logs would corrupt those channels, so pipelex's logs are silenced
-    unconditionally by the factory. For verbose debugging, use the human ``pipelex``
-    CLI instead.
+    Free-floating logs would corrupt those channels, so Python's logging system is
+    cut off process-wide via ``silence_logging_for_agent_cli`` as the very first
+    action in this callback — covering every subcommand invocation (including ones
+    like ``init`` and ``accept-gateway-terms`` that bypass
+    ``make_pipelex_for_agent_cli``). The ``--version`` eager option short-circuits
+    before this body runs, but its callback only does ``typer.echo`` + ``Exit`` and
+    touches no log path. For verbose debugging, use the human ``pipelex`` CLI instead.
     """
+    # Process-global logging cutoff, armed BEFORE any command body runs and BEFORE any
+    # error-format / runner-validation code below can route through ``log.*``. This is the
+    # primary armor for the stdout/stderr discipline; the per-call invocations inside
+    # ``make_pipelex_for_agent_cli`` and ``agent_doctor_cmd`` are kept as defense-in-depth
+    # for direct library callers that bypass this Typer entry point.
+    silence_logging_for_agent_cli()
     # Reset the error-format ContextVar at the single choke point every command passes through, so
     # a markdown command cannot leak markdown into a later JSON-only command in the same process.
     # --format / --error-format commands override this afterwards; JSON-only commands keep the JSON default.

--- a/pipelex/cli/agent_cli/_agent_cli.py
+++ b/pipelex/cli/agent_cli/_agent_cli.py
@@ -21,7 +21,6 @@ from pipelex.cli.agent_cli.commands.models_cmd import agent_models_cmd
 from pipelex.cli.agent_cli.commands.pipe_cmd import pipe_cmd
 from pipelex.cli.agent_cli.commands.run.app import run_app
 from pipelex.cli.agent_cli.commands.validate.app import validate_app
-from pipelex.tools.log.log_levels import LogLevel
 from pipelex.tools.misc.package_utils import get_package_version
 
 
@@ -91,31 +90,25 @@ def app_callback(
             is_eager=True,
         ),
     ] = False,
-    log_level: Annotated[
-        str,
-        typer.Option("--log-level", help="Log verbosity level (debug, verbose, info, warning, error, critical)."),
-    ] = "warning",
     runner: Annotated[
         str,
         typer.Option("--runner", help="Runner to use: 'pipelex' (local) or 'api' (remote MTHDS API)."),
     ] = "pipelex",
 ) -> None:
-    """Agent CLI callback - no logo, minimal output."""
+    """Agent CLI callback - no logo, minimal output.
+
+    Note: there is no ``--log-level`` flag. ``pipelex-agent`` is machine-consumed:
+    stdout is reserved for the success envelope and stderr for the error envelope.
+    Free-floating logs would corrupt those channels, so pipelex's logs are silenced
+    unconditionally by the factory. For verbose debugging, use the human ``pipelex``
+    CLI instead.
+    """
     # Reset the error-format ContextVar at the single choke point every command passes through, so
     # a markdown command cannot leak markdown into a later JSON-only command in the same process.
     # --format / --error-format commands override this afterwards; JSON-only commands keep the JSON default.
     set_agent_cli_error_format(CliOutputFormat.JSON)
 
     ctx.ensure_object(dict)
-    try:
-        ctx.obj["log_level"] = LogLevel(log_level.upper())
-    except ValueError:
-        valid_values = ", ".join(level.value.lower() for level in LogLevel)
-        agent_error(
-            f"Invalid log level '{log_level}'. Valid values: {valid_values}",
-            "ArgumentError",
-        )
-
     try:
         ctx.obj["runner"] = RunnerType(runner)
     except ValueError:

--- a/pipelex/cli/agent_cli/commands/agent_cli_factory.py
+++ b/pipelex/cli/agent_cli/commands/agent_cli_factory.py
@@ -29,61 +29,75 @@ from pipelex.tools.log.log_levels import LogLevel
 from pipelex.tools.misc.pretty import PrettyPrinter, PrettyPrintMode
 
 # Canonical leaf dict for "for any agent-CLI invocation, both Rich-managed channels land
-# on stderr." Composed by two distinct call sites:
-#   - ``_AGENT_CLI_STDERR_CONSOLE_OVERRIDES`` below wraps it in the full-config-tree shape
-#     required by ``Pipelex.make(config_overrides=...)`` for the full-init path.
+# on stderr AND all pipelex logs are silenced from the very first ``log.configure`` call."
+# Consumed by:
+#   - ``AGENT_CLI_CONFIG_OVERRIDES`` below wraps it in the full-config-tree shape required
+#     by ``Pipelex.make(config_overrides=...)`` for the full-init path.
 #   - ``pipelex.cli.agent_cli.commands.doctor_cmd`` passes it flat to
 #     ``setup_doctor_runtime(log_config_overrides=...)`` for the doctor-only path that
 #     does not go through ``Pipelex.make``.
 #
-# These two knobs only control Rich-managed diagnostic channels — NOT the agent CLI's
-# data channel:
+# Four knobs:
 #   - ``console_log_target``  -> the ``RichHandler`` for Python's logging system
 #                                (``log.debug/info/warning/error``).
 #   - ``console_print_target`` -> the ``Console`` returned by ``get_console()`` and used
 #                                for banners, deck notices, and the main ``pipelex`` CLI's
 #                                ``show backends`` / ``show models`` tables.
+#   - ``default_log_level``   -> root-logger level. Pinned at OFF so any third-party
+#                                package that inherits root (no explicit override) is
+#                                fully silenced.
+#   - ``package_log_levels``  -> per-package overrides. ``pipelex`` is pinned at OFF here;
+#                                deep-merged into the user's config, so third-party
+#                                package levels (anthropic, asyncio, ...) are preserved.
 #
-# The agent CLI's actual results (the JSON / markdown success envelope) are written by
-# ``agent_success`` / ``agent_success_formatted`` in ``agent_output.py`` via the bare
-# builtin ``print(...)`` straight to ``sys.stdout``. They do NOT go through Rich, so they
-# are unaffected by these overrides. Error envelopes go via ``print(..., file=sys.stderr)``
-# — also bypassing Rich.
+# Why silence all pipelex logs? The agent CLI is machine-consumed. Its contract is:
+# stdout = structured success envelope (JSON or markdown), stderr = structured error
+# envelope. ANY log line on stderr — DEBUG, INFO, WARNING, anything — corrupts the
+# error-envelope channel for downstream parsers (e.g. mthds-js's ``PipelexRunner``
+# doing ``JSON.parse(stderr)``). This is not a verbosity setting; it's the design.
+# There is no ``--log-level`` escape hatch on ``pipelex-agent``: when debugging is
+# needed, use the human ``pipelex`` CLI instead.
 #
-# Pinning both targets to ``stderr`` therefore ensures that EVERYTHING ELSE Pipelex might
-# emit (setup-time ``log.debug`` from ``telemetry_factory.py``, a banner from
-# ``deck_notice.py``, any future ``get_console().print(...)`` on the agent CLI setup path)
-# lands on stderr regardless of what the user's ``~/.pipelex/pipelex.toml`` says — so the
-# JSON data channel on stdout stays clean for downstream consumers like ``mthds-js``'s
-# ``PipelexRunner`` that do ``JSON.parse(stdout)``.
+# The agent CLI's actual results are written by ``agent_success`` /
+# ``agent_success_formatted`` via the bare builtin ``print(...)`` to ``sys.stdout``;
+# error envelopes via ``print(..., file=sys.stderr)``. Both bypass Rich entirely, so
+# the OFF-level pin has no effect on the structured envelopes — only on free-floating
+# ``log.*`` calls scattered through the codebase.
 #
 # Wrapped in ``MappingProxyType`` so a stray ``AGENT_CLI_STDERR_LOG_FIELDS[...] = ...`` in
 # a future contributor's hot-fix raises immediately instead of silently mutating the
-# shared canonical instance (which both consumers below alias).
+# shared canonical instance.
 AGENT_CLI_STDERR_LOG_FIELDS: Mapping[str, Any] = MappingProxyType(
     {
         "console_log_target": ConsoleTarget.STDERR,
         "console_print_target": ConsoleTarget.STDERR,
+        "default_log_level": LogLevel.OFF,
+        "package_log_levels": MappingProxyType({"pipelex": LogLevel.OFF}),
     }
 )
 
-# Direct alias: deep_update recurses into any ``Mapping`` and converts frozen leaves to
-# plain dicts at merge time, so referencing the canonical ``MappingProxyType`` here is
-# safe AND keeps mutation attempts on either reference loud (TypeError on the frozen
-# proxy) instead of silently diverging.
-_AGENT_CLI_STDERR_CONSOLE_OVERRIDES: dict[str, Any] = {
-    "pipelex": {"log_config": AGENT_CLI_STDERR_LOG_FIELDS},
-}
+# Full ``config_overrides`` tree for ``Pipelex.make()``. ``deep_update`` recurses into
+# ``package_log_levels``, so the ``pipelex = OFF`` entry merges into the user's config
+# without wiping out third-party package levels. Frozen so callers can't mutate it.
+AGENT_CLI_CONFIG_OVERRIDES: Mapping[str, Any] = MappingProxyType(
+    {
+        "pipelex": MappingProxyType(
+            {
+                "log_config": AGENT_CLI_STDERR_LOG_FIELDS,
+            },
+        ),
+    }
+)
 
 
-def apply_agent_cli_output_discipline(log_level: LogLevel = LogLevel.WARNING) -> None:
-    """Pin pipelex log level, pretty-print silence, and hub console target to stderr.
+def apply_agent_cli_output_discipline() -> None:
+    """Pin pipelex log level to OFF, silence pretty-print, and hub console target to stderr.
 
     Called from two paths:
       - ``make_pipelex_for_agent_cli`` (full-init): defense-in-depth. ``Pipelex.__init__``
         already pinned the hub console via ``set_console_print_target`` from the loaded
         log_config (whose ``console_print_target`` was overridden to STDERR by
-        ``_AGENT_CLI_STDERR_CONSOLE_OVERRIDES``).
+        ``AGENT_CLI_CONFIG_OVERRIDES``, which also pinned the pipelex log level to OFF).
       - ``agent_doctor_cmd`` (doctor-only): also defense-in-depth, since
         ``setup_doctor_runtime`` now mirrors ``Pipelex.__init__`` and applies
         ``set_console_print_target`` itself from the overridden log_config.
@@ -92,7 +106,7 @@ def apply_agent_cli_output_discipline(log_level: LogLevel = LogLevel.WARNING) ->
     skipped: ``log.redirect_to_stderr`` no-ops when no rich_handler is registered, and
     the hub print-target call is gated on a hub being installed.
     """
-    log.set_level_for_package("pipelex", log_level)
+    log.set_level_for_package("pipelex", LogLevel.OFF)
     log.redirect_to_stderr()
     PrettyPrinter.mode = PrettyPrintMode.SILENT
     hub = PipelexHub.get_optional_instance()
@@ -102,7 +116,6 @@ def apply_agent_cli_output_discipline(log_level: LogLevel = LogLevel.WARNING) ->
 
 def make_pipelex_for_agent_cli(
     library_dirs: list[str] | list[Path] | None = None,
-    log_level: LogLevel = LogLevel.WARNING,
     needs_inference: bool = True,
     needs_model_specs: bool | None = None,
 ) -> Pipelex:
@@ -117,23 +130,26 @@ def make_pipelex_for_agent_cli(
     human-readable markdown to stdout and exits 0, so the calling agent
     can display setup guidance directly.
 
-    Stdout contract: every ``pipelex-agent`` invocation reserves stdout exclusively
-    for the structured success envelope (JSON via ``--format json``, or markdown via
-    ``--format markdown``) emitted by ``agent_success`` / ``agent_success_formatted``.
-    All other output channels — logs, ``get_console().print(...)`` output, Rich pretty
-    prints, and ``agent_error`` envelopes — are pinned to stderr regardless of what the
-    user's ``pipelex.toml`` says. The factory enforces this via three layers:
+    Stdout / stderr contract: every ``pipelex-agent`` invocation reserves stdout
+    exclusively for the structured success envelope (JSON via ``--format json``, or
+    markdown via ``--format markdown``) emitted by ``agent_success`` /
+    ``agent_success_formatted``, and stderr exclusively for the structured error
+    envelope from ``agent_error``. NO free-floating logs are emitted on either channel,
+    regardless of what the user's ``pipelex.toml`` says. The factory enforces this via:
 
-      1. ``config_overrides`` injected into ``Pipelex.make()`` pins both
-         ``console_log_target`` and ``console_print_target`` to ``stderr`` from the
-         very first log/print fired during init.
+      1. ``AGENT_CLI_CONFIG_OVERRIDES`` injected into ``Pipelex.make()`` pins
+         ``console_log_target`` and ``console_print_target`` to ``stderr`` AND silences
+         pipelex's logs (``default_log_level = OFF``, ``package_log_levels.pipelex = OFF``)
+         from the very first ``log.configure`` call — so DEBUG/INFO/WARNING setup chatter
+         (e.g. ``telemetry_factory.py``'s ``log.debug``, ``validation_error_categorizer``'s
+         ``log.warning``) never reaches the handler, even when the user's
+         ``~/.pipelex/pipelex.toml`` sets ``pipelex = "DEBUG"``.
       2. ``PrettyPrinter.mode = SILENT`` neutralizes ``pretty_print(...)`` entirely.
       3. Post-init ``log.redirect_to_stderr()`` and
          ``get_pipelex_hub().set_console_print_target(STDERR)`` defense-in-depth.
 
     Args:
         library_dirs: Optional library directories to use for the Pipelex instance.
-        log_level: Log verbosity level (default WARNING for silent agent output).
         needs_inference: When False, skip inference setup (credentials, gateway, telemetry).
         needs_model_specs: When True, load real model specs even without inference.
 
@@ -152,7 +168,7 @@ def make_pipelex_for_agent_cli(
                 library_dirs=library_dirs,
                 needs_inference=needs_inference,
                 needs_model_specs=needs_model_specs,
-                config_overrides=_AGENT_CLI_STDERR_CONSOLE_OVERRIDES,
+                config_overrides=dict(AGENT_CLI_CONFIG_OVERRIDES),
             )
         # Surface a structured ``RemoteConfigStale`` entry so JSON consumers can react to
         # stale-cache operation without parsing stderr.
@@ -209,7 +225,8 @@ def make_pipelex_for_agent_cli(
             hint="Initialization failed. Run 'pipelex-agent doctor' to diagnose, or 'pipelex init config' to reset configuration",
         )
 
-    # Suppress Rich pretty-printing and INFO/DEV/DEBUG log noise so that agent
-    # commands only emit structured JSON.  Warnings and errors still reach stderr.
-    apply_agent_cli_output_discipline(log_level=log_level)
+    # Silence pipelex logs and Rich pretty-printing so the agent CLI emits only the
+    # structured success/error envelope. Defense-in-depth on top of the init-time
+    # config_overrides.
+    apply_agent_cli_output_discipline()
     return pipelex_instance

--- a/pipelex/cli/agent_cli/commands/agent_cli_factory.py
+++ b/pipelex/cli/agent_cli/commands/agent_cli_factory.py
@@ -1,5 +1,6 @@
 """Factory function for agent CLI commands -- JSON-only error output."""
 
+import logging
 import warnings
 from collections.abc import Mapping
 from pathlib import Path
@@ -25,11 +26,11 @@ from pipelex.system.pipelex_service.exceptions import (
 from pipelex.system.runtime import IntegrationMode
 from pipelex.system.telemetry.exceptions import TelemetryConfigValidationError
 from pipelex.tools.log.log import log
-from pipelex.tools.log.log_levels import LogLevel
+from pipelex.tools.log.log_levels import LOGGING_LEVEL_OFF, LogLevel
 from pipelex.tools.misc.pretty import PrettyPrinter, PrettyPrintMode
 
 # Canonical leaf dict for "for any agent-CLI invocation, both Rich-managed channels land
-# on stderr AND all pipelex logs are silenced from the very first ``log.configure`` call."
+# on stderr AND Python's logging system is globally muted from the very first init call."
 # Consumed by:
 #   - ``AGENT_CLI_CONFIG_OVERRIDES`` below wraps it in the full-config-tree shape required
 #     by ``Pipelex.make(config_overrides=...)`` for the full-init path.
@@ -37,20 +38,34 @@ from pipelex.tools.misc.pretty import PrettyPrinter, PrettyPrintMode
 #     ``setup_doctor_runtime(log_config_overrides=...)`` for the doctor-only path that
 #     does not go through ``Pipelex.make``.
 #
-# Four knobs:
+# The four knobs in this dict shape Pipelex's own log infrastructure but they CANNOT
+# enumerate every third-party logger a transitive dependency might create. The
+# bulletproof cutoff lives in ``silence_logging_for_agent_cli`` below, which calls
+# ``logging.disable(LOGGING_LEVEL_OFF)`` — a process-global threshold checked inside
+# ``Logger.isEnabledFor`` BEFORE any per-logger level. With that in effect, no record
+# is created for any logger, regardless of which package emits, how it's configured, or
+# what handlers it attaches. We call it as the very first line of
+# ``make_pipelex_for_agent_cli`` and ``agent_doctor_cmd`` so the cutoff is active before
+# any setup code can reach a ``log.*`` call.
+#
+# The dict below stays useful as defense-in-depth + Rich-channel pinning:
 #   - ``console_log_target``  -> the ``RichHandler`` for Python's logging system
-#                                (``log.debug/info/warning/error``).
+#                                (``log.debug/info/warning/error``). Pinned to stderr so
+#                                if ``logging.disable`` is ever cleared in this process,
+#                                logs still land on the diagnostic channel rather than
+#                                corrupting the stdout success envelope.
 #   - ``console_print_target`` -> the ``Console`` returned by ``get_console()`` and used
 #                                for banners, deck notices, and the main ``pipelex`` CLI's
-#                                ``show backends`` / ``show models`` tables.
-#   - ``default_log_level``   -> root-logger level. Pinned at OFF so any third-party
-#                                package that inherits root (no explicit override) is
-#                                fully silenced.
-#   - ``package_log_levels``  -> per-package overrides. ``pipelex`` is pinned at OFF here;
-#                                deep-merged into the user's config, so third-party
-#                                package levels (anthropic, asyncio, ...) are preserved.
+#                                ``show backends`` / ``show models`` tables. Rich Console
+#                                is INDEPENDENT of Python logging — ``logging.disable``
+#                                does not touch it — so this pin is the only thing
+#                                keeping Rich tables off stdout.
+#   - ``default_log_level``   -> root-logger level. Pinned at OFF as a backup in case
+#                                ``logging.disable`` is cleared.
+#   - ``package_log_levels``  -> historic ``pipelex = OFF`` pin. Redundant under
+#                                ``logging.disable`` but kept as defense.
 #
-# Why silence all pipelex logs? The agent CLI is machine-consumed. Its contract is:
+# Why silence everything? The agent CLI is machine-consumed. Its contract is:
 # stdout = structured success envelope (JSON or markdown), stderr = structured error
 # envelope. ANY log line on stderr — DEBUG, INFO, WARNING, anything — corrupts the
 # error-envelope channel for downstream parsers (e.g. mthds-js's ``PipelexRunner``
@@ -60,9 +75,9 @@ from pipelex.tools.misc.pretty import PrettyPrinter, PrettyPrintMode
 #
 # The agent CLI's actual results are written by ``agent_success`` /
 # ``agent_success_formatted`` via the bare builtin ``print(...)`` to ``sys.stdout``;
-# error envelopes via ``print(..., file=sys.stderr)``. Both bypass Rich entirely, so
-# the OFF-level pin has no effect on the structured envelopes — only on free-floating
-# ``log.*`` calls scattered through the codebase.
+# error envelopes via ``print(..., file=sys.stderr)``. Both bypass Rich and Python's
+# ``logging`` entirely, so neither ``logging.disable`` nor the pins below affect the
+# structured envelopes themselves.
 #
 # Wrapped in ``MappingProxyType`` so a stray ``AGENT_CLI_STDERR_LOG_FIELDS[...] = ...`` in
 # a future contributor's hot-fix raises immediately instead of silently mutating the
@@ -75,6 +90,31 @@ AGENT_CLI_STDERR_LOG_FIELDS: Mapping[str, Any] = MappingProxyType(
         "package_log_levels": MappingProxyType({"pipelex": LogLevel.OFF}),
     }
 )
+
+
+def silence_logging_for_agent_cli() -> None:
+    """Process-global cutoff of Python's logging system for agent CLI invocations.
+
+    Calls ``logging.disable(LOGGING_LEVEL_OFF)``, which sets
+    ``logging.Logger.manager.disable = LOGGING_LEVEL_OFF``. Every ``Logger.isEnabledFor``
+    call checks ``self.manager.disable >= level`` before the per-logger level check, so
+    no record gets created for any logger at any standard level (DEBUG through CRITICAL)
+    — regardless of which package emits, what level the logger is configured at, or
+    what handlers it has attached. This includes third-party packages we never
+    enumerate and any logger created AFTER this call.
+
+    Idempotent. Must be called at the very start of every agent CLI entry point
+    (``make_pipelex_for_agent_cli``, ``agent_doctor_cmd``) so the cutoff is active
+    before any setup code can reach a ``log.*`` call — closing the window between
+    ``log.configure`` and ``apply_agent_cli_output_discipline``.
+
+    Does NOT affect Rich ``Console`` output (banners, tables, pretty_print) — that's
+    handled by ``console_print_target = STDERR`` + ``PrettyPrinter.mode = SILENT`` +
+    the hub's ``set_console_print_target``. Does NOT affect bare ``print(...)`` calls
+    — those are reserved for the structured success/error envelopes by design.
+    """
+    logging.disable(LOGGING_LEVEL_OFF)
+
 
 # Full ``config_overrides`` tree for ``Pipelex.make()``. ``deep_update`` recurses into
 # ``package_log_levels``, so the ``pipelex = OFF`` entry merges into the user's config
@@ -91,22 +131,23 @@ AGENT_CLI_CONFIG_OVERRIDES: Mapping[str, Any] = MappingProxyType(
 
 
 def apply_agent_cli_output_discipline() -> None:
-    """Pin pipelex log level to OFF, silence pretty-print, and hub console target to stderr.
+    """Reaffirm the agent CLI output contract on the Rich/hub channels post-init.
 
-    Called from two paths:
-      - ``make_pipelex_for_agent_cli`` (full-init): defense-in-depth. ``Pipelex.__init__``
-        already pinned the hub console via ``set_console_print_target`` from the loaded
-        log_config (whose ``console_print_target`` was overridden to STDERR by
-        ``AGENT_CLI_CONFIG_OVERRIDES``, which also pinned the pipelex log level to OFF).
-      - ``agent_doctor_cmd`` (doctor-only): also defense-in-depth, since
-        ``setup_doctor_runtime`` now mirrors ``Pipelex.__init__`` and applies
-        ``set_console_print_target`` itself from the overridden log_config.
+    The bulletproof logging cutoff is ``silence_logging_for_agent_cli`` (called at the
+    start of every agent CLI entry point); this helper handles the channels that are
+    INDEPENDENT of Python's logging system:
+
+      1. ``log.redirect_to_stderr`` keeps the RichHandler's console on stderr — defense
+         in case ``logging.disable`` is ever cleared.
+      2. ``PrettyPrinter.mode = SILENT`` neutralizes ``pretty_print(...)`` entirely
+         (Rich-based, not logging-based).
+      3. Hub-level ``set_console_print_target(STDERR)`` for the Rich ``Console`` used by
+         banners / tables (also Rich-based, not logging-based).
 
     Safe to call from the broken-config doctor path where ``setup_doctor_runtime`` was
     skipped: ``log.redirect_to_stderr`` no-ops when no rich_handler is registered, and
     the hub print-target call is gated on a hub being installed.
     """
-    log.set_level_for_package("pipelex", LogLevel.OFF)
     log.redirect_to_stderr()
     PrettyPrinter.mode = PrettyPrintMode.SILENT
     hub = PipelexHub.get_optional_instance()
@@ -160,6 +201,9 @@ def make_pipelex_for_agent_cli(
         typer.Exit: If initialization fails (after printing JSON error to stderr),
             or if inference setup is required (after printing markdown to stdout).
     """
+    # Process-global logging cutoff, BEFORE Pipelex.make can trigger any third-party
+    # log line (anthropic/httpx/botocore credential probes, telemetry setup, etc.).
+    silence_logging_for_agent_cli()
     try:
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always", RemoteConfigStaleWarning)

--- a/pipelex/cli/agent_cli/commands/agent_cli_factory.py
+++ b/pipelex/cli/agent_cli/commands/agent_cli_factory.py
@@ -1,6 +1,7 @@
 """Factory function for agent CLI commands -- JSON-only error output."""
 
 import logging
+import sys
 import warnings
 from collections.abc import Mapping
 from pathlib import Path
@@ -26,7 +27,7 @@ from pipelex.system.pipelex_service.exceptions import (
 from pipelex.system.runtime import IntegrationMode
 from pipelex.system.telemetry.exceptions import TelemetryConfigValidationError
 from pipelex.tools.log.log import log
-from pipelex.tools.log.log_levels import LOGGING_LEVEL_OFF, LogLevel
+from pipelex.tools.log.log_levels import LogLevel
 from pipelex.tools.misc.pretty import PrettyPrinter, PrettyPrintMode
 
 # Canonical leaf dict for "for any agent-CLI invocation, both Rich-managed channels land
@@ -41,7 +42,7 @@ from pipelex.tools.misc.pretty import PrettyPrinter, PrettyPrintMode
 # The four knobs in this dict shape Pipelex's own log infrastructure but they CANNOT
 # enumerate every third-party logger a transitive dependency might create. The
 # bulletproof cutoff lives in ``silence_logging_for_agent_cli`` below, which calls
-# ``logging.disable(LOGGING_LEVEL_OFF)`` — a process-global threshold checked inside
+# ``logging.disable(sys.maxsize)`` — a process-global threshold checked inside
 # ``Logger.isEnabledFor`` BEFORE any per-logger level. With that in effect, no record
 # is created for any logger, regardless of which package emits, how it's configured, or
 # what handlers it attaches. We call it as the very first line of
@@ -95,13 +96,13 @@ AGENT_CLI_STDERR_LOG_FIELDS: Mapping[str, Any] = MappingProxyType(
 def silence_logging_for_agent_cli() -> None:
     """Process-global cutoff of Python's logging system for agent CLI invocations.
 
-    Calls ``logging.disable(LOGGING_LEVEL_OFF)``, which sets
-    ``logging.Logger.manager.disable = LOGGING_LEVEL_OFF``. Every ``Logger.isEnabledFor``
+    Calls ``logging.disable(sys.maxsize)``, which sets
+    ``logging.Logger.manager.disable = sys.maxsize``. Every ``Logger.isEnabledFor``
     call checks ``self.manager.disable >= level`` before the per-logger level check, so
-    no record gets created for any logger at any standard level (DEBUG through CRITICAL)
-    — regardless of which package emits, what level the logger is configured at, or
-    what handlers it has attached. This includes third-party packages we never
-    enumerate and any logger created AFTER this call.
+    no record gets created for any logger — blocks every record at every level
+    (including custom levels above CRITICAL), regardless of which package emits, what
+    level the logger is configured at, or what handlers it has attached. This includes
+    third-party packages we never enumerate and any logger created AFTER this call.
 
     Idempotent. The primary call site is ``app_callback`` in
     ``pipelex.cli.agent_cli._agent_cli`` — Typer routes every ``pipelex-agent``
@@ -117,7 +118,7 @@ def silence_logging_for_agent_cli() -> None:
     the hub's ``set_console_print_target``. Does NOT affect bare ``print(...)`` calls
     — those are reserved for the structured success/error envelopes by design.
     """
-    logging.disable(LOGGING_LEVEL_OFF)
+    logging.disable(sys.maxsize)
 
 
 # Full ``config_overrides`` tree for ``Pipelex.make()``. ``deep_update`` recurses into

--- a/pipelex/cli/agent_cli/commands/agent_cli_factory.py
+++ b/pipelex/cli/agent_cli/commands/agent_cli_factory.py
@@ -103,10 +103,14 @@ def silence_logging_for_agent_cli() -> None:
     what handlers it has attached. This includes third-party packages we never
     enumerate and any logger created AFTER this call.
 
-    Idempotent. Must be called at the very start of every agent CLI entry point
-    (``make_pipelex_for_agent_cli``, ``agent_doctor_cmd``) so the cutoff is active
-    before any setup code can reach a ``log.*`` call — closing the window between
-    ``log.configure`` and ``apply_agent_cli_output_discipline``.
+    Idempotent. The primary call site is ``app_callback`` in
+    ``pipelex.cli.agent_cli._agent_cli`` — Typer routes every ``pipelex-agent``
+    subcommand through that callback, so the cutoff is armed before any command body
+    runs (including commands like ``init`` and ``accept-gateway-terms`` that bypass
+    ``make_pipelex_for_agent_cli``). The additional invocations at the top of
+    ``make_pipelex_for_agent_cli`` and ``agent_doctor_cmd`` are belt-and-braces
+    defense for direct library callers that bypass the Typer entry point (and for
+    the unit tests that drive those factories directly).
 
     Does NOT affect Rich ``Console`` output (banners, tables, pretty_print) — that's
     handled by ``console_print_target = STDERR`` + ``PrettyPrinter.mode = SILENT`` +

--- a/pipelex/cli/agent_cli/commands/check_model_cmd.py
+++ b/pipelex/cli/agent_cli/commands/check_model_cmd.py
@@ -51,7 +51,6 @@ def _format_check_markdown(result: dict[str, Any]) -> str:
 
 
 def agent_check_model_cmd(
-    ctx: typer.Context,
     name: Annotated[
         str,
         typer.Argument(help="Model reference to check (e.g. $writing-creative, @best-claude, gpt-4o)"),
@@ -76,7 +75,7 @@ def agent_check_model_cmd(
     """
     set_agent_cli_error_format(error_format or output_format)
     try:
-        make_pipelex_for_agent_cli(log_level=ctx.obj["log_level"], needs_inference=False, needs_model_specs=True)
+        make_pipelex_for_agent_cli(needs_inference=False, needs_model_specs=True)
 
         model_deck = get_model_deck()
         ref = ModelReference.parse(name)

--- a/pipelex/cli/agent_cli/commands/doctor_cmd.py
+++ b/pipelex/cli/agent_cli/commands/doctor_cmd.py
@@ -5,7 +5,11 @@ from typing import Annotated, Any
 import typer
 
 from pipelex.base_exceptions import PipelexConfigError
-from pipelex.cli.agent_cli.commands.agent_cli_factory import AGENT_CLI_STDERR_LOG_FIELDS, apply_agent_cli_output_discipline
+from pipelex.cli.agent_cli.commands.agent_cli_factory import (
+    AGENT_CLI_STDERR_LOG_FIELDS,
+    apply_agent_cli_output_discipline,
+    silence_logging_for_agent_cli,
+)
 from pipelex.cli.agent_cli.commands.agent_output import CliOutputFormat, agent_error, agent_success, set_agent_cli_error_format
 from pipelex.cli.commands.doctor_cmd import (
     BackendFileReport,
@@ -125,6 +129,9 @@ def agent_doctor_cmd(
     Use --global/-g to force checking the global ~/.pipelex/ directory.
     """
     set_agent_cli_error_format(error_format or output_format)
+    # Process-global logging cutoff, BEFORE setup_doctor_runtime / check_* can trigger
+    # any third-party log line.
+    silence_logging_for_agent_cli()
     try:
         # When --global, force checking ~/.pipelex/ only; otherwise use layered resolution
         config_dir = config_manager.global_config_dir if global_ else None

--- a/pipelex/cli/agent_cli/commands/inputs/bundle_cmd.py
+++ b/pipelex/cli/agent_cli/commands/inputs/bundle_cmd.py
@@ -21,7 +21,6 @@ from pipelex.pipeline.validate_bundle import ValidateBundleError
 
 
 def inputs_bundle_cmd(
-    ctx: typer.Context,
     path: Annotated[
         str,
         typer.Argument(help="Path to a .mthds bundle file or a pipeline directory"),
@@ -84,7 +83,7 @@ def inputs_bundle_cmd(
 
     pipe_code: str | None = pipe
     library_dirs = [Path(lib_dir) for lib_dir in library_dir] if library_dir else None
-    make_pipelex_for_agent_cli(library_dirs=library_dirs, log_level=ctx.obj["log_level"], needs_inference=False, needs_model_specs=True)
+    make_pipelex_for_agent_cli(library_dirs=library_dirs, needs_inference=False, needs_model_specs=True)
 
     try:
         result = asyncio.run(inputs_core(pipe_code=pipe_code, bundle_path=Path(bundle_path), library_dirs=library_dirs))  # type: ignore[arg-type]

--- a/pipelex/cli/agent_cli/commands/inputs/method_cmd.py
+++ b/pipelex/cli/agent_cli/commands/inputs/method_cmd.py
@@ -20,7 +20,6 @@ from pipelex.pipeline.validate_bundle import ValidateBundleError
 
 
 def inputs_method_cmd(
-    ctx: typer.Context,
     name: Annotated[
         str,
         typer.Argument(help="Name of the installed method"),
@@ -56,7 +55,7 @@ def inputs_method_cmd(
     if library_dir:
         library_dirs_paths.extend(Path(lib_dir) for lib_dir in library_dir)
 
-    make_pipelex_for_agent_cli(library_dirs=library_dirs_paths, log_level=ctx.obj["log_level"], needs_inference=False, needs_model_specs=True)
+    make_pipelex_for_agent_cli(library_dirs=library_dirs_paths, needs_inference=False, needs_model_specs=True)
 
     try:
         result = asyncio.run(inputs_core(pipe_code=pipe_code, bundle_path=bundle_path, library_dirs=library_dirs_paths))

--- a/pipelex/cli/agent_cli/commands/inputs/pipe_cmd.py
+++ b/pipelex/cli/agent_cli/commands/inputs/pipe_cmd.py
@@ -21,7 +21,6 @@ from pipelex.pipeline.validate_bundle import ValidateBundleError
 
 
 def inputs_pipe_cmd(
-    ctx: typer.Context,
     pipe_code: Annotated[
         str,
         typer.Argument(help="Pipe code to get inputs for"),
@@ -64,7 +63,7 @@ def inputs_pipe_cmd(
             library_dir = [*export_dirs, *library_dir]
 
     library_dirs = [Path(lib_dir) for lib_dir in library_dir] if library_dir else None
-    make_pipelex_for_agent_cli(library_dirs=library_dirs, log_level=ctx.obj["log_level"], needs_inference=False, needs_model_specs=True)
+    make_pipelex_for_agent_cli(library_dirs=library_dirs, needs_inference=False, needs_model_specs=True)
 
     try:
         result = asyncio.run(inputs_core(pipe_code=pipe_code, bundle_path=None, library_dirs=library_dirs))

--- a/pipelex/cli/agent_cli/commands/models_cmd.py
+++ b/pipelex/cli/agent_cli/commands/models_cmd.py
@@ -11,7 +11,6 @@ from pipelex.pipelex import Pipelex
 
 
 def agent_models_cmd(
-    ctx: typer.Context,
     model_type: Annotated[
         list[ModelCategory] | None,
         typer.Option("--type", "-t", help="Filter by model category (repeatable): llm, extract, img_gen, search"),
@@ -36,7 +35,7 @@ def agent_models_cmd(
     """
     set_agent_cli_error_format(error_format or output_format)
     try:
-        make_pipelex_for_agent_cli(log_level=ctx.obj["log_level"], needs_inference=False, needs_model_specs=backend is not None)
+        make_pipelex_for_agent_cli(needs_inference=False, needs_model_specs=backend is not None)
 
         result = list_models(categories=model_type, backend=backend)
 

--- a/pipelex/cli/agent_cli/commands/run/bundle_cmd.py
+++ b/pipelex/cli/agent_cli/commands/run/bundle_cmd.py
@@ -187,7 +187,7 @@ def run_bundle_cmd(
                 agent_error(str(exc), type(exc).__name__, cause=exc)
 
         case RunnerType.PIPELEX:
-            make_pipelex_for_agent_cli(log_level=ctx.obj["log_level"], needs_inference=not dry_run, needs_model_specs=True)
+            make_pipelex_for_agent_cli(needs_inference=not dry_run, needs_model_specs=True)
 
             try:
                 result = asyncio.run(

--- a/pipelex/cli/agent_cli/commands/run/method_cmd.py
+++ b/pipelex/cli/agent_cli/commands/run/method_cmd.py
@@ -144,7 +144,7 @@ def run_method_cmd(
                 agent_error(str(exc), type(exc).__name__, cause=exc)
 
         case RunnerType.PIPELEX:
-            make_pipelex_for_agent_cli(log_level=ctx.obj["log_level"], needs_inference=not dry_run, needs_model_specs=True)
+            make_pipelex_for_agent_cli(needs_inference=not dry_run, needs_model_specs=True)
 
             try:
                 result = asyncio.run(

--- a/pipelex/cli/agent_cli/commands/run/pipe_cmd.py
+++ b/pipelex/cli/agent_cli/commands/run/pipe_cmd.py
@@ -141,7 +141,7 @@ def run_pipe_cmd(
                 agent_error(str(exc), type(exc).__name__, cause=exc)
 
         case RunnerType.PIPELEX:
-            make_pipelex_for_agent_cli(log_level=ctx.obj["log_level"], needs_inference=not dry_run, needs_model_specs=True)
+            make_pipelex_for_agent_cli(needs_inference=not dry_run, needs_model_specs=True)
 
             try:
                 result = asyncio.run(

--- a/pipelex/cli/agent_cli/commands/validate/bundle_cmd.py
+++ b/pipelex/cli/agent_cli/commands/validate/bundle_cmd.py
@@ -33,7 +33,6 @@ from pipelex.tools.misc.chart_utils import FlowchartDirection
 
 
 def validate_bundle_cmd(
-    ctx: typer.Context,
     path: Annotated[
         str,
         typer.Argument(help="Path to a .mthds bundle file or a pipeline directory"),
@@ -127,7 +126,7 @@ def validate_bundle_cmd(
     # Convert library_dirs to list[str] for graph helper
     library_dir_strings = [str(lib_dir) for lib_dir in library_dirs] if library_dirs else None
 
-    make_pipelex_for_agent_cli(library_dirs=library_dirs, log_level=ctx.obj["log_level"], needs_inference=False, needs_model_specs=True)
+    make_pipelex_for_agent_cli(library_dirs=library_dirs, needs_inference=False, needs_model_specs=True)
 
     try:
         if pipe:

--- a/pipelex/cli/agent_cli/commands/validate/method_cmd.py
+++ b/pipelex/cli/agent_cli/commands/validate/method_cmd.py
@@ -29,7 +29,6 @@ from pipelex.pipeline.validate_bundle import ValidateBundleError
 
 
 def validate_method_cmd(
-    ctx: typer.Context,
     name: Annotated[
         str,
         typer.Argument(help="Name of the installed method"),
@@ -78,7 +77,7 @@ def validate_method_cmd(
     if library_dir:
         library_dirs_paths.extend(Path(lib_dir) for lib_dir in library_dir)
 
-    make_pipelex_for_agent_cli(library_dirs=library_dirs_paths, log_level=ctx.obj["log_level"], needs_inference=False, needs_model_specs=True)
+    make_pipelex_for_agent_cli(library_dirs=library_dirs_paths, needs_inference=False, needs_model_specs=True)
 
     try:
         if pipe:

--- a/pipelex/cli/agent_cli/commands/validate/pipe_cmd.py
+++ b/pipelex/cli/agent_cli/commands/validate/pipe_cmd.py
@@ -29,7 +29,6 @@ from pipelex.pipeline.validate_bundle import ValidateBundleError
 
 
 def validate_pipe_cmd(
-    ctx: typer.Context,
     pipe_code: Annotated[
         str | None,
         typer.Argument(help="Pipe code to validate"),
@@ -70,7 +69,7 @@ def validate_pipe_cmd(
         if pipe_code:
             agent_error("--all cannot be used with a pipe code", "ArgumentError")
 
-        make_pipelex_for_agent_cli(library_dirs=library_dirs, log_level=ctx.obj["log_level"], needs_inference=False, needs_model_specs=True)
+        make_pipelex_for_agent_cli(library_dirs=library_dirs, needs_inference=False, needs_model_specs=True)
 
         try:
             result = asyncio.run(validate_all_core(library_dirs=library_dirs))
@@ -141,7 +140,7 @@ def validate_pipe_cmd(
         else:
             library_dirs = [*export_paths, *library_dirs]
 
-    make_pipelex_for_agent_cli(library_dirs=library_dirs, log_level=ctx.obj["log_level"], needs_inference=False, needs_model_specs=True)
+    make_pipelex_for_agent_cli(library_dirs=library_dirs, needs_inference=False, needs_model_specs=True)
 
     try:
         result = asyncio.run(validate_pipe_core(pipe_code=pipe_code, library_dirs=library_dirs))

--- a/pipelex/cli/commands/doctor_cmd.py
+++ b/pipelex/cli/commands/doctor_cmd.py
@@ -58,6 +58,7 @@ from pipelex.system.telemetry.telemetry_config import TELEMETRY_CONFIG_FILE_NAME
 from pipelex.tools.log.log_config import LogConfig
 from pipelex.tools.misc.dict_utils import extract_vars_from_strings_recursive
 from pipelex.tools.misc.file_utils import path_exists
+from pipelex.tools.misc.json_utils import deep_update
 from pipelex.tools.misc.placeholder import value_is_placeholder
 from pipelex.tools.misc.toml_utils import TomlError, load_toml_from_path
 from pipelex.tools.secrets.env_secrets_provider import EnvSecretsProvider
@@ -752,8 +753,10 @@ def setup_doctor_runtime(
     stdout stays clean for downstream consumers. The human doctor passes nothing and
     inherits the user's configured log targets.
 
-    Overrides are merged via ``LogConfig.model_validate`` (full re-validation) so that
-    a wrong-typed override surfaces loudly instead of silently breaking downstream
+    Overrides are merged via ``deep_update`` so nested dicts (notably
+    ``package_log_levels``) merge into the loaded config instead of replacing it
+    wholesale, then passed through ``LogConfig.model_validate`` (full re-validation) so
+    that a wrong-typed override surfaces loudly instead of silently breaking downstream
     match/case dispatch on ``ConsoleTarget`` etc.
 
     ``log.configure`` is invoked through ``configure_if_unset`` so that if a library
@@ -781,7 +784,9 @@ def setup_doctor_runtime(
 
     log_config = get_config().pipelex.log_config
     if log_config_overrides is not None:
-        log_config = LogConfig.model_validate({**log_config.model_dump(), **log_config_overrides})
+        merged = log_config.model_dump()
+        deep_update(merged, log_config_overrides)
+        log_config = LogConfig.model_validate(merged)
     pipelex_hub.set_console_print_target(target=log_config.console_print_target)
     log.configure_if_unset(log_config=log_config)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pipelex"
-version = "0.30.0"
+version = "0.30.1"
 description = "Execute composable AI methods declared in the MTHDS open standard"
 authors = [{ name = "Evotis S.A.S.", email = "oss@pipelex.com" }]
 maintainers = [{ name = "Pipelex staff", email = "oss@pipelex.com" }]

--- a/tests/e2e/agent_cli/test_stdout_is_clean_json.py
+++ b/tests/e2e/agent_cli/test_stdout_is_clean_json.py
@@ -191,9 +191,10 @@ class TestAgentCliStdoutIsCleanJson:
         Before the fix the agent CLI's ``package_log_levels`` override only pinned
         ``pipelex = OFF`` and let third-party loggers keep their configured level,
         leaking INFO/DEBUG records onto stderr via the root's RichHandler. The fix is
-        ``logging.disable(LOGGING_LEVEL_OFF)`` at the start of every agent CLI entry
-        point — a process-global cutoff that blocks every record for every logger,
-        regardless of which package emits.
+        ``logging.disable(sys.maxsize)`` at the start of every agent CLI entry point
+        — a process-global cutoff that blocks every record for every logger at every
+        level (including custom levels above CRITICAL), regardless of which package
+        emits.
         """
         pipelex_toml = hermetic_home / ".pipelex" / "pipelex.toml"
         for package_name in ("anthropic", "httpx", "botocore", "openai"):

--- a/tests/e2e/agent_cli/test_stdout_is_clean_json.py
+++ b/tests/e2e/agent_cli/test_stdout_is_clean_json.py
@@ -35,6 +35,7 @@ from typing import TYPE_CHECKING, cast
 
 import pytest
 
+from pipelex.tools.misc.toml_utils import load_toml_with_tomlkit, save_toml_to_path
 from tests.e2e.agent_cli.conftest import PIPELEX_AGENT_BIN
 
 if TYPE_CHECKING:
@@ -44,52 +45,51 @@ if TYPE_CHECKING:
 def _set_package_log_level(pipelex_toml_path: Path, *, package_name: str, level: str) -> None:
     """Set ``<package_name> = "<level>"`` inside ``[pipelex.log_config.package_log_levels]``.
 
-    If the package key already exists in the section, rewrites its value. Otherwise
-    appends a new line at the end of the section. Either way the user's TOML ends up
-    explicitly carrying the level, which is what we need to exercise the
-    "user-configured third-party logger" leak scenario.
-
-    Asserts on missing-section so a future kit refactor surfaces here instead of
-    silently neutering the test.
+    Uses the project's ``tomlkit``-based helpers (the same pair ``init_cmd`` relies
+    on) to parse-edit-dump the file. This handles every edge case the previous
+    line-based rewriter had to special-case (duplicate section headers, whitespace
+    variants in key lines, missing trailing newlines) — tomlkit's parser is the
+    source of truth for what the agent CLI ultimately reads back via Pipelex's
+    config loader.
     """
-    original_text = pipelex_toml_path.read_text(encoding="utf-8")
-    lines = original_text.splitlines(keepends=True)
-    target_section_start: int | None = None
-    target_section_end: int | None = None
-    in_target_section = False
-    for index, line in enumerate(lines):
-        stripped = line.strip()
-        if stripped.startswith("[") and stripped.endswith("]"):
-            if in_target_section:
-                target_section_end = index
-                in_target_section = False
-            if stripped == "[pipelex.log_config.package_log_levels]":
-                in_target_section = True
-                target_section_start = index
-    if in_target_section:
-        target_section_end = len(lines)
-    if target_section_start is None or target_section_end is None:
-        msg = f"Could not find [pipelex.log_config.package_log_levels] in {pipelex_toml_path}"
-        raise AssertionError(msg)
-
-    new_line = f'{package_name} = "{level}"\n'
-    for index in range(target_section_start + 1, target_section_end):
-        if lines[index].strip().startswith(f"{package_name} "):
-            lines[index] = new_line
-            break
-    else:
-        # Insert before the first trailing blank line so the section's contents stay grouped.
-        insert_index = target_section_end
-        while insert_index > target_section_start + 1 and lines[insert_index - 1].strip() == "":
-            insert_index -= 1
-        lines.insert(insert_index, new_line)
-
-    pipelex_toml_path.write_text("".join(lines), encoding="utf-8")
+    doc = load_toml_with_tomlkit(pipelex_toml_path)
+    doc["pipelex"]["log_config"]["package_log_levels"][package_name] = level  # type: ignore[index]
+    save_toml_to_path(doc, pipelex_toml_path)
 
 
 def _set_pipelex_package_log_level_to_debug(pipelex_toml_path: Path) -> None:
     """Compatibility shim for the original two callers — bumps pipelex to DEBUG."""
     _set_package_log_level(pipelex_toml_path, package_name="pipelex", level="DEBUG")
+
+
+def _assert_stderr_is_clean_or_structured_envelope(stderr: str) -> None:
+    """Assert that ``stderr`` is either empty or a parseable structured error envelope.
+
+    The agent CLI's contract is: stderr is reserved for the structured error envelope
+    (a JSON object with an ``error`` field). The strictest catch on a third-party
+    logger leak is: any free-floating log line on stderr would NOT be valid JSON, so
+    ``json.loads`` fails. This relaxation lets the test tolerate the edge case where
+    the envelope itself legitimately appears on stderr (which would never happen on a
+    successful run, but it absorbs unrelated environmental noise that still parses
+    cleanly), while still failing loudly on the log-leak shape we actually guard
+    against.
+    """
+    if stderr == "":
+        return
+    try:
+        parsed = json.loads(stderr)
+    except json.JSONDecodeError as exc:
+        msg = (
+            f"stderr must be either empty or a parseable JSON error envelope — any other "
+            f"content (log line, warning, print) means something leaked through the agent "
+            f"CLI's stdout/stderr discipline.\nstderr={stderr!r}\nparse error={exc!s}"
+        )
+        raise AssertionError(msg) from exc
+    if not (isinstance(parsed, dict) and "error" in parsed):
+        msg = (
+            f"stderr parsed as JSON but is not the structured error envelope shape (expected a dict containing an ``error`` key).\nstderr={stderr!r}"
+        )
+        raise AssertionError(msg)
 
 
 def _set_console_targets(pipelex_toml_path: Path, *, log_target: str, print_target: str) -> None:
@@ -221,14 +221,10 @@ class TestAgentCliStdoutIsCleanJson:
         # stdout must parse as JSON in one shot — no log line preceding/following the envelope.
         parsed = json.loads(result.stdout)
         assert isinstance(parsed, dict)
-        # stderr must stay empty — any line here proves a third-party logger leaked through
-        # the root RichHandler. Empty-stderr is the strictest possible assertion on the
-        # "no log corrupts the error envelope" contract.
-        assert result.stderr == "", (
-            f"stderr must stay clean even when third-party loggers are bumped to DEBUG — "
-            f"otherwise their records leak through the root's RichHandler and corrupt the "
-            f"JSON error envelope.\nstderr={result.stderr!r}"
-        )
+        # stderr must be either empty (the expected case for a successful run) or a
+        # parseable structured error envelope — anything else (log line, warning, print)
+        # proves a third-party logger leaked through the root RichHandler.
+        _assert_stderr_is_clean_or_structured_envelope(result.stderr)
 
     def test_models_json_stdout_resists_user_targets_override_to_stdout(
         self,

--- a/tests/e2e/agent_cli/test_stdout_is_clean_json.py
+++ b/tests/e2e/agent_cli/test_stdout_is_clean_json.py
@@ -41,31 +41,55 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
-def _set_pipelex_package_log_level_to_debug(pipelex_toml_path: Path) -> None:
-    """Rewrite the ``pipelex = "INFO"`` line inside ``[pipelex.log_config.package_log_levels]``
-    to ``"DEBUG"`` so any setup-time ``log.debug`` in the ``pipelex.*`` namespace fires.
+def _set_package_log_level(pipelex_toml_path: Path, *, package_name: str, level: str) -> None:
+    """Set ``<package_name> = "<level>"`` inside ``[pipelex.log_config.package_log_levels]``.
 
-    Targets the specific kit-template structure (``pipelex = "INFO"`` lives directly under
-    that section). Asserts on no-match so a future kit refactor surfaces here instead of
+    If the package key already exists in the section, rewrites its value. Otherwise
+    appends a new line at the end of the section. Either way the user's TOML ends up
+    explicitly carrying the level, which is what we need to exercise the
+    "user-configured third-party logger" leak scenario.
+
+    Asserts on missing-section so a future kit refactor surfaces here instead of
     silently neutering the test.
     """
     original_text = pipelex_toml_path.read_text(encoding="utf-8")
     lines = original_text.splitlines(keepends=True)
+    target_section_start: int | None = None
+    target_section_end: int | None = None
     in_target_section = False
-    rewrote = False
     for index, line in enumerate(lines):
         stripped = line.strip()
         if stripped.startswith("[") and stripped.endswith("]"):
-            in_target_section = stripped == "[pipelex.log_config.package_log_levels]"
-            continue
-        if in_target_section and stripped.startswith("pipelex"):
-            lines[index] = 'pipelex = "DEBUG"\n'
-            rewrote = True
-            break
-    if not rewrote:
-        msg = f"Could not find 'pipelex = ...' under [pipelex.log_config.package_log_levels] in {pipelex_toml_path}"
+            if in_target_section:
+                target_section_end = index
+                in_target_section = False
+            if stripped == "[pipelex.log_config.package_log_levels]":
+                in_target_section = True
+                target_section_start = index
+    if in_target_section:
+        target_section_end = len(lines)
+    if target_section_start is None or target_section_end is None:
+        msg = f"Could not find [pipelex.log_config.package_log_levels] in {pipelex_toml_path}"
         raise AssertionError(msg)
+
+    new_line = f'{package_name} = "{level}"\n'
+    for index in range(target_section_start + 1, target_section_end):
+        if lines[index].strip().startswith(f"{package_name} "):
+            lines[index] = new_line
+            break
+    else:
+        # Insert before the first trailing blank line so the section's contents stay grouped.
+        insert_index = target_section_end
+        while insert_index > target_section_start + 1 and lines[insert_index - 1].strip() == "":
+            insert_index -= 1
+        lines.insert(insert_index, new_line)
+
     pipelex_toml_path.write_text("".join(lines), encoding="utf-8")
+
+
+def _set_pipelex_package_log_level_to_debug(pipelex_toml_path: Path) -> None:
+    """Compatibility shim for the original two callers — bumps pipelex to DEBUG."""
+    _set_package_log_level(pipelex_toml_path, package_name="pipelex", level="DEBUG")
 
 
 def _set_console_targets(pipelex_toml_path: Path, *, log_target: str, print_target: str) -> None:
@@ -152,6 +176,58 @@ class TestAgentCliStdoutIsCleanJson:
         assert isinstance(parsed, dict), f"Expected a JSON object envelope; got {type(parsed).__name__}: {parsed!r}"
         payload = cast("dict[str, object]", parsed)
         assert payload.get("success") is True, f"Expected ``success=True`` in envelope; got {payload!r}"
+
+    def test_models_json_stdout_and_stderr_stay_clean_under_third_party_logger_enabled(
+        self,
+        hermetic_home: Path,
+        offline_subprocess_env: dict[str, str],
+    ) -> None:
+        """Regression for the third-party-logger leak: even when the user bumps a
+        third-party logger (anthropic, httpx) to DEBUG in their ``pipelex.toml``, the
+        agent CLI's stdout AND stderr channels must stay clean — stdout parseable as a
+        single JSON envelope, stderr free of any log line that would corrupt the
+        structured error envelope.
+
+        Before the fix the agent CLI's ``package_log_levels`` override only pinned
+        ``pipelex = OFF`` and let third-party loggers keep their configured level,
+        leaking INFO/DEBUG records onto stderr via the root's RichHandler. The fix is
+        ``logging.disable(LOGGING_LEVEL_OFF)`` at the start of every agent CLI entry
+        point — a process-global cutoff that blocks every record for every logger,
+        regardless of which package emits.
+        """
+        pipelex_toml = hermetic_home / ".pipelex" / "pipelex.toml"
+        for package_name in ("anthropic", "httpx", "botocore", "openai"):
+            _set_package_log_level(pipelex_toml, package_name=package_name, level="DEBUG")
+
+        result = subprocess.run(  # noqa: S603
+            [
+                str(PIPELEX_AGENT_BIN),
+                "models",
+                "--format",
+                "json",
+            ],
+            env=offline_subprocess_env,
+            cwd=str(hermetic_home),
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=120,
+        )
+
+        assert result.returncode == 0, (
+            f"pipelex-agent models --format json must succeed with third-party loggers at DEBUG.\nstdout={result.stdout!r}\nstderr={result.stderr!r}"
+        )
+        # stdout must parse as JSON in one shot — no log line preceding/following the envelope.
+        parsed = json.loads(result.stdout)
+        assert isinstance(parsed, dict)
+        # stderr must stay empty — any line here proves a third-party logger leaked through
+        # the root RichHandler. Empty-stderr is the strictest possible assertion on the
+        # "no log corrupts the error envelope" contract.
+        assert result.stderr == "", (
+            f"stderr must stay clean even when third-party loggers are bumped to DEBUG — "
+            f"otherwise their records leak through the root's RichHandler and corrupt the "
+            f"JSON error envelope.\nstderr={result.stderr!r}"
+        )
 
     def test_models_json_stdout_resists_user_targets_override_to_stdout(
         self,

--- a/tests/e2e/agent_cli/test_stdout_is_clean_json.py
+++ b/tests/e2e/agent_cli/test_stdout_is_clean_json.py
@@ -117,16 +117,15 @@ class TestAgentCliStdoutIsCleanJson:
 
         Bumps ``package_log_levels.pipelex`` to DEBUG (the exact knob a downstream user
         would flip when debugging) so the latent ``console_log_target`` bug surfaces as
-        DEBUG lines on stdout. Then ``json.loads`` on the entire stdout (with no slicing,
-        no last-object walker) must succeed and return a dict envelope.
+        DEBUG lines on stdout. The agent CLI's ``config_overrides`` MUST win over the
+        user-TOML override (pinning pipelex to OFF), so ``json.loads`` on the entire
+        stdout must succeed and return a dict envelope.
         """
         _set_pipelex_package_log_level_to_debug(hermetic_home / ".pipelex" / "pipelex.toml")
 
         result = subprocess.run(  # noqa: S603
             [
                 str(PIPELEX_AGENT_BIN),
-                "--log-level",
-                "debug",
                 "models",
                 "--format",
                 "json",
@@ -177,8 +176,6 @@ class TestAgentCliStdoutIsCleanJson:
         result = subprocess.run(  # noqa: S603
             [
                 str(PIPELEX_AGENT_BIN),
-                "--log-level",
-                "debug",
                 "models",
                 "--format",
                 "json",

--- a/tests/unit/pipelex/cli/agent_cli/test_error_format_independent.py
+++ b/tests/unit/pipelex/cli/agent_cli/test_error_format_independent.py
@@ -9,7 +9,6 @@ from mthds.runners.types import RunnerType
 
 from pipelex.cli.agent_cli.commands.agent_output import CliOutputFormat
 from pipelex.cli.agent_cli.commands.run.pipe_cmd import run_pipe_cmd
-from pipelex.tools.log.log_levels import LogLevel
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
@@ -26,13 +25,13 @@ class TestErrorFormatIndependent:
         mocker.patch(f"{RUN_PIPE_MODULE}.parse_cli_inputs", return_value=None)
         mocker.patch(f"{RUN_PIPE_MODULE}.run_pipeline_core", new=mocker.AsyncMock(return_value=result))
         ctx = mocker.MagicMock()
-        ctx.obj = {"log_level": LogLevel.WARNING, "runner": RunnerType.PIPELEX}
+        ctx.obj = {"runner": RunnerType.PIPELEX}
         return ctx
 
     def _ctx_for_error_path(self, mocker: MockerFixture) -> Any:
         """Mock typer.Context shaped for the error path (no Pipelex init needed)."""
         ctx = mocker.MagicMock()
-        ctx.obj = {"log_level": LogLevel.WARNING, "runner": RunnerType.PIPELEX}
+        ctx.obj = {"runner": RunnerType.PIPELEX}
         return ctx
 
     @pytest.mark.parametrize(

--- a/tests/unit/pipelex/cli/agent_cli/test_run_format.py
+++ b/tests/unit/pipelex/cli/agent_cli/test_run_format.py
@@ -10,7 +10,6 @@ from mthds.runners.types import RunnerType
 
 from pipelex.cli.agent_cli.commands.agent_output import CliOutputFormat
 from pipelex.cli.agent_cli.commands.run.pipe_cmd import run_pipe_cmd
-from pipelex.tools.log.log_levels import LogLevel
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
@@ -29,7 +28,7 @@ class TestRunFormat:
         mocker.patch(f"{RUN_PIPE_MODULE}.parse_cli_inputs", return_value=None)
         mocker.patch(f"{RUN_PIPE_MODULE}.run_pipeline_core", new=mocker.AsyncMock(return_value=result))
         ctx = mocker.MagicMock()
-        ctx.obj = {"log_level": LogLevel.WARNING, "runner": RunnerType.PIPELEX}
+        ctx.obj = {"runner": RunnerType.PIPELEX}
         return ctx
 
     def test_run_pipe_markdown_is_default(self, mocker: MockerFixture, capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/unit/pipelex/cli/agent_cli/test_validate_format.py
+++ b/tests/unit/pipelex/cli/agent_cli/test_validate_format.py
@@ -9,7 +9,6 @@ import pytest
 
 from pipelex.cli.agent_cli.commands.agent_output import CliOutputFormat
 from pipelex.cli.agent_cli.commands.validate.pipe_cmd import validate_pipe_cmd
-from pipelex.tools.log.log_levels import LogLevel
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
@@ -20,8 +19,8 @@ VALIDATE_PIPE_MODULE = "pipelex.cli.agent_cli.commands.validate.pipe_cmd"
 class TestValidateFormat:
     """validate pipe --all emits markdown by default and JSON with --format json."""
 
-    def _patch_validate(self, mocker: MockerFixture) -> Any:
-        """Patch the validate pipe command's dependencies and return a mock typer context."""
+    def _patch_validate(self, mocker: MockerFixture) -> None:
+        """Patch the validate pipe command's dependencies."""
         result: dict[str, Any] = {
             "success": True,
             "validated_pipes": [{"pipe_code": "p1", "status": "SUCCESS"}],
@@ -30,15 +29,12 @@ class TestValidateFormat:
         mocker.patch(f"{VALIDATE_PIPE_MODULE}.make_pipelex_for_agent_cli")
         mocker.patch(f"{VALIDATE_PIPE_MODULE}.Pipelex.teardown_if_needed")
         mocker.patch(f"{VALIDATE_PIPE_MODULE}.validate_all_core", new=mocker.AsyncMock(return_value=result))
-        ctx = mocker.MagicMock()
-        ctx.obj = {"log_level": LogLevel.WARNING}
-        return ctx
 
     def test_validate_markdown_is_default(self, mocker: MockerFixture, capsys: pytest.CaptureFixture[str]) -> None:
         """Validate pipe --all with no --format produces markdown to stdout."""
-        ctx = self._patch_validate(mocker)
+        self._patch_validate(mocker)
 
-        validate_pipe_cmd(ctx=ctx, validate_all=True, output_format=CliOutputFormat.MARKDOWN)
+        validate_pipe_cmd(validate_all=True, output_format=CliOutputFormat.MARKDOWN)
 
         out = capsys.readouterr().out
         assert out.startswith("# Validation passed")
@@ -48,9 +44,9 @@ class TestValidateFormat:
 
     def test_validate_json_with_format_json(self, mocker: MockerFixture, capsys: pytest.CaptureFixture[str]) -> None:
         """Validate pipe --all --format json produces valid JSON to stdout."""
-        ctx = self._patch_validate(mocker)
+        self._patch_validate(mocker)
 
-        validate_pipe_cmd(ctx=ctx, validate_all=True, output_format=CliOutputFormat.JSON)
+        validate_pipe_cmd(validate_all=True, output_format=CliOutputFormat.JSON)
 
         parsed = json.loads(capsys.readouterr().out)
         assert parsed["success"] is True

--- a/tests/unit/pipelex/cli/conftest.py
+++ b/tests/unit/pipelex/cli/conftest.py
@@ -2,17 +2,14 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import pytest
 
 from pipelex.cli.agent_cli.commands.agent_output import CliOutputFormat, set_agent_cli_error_format
-from pipelex.tools.log.log_levels import LogLevel
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
-
-    from pytest_mock import MockerFixture
 
 
 @pytest.fixture(autouse=True)
@@ -27,11 +24,3 @@ def reset_agent_cli_error_format() -> Iterator[None]:
     set_agent_cli_error_format(CliOutputFormat.JSON)
     yield
     set_agent_cli_error_format(CliOutputFormat.JSON)
-
-
-@pytest.fixture
-def agent_ctx(mocker: MockerFixture) -> Any:
-    """Create a mock typer.Context with log_level in obj, for direct command-function calls."""
-    ctx = mocker.MagicMock()
-    ctx.obj = {"log_level": LogLevel.WARNING}
-    return ctx

--- a/tests/unit/pipelex/cli/test_agent_cli_factory.py
+++ b/tests/unit/pipelex/cli/test_agent_cli_factory.py
@@ -30,13 +30,19 @@ class TestMakePipelexForAgentCli:
 
     @pytest.fixture(autouse=True)
     def _restore_globals(self):
-        """Restore PrettyPrinter.mode and root log level after tests that call the factory successfully."""
+        """Restore PrettyPrinter.mode, root log level, and the process-global
+        ``logging.disable`` threshold after tests that call the factory successfully —
+        otherwise the agent CLI cutoff (armed by ``silence_logging_for_agent_cli`` inside
+        the factory) leaks into other tests in the suite.
+        """
         original_mode = PrettyPrinter.mode
         root_logger = logging.getLogger()
         original_level: int = root_logger.level
+        original_disable = logging.root.manager.disable
         yield
         PrettyPrinter.mode = original_mode
         root_logger.setLevel(original_level)
+        logging.disable(original_disable)
 
     def test_successful_initialization(self, mocker: MockerFixture) -> None:
         """Should return the Pipelex instance when make() succeeds."""

--- a/tests/unit/pipelex/cli/test_agent_cli_factory_init_overrides.py
+++ b/tests/unit/pipelex/cli/test_agent_cli_factory_init_overrides.py
@@ -6,9 +6,10 @@ Regression guard: a user TOML with ``[pipelex.log_config.package_log_levels] pip
 ``log.warning``) onto stderr — corrupting the JSON error envelope that downstream agent
 consumers parse. The bulletproof cutoff is ``silence_logging_for_agent_cli`` which is
 called at the very start of every agent CLI entry point and uses
-``logging.disable(LOGGING_LEVEL_OFF)`` — a process-global threshold that blocks any
-record for any logger, regardless of which package emits or what level it's configured
-at. The ``config_overrides`` carry defense-in-depth pins on top.
+``logging.disable(sys.maxsize)`` — a process-global threshold that blocks any record
+for any logger at any level (including custom levels above CRITICAL), regardless of
+which package emits or what level it's configured at. The ``config_overrides`` carry
+defense-in-depth pins on top.
 
 The agent CLI has NO ``--log-level`` flag. Suppression is unconditional by design — the
 CLI is machine-consumed and stderr is reserved for the structured error envelope.
@@ -17,6 +18,7 @@ CLI is machine-consumed and stderr is reserved for the structured error envelope
 from __future__ import annotations
 
 import logging
+import sys
 from typing import TYPE_CHECKING
 
 import pytest
@@ -29,7 +31,7 @@ from pipelex.cli.agent_cli.commands.agent_cli_factory import (
     make_pipelex_for_agent_cli,
 )
 from pipelex.system.console_target import ConsoleTarget
-from pipelex.tools.log.log_levels import LOGGING_LEVEL_OFF, LogLevel
+from pipelex.tools.log.log_levels import LogLevel
 
 
 class TestAgentCliFactoryInitOverrides:
@@ -63,9 +65,9 @@ class TestAgentCliFactoryInitOverrides:
            table / pretty-print fires.
         2. ``silence_logging_for_agent_cli`` (called before ``Pipelex.make`` so the
            cutoff is active during init) must have armed ``logging.disable`` at
-           ``LOGGING_LEVEL_OFF`` — the bulletproof handler-side cutoff that blocks
-           every record for every logger, including third-party libraries we don't
-           enumerate.
+           ``sys.maxsize`` — the bulletproof handler-side cutoff that blocks every
+           record for every logger at every level (including custom levels above
+           CRITICAL), including third-party libraries we don't enumerate.
         """
         mock_pipelex = mocker.MagicMock()
         mock_make = mocker.patch(
@@ -82,8 +84,8 @@ class TestAgentCliFactoryInitOverrides:
         assert log_config_overrides["console_log_target"] is ConsoleTarget.STDERR
         assert log_config_overrides["console_print_target"] is ConsoleTarget.STDERR
 
-        assert logging.root.manager.disable == LOGGING_LEVEL_OFF, (
+        assert logging.root.manager.disable == sys.maxsize, (
             "make_pipelex_for_agent_cli must call silence_logging_for_agent_cli (which arms "
-            "logging.disable at LOGGING_LEVEL_OFF) BEFORE Pipelex.make — otherwise any "
+            "logging.disable at sys.maxsize) BEFORE Pipelex.make — otherwise any "
             "third-party logger configured at INFO/WARNING leaks records during init."
         )

--- a/tests/unit/pipelex/cli/test_agent_cli_factory_init_overrides.py
+++ b/tests/unit/pipelex/cli/test_agent_cli_factory_init_overrides.py
@@ -4,9 +4,11 @@ Regression guard: a user TOML with ``[pipelex.log_config.package_log_levels] pip
 "DEBUG"`` used to leak setup-time logs (e.g. ``telemetry_factory.py``'s
 ``log.debug("Telemetry is disabled...")``, ``validation_error_categorizer.py``'s
 ``log.warning``) onto stderr — corrupting the JSON error envelope that downstream agent
-consumers parse. The fix pins ``package_log_levels.pipelex = OFF`` via
-``config_overrides`` so suppression takes effect from the very first ``log.configure``
-call inside ``Pipelex.make``, not post-init via ``apply_agent_cli_output_discipline``.
+consumers parse. The bulletproof cutoff is ``silence_logging_for_agent_cli`` which is
+called at the very start of every agent CLI entry point and uses
+``logging.disable(LOGGING_LEVEL_OFF)`` — a process-global threshold that blocks any
+record for any logger, regardless of which package emits or what level it's configured
+at. The ``config_overrides`` carry defense-in-depth pins on top.
 
 The agent CLI has NO ``--log-level`` flag. Suppression is unconditional by design — the
 CLI is machine-consumed and stderr is reserved for the structured error envelope.
@@ -14,7 +16,10 @@ CLI is machine-consumed and stderr is reserved for the structured error envelope
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
+
+import pytest
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
@@ -24,25 +29,43 @@ from pipelex.cli.agent_cli.commands.agent_cli_factory import (
     make_pipelex_for_agent_cli,
 )
 from pipelex.system.console_target import ConsoleTarget
-from pipelex.tools.log.log_levels import LogLevel
+from pipelex.tools.log.log_levels import LOGGING_LEVEL_OFF, LogLevel
 
 
 class TestAgentCliFactoryInitOverrides:
-    """Pins the contract that init-time logs are suppressed via config_overrides."""
+    """Pins the contract that init-time logs are suppressed via global cutoff + overrides."""
+
+    @pytest.fixture(autouse=True)
+    def _restore_global_logging_disable(self):
+        """``make_pipelex_for_agent_cli`` mutates process-global state via
+        ``logging.disable``. Snapshot the manager's disable level and restore it after
+        each test so the agent CLI cutoff does not leak into other tests in the suite.
+        """
+        original_disable = logging.root.manager.disable
+        yield
+        logging.disable(original_disable)
 
     def test_static_leaf_pins_off_for_pipelex_package(self) -> None:
         """The doctor path and the full-init path BOTH use ``AGENT_CLI_STDERR_LOG_FIELDS``,
-        so the leaf itself must silence pipelex logs at OFF.
+        so the leaf itself must silence pipelex logs at OFF as defense-in-depth on top of
+        the global ``logging.disable`` cutoff.
         """
         assert AGENT_CLI_STDERR_LOG_FIELDS["default_log_level"] == LogLevel.OFF
         assert AGENT_CLI_STDERR_LOG_FIELDS["package_log_levels"]["pipelex"] == LogLevel.OFF
         assert AGENT_CLI_STDERR_LOG_FIELDS["console_log_target"] is ConsoleTarget.STDERR
         assert AGENT_CLI_STDERR_LOG_FIELDS["console_print_target"] is ConsoleTarget.STDERR
 
-    def test_make_injects_off_overrides_into_pipelex_make(self, mocker: MockerFixture) -> None:
-        """``Pipelex.make`` must receive a ``config_overrides`` carrying the OFF pins so
-        suppression takes effect at ``log.configure`` time — before any setup-time
-        ``log.*`` call can fire on stderr.
+    def test_make_injects_overrides_and_arms_global_logging_cutoff(self, mocker: MockerFixture) -> None:
+        """Two contracts in one call:
+
+        1. ``Pipelex.make`` must receive a ``config_overrides`` carrying the OFF pins +
+           stderr targets so the Rich channels are correctly aimed before any banner /
+           table / pretty-print fires.
+        2. ``silence_logging_for_agent_cli`` (called before ``Pipelex.make`` so the
+           cutoff is active during init) must have armed ``logging.disable`` at
+           ``LOGGING_LEVEL_OFF`` — the bulletproof handler-side cutoff that blocks
+           every record for every logger, including third-party libraries we don't
+           enumerate.
         """
         mock_pipelex = mocker.MagicMock()
         mock_make = mocker.patch(
@@ -58,3 +81,9 @@ class TestAgentCliFactoryInitOverrides:
         assert log_config_overrides["package_log_levels"]["pipelex"] is LogLevel.OFF
         assert log_config_overrides["console_log_target"] is ConsoleTarget.STDERR
         assert log_config_overrides["console_print_target"] is ConsoleTarget.STDERR
+
+        assert logging.root.manager.disable == LOGGING_LEVEL_OFF, (
+            "make_pipelex_for_agent_cli must call silence_logging_for_agent_cli (which arms "
+            "logging.disable at LOGGING_LEVEL_OFF) BEFORE Pipelex.make — otherwise any "
+            "third-party logger configured at INFO/WARNING leaks records during init."
+        )

--- a/tests/unit/pipelex/cli/test_agent_cli_factory_init_overrides.py
+++ b/tests/unit/pipelex/cli/test_agent_cli_factory_init_overrides.py
@@ -32,20 +32,28 @@ from pipelex.cli.agent_cli.commands.agent_cli_factory import (
 )
 from pipelex.system.console_target import ConsoleTarget
 from pipelex.tools.log.log_levels import LogLevel
+from pipelex.tools.misc.pretty import PrettyPrinter
 
 
 class TestAgentCliFactoryInitOverrides:
     """Pins the contract that init-time logs are suppressed via global cutoff + overrides."""
 
     @pytest.fixture(autouse=True)
-    def _restore_global_logging_disable(self):
-        """``make_pipelex_for_agent_cli`` mutates process-global state via
-        ``logging.disable``. Snapshot the manager's disable level and restore it after
-        each test so the agent CLI cutoff does not leak into other tests in the suite.
+    def _restore_globals(self):
+        """``make_pipelex_for_agent_cli`` mutates two pieces of process-global state:
+        ``logging.disable`` (via ``silence_logging_for_agent_cli``) and
+        ``PrettyPrinter.mode`` (set to ``SILENT`` by ``apply_agent_cli_output_discipline``
+        at the end of the factory). Snapshot both and restore them after each test so
+        the agent CLI's discipline does not leak into other test classes in the same
+        xdist worker — under pytest-xdist the failure mode is downstream
+        ``pretty_print``-based tests (e.g. ``test_json_content_rendering``) producing
+        empty output and asserting ``'x' in ''``.
         """
         original_disable = logging.root.manager.disable
+        original_pretty_mode = PrettyPrinter.mode
         yield
         logging.disable(original_disable)
+        PrettyPrinter.mode = original_pretty_mode
 
     def test_static_leaf_pins_off_for_pipelex_package(self) -> None:
         """The doctor path and the full-init path BOTH use ``AGENT_CLI_STDERR_LOG_FIELDS``,

--- a/tests/unit/pipelex/cli/test_agent_cli_factory_init_overrides.py
+++ b/tests/unit/pipelex/cli/test_agent_cli_factory_init_overrides.py
@@ -1,0 +1,60 @@
+"""Tests for init-time log suppression via config_overrides in the agent CLI factory.
+
+Regression guard: a user TOML with ``[pipelex.log_config.package_log_levels] pipelex =
+"DEBUG"`` used to leak setup-time logs (e.g. ``telemetry_factory.py``'s
+``log.debug("Telemetry is disabled...")``, ``validation_error_categorizer.py``'s
+``log.warning``) onto stderr — corrupting the JSON error envelope that downstream agent
+consumers parse. The fix pins ``package_log_levels.pipelex = OFF`` via
+``config_overrides`` so suppression takes effect from the very first ``log.configure``
+call inside ``Pipelex.make``, not post-init via ``apply_agent_cli_output_discipline``.
+
+The agent CLI has NO ``--log-level`` flag. Suppression is unconditional by design — the
+CLI is machine-consumed and stderr is reserved for the structured error envelope.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+from pipelex.cli.agent_cli.commands.agent_cli_factory import (
+    AGENT_CLI_STDERR_LOG_FIELDS,
+    make_pipelex_for_agent_cli,
+)
+from pipelex.system.console_target import ConsoleTarget
+from pipelex.tools.log.log_levels import LogLevel
+
+
+class TestAgentCliFactoryInitOverrides:
+    """Pins the contract that init-time logs are suppressed via config_overrides."""
+
+    def test_static_leaf_pins_off_for_pipelex_package(self) -> None:
+        """The doctor path and the full-init path BOTH use ``AGENT_CLI_STDERR_LOG_FIELDS``,
+        so the leaf itself must silence pipelex logs at OFF.
+        """
+        assert AGENT_CLI_STDERR_LOG_FIELDS["default_log_level"] == LogLevel.OFF
+        assert AGENT_CLI_STDERR_LOG_FIELDS["package_log_levels"]["pipelex"] == LogLevel.OFF
+        assert AGENT_CLI_STDERR_LOG_FIELDS["console_log_target"] is ConsoleTarget.STDERR
+        assert AGENT_CLI_STDERR_LOG_FIELDS["console_print_target"] is ConsoleTarget.STDERR
+
+    def test_make_injects_off_overrides_into_pipelex_make(self, mocker: MockerFixture) -> None:
+        """``Pipelex.make`` must receive a ``config_overrides`` carrying the OFF pins so
+        suppression takes effect at ``log.configure`` time — before any setup-time
+        ``log.*`` call can fire on stderr.
+        """
+        mock_pipelex = mocker.MagicMock()
+        mock_make = mocker.patch(
+            "pipelex.cli.agent_cli.commands.agent_cli_factory.Pipelex.make",
+            return_value=mock_pipelex,
+        )
+
+        make_pipelex_for_agent_cli()
+
+        config_overrides = mock_make.call_args.kwargs["config_overrides"]
+        log_config_overrides = config_overrides["pipelex"]["log_config"]
+        assert log_config_overrides["default_log_level"] is LogLevel.OFF
+        assert log_config_overrides["package_log_levels"]["pipelex"] is LogLevel.OFF
+        assert log_config_overrides["console_log_target"] is ConsoleTarget.STDERR
+        assert log_config_overrides["console_print_target"] is ConsoleTarget.STDERR

--- a/tests/unit/pipelex/cli/test_agent_cli_factory_suppression.py
+++ b/tests/unit/pipelex/cli/test_agent_cli_factory_suppression.py
@@ -11,22 +11,23 @@ if TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
 from pipelex.cli.agent_cli.commands.agent_cli_factory import make_pipelex_for_agent_cli
-from pipelex.tools.log.log_levels import LogLevel
 from pipelex.tools.misc.pretty import PrettyPrinter, PrettyPrintMode
 
 
 class TestAgentCliFactorySuppression:
-    """After successful init, the factory should silence pretty-print and lower log verbosity."""
+    """After successful init, the factory should silence pretty-print and Python logging."""
 
     @pytest.fixture(autouse=True)
     def _restore_globals(self):
-        """Save and restore PrettyPrinter.mode and pipelex log level around each test."""
+        """Save and restore PrettyPrinter.mode and the process-global logging disable
+        threshold around each test so the agent CLI cutoff does not leak into the rest
+        of the suite.
+        """
         original_mode = PrettyPrinter.mode
-        pipelex_logger = logging.getLogger("pipelex")
-        original_level: int = pipelex_logger.level
+        original_disable = logging.root.manager.disable
         yield
         PrettyPrinter.mode = original_mode
-        pipelex_logger.setLevel(original_level)
+        logging.disable(original_disable)
 
     def test_sets_silent_pretty_print_mode(self, mocker: MockerFixture) -> None:
         """PrettyPrinter.mode should be SILENT after make_pipelex_for_agent_cli succeeds."""
@@ -37,15 +38,25 @@ class TestAgentCliFactorySuppression:
 
         assert PrettyPrinter.mode is PrettyPrintMode.SILENT
 
-    def test_silences_pipelex_logger(self, mocker: MockerFixture) -> None:
-        """The pipelex package logger must be pinned at OFF (LOGGING_LEVEL_OFF=999) — the
-        agent CLI's contract is "no free-floating logs on stderr." There is no log_level
-        parameter; suppression is unconditional.
+    def test_silences_every_logger_via_global_logging_disable(self, mocker: MockerFixture) -> None:
+        """The factory must arm ``logging.disable`` so no record can be emitted by any
+        logger — pipelex, anthropic, httpx, botocore, openai, or anything a transitive
+        dependency creates. There is no log_level parameter; suppression is unconditional.
+
+        Checks the observable behavior (``isEnabledFor`` short-circuits to False), not
+        the per-logger level — because under ``logging.disable`` the per-logger level is
+        irrelevant by design.
         """
         mock_pipelex = mocker.MagicMock()
         mocker.patch("pipelex.cli.agent_cli.commands.agent_cli_factory.Pipelex.make", return_value=mock_pipelex)
+        # Arm a few loggers at INFO/WARNING as a downstream library might.
+        for logger_name in ("pipelex", "anthropic", "httpx", "some.unknown.transitive.dep"):
+            logging.getLogger(logger_name).setLevel(logging.DEBUG)
 
         make_pipelex_for_agent_cli()
 
-        pipelex_logger = logging.getLogger("pipelex")
-        assert pipelex_logger.level == LogLevel.OFF.int_logging_level
+        for logger_name in ("pipelex", "anthropic", "httpx", "some.unknown.transitive.dep"):
+            assert not logging.getLogger(logger_name).isEnabledFor(logging.INFO), (
+                f"logger '{logger_name}' must be silenced by the agent CLI global cutoff; "
+                f"any record it emits leaks to stderr and corrupts the JSON error envelope."
+            )

--- a/tests/unit/pipelex/cli/test_agent_cli_factory_suppression.py
+++ b/tests/unit/pipelex/cli/test_agent_cli_factory_suppression.py
@@ -13,21 +13,36 @@ if TYPE_CHECKING:
 from pipelex.cli.agent_cli.commands.agent_cli_factory import make_pipelex_for_agent_cli
 from pipelex.tools.misc.pretty import PrettyPrinter, PrettyPrintMode
 
+# Loggers armed by the test below at non-default levels. Their ``.level`` attribute is
+# snapshot in the autouse fixture and restored after each test so the per-logger state
+# does not leak into the rest of the suite (other tests may rely on the default NOTSET).
+_ARMED_LOGGER_NAMES: tuple[str, ...] = (
+    "pipelex",
+    "anthropic",
+    "httpx",
+    "some.unknown.transitive.dep",
+)
+
 
 class TestAgentCliFactorySuppression:
     """After successful init, the factory should silence pretty-print and Python logging."""
 
     @pytest.fixture(autouse=True)
     def _restore_globals(self):
-        """Save and restore PrettyPrinter.mode and the process-global logging disable
-        threshold around each test so the agent CLI cutoff does not leak into the rest
-        of the suite.
+        """Save and restore PrettyPrinter.mode, the process-global logging disable
+        threshold, AND the per-logger ``.level`` for every logger this test class arms.
+        Without restoring the per-logger levels, the ``setLevel`` calls in the test body
+        leak into shared module-level loggers (``pipelex``, ``anthropic``, ``httpx``, ...)
+        and affect any other test that assumes default NOTSET.
         """
         original_mode = PrettyPrinter.mode
         original_disable = logging.root.manager.disable
+        original_levels = {name: logging.getLogger(name).level for name in _ARMED_LOGGER_NAMES}
         yield
         PrettyPrinter.mode = original_mode
         logging.disable(original_disable)
+        for name, level in original_levels.items():
+            logging.getLogger(name).setLevel(level)
 
     def test_sets_silent_pretty_print_mode(self, mocker: MockerFixture) -> None:
         """PrettyPrinter.mode should be SILENT after make_pipelex_for_agent_cli succeeds."""

--- a/tests/unit/pipelex/cli/test_agent_cli_factory_suppression.py
+++ b/tests/unit/pipelex/cli/test_agent_cli_factory_suppression.py
@@ -37,24 +37,15 @@ class TestAgentCliFactorySuppression:
 
         assert PrettyPrinter.mode is PrettyPrintMode.SILENT
 
-    def test_sets_warning_log_level(self, mocker: MockerFixture) -> None:
-        """Log level should be WARNING by default after make_pipelex_for_agent_cli succeeds."""
+    def test_silences_pipelex_logger(self, mocker: MockerFixture) -> None:
+        """The pipelex package logger must be pinned at OFF (LOGGING_LEVEL_OFF=999) — the
+        agent CLI's contract is "no free-floating logs on stderr." There is no log_level
+        parameter; suppression is unconditional.
+        """
         mock_pipelex = mocker.MagicMock()
         mocker.patch("pipelex.cli.agent_cli.commands.agent_cli_factory.Pipelex.make", return_value=mock_pipelex)
 
         make_pipelex_for_agent_cli()
 
         pipelex_logger = logging.getLogger("pipelex")
-        assert pipelex_logger.level == logging.WARNING
-        assert pipelex_logger.level == LogLevel.WARNING.int_logging_level
-
-    def test_sets_custom_log_level(self, mocker: MockerFixture) -> None:
-        """Log level should match the provided log_level parameter."""
-        mock_pipelex = mocker.MagicMock()
-        mocker.patch("pipelex.cli.agent_cli.commands.agent_cli_factory.Pipelex.make", return_value=mock_pipelex)
-
-        make_pipelex_for_agent_cli(log_level=LogLevel.DEBUG)
-
-        pipelex_logger = logging.getLogger("pipelex")
-        assert pipelex_logger.level == logging.DEBUG
-        assert pipelex_logger.level == LogLevel.DEBUG.int_logging_level
+        assert pipelex_logger.level == LogLevel.OFF.int_logging_level

--- a/tests/unit/pipelex/cli/test_agent_cli_output_discipline.py
+++ b/tests/unit/pipelex/cli/test_agent_cli_output_discipline.py
@@ -44,12 +44,12 @@ class TestApplyAgentCliOutputDiscipline:
             return_value=mock_hub,
         )
 
-        apply_agent_cli_output_discipline(log_level=LogLevel.WARNING)
+        apply_agent_cli_output_discipline()
 
         mock_redirect.assert_called_once()
         mock_hub.set_console_print_target.assert_called_once_with(target=ConsoleTarget.STDERR)
         assert PrettyPrinter.mode is PrettyPrintMode.SILENT
-        assert logging.getLogger("pipelex").level == LogLevel.WARNING.int_logging_level
+        assert logging.getLogger("pipelex").level == LogLevel.OFF.int_logging_level
 
     def test_no_hub_path_skips_hub_call_safely(self, mocker: MockerFixture) -> None:
         """When no hub is installed (broken-config doctor path), the helper must still pin
@@ -61,8 +61,8 @@ class TestApplyAgentCliOutputDiscipline:
             return_value=None,
         )
 
-        apply_agent_cli_output_discipline(log_level=LogLevel.WARNING)
+        apply_agent_cli_output_discipline()
 
         mock_redirect.assert_called_once()
         assert PrettyPrinter.mode is PrettyPrintMode.SILENT
-        assert logging.getLogger("pipelex").level == LogLevel.WARNING.int_logging_level
+        assert logging.getLogger("pipelex").level == LogLevel.OFF.int_logging_level

--- a/tests/unit/pipelex/cli/test_agent_cli_output_discipline.py
+++ b/tests/unit/pipelex/cli/test_agent_cli_output_discipline.py
@@ -1,11 +1,18 @@
-"""Unit tests for apply_agent_cli_output_discipline real side effects.
+"""Unit tests for the agent CLI output discipline functions.
 
-The discipline helper is the single source of truth for "agent CLI stdout stays clean."
-The existing test_agent_doctor_cmd suite asserts the helper is called, but the autouse
-fixture there stubs the helper out — so a typo regression inside the helper would ship
-green. This module covers the real side effects (log redirect, PrettyPrinter mode flip,
-hub print-target swap) by patching the dependencies the helper touches and asserting
-the helper drives them correctly.
+Covers two helpers:
+
+  - ``silence_logging_for_agent_cli`` — process-global ``logging.disable`` cutoff that
+    blocks any record for any logger, regardless of package or level. This is the
+    bulletproof defense against third-party logger leaks (anthropic, httpx, botocore,
+    openai, asyncio, ...) that we can't (and shouldn't try to) enumerate by name.
+  - ``apply_agent_cli_output_discipline`` — pins the Rich/Pretty channels that are
+    INDEPENDENT of Python's logging system (Rich Console for tables/banners,
+    PrettyPrinter for pretty_print, hub-level console target).
+
+The existing test_agent_doctor_cmd suite asserts these helpers are called, but the
+autouse fixture there stubs them out — so a typo regression inside the helper itself
+would ship green. This module covers the real side effects.
 """
 
 from __future__ import annotations
@@ -18,24 +25,54 @@ import pytest
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
-from pipelex.cli.agent_cli.commands.agent_cli_factory import apply_agent_cli_output_discipline
+from pipelex.cli.agent_cli.commands.agent_cli_factory import (
+    apply_agent_cli_output_discipline,
+    silence_logging_for_agent_cli,
+)
 from pipelex.system.console_target import ConsoleTarget
-from pipelex.tools.log.log_levels import LogLevel
+from pipelex.tools.log.log_levels import LOGGING_LEVEL_OFF
 from pipelex.tools.misc.pretty import PrettyPrinter, PrettyPrintMode
 
 
-class TestApplyAgentCliOutputDiscipline:
+class TestAgentCliOutputDiscipline:
     @pytest.fixture(autouse=True)
     def _restore_globals(self):
-        """Restore PrettyPrinter.mode and the pipelex logger level after each test."""
+        """Restore PrettyPrinter.mode and process-global ``logging.disable`` after each
+        test so the agent CLI cutoff does not leak into other tests in the suite.
+        """
         original_mode = PrettyPrinter.mode
-        pipelex_logger = logging.getLogger("pipelex")
-        original_level = pipelex_logger.level
+        original_disable = logging.root.manager.disable
         yield
         PrettyPrinter.mode = original_mode
-        pipelex_logger.setLevel(original_level)
+        logging.disable(original_disable)
 
-    def test_pins_console_print_target_to_stderr_when_hub_installed(self, mocker: MockerFixture) -> None:
+    def test_silence_logging_disables_every_third_party_logger_regardless_of_configured_level(self) -> None:
+        """Regression: ``silence_logging_for_agent_cli`` must call ``logging.disable`` at
+        ``LOGGING_LEVEL_OFF`` so that every logger — pipelex, anthropic, httpx, botocore,
+        openai, anything a transitive dep ever creates — has ``isEnabledFor`` short-circuit
+        to False before its own level check fires. This is the only defense that scales
+        without an enumeration of package names.
+        """
+        # Arm a couple of loggers at INFO/WARNING as if a downstream library had configured
+        # them. The global disable must override their own level checks.
+        anthropic_logger = logging.getLogger("anthropic")
+        anthropic_logger.setLevel(logging.INFO)
+        httpx_logger = logging.getLogger("httpx")
+        httpx_logger.setLevel(logging.WARNING)
+        # A name we never enumerate, to prove the defense is not list-based.
+        random_logger = logging.getLogger("some.transitive.dep.we.never.heard.of")
+        random_logger.setLevel(logging.DEBUG)
+
+        silence_logging_for_agent_cli()
+
+        assert logging.root.manager.disable == LOGGING_LEVEL_OFF
+        assert not anthropic_logger.isEnabledFor(logging.INFO)
+        assert not anthropic_logger.isEnabledFor(logging.CRITICAL)
+        assert not httpx_logger.isEnabledFor(logging.WARNING)
+        assert not random_logger.isEnabledFor(logging.DEBUG)
+        assert not random_logger.isEnabledFor(logging.CRITICAL)
+
+    def test_apply_discipline_pins_console_print_target_to_stderr_when_hub_installed(self, mocker: MockerFixture) -> None:
         """When a hub is installed, the helper must pin its console_print_target to STDERR."""
         mock_redirect = mocker.patch("pipelex.cli.agent_cli.commands.agent_cli_factory.log.redirect_to_stderr")
         mock_hub = mocker.MagicMock()
@@ -49,9 +86,8 @@ class TestApplyAgentCliOutputDiscipline:
         mock_redirect.assert_called_once()
         mock_hub.set_console_print_target.assert_called_once_with(target=ConsoleTarget.STDERR)
         assert PrettyPrinter.mode is PrettyPrintMode.SILENT
-        assert logging.getLogger("pipelex").level == LogLevel.OFF.int_logging_level
 
-    def test_no_hub_path_skips_hub_call_safely(self, mocker: MockerFixture) -> None:
+    def test_apply_discipline_no_hub_path_skips_hub_call_safely(self, mocker: MockerFixture) -> None:
         """When no hub is installed (broken-config doctor path), the helper must still pin
         log + PrettyPrinter without raising — the hub call is gated on get_optional_instance.
         """
@@ -65,4 +101,3 @@ class TestApplyAgentCliOutputDiscipline:
 
         mock_redirect.assert_called_once()
         assert PrettyPrinter.mode is PrettyPrintMode.SILENT
-        assert logging.getLogger("pipelex").level == LogLevel.OFF.int_logging_level

--- a/tests/unit/pipelex/cli/test_agent_cli_output_discipline.py
+++ b/tests/unit/pipelex/cli/test_agent_cli_output_discipline.py
@@ -18,6 +18,7 @@ would ship green. This module covers the real side effects.
 from __future__ import annotations
 
 import logging
+import sys
 from typing import TYPE_CHECKING
 
 import pytest
@@ -30,28 +31,42 @@ from pipelex.cli.agent_cli.commands.agent_cli_factory import (
     silence_logging_for_agent_cli,
 )
 from pipelex.system.console_target import ConsoleTarget
-from pipelex.tools.log.log_levels import LOGGING_LEVEL_OFF
 from pipelex.tools.misc.pretty import PrettyPrinter, PrettyPrintMode
+
+# Loggers armed by the test below at non-OFF levels. Their ``.level`` attribute is
+# snapshot in the autouse fixture and restored after each test so the per-logger state
+# does not leak into the rest of the suite (other tests may rely on the default NOTSET).
+_ARMED_LOGGER_NAMES: tuple[str, ...] = (
+    "anthropic",
+    "httpx",
+    "some.transitive.dep.we.never.heard.of",
+)
 
 
 class TestAgentCliOutputDiscipline:
     @pytest.fixture(autouse=True)
     def _restore_globals(self):
-        """Restore PrettyPrinter.mode and process-global ``logging.disable`` after each
-        test so the agent CLI cutoff does not leak into other tests in the suite.
+        """Restore PrettyPrinter.mode, the process-global ``logging.disable`` threshold,
+        AND the per-logger ``.level`` for every logger this test class arms — otherwise
+        the levels set on shared module-level loggers (``anthropic``, ``httpx``, ...) leak
+        into other tests that assume default NOTSET.
         """
         original_mode = PrettyPrinter.mode
         original_disable = logging.root.manager.disable
+        original_levels = {name: logging.getLogger(name).level for name in _ARMED_LOGGER_NAMES}
         yield
         PrettyPrinter.mode = original_mode
         logging.disable(original_disable)
+        for name, level in original_levels.items():
+            logging.getLogger(name).setLevel(level)
 
     def test_silence_logging_disables_every_third_party_logger_regardless_of_configured_level(self) -> None:
         """Regression: ``silence_logging_for_agent_cli`` must call ``logging.disable`` at
-        ``LOGGING_LEVEL_OFF`` so that every logger — pipelex, anthropic, httpx, botocore,
+        ``sys.maxsize`` so that every logger — pipelex, anthropic, httpx, botocore,
         openai, anything a transitive dep ever creates — has ``isEnabledFor`` short-circuit
-        to False before its own level check fires. This is the only defense that scales
-        without an enumeration of package names.
+        to False before its own level check fires, at every level (including custom levels
+        above CRITICAL). This is the only defense that scales without an enumeration of
+        package names.
         """
         # Arm a couple of loggers at INFO/WARNING as if a downstream library had configured
         # them. The global disable must override their own level checks.
@@ -65,7 +80,7 @@ class TestAgentCliOutputDiscipline:
 
         silence_logging_for_agent_cli()
 
-        assert logging.root.manager.disable == LOGGING_LEVEL_OFF
+        assert logging.root.manager.disable == sys.maxsize
         assert not anthropic_logger.isEnabledFor(logging.INFO)
         assert not anthropic_logger.isEnabledFor(logging.CRITICAL)
         assert not httpx_logger.isEnabledFor(logging.WARNING)

--- a/tests/unit/pipelex/cli/test_agent_doctor_cmd.py
+++ b/tests/unit/pipelex/cli/test_agent_doctor_cmd.py
@@ -23,16 +23,20 @@ class TestAgentDoctorCmd:
 
     @pytest.fixture(autouse=True)
     def _mock_doctor_bootstrap(self, mocker: MockerFixture) -> None:
-        """Stub the runtime bootstrap so unit tests don't load real config or reconfigure logging.
+        """Stub the runtime bootstrap so unit tests don't load real config or mutate
+        global logging / PrettyPrinter state.
 
         ``setup_doctor_runtime`` instantiates a PipelexHub, loads config from disk, and
         calls ``log.configure`` (once-per-process). ``apply_agent_cli_output_discipline``
-        mutates global PrettyPrinter mode and the hub's console target. Both are out of
-        scope for these tests — they cover the command's output shape, not the runtime
-        bootstrap mechanics.
+        mutates global PrettyPrinter mode and the hub's console target.
+        ``silence_logging_for_agent_cli`` arms ``logging.disable`` at LOGGING_LEVEL_OFF
+        — process-global and would leak into other tests in the suite. All three are
+        out of scope for these tests — they cover the command's output shape, not the
+        runtime bootstrap mechanics.
         """
         mocker.patch("pipelex.cli.agent_cli.commands.doctor_cmd.setup_doctor_runtime")
         mocker.patch("pipelex.cli.agent_cli.commands.doctor_cmd.apply_agent_cli_output_discipline")
+        mocker.patch("pipelex.cli.agent_cli.commands.doctor_cmd.silence_logging_for_agent_cli")
 
     def test_healthy_output_json(self, mocker: MockerFixture, capsys: pytest.CaptureFixture[str]) -> None:
         """Healthy checks should produce JSON with all_healthy=true and no recommended_actions."""

--- a/tests/unit/pipelex/cli/test_agent_doctor_cmd.py
+++ b/tests/unit/pipelex/cli/test_agent_doctor_cmd.py
@@ -29,7 +29,7 @@ class TestAgentDoctorCmd:
         ``setup_doctor_runtime`` instantiates a PipelexHub, loads config from disk, and
         calls ``log.configure`` (once-per-process). ``apply_agent_cli_output_discipline``
         mutates global PrettyPrinter mode and the hub's console target.
-        ``silence_logging_for_agent_cli`` arms ``logging.disable`` at LOGGING_LEVEL_OFF
+        ``silence_logging_for_agent_cli`` arms ``logging.disable`` at ``sys.maxsize``
         — process-global and would leak into other tests in the suite. All three are
         out of scope for these tests — they cover the command's output shape, not the
         runtime bootstrap mechanics.

--- a/tests/unit/pipelex/cli/test_agent_models_cmd.py
+++ b/tests/unit/pipelex/cli/test_agent_models_cmd.py
@@ -105,11 +105,11 @@ def _setup_mocks(mocker: MockerFixture) -> None:
 class TestAgentModelsCmd:
     """Tests for agent_models_cmd JSON output with --type and --backend filters."""
 
-    def test_no_filters_returns_all_categories(self, agent_ctx: Any, mocker: MockerFixture, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_no_filters_returns_all_categories(self, mocker: MockerFixture, capsys: pytest.CaptureFixture[str]) -> None:
         """No filters should return all categories in every section."""
         _setup_mocks(mocker)
 
-        agent_models_cmd(ctx=agent_ctx, output_format=CliOutputFormat.JSON)
+        agent_models_cmd(output_format=CliOutputFormat.JSON)
 
         parsed = json.loads(capsys.readouterr().out)
         assert parsed["success"] is True
@@ -118,21 +118,21 @@ class TestAgentModelsCmd:
             assert "img_gen" in parsed[section], f"img_gen missing from {section}"
             assert "extract" in parsed[section], f"extract missing from {section}"
 
-    def test_no_talent_mappings_in_output(self, agent_ctx: Any, mocker: MockerFixture, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_no_talent_mappings_in_output(self, mocker: MockerFixture, capsys: pytest.CaptureFixture[str]) -> None:
         """Output should not contain talent_mappings or usage hint."""
         _setup_mocks(mocker)
 
-        agent_models_cmd(ctx=agent_ctx, output_format=CliOutputFormat.JSON)
+        agent_models_cmd(output_format=CliOutputFormat.JSON)
 
         parsed = json.loads(capsys.readouterr().out)
         assert "talent_mappings" not in parsed
         assert "talent_mappings_usage_hint" not in parsed
 
-    def test_no_filters_preset_content(self, agent_ctx: Any, mocker: MockerFixture, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_no_filters_preset_content(self, mocker: MockerFixture, capsys: pytest.CaptureFixture[str]) -> None:
         """No filters should include all preset entries with correct data."""
         _setup_mocks(mocker)
 
-        agent_models_cmd(ctx=agent_ctx, output_format=CliOutputFormat.JSON)
+        agent_models_cmd(output_format=CliOutputFormat.JSON)
 
         parsed = json.loads(capsys.readouterr().out)
         llm_preset_names = [preset["name"] for preset in parsed["presets"]["llm"]]
@@ -141,11 +141,11 @@ class TestAgentModelsCmd:
         fast_preset = next(preset for preset in parsed["presets"]["llm"] if preset["name"] == "fast")
         assert fast_preset["description"] == "Fast LLM"
 
-    def test_type_llm_only(self, agent_ctx: Any, mocker: MockerFixture, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_type_llm_only(self, mocker: MockerFixture, capsys: pytest.CaptureFixture[str]) -> None:
         """--type llm should return only llm keys in all sections."""
         _setup_mocks(mocker)
 
-        agent_models_cmd(ctx=agent_ctx, model_type=[ModelCategory.LLM], output_format=CliOutputFormat.JSON)
+        agent_models_cmd(model_type=[ModelCategory.LLM], output_format=CliOutputFormat.JSON)
 
         parsed = json.loads(capsys.readouterr().out)
         for section in ("presets", "aliases", "waterfalls"):
@@ -153,11 +153,11 @@ class TestAgentModelsCmd:
             assert "img_gen" not in parsed[section], f"img_gen should not be in {section}"
             assert "extract" not in parsed[section], f"extract should not be in {section}"
 
-    def test_type_extract_only(self, agent_ctx: Any, mocker: MockerFixture, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_type_extract_only(self, mocker: MockerFixture, capsys: pytest.CaptureFixture[str]) -> None:
         """--type extract should return only extract keys in all sections."""
         _setup_mocks(mocker)
 
-        agent_models_cmd(ctx=agent_ctx, model_type=[ModelCategory.EXTRACT], output_format=CliOutputFormat.JSON)
+        agent_models_cmd(model_type=[ModelCategory.EXTRACT], output_format=CliOutputFormat.JSON)
 
         parsed = json.loads(capsys.readouterr().out)
         for section in ("presets", "aliases", "waterfalls"):
@@ -165,11 +165,11 @@ class TestAgentModelsCmd:
             assert "llm" not in parsed[section], f"llm should not be in {section}"
             assert "img_gen" not in parsed[section], f"img_gen should not be in {section}"
 
-    def test_type_img_gen_only(self, agent_ctx: Any, mocker: MockerFixture, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_type_img_gen_only(self, mocker: MockerFixture, capsys: pytest.CaptureFixture[str]) -> None:
         """--type img_gen should return only img_gen keys in all sections."""
         _setup_mocks(mocker)
 
-        agent_models_cmd(ctx=agent_ctx, model_type=[ModelCategory.IMG_GEN], output_format=CliOutputFormat.JSON)
+        agent_models_cmd(model_type=[ModelCategory.IMG_GEN], output_format=CliOutputFormat.JSON)
 
         parsed = json.loads(capsys.readouterr().out)
         for section in ("presets", "aliases", "waterfalls"):
@@ -177,11 +177,11 @@ class TestAgentModelsCmd:
             assert "llm" not in parsed[section], f"llm should not be in {section}"
             assert "extract" not in parsed[section], f"extract should not be in {section}"
 
-    def test_type_llm_and_img_gen(self, agent_ctx: Any, mocker: MockerFixture, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_type_llm_and_img_gen(self, mocker: MockerFixture, capsys: pytest.CaptureFixture[str]) -> None:
         """--type llm --type img_gen should return both llm and img_gen, but not extract."""
         _setup_mocks(mocker)
 
-        agent_models_cmd(ctx=agent_ctx, model_type=[ModelCategory.LLM, ModelCategory.IMG_GEN], output_format=CliOutputFormat.JSON)
+        agent_models_cmd(model_type=[ModelCategory.LLM, ModelCategory.IMG_GEN], output_format=CliOutputFormat.JSON)
 
         parsed = json.loads(capsys.readouterr().out)
         for section in ("presets", "aliases", "waterfalls"):
@@ -189,11 +189,11 @@ class TestAgentModelsCmd:
             assert "img_gen" in parsed[section], f"img_gen missing from {section}"
             assert "extract" not in parsed[section], f"extract should not be in {section}"
 
-    def test_backend_filter_openai(self, agent_ctx: Any, mocker: MockerFixture, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_backend_filter_openai(self, mocker: MockerFixture, capsys: pytest.CaptureFixture[str]) -> None:
         """--backend openai should filter presets/aliases/waterfalls to only openai-backed models."""
         _setup_mocks(mocker)
 
-        agent_models_cmd(ctx=agent_ctx, backend="openai", output_format=CliOutputFormat.JSON)
+        agent_models_cmd(backend="openai", output_format=CliOutputFormat.JSON)
 
         parsed = json.loads(capsys.readouterr().out)
         llm_preset_names = [preset["name"] for preset in parsed["presets"]["llm"]]
@@ -204,11 +204,11 @@ class TestAgentModelsCmd:
         assert "hd-image" in img_gen_preset_names
         assert len(parsed["presets"]["extract"]) == 0
 
-    def test_backend_filter_anthropic(self, agent_ctx: Any, mocker: MockerFixture, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_backend_filter_anthropic(self, mocker: MockerFixture, capsys: pytest.CaptureFixture[str]) -> None:
         """--backend anthropic should include only anthropic-backed models."""
         _setup_mocks(mocker)
 
-        agent_models_cmd(ctx=agent_ctx, backend="anthropic", output_format=CliOutputFormat.JSON)
+        agent_models_cmd(backend="anthropic", output_format=CliOutputFormat.JSON)
 
         parsed = json.loads(capsys.readouterr().out)
         llm_preset_names = [preset["name"] for preset in parsed["presets"]["llm"]]
@@ -216,11 +216,11 @@ class TestAgentModelsCmd:
         assert "fast" not in llm_preset_names
         assert "best-llm" in parsed["aliases"]["llm"]
 
-    def test_type_and_backend_combined(self, agent_ctx: Any, mocker: MockerFixture, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_type_and_backend_combined(self, mocker: MockerFixture, capsys: pytest.CaptureFixture[str]) -> None:
         """--type llm --backend openai should combine both filters."""
         _setup_mocks(mocker)
 
-        agent_models_cmd(ctx=agent_ctx, model_type=[ModelCategory.LLM], backend="openai", output_format=CliOutputFormat.JSON)
+        agent_models_cmd(model_type=[ModelCategory.LLM], backend="openai", output_format=CliOutputFormat.JSON)
 
         parsed = json.loads(capsys.readouterr().out)
         assert "llm" in parsed["presets"]
@@ -230,11 +230,11 @@ class TestAgentModelsCmd:
         assert "fast" in llm_preset_names
         assert "smart" not in llm_preset_names
 
-    def test_backend_nonexistent(self, agent_ctx: Any, mocker: MockerFixture, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_backend_nonexistent(self, mocker: MockerFixture, capsys: pytest.CaptureFixture[str]) -> None:
         """--backend nonexistent should produce empty presets/aliases/waterfalls."""
         _setup_mocks(mocker)
 
-        agent_models_cmd(ctx=agent_ctx, backend="nonexistent", output_format=CliOutputFormat.JSON)
+        agent_models_cmd(backend="nonexistent", output_format=CliOutputFormat.JSON)
 
         parsed = json.loads(capsys.readouterr().out)
         assert parsed["success"] is True
@@ -242,11 +242,11 @@ class TestAgentModelsCmd:
             for category in ("llm", "img_gen", "extract"):
                 assert len(parsed[section][category]) == 0, f"{section}.{category} should be empty"
 
-    def test_waterfalls_backend_filter(self, agent_ctx: Any, mocker: MockerFixture, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_waterfalls_backend_filter(self, mocker: MockerFixture, capsys: pytest.CaptureFixture[str]) -> None:
         """--backend anthropic should include llm waterfall (has claude-sonnet) but not img waterfall."""
         _setup_mocks(mocker)
 
-        agent_models_cmd(ctx=agent_ctx, backend="anthropic", output_format=CliOutputFormat.JSON)
+        agent_models_cmd(backend="anthropic", output_format=CliOutputFormat.JSON)
 
         parsed = json.loads(capsys.readouterr().out)
         assert "llm-wf" in parsed["waterfalls"]["llm"]

--- a/tests/unit/pipelex/cli/test_agent_validate_cmd.py
+++ b/tests/unit/pipelex/cli/test_agent_validate_cmd.py
@@ -26,7 +26,6 @@ class TestValidateBundleCmd:
 
     def test_graph_generation_failure_emits_single_json_error(
         self,
-        agent_ctx: Any,
         mocker: MockerFixture,
         capsys: pytest.CaptureFixture[str],
         tmp_path: Path,
@@ -71,7 +70,6 @@ class TestValidateBundleCmd:
 
         with pytest.raises(typer.Exit) as exc_info:
             validate_bundle_cmd(
-                ctx=agent_ctx,
                 path=str(mthds_file),
                 graph=True,
                 output_format=CliOutputFormat.JSON,

--- a/tests/unit/pipelex/cli/test_check_model_cmd.py
+++ b/tests/unit/pipelex/cli/test_check_model_cmd.py
@@ -97,7 +97,6 @@ def _setup_mocks(mocker: MockerFixture) -> None:
 
 
 def _run_check(
-    agent_ctx: Any,
     mocker: MockerFixture,
     capsys: pytest.CaptureFixture[str],
     name: str,
@@ -106,7 +105,7 @@ def _run_check(
 ) -> dict[str, Any]:
     """Run check-model and return parsed JSON output."""
     _setup_mocks(mocker)
-    agent_check_model_cmd(ctx=agent_ctx, name=name, model_type=model_type, output_format=output_format)
+    agent_check_model_cmd(name=name, model_type=model_type, output_format=output_format)
     parsed: dict[str, Any] = json.loads(capsys.readouterr().out)
     return parsed
 
@@ -114,57 +113,57 @@ def _run_check(
 class TestCheckModelCmd:
     """Tests for agent_check_model_cmd validation and fuzzy matching."""
 
-    def test_valid_preset(self, agent_ctx: Any, mocker: MockerFixture, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_valid_preset(self, mocker: MockerFixture, capsys: pytest.CaptureFixture[str]) -> None:
         """A known preset name with $ sigil should be valid."""
-        result = _run_check(agent_ctx, mocker, capsys, "$writing-creative")
+        result = _run_check(mocker, capsys, "$writing-creative")
         assert result["valid"] is True
         assert result["kind"] == "preset"
 
-    def test_valid_alias(self, agent_ctx: Any, mocker: MockerFixture, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_valid_alias(self, mocker: MockerFixture, capsys: pytest.CaptureFixture[str]) -> None:
         """A known alias name with @ sigil should be valid."""
-        result = _run_check(agent_ctx, mocker, capsys, "@best-claude")
+        result = _run_check(mocker, capsys, "@best-claude")
         assert result["valid"] is True
         assert result["kind"] == "alias"
 
-    def test_valid_handle(self, agent_ctx: Any, mocker: MockerFixture, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_valid_handle(self, mocker: MockerFixture, capsys: pytest.CaptureFixture[str]) -> None:
         """A known bare model handle should be valid."""
-        result = _run_check(agent_ctx, mocker, capsys, "claude-4.5-sonnet")
+        result = _run_check(mocker, capsys, "claude-4.5-sonnet")
         assert result["valid"] is True
         assert result["kind"] == "handle"
 
-    def test_invalid_preset_with_fuzzy_suggestions(self, agent_ctx: Any, mocker: MockerFixture, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_invalid_preset_with_fuzzy_suggestions(self, mocker: MockerFixture, capsys: pytest.CaptureFixture[str]) -> None:
         """A typo in a preset name should return fuzzy suggestions with $ prefix."""
-        result = _run_check(agent_ctx, mocker, capsys, "$writting-creative")
+        result = _run_check(mocker, capsys, "$writting-creative")
         assert result["valid"] is False
         assert any("$writing-creative" in suggestion for suggestion in result["suggestions"])
 
-    def test_wrong_sigil_detected(self, agent_ctx: Any, mocker: MockerFixture, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_wrong_sigil_detected(self, mocker: MockerFixture, capsys: pytest.CaptureFixture[str]) -> None:
         """Using $ for a name that exists as an alias should produce a wrong-sigil hint."""
-        result = _run_check(agent_ctx, mocker, capsys, "$best-claude")
+        result = _run_check(mocker, capsys, "$best-claude")
         assert result["valid"] is False
         assert any("@best-claude" in hint for hint in result["wrong_sigil_hints"])
 
-    def test_invalid_handle_cross_collection_suggestions(self, agent_ctx: Any, mocker: MockerFixture, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_invalid_handle_cross_collection_suggestions(self, mocker: MockerFixture, capsys: pytest.CaptureFixture[str]) -> None:
         """A bare name matching a preset should suggest the prefixed version."""
-        result = _run_check(agent_ctx, mocker, capsys, "writing-creative")
+        result = _run_check(mocker, capsys, "writing-creative")
         assert result["valid"] is False
         assert any("$writing-creative" in hint for hint in result["wrong_sigil_hints"])
 
-    def test_invalid_handle_fuzzy_suggestions(self, agent_ctx: Any, mocker: MockerFixture, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_invalid_handle_fuzzy_suggestions(self, mocker: MockerFixture, capsys: pytest.CaptureFixture[str]) -> None:
         """A typo in a handle should return fuzzy suggestions without sigil prefix."""
-        result = _run_check(agent_ctx, mocker, capsys, "claude-4.5-sonet")
+        result = _run_check(mocker, capsys, "claude-4.5-sonet")
         assert result["valid"] is False
         assert "claude-4.5-sonnet" in result["suggestions"]
 
-    def test_completely_unknown_name(self, agent_ctx: Any, mocker: MockerFixture, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_completely_unknown_name(self, mocker: MockerFixture, capsys: pytest.CaptureFixture[str]) -> None:
         """A completely unknown name should return no suggestions."""
-        result = _run_check(agent_ctx, mocker, capsys, "$zzz-nonexistent-xyz")
+        result = _run_check(mocker, capsys, "$zzz-nonexistent-xyz")
         assert result["valid"] is False
         assert len(result["suggestions"]) == 0
 
-    def test_json_output_structure(self, agent_ctx: Any, mocker: MockerFixture, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_json_output_structure(self, mocker: MockerFixture, capsys: pytest.CaptureFixture[str]) -> None:
         """JSON output should contain all expected keys on failure."""
-        result = _run_check(agent_ctx, mocker, capsys, "$nonexistent")
+        result = _run_check(mocker, capsys, "$nonexistent")
         assert result["success"] is True
         assert result["valid"] is False
         assert "suggestions" in result
@@ -172,23 +171,23 @@ class TestCheckModelCmd:
         assert "cross_collection_suggestions" in result
         assert result["model_type"] == "llm"
 
-    def test_markdown_valid_output(self, agent_ctx: Any, mocker: MockerFixture, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_markdown_valid_output(self, mocker: MockerFixture, capsys: pytest.CaptureFixture[str]) -> None:
         """Markdown output for a valid reference should be a single confirmation line."""
         _setup_mocks(mocker)
-        agent_check_model_cmd(ctx=agent_ctx, name="$writing-creative", model_type=ModelCategory.LLM, output_format=CliOutputFormat.MARKDOWN)
+        agent_check_model_cmd(name="$writing-creative", model_type=ModelCategory.LLM, output_format=CliOutputFormat.MARKDOWN)
         output = capsys.readouterr().out.strip()
         assert output == "$writing-creative is a valid llm preset."
 
-    def test_markdown_invalid_output_has_suggestions(self, agent_ctx: Any, mocker: MockerFixture, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_markdown_invalid_output_has_suggestions(self, mocker: MockerFixture, capsys: pytest.CaptureFixture[str]) -> None:
         """Markdown output for an invalid reference should include 'Did you mean' suggestions."""
         _setup_mocks(mocker)
-        agent_check_model_cmd(ctx=agent_ctx, name="$writting-creative", model_type=ModelCategory.LLM, output_format=CliOutputFormat.MARKDOWN)
+        agent_check_model_cmd(name="$writting-creative", model_type=ModelCategory.LLM, output_format=CliOutputFormat.MARKDOWN)
         output = capsys.readouterr().out
         assert "is not a valid" in output
         assert "Did you mean:" in output
 
-    def test_valid_waterfall(self, agent_ctx: Any, mocker: MockerFixture, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_valid_waterfall(self, mocker: MockerFixture, capsys: pytest.CaptureFixture[str]) -> None:
         """A known waterfall name with ~ sigil should be valid."""
-        result = _run_check(agent_ctx, mocker, capsys, "~robust-llm")
+        result = _run_check(mocker, capsys, "~robust-llm")
         assert result["valid"] is True
         assert result["kind"] == "waterfall"

--- a/uv.lock
+++ b/uv.lock
@@ -3644,7 +3644,7 @@ wheels = [
 
 [[package]]
 name = "pipelex"
-version = "0.30.0"
+version = "0.30.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Release v0.30.1

Bumps version from `0.30.0` to `0.30.1`.

### Changelog

### Fixed

- **`pipelex-agent` now silences all pipelex logs on stderr regardless of user TOML.** The agent CLI is machine-consumed: stdout is reserved for the structured success envelope (JSON / markdown) and stderr for the structured error envelope. Free-floating `log.*` calls — even a single `log.debug` from `telemetry_factory.py` or a `log.warning` from `validation_error_categorizer.py` — would corrupt the stderr channel for downstream parsers (`mthds-js`'s `PipelexRunner` doing `JSON.parse(stderr)` on the validate hook). `make_pipelex_for_agent_cli` now injects `config_overrides` into `Pipelex.make()` that pin `default_log_level = OFF` and `package_log_levels.pipelex = OFF` from the very first `log.configure` call — so a user setting `[pipelex.log_config.package_log_levels] pipelex = "DEBUG"` in `~/.pipelex/pipelex.toml` can no longer leak DEBUG/INFO/WARNING lines onto the agent CLI's stderr channel. The DEBUG log line in `telemetry_factory.py:77` itself is unchanged — it's still useful diagnostic info for the human `pipelex` CLI.

### Changed

- **`pipelex-agent` no longer accepts `--log-level`.** Log suppression is unconditional by design — there is no verbosity setting on the agent CLI. The `log_level` parameter is removed from `make_pipelex_for_agent_cli()` and `apply_agent_cli_output_discipline()`, and the corresponding `ctx.obj["log_level"]` plumbing is gone from every caller. For verbose debugging, use the human `pipelex` CLI, which honors the user's TOML log config.

- **`pipelex/cli/commands/doctor_cmd.py::setup_doctor_runtime` now `deep_update`s `log_config_overrides` into the loaded config** (was a flat-merge that silently replaced nested dicts like `package_log_levels`). With the flat merge, pinning `package_log_levels.pipelex = OFF` for the agent doctor path would have wiped out all the third-party package levels (`anthropic`, `asyncio`, `botocore`, ...) shipped in the default config. The deep merge preserves them.

- **Removed `ctx: typer.Context` from 8 agent CLI commands that no longer used it.** `validate/{pipe,bundle,method}_cmd.py`, `inputs/{pipe,bundle,method}_cmd.py`, `models_cmd.py`, `check_model_cmd.py` had `ctx.obj["log_level"]` as their only ctx usage; with `--log-level` gone, the parameter became dead weight. The `run/` commands keep `ctx` because they still read `ctx.obj["runner"]`. Test callers (and the now-unused `agent_ctx` conftest fixture) updated to match.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Silences all Python logging in `pipelex-agent` from startup and removes `--log-level` so stdout/stderr stay strictly structured for downstream parsers (e.g. `mthds-js`). Also deep‑merges doctor log overrides, hardens tests (e2e + isolation), and bumps to v0.30.1.

- **Bug Fixes**
  - Add a process‑global cutoff via `silence_logging_for_agent_cli()` (`logging.disable(sys.maxsize)`) wired in the Typer `app_callback` so every subcommand (incl. `init` and `accept-gateway-terms`) is quiet; keep a per‑call backstop in command bodies. Init also injects config overrides to pin `default_log_level=OFF`, `package_log_levels.pipelex=OFF`, and route both Rich consoles to stderr.
  - `doctor` now deep‑merges `log_config_overrides` to preserve third‑party package levels.
  - Tests: swap e2e TOML edits to tomlkit and relax stderr checks; restore `PrettyPrinter.mode` and `logging.disable` in fixtures to prevent global state leaks under xdist.

- **Changed**
  - Remove `--log-level` from `pipelex-agent`; delete all `ctx.obj["log_level"]` plumbing.
  - Drop unused `ctx: typer.Context` from 8 agent commands; keep it only for `run/*` commands that use `runner`.

<sup>Written for commit 62f0e944abba416140682712e61e030b583be5fe. Summary will update on new commits. <a href="https://cubic.dev/pr/Pipelex/pipelex/pull/939?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

