### PR TITLE
Release v0.30.3

### DIFF
--- a/.pipelex-dev/test_profiles.toml
+++ b/.pipelex-dev/test_profiles.toml
@@ -69,6 +69,7 @@ anthropic = [
   "claude-4.6-sonnet",
   "claude-4.6-opus",
   "claude-4.7-opus",
+  "claude-4.8-opus",
 ]
 
 # --- DeepSeek Models ---

--- a/.pipelex/inference/backends/anthropic.toml
+++ b/.pipelex/inference/backends/anthropic.toml
@@ -129,3 +129,14 @@ max_prompt_images = 100
 costs = { input = 5.0, output = 25.0 }
 thinking_mode = "adaptive"
 listed_constraints = ["temperature_unsupported"]
+
+# --- Claude 4.8 Series --------------------------------------------------------
+["claude-4.8-opus"]
+model_id = "claude-opus-4-8"
+max_tokens = 128000
+inputs = ["text", "images", "pdf"]
+outputs = ["text", "structured"]
+max_prompt_images = 100
+costs = { input = 5.0, output = 25.0 }
+thinking_mode = "adaptive"
+listed_constraints = ["temperature_unsupported"]

--- a/.pipelex/inference/backends/bedrock.toml
+++ b/.pipelex/inference/backends/bedrock.toml
@@ -156,3 +156,15 @@ max_prompt_images = 100
 costs = { input = 5.0, output = 25.0 }
 thinking_mode = "adaptive"
 listed_constraints = ["temperature_unsupported"]
+
+# --- Claude 4.8 Series --------------------------------------------------------
+["claude-4.8-opus"]
+sdk = "bedrock_anthropic"
+model_id = "global.anthropic.claude-opus-4-8"
+max_tokens = 128000
+inputs = ["text", "images", "pdf"]
+outputs = ["text", "structured"]
+max_prompt_images = 100
+costs = { input = 5.0, output = 25.0 }
+thinking_mode = "adaptive"
+listed_constraints = ["temperature_unsupported"]

