### PR TITLE
Release v0.30.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v0.30.2] - 2026-05-26
+
+### Changed
+
+- **`pipelex-agent` markdown error envelope no longer includes the `## Error source` stack-frame section.** Markdown is the agent / human-facing channel; internal frames like `LibraryError @ pipelex/libraries/library.py:140` are noise for an LLM trying to fix a `.mthds` file and forced every consumer (e.g. the `mthds-plugins` validate hook) to strip them. The `error_source` field remains in the JSON envelope (`--error-format json`) untouched for programmatic consumers — same shape, same cause-chain ordering — so any tooling that parses JSON keeps the full diagnostic surface. The `## Details` section (which carries `error_domain` and other structured fields) is unchanged. No change to error categorization, `error_domain` values, message wording, or stdout/stderr routing.
+
 ## [v0.30.1] - 2026-05-26
 
 ### Fixed

--- a/pipelex/cli/agent_cli/CLAUDE.md
+++ b/pipelex/cli/agent_cli/CLAUDE.md
@@ -18,7 +18,7 @@ Markdown structure per command:
 - `run`: `# Pipeline run complete`, a `## Result` section (the rendered `main_stuff` markdown with `--with-memory`, otherwise the concept JSON in a fenced block), and output / graph file paths.
 - `validate`: `# Validation passed`, the bundle path when relevant, and a list of validated pipes with their status.
 - `init`: `# Pipelex initialized` with target directory, enabled backends, and routing profile.
-- error path: `# Error: <error_type>`, the message, the hint as a `> 💡` callout, a `## Details` section, and `## Error source` as a code block.
+- error path: `# Error: <error_type>`, the message, the hint as a `> 💡` callout, and a `## Details` section. `error_source` (internal stack frames) is omitted from markdown — it remains in the JSON envelope (`--error-format json`) for programmatic consumers.
 
 ## Companion: Agent Skills
 

