### PR TITLE
fix(deps): patch security vulnerabilities (urllib3, idna, pymdown-extensions)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,11 +34,22 @@
 
 - **`recover_error_report()` is now a total function.** It returns an `ErrorReport` rather than `ErrorReport | None`: when a Temporal failure carries no embedded report — or its payload fails to rehydrate — it synthesizes one from the new `UnrecoverableWorkflowFailureError`, surfacing the deepest worker-side cause message. Callers no longer branch on `None`.
 
+- **Dev tooling: `pyright` bumped `1.1.408 → 1.1.410`.** Drove two internal, behavior-neutral adjustments: `@contextmanager` / `@asynccontextmanager` helpers now annotate their return as `Generator` / `AsyncGenerator` (was `Iterator` / `AsyncIterator`), and `AsyncAnthropicBedrock` is imported from `anthropic.lib.bedrock` (relocated in the SDK).
+
 ### Fixed
 
 - **The generated MTHDS schema now requires `type` on every pipe.** In the schema consumed by `plxt` lint and the VS Code Taplo LSP, each pipe blueprint variant declared `type` with a literal default — so it was optional, and because the Draft-4 export drops the union discriminator, a pipe table written without `type` matched several `oneOf` branches at once and was rejected with an ambiguous multi-match (worse, a type-less table carrying fields unique to one variant validated silently). `type` is now required on every variant, so a type-less pipe table fails with a clear "missing type" and a typed table resolves to exactly one variant. The patched set is derived from `PipeBlueprintUnion`, so newly added pipe types are covered automatically. Regenerate with `pipelex-dev generate-mthds-schema`; the bundled copy ships in `pipelex-tools` 0.6.0 and the VS Code extension.
 
 - **`InputStuffSpecsFactoryError` was shadowed by a duplicate class definition.** `pipelex/core/pipes/inputs/input_stuff_specs_factory.py` declared a local class with the same name as the canonical one in the package's `exceptions.py`, leaving two distinct class objects in play so an `except` on one would miss the other. Consolidated to the single canonical class.
+
+### Security
+
+- **urllib3 floor `>=2.7.0`** to patch two high-severity issues: CVE-2026-44431 (GHSA-qccp-gfcp-xxvc) forwards sensitive headers across origins on proxied low-level redirects, and CVE-2026-44432 (GHSA-mf9v-mfxr-j63j) bypasses the decompression-bomb safeguards in parts of the streaming API. Floor added to the runtime `dependencies` in `pyproject.toml` so downstream installs cannot resolve a vulnerable version.
+- **pymdown-extensions floor `>=10.21.3`** to patch CVE-2026-46338 (GHSA-62q4-447f-wv8h, medium): a regression in `pymdownx.snippets` reintroduced the sibling-prefix path-traversal bypass despite `restrict_base_path`. Docs-only dependency; floor added to the `docs` extra.
+- **idna floor `>=3.15`** (lockfile resolves to 3.18) to patch CVE-2026-45409 (GHSA-65pc-fj4g-8rjx, medium): specially crafted inputs to `idna.encode()` could bypass the CVE-2024-3651 fix. Floor added to the runtime `dependencies`.
+- **Proactive floor bumps in the same hardening pass** — past known-vulnerable releases, so fresh resolves can't pick a bad version: pillow `>=12.1.1`, protobuf `>=6.33.5`, python-dotenv `>=1.2.2`, and requests `>=2.33.0` (runtime); aiohttp `>=3.12.14` (`temporal` extra); Pygments `>=2.20.0` (`docs` extra).
+
+Together these close the open GitHub Dependabot alerts on the default branch — urllib3 (two high), pymdown-extensions (medium), and idna (medium); the alerts remain visible on `main` only until this branch merges.
 
 ## [v0.30.3] - 2026-05-28
 

--- a/pipelex/hub.py
+++ b/pipelex/hub.py
@@ -1,5 +1,5 @@
 import sys
-from collections.abc import Iterator, Sequence
+from collections.abc import Generator, Sequence
 from contextlib import contextmanager
 from contextvars import ContextVar
 from pathlib import Path
@@ -515,7 +515,7 @@ def clear_current_library() -> None:
 
 
 @contextmanager