--- a/.pipelex/inference/backends/pipelex_gateway_models.md
+++ b/.pipelex/inference/backends/pipelex_gateway_models.md
@@ -93,6 +93,14 @@ For configuration details, see the [documentation](https://docs.pipelex.com/late
 <td style="text-align:center;background-color:rgba(76,175,80,0.15)">✅</td>
 </tr>
 <tr>
+<td>claude-4.8-opus</td>
+<td style="text-align:center;background-color:rgba(33,150,243,0.15)">✅</td>
+<td style="text-align:center;background-color:rgba(33,150,243,0.15)">✅</td>
+<td style="text-align:center;background-color:rgba(33,150,243,0.15)">✅</td>
+<td style="text-align:center;background-color:rgba(76,175,80,0.15)">✅</td>
+<td style="text-align:center;background-color:rgba(76,175,80,0.15)">✅</td>
+</tr>
+<tr>
 <td>deepseek-v3.2</td>
 <td style="text-align:center;background-color:rgba(33,150,243,0.15)">✅</td>
 <td style="text-align:center;background-color:rgba(33,150,243,0.15)">❌</td>
@@ -606,6 +614,6 @@ For configuration details, see the [documentation](https://docs.pipelex.com/late
 
 
 > **AUTO-GENERATED FILE** - Do not edit manually.
-> Last updated: 2026-05-20T11:45:37Z
+> Last updated: 2026-05-28T20:52:54Z
 >
 > Run `pipelex-dev update-gateway-models` or `make ugm` to regenerate.

--- a/.pipelex/inference/backends/pipelex_gateway_models_plain.md
+++ b/.pipelex/inference/backends/pipelex_gateway_models_plain.md
@@ -34,6 +34,9 @@ For configuration details, see the [documentation](https://docs.pipelex.com/late
 - **claude-4.7-opus**
   - inputs: text, images, pdf
   - outputs: text, structured
+- **claude-4.8-opus**
+  - inputs: text, images, pdf
+  - outputs: text, structured
 - **deepseek-v3.2**
   - inputs: text
   - outputs: text, structured
@@ -226,6 +229,6 @@ For configuration details, see the [documentation](https://docs.pipelex.com/late
 
 
 > **AUTO-GENERATED FILE** - Do not edit manually.
-> Last updated: 2026-05-20T11:45:37Z
+> Last updated: 2026-05-28T20:52:54Z
 >
 > Run `pipelex-dev update-gateway-models` or `make ugm` to regenerate.

--- a/.pipelex/inference/deck/1_llm_deck.toml
+++ b/.pipelex/inference/deck/1_llm_deck.toml
@@ -32,16 +32,16 @@ for_object = "@default-general"
 ####################################################################################################
 
 [llm.aliases]
-best-gpt = "gpt-5.2"
-best-claude = "claude-4.7-opus"
+best-gpt = "gpt-5.5"
+best-claude = "claude-4.8-opus"
 best-gemini = "gemini-pro-latest"
 best-mistral = "mistral-large"
 
 # Default aliases (first choice from waterfalls)
 default-general = "claude-4.6-sonnet"
-default-premium = "claude-4.7-opus"
-default-premium-vision = "claude-4.7-opus"
-default-premium-structured = "claude-4.7-opus"
+default-premium = "claude-4.8-opus"
+default-premium-vision = "claude-4.8-opus"
+default-premium-structured = "claude-4.8-opus"
 default-large-context-code = "gemini-pro-latest"
 default-large-context-text = "gemini-flash-latest"
 default-small = "gpt-4o-mini"
@@ -64,7 +64,7 @@ writing-creative-cheap = { model = "@default-small-creative", temperature = 0.9,
 # Retrieval
 retrieval = { model = "@default-large-context-text", temperature = 0.1, description = "Data retrieval from large text corpora" }
 retrieval-cheap = { model = "gemini-flash-lite-latest", temperature = 0.1, description = "Cheap data retrieval from large text corpora" }
-retrieval-premium = { model = "claude-4.7-opus", temperature = 0.1, description = "Premium data retrieval with highest accuracy" }
+retrieval-premium = { model = "claude-4.8-opus", temperature = 0.1, description = "Premium data retrieval with highest accuracy" }
 
 # Engineering
 engineering-structured = { model = "@default-premium-structured", temperature = 0.2, description = "Structured engineering output (JSON, schemas)" }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v0.30.3] - 2026-05-28
+
+### Added
+
+- **`claude-4.8-opus` model** added to the `anthropic` and `bedrock` backends. Adaptive thinking mode, supports text / images / pdf in and structured outputs, `max_prompt_images = 100`, `max_tokens = 128000`, costs `{ input = 5.0, output = 25.0 }` per million tokens. Carries the `temperature_unsupported` constraint like `claude-4.7-opus`. Also available via the Pipelex Gateway.
+
 ## [v0.30.2] - 2026-05-26
 
 ### Changed

--- a/pipelex/kit/configs/inference/backends/anthropic.toml
+++ b/pipelex/kit/configs/inference/backends/anthropic.toml
@@ -129,3 +129,14 @@ max_prompt_images = 100
 costs = { input = 5.0, output = 25.0 }
 thinking_mode = "adaptive"
 listed_constraints = ["temperature_unsupported"]
+
+# --- Claude 4.8 Series --------------------------------------------------------
+["claude-4.8-opus"]
+model_id = "claude-opus-4-8"
+max_tokens = 128000
+inputs = ["text", "images", "pdf"]
+outputs = ["text", "structured"]
+max_prompt_images = 100
+costs = { input = 5.0, output = 25.0 }
+thinking_mode = "adaptive"
+listed_constraints = ["temperature_unsupported"]

--- a/pipelex/kit/configs/inference/backends/bedrock.toml
+++ b/pipelex/kit/configs/inference/backends/bedrock.toml
@@ -156,3 +156,15 @@ max_prompt_images = 100
 costs = { input = 5.0, output = 25.0 }
 thinking_mode = "adaptive"
 listed_constraints = ["temperature_unsupported"]
+
+# --- Claude 4.8 Series --------------------------------------------------------
+["claude-4.8-opus"]
+sdk = "bedrock_anthropic"
+model_id = "global.anthropic.claude-opus-4-8"
+max_tokens = 128000
+inputs = ["text", "images", "pdf"]
+outputs = ["text", "structured"]
+max_prompt_images = 100
+costs = { input = 5.0, output = 25.0 }
+thinking_mode = "adaptive"
+listed_constraints = ["temperature_unsupported"]

--- a/pipelex/kit/configs/inference/backends/pipelex_gateway_models.md
+++ b/pipelex/kit/configs/inference/backends/pipelex_gateway_models.md
@@ -93,6 +93,14 @@ For configuration details, see the [documentation](https://docs.pipelex.com/late
 <td style="text-align:center;background-color:rgba(76,175,80,0.15)">✅</td>
 </tr>
 <tr>
+<td>claude-4.8-opus</td>
+<td style="text-align:center;background-color:rgba(33,150,243,0.15)">✅</td>
+<td style="text-align:center;background-color:rgba(33,150,243,0.15)">✅</td>
+<td style="text-align:center;background-color:rgba(33,150,243,0.15)">✅</td>
+<td style="text-align:center;background-color:rgba(76,175,80,0.15)">✅</td>
+<td style="text-align:center;background-color:rgba(76,175,80,0.15)">✅</td>
+</tr>
+<tr>
 <td>deepseek-v3.2</td>
 <td style="text-align:center;background-color:rgba(33,150,243,0.15)">✅</td>
 <td style="text-align:center;background-color:rgba(33,150,243,0.15)">❌</td>
@@ -606,6 +614,6 @@ For configuration details, see the [documentation](https://docs.pipelex.com/late
 
 
 > **AUTO-GENERATED FILE** - Do not edit manually.
-> Last updated: 2026-05-20T11:45:37Z
+> Last updated: 2026-05-28T20:52:54Z
 >
 > Run `pipelex-dev update-gateway-models` or `make ugm` to regenerate.

--- a/pipelex/kit/configs/inference/backends/pipelex_gateway_models_plain.md
+++ b/pipelex/kit/configs/inference/backends/pipelex_gateway_models_plain.md
@@ -34,6 +34,9 @@ For configuration details, see the [documentation](https://docs.pipelex.com/late
 - **claude-4.7-opus**
   - inputs: text, images, pdf
   - outputs: text, structured
+- **claude-4.8-opus**
+  - inputs: text, images, pdf
+  - outputs: text, structured
 - **deepseek-v3.2**
   - inputs: text
   - outputs: text, structured
@@ -226,6 +229,6 @@ For configuration details, see the [documentation](https://docs.pipelex.com/late
 
 
 > **AUTO-GENERATED FILE** - Do not edit manually.
-> Last updated: 2026-05-20T11:45:37Z
+> Last updated: 2026-05-28T20:52:54Z
 >
 > Run `pipelex-dev update-gateway-models` or `make ugm` to regenerate.

--- a/pipelex/kit/configs/inference/deck/1_llm_deck.toml
+++ b/pipelex/kit/configs/inference/deck/1_llm_deck.toml
@@ -32,16 +32,16 @@ for_object = "@default-general"
 ####################################################################################################
 
 [llm.aliases]
-best-gpt = "gpt-5.2"
-best-claude = "claude-4.7-opus"
+best-gpt = "gpt-5.5"
+best-claude = "claude-4.8-opus"
 best-gemini = "gemini-pro-latest"
 best-mistral = "mistral-large"
 
 # Default aliases (first choice from waterfalls)
 default-general = "claude-4.6-sonnet"
-default-premium = "claude-4.7-opus"
-default-premium-vision = "claude-4.7-opus"
-default-premium-structured = "claude-4.7-opus"
+default-premium = "claude-4.8-opus"
+default-premium-vision = "claude-4.8-opus"
+default-premium-structured = "claude-4.8-opus"
 default-large-context-code = "gemini-pro-latest"
 default-large-context-text = "gemini-flash-latest"
 default-small = "gpt-4o-mini"
@@ -64,7 +64,7 @@ writing-creative-cheap = { model = "@default-small-creative", temperature = 0.9,
 # Retrieval
 retrieval = { model = "@default-large-context-text", temperature = 0.1, description = "Data retrieval from large text corpora" }
 retrieval-cheap = { model = "gemini-flash-lite-latest", temperature = 0.1, description = "Cheap data retrieval from large text corpora" }
-retrieval-premium = { model = "claude-4.7-opus", temperature = 0.1, description = "Premium data retrieval with highest accuracy" }
+retrieval-premium = { model = "claude-4.8-opus", temperature = 0.1, description = "Premium data retrieval with highest accuracy" }
 
 # Engineering
 engineering-structured = { model = "@default-premium-structured", temperature = 0.2, description = "Structured engineering output (JSON, schemas)" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pipelex"
-version = "0.30.2"
+version = "0.30.3"
 description = "Execute composable AI methods declared in the MTHDS open standard"
 authors = [{ name = "Evotis S.A.S.", email = "oss@pipelex.com" }]
 maintainers = [{ name = "Pipelex staff", email = "oss@pipelex.com" }]

--- a/uv.lock
+++ b/uv.lock
@@ -3644,7 +3644,7 @@ wheels = [
 
 [[package]]
 name = "pipelex"
-version = "0.30.2"
+version = "0.30.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Release v0.30.3

Bumps version from `0.30.2` to `0.30.3`.

### Changelog

### Added

- **`claude-4.8-opus` model** added to the `anthropic` and `bedrock` backends. Adaptive thinking mode, supports text / images / pdf in and structured outputs, `max_prompt_images = 100`, `max_tokens = 128000`, costs `{ input = 5.0, output = 25.0 }` per million tokens. Carries the `temperature_unsupported` constraint like `claude-4.7-opus`. Also available via the Pipelex Gateway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v0.30.3 adds `claude-4.8-opus` to the `anthropic` and `bedrock` backends, promotes it as the default premium model, and updates the Pipelex Gateway model list; `best-gpt` is now `gpt-5.5`.

- New Features
  - `claude-4.8-opus`: adaptive thinking; text/images/pdf in, text/structured out; via the Pipelex Gateway. Limits: `max_tokens` 128k, `max_prompt_images` 100. Pricing: 5.0 (in) / 25.0 (out) per 1M tokens. Constraint: `temperature_unsupported`. Gateway model lists and `pipelex/kit` configs synced.
  - Deck aliases: `best-claude` and `default-premium*` now `claude-4.8-opus`; `best-gpt` now `gpt-5.5`; `retrieval-premium` now `claude-4.8-opus`.

<sup>Written for commit 1008c79765a5e12fac17ffe46518865cd126330a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Pipelex/pipelex/pull/946?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