--- a/pipelex/cli/agent_cli/commands/agent_output.py
+++ b/pipelex/cli/agent_cli/commands/agent_output.py
@@ -279,7 +279,10 @@ def _assemble_error_payload(message: str, error_type: str, cause: BaseException 
 
 
 # Payload keys that the markdown renderer treats specially (heading / body /
-# tip / code block) rather than listing under the "Details" section.
+# tip) or omits entirely rather than listing under the "Details" section.
+# ``error_source`` is dropped from markdown — it's internal stack frames that
+# don't help an LLM fix a `.mthds` file. The field stays in the JSON envelope
+# for programmatic consumers.
 _MARKDOWN_RESERVED_KEYS: frozenset[str] = frozenset({"error", "error_type", "message", "hint", "error_source"})
 
 
@@ -301,10 +304,6 @@ def _render_error_markdown(payload: dict[str, Any]) -> str:
             else:
                 lines += [f"- **{key}:**", "", "```json", clean_json_dumps(value, indent=2), "```", ""]
 
-    error_source = payload.get("error_source")
-    if error_source:
-        lines += ["", "## Error source", "", "```", *(str(frame) for frame in error_source), "```"]
-
     return "\n".join(lines)
 
 
@@ -319,8 +318,10 @@ def agent_error_markdown(message: str, error_type: str, cause: BaseException | N
     """Print a markdown-rendered error to stderr and exit with code 1.
 
     The markdown sibling of :func:`agent_error`'s JSON path: an error-type
-    heading, the message body, the hint as a tip callout, structured fields
-    under a Details section, and ``error_source`` as a code block.
+    heading, the message body, the hint as a tip callout, and structured fields
+    under a Details section. ``error_source`` (internal stack frames) is
+    deliberately omitted from markdown — the field remains in the JSON envelope
+    for programmatic consumers.
 
     Args:
         message: Human-readable error message.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pipelex"
-version = "0.30.1"
+version = "0.30.2"
 description = "Execute composable AI methods declared in the MTHDS open standard"
 authors = [{ name = "Evotis S.A.S.", email = "oss@pipelex.com" }]
 maintainers = [{ name = "Pipelex staff", email = "oss@pipelex.com" }]

--- a/tests/integration/pipelex/cli/agent_cli/test_run_error_chain.py
+++ b/tests/integration/pipelex/cli/agent_cli/test_run_error_chain.py
@@ -108,7 +108,13 @@ class TestRunErrorChain:
         mocker: MockerFixture,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
-        """The markdown error output carries the error type, message, hint, and source frames."""
+        """The markdown error output carries the error type, message, hint, and structured details — but no source frames.
+
+        ``error_source`` (the internal Python stack chain — ``PipeRouterError``,
+        ``LLMCompletionError``, etc.) is deliberately stripped from markdown. It's
+        noise for an LLM trying to fix a `.mthds` file. The JSON test above is what
+        pins the wrapping-chain contract.
+        """
         self._invoke_failing_run(mocker, CliOutputFormat.MARKDOWN)
 
         captured = capsys.readouterr()
@@ -118,11 +124,15 @@ class TestRunErrorChain:
         assert markdown.startswith("# Error: PipelineExecutionError")
         assert WORKER_ERROR_MESSAGE in markdown
         assert "💡" in markdown  # hint callout
-        assert "## Error source" in markdown
         assert "error_category" in markdown
         assert "transient" in markdown
-        # The source code block names the wrapping chain.
-        assert "PipeRouterError" in markdown
-        assert "LLMCompletionError" in markdown
+        # The whole stack-trace section is gone. The stack-frame format from
+        # _build_error_source is "<ExceptionType> @ <file>:<line> (in <func>)" —
+        # check the section header and the frame format are both absent.
+        # Note: structured cause fields like ``cause_type`` may legitimately
+        # surface exception names under ``## Details``; that's not a stack frame.
+        assert "## Error source" not in markdown
+        assert " @ pipelex/" not in markdown
+        assert "(in " not in markdown
         with pytest.raises(json.JSONDecodeError):
             json.loads(markdown)

--- a/tests/unit/pipelex/cli/agent_cli/test_agent_error_format.py
+++ b/tests/unit/pipelex/cli/agent_cli/test_agent_error_format.py
@@ -40,8 +40,13 @@ class TestAgentErrorFormat:
         with pytest.raises(json.JSONDecodeError):
             json.loads(captured.err)
 
-    def test_agent_error_markdown_renders_hint_details_and_source(self, capsys: pytest.CaptureFixture[str]) -> None:
-        """agent_error_markdown renders the heading, hint callout, details, and source block."""
+    def test_agent_error_markdown_renders_hint_and_details_but_omits_source(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """agent_error_markdown renders the heading, hint callout, and details — but not the source block.
+
+        ``error_source`` (internal stack frames) is deliberately omitted from markdown — it's
+        noise for an LLM trying to fix a `.mthds` file. The field still appears in the JSON
+        envelope for programmatic consumers; that's covered by the integration test.
+        """
         cause = ValueError("bad value")
         with pytest.raises(typer.Exit):
             agent_error_markdown(
@@ -55,4 +60,5 @@ class TestAgentErrorFormat:
         assert "model issue" in err
         assert "💡" in err  # hint callout for a known error type
         assert "**pipe_code:** my_pipe" in err
-        assert "## Error source" in err
+        assert "## Error source" not in err
+        assert "error_source" not in err

--- a/uv.lock
+++ b/uv.lock
@@ -3644,7 +3644,7 @@ wheels = [
 
 [[package]]
 name = "pipelex"
-version = "0.30.1"
+version = "0.30.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Release v0.30.2

Bumps version from `0.30.1` to `0.30.2`.

### Changelog

### Changed

- **`pipelex-agent` markdown error envelope no longer includes the `## Error source` stack-frame section.** Markdown is the agent / human-facing channel; internal frames like `LibraryError @ pipelex/libraries/library.py:140` are noise for an LLM trying to fix a `.mthds` file and forced every consumer (e.g. the `mthds-plugins` validate hook) to strip them. The `error_source` field remains in the JSON envelope (`--error-format json`) untouched for programmatic consumers — same shape, same cause-chain ordering — so any tooling that parses JSON keeps the full diagnostic surface. The `## Details` section (which carries `error_domain` and other structured fields) is unchanged. No change to error categorization, `error_domain` values, message wording, or stdout/stderr routing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v0.30.2 removes the `## Error source` stack-frame section from `pipelex-agent` markdown errors to reduce noise. The full `error_source` stays in the JSON envelope for programmatic consumers (so tools like `mthds-plugins` no longer need to strip frames); docs and tests updated, version bumped, and no changes to error domains, messages, or JSON schema.

<sup>Written for commit 140458c55fcd3b0670546e32ee3fde386ed79545. Summary will update on new commits. <a href="https://cubic.dev/pr/Pipelex/pipelex/pull/940?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