-def scoped_current_library(library_id: str) -> Iterator[None]:
+def scoped_current_library(library_id: str) -> Generator[None, None, None]:
     """Set ``library_id`` for the scope, then restore the prior value on exit.
 
     Captures the prior ``_library_id`` ContextVar value before setting the new

--- a/pipelex/pipeline/validate_bundle.py
+++ b/pipelex/pipeline/validate_bundle.py
@@ -1,5 +1,5 @@
 import asyncio
-from collections.abc import Iterator
+from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Literal, Sequence, TypedDict
@@ -65,7 +65,7 @@ def build_validated_pipes(dry_run_result: dict[str, DryRunOutput]) -> list[Valid
 
 
 @contextmanager
-def _translate_to_validate_bundle_error(category: Literal["pipe", "concept"]) -> Iterator[None]:
+def _translate_to_validate_bundle_error(category: Literal["pipe", "concept"]) -> Generator[None, None, None]:
     """Translate the bundle-loading exception surface into a single ``ValidateBundleError``.
 
     Single source of truth for the bundle-loading error cascade, used by all

--- a/pipelex/plugins/anthropic/anthropic_factory.py
+++ b/pipelex/plugins/anthropic/anthropic_factory.py
@@ -1,7 +1,8 @@
 import math
 from typing import TYPE_CHECKING
 
-from anthropic import AsyncAnthropic, AsyncAnthropicBedrock
+from anthropic import AsyncAnthropic
+from anthropic.lib.bedrock import AsyncAnthropicBedrock
 from anthropic.types import Usage
 from anthropic.types.document_block_param import DocumentBlockParam
 from anthropic.types.image_block_param import ImageBlockParam

--- a/pipelex/plugins/anthropic/anthropic_llm_worker.py
+++ b/pipelex/plugins/anthropic/anthropic_llm_worker.py
@@ -4,9 +4,9 @@ from anthropic import (
     APIConnectionError,
     APIStatusError,
     AsyncAnthropic,
-    AsyncAnthropicBedrock,
     omit,
 )
+from anthropic.lib.bedrock import AsyncAnthropicBedrock
 from anthropic.types import OutputConfigParam, ThinkingConfigParam
 from pydantic.dataclasses import dataclass as pydantic_dataclass
 from typing_extensions import override

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
   "datamodel-code-generator>=0.55.0",
   "filetype>=1.2.0",
   "httpx>=0.23.0,<1.0.0",
+  "idna>=3.15",
   "instructor>=1.13",                                   # 1.13+ exposes instructor.core; 1.11/1.12 had mypy typing errors
   "jinja2>=3.1.4",
   "json2html>=1.3.0",
