### PR TITLE
fix(docs): bootstrap generate-error-pages without inference so docs deploy survives a fresh runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ This cycle reworks **cost reporting** so it survives distributed execution and s
 
 ### Fixed
 
+- **Docs deploy crashed on a fresh runner with `InferenceSetupRequiredError`.** `pipelex-dev generate-error-pages` (a prerequisite of every `docs-*` make target) bootstrapped Pipelex with `needs_inference=True`, so on a CI runner with the gateway enabled but no on-disk service config it hit the first-run inference-setup gate and exited non-zero — breaking the `Deploy docs` workflow on `main`. The command only introspects `PipelexError` subclasses to write markdown and never calls inference, so it now bootstraps with `needs_inference=False`.
+
 - **`UsageRegistry` success-path leak.** The per-run cost registry was opened during run setup but closed only on the failure path, so every successful run leaked its registry — and in a long-lived process (e.g. the Pipelex API) reusing a `pipeline_run_id` could collide on the orphaned registry. The registry is removed entirely, so the leak is structurally impossible.
 
 ## [v0.31.0] - 2026-06-04

--- a/pipelex/cli/dev_cli/commands/generate_error_pages_cmd.py
+++ b/pipelex/cli/dev_cli/commands/generate_error_pages_cmd.py
@@ -16,13 +16,17 @@ ERROR_PAGES_DIR = Path("docs/errors")
 def generate_error_pages_cmd(output: Path | None = None, quiet: bool = False) -> None:
     """Generate per-class error documentation pages.
 
-    Bootstraps Pipelex (kept for parity with other dev CLI commands and to surface
-    config / setup errors loudly), then calls :func:`generate_error_pages`. The
-    underlying discovery rglobs every ``exceptions.py`` / ``*_exceptions.py``
-    via :func:`iter_pipelex_error_subclasses` — no manual import or class-list
-    update is needed when a new error class lands. Pages already carrying
-    ``<!-- pipelex:authored -->`` are preserved so hand-edited reference content
-    is never clobbered.
+    Bootstraps Pipelex with ``needs_inference=False`` (kept for parity with other
+    dev CLI commands and to surface config / setup errors loudly), then calls
+    :func:`generate_error_pages`. Inference is never invoked here — the command only
+    introspects ``PipelexError`` subclasses and writes markdown — so the bootstrap
+    must skip the inference-setup / gateway-terms checks; otherwise CI environments
+    with no configured backend (e.g. the docs deploy job) hit
+    ``InferenceSetupRequiredError``. The underlying discovery rglobs every
+    ``exceptions.py`` / ``*_exceptions.py`` via :func:`iter_pipelex_error_subclasses`
+    — no manual import or class-list update is needed when a new error class lands.
+    Pages already carrying ``<!-- pipelex:authored -->`` are preserved so hand-edited
+    reference content is never clobbered.
 
     Args:
         output: Custom output directory. Defaults to ``docs/errors/``.
@@ -36,7 +40,7 @@ def generate_error_pages_cmd(output: Path | None = None, quiet: bool = False) ->
         console.print("[bold]Generating per-class error documentation pages...[/bold]")
         console.print()
 
-    Pipelex.make()
+    Pipelex.make(needs_inference=False)
     try:
         report = generate_error_pages(output_dir=output_path)
     finally:


### PR DESCRIPTION
## Problem

The `Deploy docs` workflow failed on `main` at the **Deploy documentation** step for v0.31.0 ([run 26961749663](https://github.com/Pipelex/pipelex/actions/runs/26961749663/job/79553631485)).

Chain:

```
make docs-deploy-stable
  └─► (prereq) generate-error-pages-quiet
        └─► pipelex-dev generate-error-pages --quiet
              └─► Pipelex.make()              ← needs_inference defaults to True
                    └─► setup() → InferenceSetupRequiredError → exit 2
```

The repo's own `.pipelex/inference/backends.toml` has `[pipelex_gateway] enabled = true`, so setup takes the gateway path. On a fresh CI runner there's no `~/.pipelex` service config (no onboarding, no accepted terms), so the first-run gate at `pipelex.py:233` fires and raises `InferenceSetupRequiredError`. It doesn't fail locally because developers have inference/gateway configured.

Introduced in #943, which both added `generate-error-pages` (with a bare `Pipelex.make()`) and wired it as a prerequisite into every `docs-*` target. v0.31.0 is the first stable release that ran it on `main`.

## Fix

`generate-error-pages` only rglobs `*_exceptions.py`, introspects `PipelexError` subclasses, and writes markdown — it never calls inference. Bootstrap it with `needs_inference=False`, matching the established pattern for read-only commands. Setup then takes the dummy-remote-config path and never reaches the terms/first-run check.

## Verification

Reproduced the CI condition locally (empty `HOME`, gateway enabled, no service config):

- Old `Pipelex.make()` → `InferenceSetupRequiredError` (the exact CI failure)
- New `Pipelex.make(needs_inference=False)` → no error, deploy proceeds

`make agent-check` is green; `generate-error-pages` still passes.

## Note

The broken `Deploy docs` job only runs on `main`. Merging via `dev` won't re-deploy docs until the next release reaches `main`; a direct hotfix to `main` is what unblocks the live docs deploy immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the docs deploy failing on fresh CI runners by bootstrapping `pipelex-dev generate-error-pages` without inference. This removes the first-run gateway setup gate and lets the docs job complete.

- **Bug Fixes**
  - Use `Pipelex.make(needs_inference=False)` in `generate_error_pages_cmd.py` since the command only introspects `PipelexError` subclasses and writes markdown.
  - Prevents `InferenceSetupRequiredError` when the gateway is enabled but the runner has no `~/.pipelex` config, so `docs-*` targets (including deploy) run cleanly.

<sup>Written for commit f743512a4caf4b63b7a205e671deff88d8c93352. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Pipelex/pipelex/pull/972?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