@@ -36,15 +37,17 @@ dependencies = [
   "opentelemetry-exporter-otlp-proto-http",
   "opentelemetry-semantic-conventions",
   "opentelemetry-sdk",
-  "pillow>=11.2.1",
+  "pillow>=12.1.1",
   "polyfactory>=2.21.0",
   "portkey-ai>=2.1.0",
   "posthog>=6.7.0",
+  "protobuf>=6.33.5",
   "pypdfium2>=4.30.0,!=4.30.1,<5.0.0",
   "pydantic>=2.10.6,<3.0.0",
-  "python-dotenv>=1.0.1",
+  "python-dotenv>=1.2.2",
   "PyYAML>=6.0.2",
   "reportlab>=4.0,<5",                                  # for generating synthetic PDFs
+  "requests>=2.33.0",
   "rich>=13.8.1",
   "semantic-version>=2.10.0",
   "shortuuid>=1.0.13",
@@ -52,6 +55,7 @@ dependencies = [
   "tomlkit>=0.13.2",
   "typer>=0.16.0",
   "typing-extensions>=4.13.2",
+  "urllib3>=2.7.0",
 ]
 
 [project.urls]
@@ -87,7 +91,7 @@ linkup = ["linkup-sdk>=0.12.0"]
 mistralai = ["mistralai>=1.12.0"]
 dynamodb = ["boto3>=1.34.131"]
 s3 = ["boto3>=1.34.131", "aioboto3>=13.4.0"]
-temporal = ["temporalio==1.23.0", "aiohttp>=3.9.0"]
+temporal = ["temporalio==1.23.0", "aiohttp>=3.12.14"]
 docs = [
   "mike>=2.1.3",
   "mkdocs>=1.6.1",
@@ -96,6 +100,8 @@ docs = [
   "mkdocs-meta-manager>=1.1.0",
   "mkdocs-redirects==1.2.2",
   "mkdocs-llmstxt-md>=0.2.0",
+  "Pygments>=2.20.0",
+  "pymdown-extensions>=10.21.3",
 ]
 
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,7 +111,7 @@ dev = [
   "moto[dynamodb,s3]>=5.0.0",
   "mypy==1.19.1",
   "pipelex-tools>=0.6.0",
-  "pyright==1.1.408",
+  "pyright==1.1.410",
   "pylint==4.0.4",
   "pytest>=9.0.3",
   "pytest-asyncio>=0.24.0",

--- a/tests/integration/pipelex/temporal/tracing/helpers.py
+++ b/tests/integration/pipelex/temporal/tracing/helpers.py
@@ -2,7 +2,7 @@
 
 import uuid
 from collections import defaultdict
-from collections.abc import AsyncIterator, Iterable, Iterator
+from collections.abc import AsyncGenerator, Generator, Iterable
 from contextlib import asynccontextmanager, contextmanager
 from datetime import datetime
 from pathlib import Path
@@ -34,7 +34,7 @@ from tests.integration.pipelex.temporal.library_crate.helpers import rehydrate_p
 
 
 @contextmanager
-def route_activities_to(queue: str, activity_names: Iterable[str]) -> Iterator[None]:
+def route_activities_to(queue: str, activity_names: Iterable[str]) -> Generator[None, None, None]:
     """Temporarily route the given activity names to ``queue`` via
     ``worker_config.activity_queues``, restoring prior entries on exit.
 
@@ -240,7 +240,7 @@ async def make_split_workers(
     temporal_client: TemporalClient,
     q_router: str,
     q_runner: str,
-) -> AsyncIterator[None]:
+) -> AsyncGenerator[None, None]:
     """Open two scoped workers on two task queues in the current process.
 
     - `q_router`: workflows + `act_flush_trace_events`. We don't use the bare

--- a/uv.lock
+++ b/uv.lock
@@ -1707,11 +1707,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.13"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -3652,6 +3652,7 @@ dependencies = [
     { name = "datamodel-code-generator" },
     { name = "filetype" },
     { name = "httpx" },
+    { name = "idna" },
     { name = "instructor" },
     { name = "jinja2" },
     { name = "json2html" },
@@ -3669,11 +3670,13 @@ dependencies = [
     { name = "polyfactory" },
     { name = "portkey-ai" },
     { name = "posthog" },
+    { name = "protobuf" },
     { name = "pydantic" },
     { name = "pypdfium2" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
     { name = "reportlab" },
+    { name = "requests" },
     { name = "rich" },
     { name = "semantic-version" },
     { name = "shortuuid" },
@@ -3681,6 +3684,7 @@ dependencies = [
     { name = "tomlkit" },
     { name = "typer" },
     { name = "typing-extensions" },
+    { name = "urllib3" },
 ]
 
 [package.optional-dependencies]
@@ -3727,6 +3731,8 @@ docs = [
     { name = "mkdocs-material" },
     { name = "mkdocs-meta-manager" },
     { name = "mkdocs-redirects" },
+    { name = "pygments" },
+    { name = "pymdown-extensions" },
 ]
 dynamodb = [
     { name = "boto3" },
@@ -3770,7 +3776,7 @@ requires-dist = [
     { name = "aioboto3", marker = "extra == 'bedrock'", specifier = ">=13.4.0" },
     { name = "aioboto3", marker = "extra == 's3'", specifier = ">=13.4.0" },
     { name = "aiofiles", specifier = ">=23.2.1" },
-    { name = "aiohttp", marker = "extra == 'temporal'", specifier = ">=3.9.0" },
+    { name = "aiohttp", marker = "extra == 'temporal'", specifier = ">=3.12.14" },
     { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.78.0" },
     { name = "backports-strenum", marker = "python_full_version < '3.11'", specifier = ">=1.3.0" },
     { name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.34.131" },
@@ -3790,6 +3796,7 @@ requires-dist = [
     { name = "google-genai", marker = "extra == 'google-genai'" },
     { name = "httpx", specifier = ">=0.23.0,<1.0.0" },
     { name = "huggingface-hub", marker = "extra == 'huggingface'", specifier = ">=0.23,<1.0.0" },
+    { name = "idna", specifier = ">=3.15" },
     { name = "instructor", specifier = ">=1.13" },
     { name = "instructor", extras = ["google-genai"], marker = "extra == 'google-genai'" },
     { name = "jinja2", specifier = ">=3.1.4" },
@@ -3816,13 +3823,16 @@ requires-dist = [
     { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-sdk" },
     { name = "opentelemetry-semantic-conventions" },
-    { name = "pillow", specifier = ">=11.2.1" },
+    { name = "pillow", specifier = ">=12.1.1" },
     { name = "pipelex-tools", marker = "extra == 'dev'", specifier = ">=0.6.0" },
     { name = "polyfactory", specifier = ">=2.21.0" },
     { name = "portkey-ai", specifier = ">=2.1.0" },
     { name = "posthog", specifier = ">=6.7.0" },
+    { name = "protobuf", specifier = ">=6.33.5" },
     { name = "pydantic", specifier = ">=2.10.6,<3.0.0" },
+    { name = "pygments", marker = "extra == 'docs'", specifier = ">=2.20.0" },
     { name = "pylint", marker = "extra == 'dev'", specifier = "==4.0.4" },
+    { name = "pymdown-extensions", marker = "extra == 'docs'", specifier = ">=10.21.3" },
     { name = "pypdfium2", specifier = ">=4.30.0,!=4.30.1,<5.0.0" },
     { name = "pyright", marker = "extra == 'dev'", specifier = "==1.1.408" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
@@ -3832,9 +3842,10 @@ requires-dist = [
     { name = "pytest-sugar", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "pytest-timeout", marker = "extra == 'dev'", specifier = ">=2.3.1" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.6.1" },
-    { name = "python-dotenv", specifier = ">=1.0.1" },
+    { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "reportlab", specifier = ">=4.0,<5" },
+    { name = "requests", specifier = ">=2.33.0" },
     { name = "rich", specifier = ">=13.8.1" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.14.13" },
     { name = "semantic-version", specifier = ">=2.10.0" },
@@ -3850,6 +3861,7 @@ requires-dist = [
     { name = "types-networkx", marker = "extra == 'dev'", specifier = ">=3.3.0.20241020" },
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0.12.20250326" },
     { name = "typing-extensions", specifier = ">=4.13.2" },
+    { name = "urllib3", specifier = ">=2.7.0" },
 ]
 provides-extras = ["anthropic", "bedrock", "docling", "fal", "gcp-storage", "google", "google-genai", "huggingface", "linkup", "mistralai", "dynamodb", "s3", "temporal", "docs", "dev"]
 
@@ -4367,15 +4379,15 @@ wheels = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.21.2"
+version = "10.21.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/08/f1c908c581fd11913da4711ea7ba32c0eee40b0190000996bb863b0c9349/pymdown_extensions-10.21.2.tar.gz", hash = "sha256:c3f55a5b8a1d0edf6699e35dcbea71d978d34ff3fa79f3d807b8a5b3fa90fbdc", size = 853922, upload-time = "2026-03-29T15:01:55.233Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/26/d1015444da4d952a1ca487a236b522eb979766f0295a0bd0c5fc089989a9/pymdown_extensions-10.21.3.tar.gz", hash = "sha256:72cfcf55f07aea0d4af2c4f11dd4e52466ddfb1bb819673146398e0bd3a77354", size = 854140, upload-time = "2026-05-13T12:57:32.267Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/27/a2fc51a4a122dfd1015e921ae9d22fee3d20b0b8080d9a704578bf9deece/pymdown_extensions-10.21.2-py3-none-any.whl", hash = "sha256:5c0fd2a2bea14eb39af8ff284f1066d898ab2187d81b889b75d46d4348c01638", size = 268901, upload-time = "2026-03-29T15:01:53.244Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/85/545a951eecc270fcd688288c600017e2050a1aacb56c711d208586d3e470/pymdown_extensions-10.21.3-py3-none-any.whl", hash = "sha256:d7a5d08014fc571e80ca21dd6f854e31f94c489800350564d55d15b3c41e76b6", size = 269002, upload-time = "2026-05-13T12:57:30.296Z" },
 ]
 
 [[package]]
@@ -6112,11 +6124,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -3834,7 +3834,7 @@ requires-dist = [
     { name = "pylint", marker = "extra == 'dev'", specifier = "==4.0.4" },
     { name = "pymdown-extensions", marker = "extra == 'docs'", specifier = ">=10.21.3" },
     { name = "pypdfium2", specifier = ">=4.30.0,!=4.30.1,<5.0.0" },
-    { name = "pyright", marker = "extra == 'dev'", specifier = "==1.1.408" },
+    { name = "pyright", marker = "extra == 'dev'", specifier = "==1.1.410" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.1.1" },
@@ -4421,15 +4421,15 @@ wheels = [
 
 [[package]]
 name = "pyright"
-version = "1.1.408"
+version = "1.1.410"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nodeenv" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/74/b2/5db700e52554b8f025faa9c3c624c59f1f6c8841ba81ab97641b54322f16/pyright-1.1.408.tar.gz", hash = "sha256:f28f2321f96852fa50b5829ea492f6adb0e6954568d1caa3f3af3a5f555eb684", size = 4400578, upload-time = "2026-01-08T08:07:38.795Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/10/53/e4d8ea1391bd4355231be6f91bf239479aa0014260ed3fb5526eeb12a1f2/pyright-1.1.410.tar.gz", hash = "sha256:07a073b8ba6749826773c1269773efa11b93440d9a6aa60419d9a3172d6dc488", size = 4062013, upload-time = "2026-06-01T17:35:48.894Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/82/a2c93e32800940d9573fb28c346772a14778b84ba7524e691b324620ab89/pyright-1.1.408-py3-none-any.whl", hash = "sha256:090b32865f4fdb1e0e6cd82bf5618480d48eecd2eb2e70f960982a3d9a4c17c1", size = 6399144, upload-time = "2026-01-08T08:07:37.082Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/33/288b5868fa00846dacf249633719d747893e54aebd196b9968ac1878a5d3/pyright-1.1.410-py3-none-any.whl", hash = "sha256:5e961bed37cacf96b3f7cd7b1da39b350a9239aa2e69138d0e88f728cfaf296c", size = 6082448, upload-time = "2026-06-01T17:35:46.387Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Dependency-hardening pass that closes the open GitHub Dependabot alerts and raises floors past known-vulnerable releases. Also bumps the `pyright` dev pin and makes the small, behavior-neutral code adjustments it required.

### Security (Dependabot-flagged)

- **urllib3 `>=2.7.0`** — CVE-2026-44431 (GHSA-qccp-gfcp-xxvc, high): sensitive headers forwarded across origins on proxied low-level redirects; CVE-2026-44432 (GHSA-mf9v-mfxr-j63j, high): decompression-bomb safeguards bypassed in parts of the streaming API.
- **pymdown-extensions `>=10.21.3`** — CVE-2026-46338 (GHSA-62q4-447f-wv8h, medium): `pymdownx.snippets` sibling-prefix path-traversal bypass despite `restrict_base_path`. `docs` extra.
- **idna `>=3.15`** (lockfile resolves to 3.18) — CVE-2026-45409 (GHSA-65pc-fj4g-8rjx, medium): crafted inputs to `idna.encode()` bypass the CVE-2024-3651 fix.

### Security (proactive floor bumps)

pillow `>=12.1.1`, protobuf `>=6.33.5`, python-dotenv `>=1.2.2`, requests `>=2.33.0` (runtime); aiohttp `>=3.12.14` (`temporal` extra); Pygments `>=2.20.0` (`docs` extra).

### Dev tooling

- `pyright` `1.1.408 -> 1.1.410`, which drove: `@contextmanager` / `@asynccontextmanager` return hints `Iterator`/`AsyncIterator` -> `Generator`/`AsyncGenerator`, and `AsyncAnthropicBedrock` imported from `anthropic.lib.bedrock` (relocated in the SDK).

## Notes

These bumps remediate all four open Dependabot alerts (two high urllib3, one medium pymdown-extensions, one medium idna). The alerts are scanned against the default branch, so they remain visible on `main` until this work lands there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raise dependency floors to patch security vulnerabilities and prevent resolving to known-bad versions. Update `pyright` and adjust annotations/imports; no behavior changes.

- **Dependencies**
  - Security: `urllib3>=2.7.0`, `pymdown-extensions>=10.21.3` (docs), `idna>=3.15` — closes current Dependabot alerts.
  - Proactive: `pillow>=12.1.1`, `protobuf>=6.33.5`, `python-dotenv>=1.2.2`, `requests>=2.33.0`; `aiohttp>=3.12.14` (`temporal` extra); `Pygments>=2.20.0` (docs).
  - Dev: `pyright==1.1.410`.

- **Refactors**
  - Update contextmanager return hints to `Generator`/`AsyncGenerator`.
  - Import `AsyncAnthropicBedrock` from `anthropic.lib.bedrock`.

<sup>Written for commit b25ba318da7972fe6205d544897d61b0e233085e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Pipelex/pipelex/pull/958?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

