### PR TITLE
refactor: concept_code → concept_ref in pipe_io_contracts (+ main_pipe_ref locals)

### DIFF
--- a/pipelex/builder/operations/inputs_ops.py
+++ b/pipelex/builder/operations/inputs_ops.py
@@ -52,11 +52,11 @@ async def build_inputs_for_pipe(
         blueprints = validate_bundle_result.blueprints
         if not pipe_code:
             # Domain-qualified main pipe of the primary blueprint — the one shared selection rule.
-            main_pipe_code = select_primary_blueprint(blueprints).main_pipe_ref
-            if not main_pipe_code:
+            main_pipe_ref = select_primary_blueprint(blueprints).main_pipe_ref
+            if not main_pipe_ref:
                 msg = "Bundle does not declare a main_pipe. Specify a pipe code."
                 raise ValueError(msg)
-            pipe_code = main_pipe_code
+            pipe_code = main_pipe_ref
     elif bundle_path:
         # allow_signatures=True: see the mthds_contents branch — rendering inputs tolerates placeholders.
         validate_bundle_result = await validate_bundle(mthds_file_path=bundle_path, library_dirs=library_dirs, allow_signatures=True)

--- a/pipelex/pipeline/dry_run_pipeline.py
+++ b/pipelex/pipeline/dry_run_pipeline.py
@@ -42,7 +42,7 @@ async def dry_run_pipeline(
         library_dirs: Optional library directories for pipe resolution.
 
     Returns:
-        Tuple of (GraphSpec, pipe_code).
+        Tuple of (GraphSpec, domain-qualified main-pipe ref).
 
     Raises:
         PipelexInterpreterError: If content parsing fails or main_pipe is missing.
@@ -53,18 +53,18 @@ async def dry_run_pipeline(
         msg = "mthds_contents must be provided"
         raise ValueError(msg)
 
-    # Pre-parse contents to extract main_pipe_code via the one shared selection rule.
-    # Note: pipeline_run_setup will re-parse these contents. The double-parse is
-    # accepted because the runner interface requires pipe_code upfront and does not
-    # expose the internally-resolved pipe code in its response.
+    # Pre-parse contents to extract the main pipe's domain-qualified ref via the one shared
+    # selection rule. Note: pipeline_run_setup will re-parse these contents. The double-parse
+    # is accepted because the runner interface requires the pipe ref upfront and does not
+    # expose the internally-resolved pipe ref in its response.
     blueprints = [PipelexInterpreter.make_pipelex_bundle_blueprint(mthds_content=content) for content in mthds_contents]
-    main_pipe_code = select_primary_blueprint(blueprints).main_pipe_ref
+    main_pipe_ref = select_primary_blueprint(blueprints).main_pipe_ref
 
-    if not main_pipe_code:
+    if not main_pipe_ref:
         msg = "Bundle does not declare a main_pipe, cannot generate graph"
         raise PipelexInterpreterError(msg)
 
-    pipe_code: str = main_pipe_code
+    pipe_ref: str = main_pipe_ref
 
     execution_config = get_config().pipelex.pipeline_execution_config.with_execution_overrides(
         generate_graph=True,
@@ -84,7 +84,7 @@ async def dry_run_pipeline(
     # with a configured backend doesn't get trace files written as a side effect of validation.
     with scoped_event_log(InMemoryEventLog()):
         response = await runner.execute(
-            pipe_code=pipe_code,
+            pipe_code=pipe_ref,
             mthds_contents=mthds_contents,
         )
     pipe_output = response.pipe_output
@@ -93,4 +93,4 @@ async def dry_run_pipeline(
         msg = "Pipeline execution did not produce a graph spec"
         raise DryRunGraphNotProducedError(msg)
 
-    return pipe_output.graph_spec, pipe_code
+    return pipe_output.graph_spec, pipe_ref

--- a/pipelex/pipeline/pipe_io_contracts.py
+++ b/pipelex/pipeline/pipe_io_contracts.py
@@ -42,14 +42,14 @@ class IOMultiplicity(StrEnum):
 class PipeInputContract(BaseModel):
     """One declared input: the concept it expects and the JSON Schema of its content."""
 
-    concept_code: str
+    concept_ref: str
     json_schema: dict[str, Any] = Field(default_factory=dict)
 
 
 class PipeOutputContract(BaseModel):
     """The pipe's output: the concept it produces and whether it is one item or a list."""
 
-    concept_code: str
+    concept_ref: str
     multiplicity: IOMultiplicity
 
 
@@ -106,11 +106,11 @@ def build_pipe_io_contracts(pipes: Sequence[PipeAbstract]) -> dict[str, PipeIOCo
                     raise PipeIOContractError(message=msg) from exc
                 schema_memo[memo_key] = json_schema
             pipe_inputs[var_name] = PipeInputContract(
-                concept_code=stuff_spec.concept.concept_ref,
+                concept_ref=stuff_spec.concept.concept_ref,
                 json_schema=json_schema,
             )
         pipe_output = PipeOutputContract(
-            concept_code=pipe.output.concept.concept_ref,
+            concept_ref=pipe.output.concept.concept_ref,
             multiplicity=IOMultiplicity.VARIABLE if pipe.output.is_multiple() else IOMultiplicity.SINGLE,
         )
         io_contracts[pipe.pipe_ref] = PipeIOContract(inputs=pipe_inputs, output=pipe_output)

--- a/tests/integration/pipelex/pipeline/test_pipe_io_contracts.py
+++ b/tests/integration/pipelex/pipeline/test_pipe_io_contracts.py
@@ -80,13 +80,13 @@ class TestBuildPipeIOContracts:
         assert set(io_contracts) == {"structures_test.make_one", "structures_test.make_many"}
 
         make_one = io_contracts["structures_test.make_one"]
-        assert make_one.output.concept_code == "structures_test.Item"
+        assert make_one.output.concept_ref == "structures_test.Item"
         assert make_one.output.multiplicity == IOMultiplicity.SINGLE
-        assert make_one.inputs["doc"].concept_code == "native.Text"
+        assert make_one.inputs["doc"].concept_ref == "native.Text"
         assert make_one.inputs["doc"].json_schema
 
         make_many = io_contracts["structures_test.make_many"]
-        assert make_many.output.concept_code == "structures_test.Item"
+        assert make_many.output.concept_ref == "structures_test.Item"
         assert make_many.output.multiplicity == IOMultiplicity.VARIABLE
         # A list-typed input renders an array JSON Schema.
         assert make_many.inputs["docs"].json_schema.get("type") == "array"
@@ -127,9 +127,9 @@ class TestBuildPipeIOContracts:
 
         # The signature (forward declaration) and the controller referencing it both report contracts.
         signature_contract = io_contracts["research.find_key_findings"]
-        assert signature_contract.output.concept_code == "research.KeyFinding"
+        assert signature_contract.output.concept_ref == "research.KeyFinding"
         assert signature_contract.output.multiplicity == IOMultiplicity.SINGLE
-        assert signature_contract.inputs["doc"].concept_code == "native.Text"
+        assert signature_contract.inputs["doc"].concept_ref == "native.Text"
 
         controller_contract = io_contracts["research.research_brief"]
-        assert controller_contract.output.concept_code == "research.KeyFinding"
+        assert controller_contract.output.concept_ref == "research.KeyFinding"

--- a/tests/integration/pipelex/pipeline/test_protocol_validate.py
+++ b/tests/integration/pipelex/pipeline/test_protocol_validate.py
@@ -101,7 +101,7 @@ class TestProtocolValidate:
             assert report.is_runnable is True
             assert report.bundle_blueprint.domain == "protocol_validate"
             # `pipe_io_contracts` and `validated_pipes` are keyed/identified by namespaced pipe_ref.
-            assert report.pipe_io_contracts["protocol_validate.summarize"].output.concept_code == "protocol_validate.Summary"
+            assert report.pipe_io_contracts["protocol_validate.summarize"].output.concept_ref == "protocol_validate.Summary"
             assert {(entry["pipe_ref"], entry["status"]) for entry in report.validated_pipes} == {
                 ("protocol_validate.summarize", DryRunStatus.SUCCESS)
             }

--- a/tests/integration/pipelex/temporal/test_dry_validate_activity_in_memory.py
+++ b/tests/integration/pipelex/temporal/test_dry_validate_activity_in_memory.py
@@ -224,8 +224,8 @@ class TestDryValidateActivityInMemory:
             "dry_validate_alpha.alpha_second",
         }
         sequence_contract = result.pipe_io_contracts["dry_validate_alpha.alpha_sequence"]
-        assert sequence_contract.inputs["subject"].concept_code == "native.Text"
-        assert sequence_contract.output.concept_code == "native.Text"
+        assert sequence_contract.inputs["subject"].concept_ref == "native.Text"
+        assert sequence_contract.output.concept_ref == "native.Text"
 
     async def test_graph_failure_is_best_effort(self, temporal_client: TemporalClient, mocker: MockerFixture) -> None:
         """D5: an expected dry-run failure in the graph arm yields graph_spec=None, validation still OK."""
@@ -279,7 +279,7 @@ class TestDryValidateActivityInMemory:
         assert result.graph_spec is not None
         assert result.pending_signatures == ["dry_validate_sig.unimplemented_sig"]
         assert "dry_validate_sig.unimplemented_sig" in result.pipe_io_contracts
-        assert result.pipe_io_contracts["dry_validate_sig.unimplemented_sig"].output.concept_code == "native.Text"
+        assert result.pipe_io_contracts["dry_validate_sig.unimplemented_sig"].output.concept_ref == "native.Text"
 
     async def test_validation_failure_does_not_retry_activity(self, temporal_client: TemporalClient, mocker: MockerFixture) -> None:
         """D-C5 regression: a deterministic validation failure must run the activity exactly once.

--- a/tests/unit/pipelex/pipeline/test_validation_report.py
+++ b/tests/unit/pipelex/pipeline/test_validation_report.py
@@ -45,7 +45,7 @@ class TestBuildValidationReport:
         pipe_io_contracts = {
             "beta.do_it": PipeIOContract(
                 inputs={},
-                output=PipeOutputContract(concept_code="native.Text", multiplicity=IOMultiplicity.SINGLE),
+                output=PipeOutputContract(concept_ref="native.Text", multiplicity=IOMultiplicity.SINGLE),
             ),
         }
         dry_run_result: dict[str, DryRunOutput] = {


### PR DESCRIPTION
## What

`concept_code` → `concept_ref` in the validate IO-contract surface, plus `main_pipe_code` → `main_pipe_ref` locals.

This is the **shape owner** of a small cross-repo rename (pipelex → pipelex-api → pipelex-app).

## Why

The renamed identifiers are always domain-qualified references (`domain.Concept`), so `concept_code`/`main_pipe_code` were *lies* — the value is a `_ref`, not a bare code. The rule we're enforcing: `pipe_code`/`concept_code` stay the default for identifiers that *may* be bare; reserve `pipe_ref`/`concept_ref` for the few places where "always namespaced" is an invariant worth asserting.

## Scope (deliberately narrow — "lies only")

- `pipeline/pipe_io_contracts.py`: `PipeInputContract.concept_code` / `PipeOutputContract.concept_code` → `concept_ref` (+ the two construction sites).
- `pipeline/dry_run_pipeline.py`, `builder/operations/inputs_ops.py`: `main_pipe_code` → `main_pipe_ref` (locals only; runner kwarg + bare-code branch left).
- Consuming tests updated.

**Deliberately left `_code`** (these are *either-sinks* — the value can legitimately be bare): `get_required_pipe(pipe_code=…)`, `RunRequest.pipe_code`, error-envelope concept fields, graph result keys, MTHDS language keywords. Leaving these is the decision, not an oversight.

## Verification

`make agent-check` (pyright 0) + `make agent-test` — green.

## Merge order

Lands **first** — mergeable standalone. `pipelex-api` pins this branch's commit and must re-point its pin once this is merged/released.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed `concept_code` to `concept_ref` in IO contract models and switched locals to `main_pipe_ref` where the value is always namespaced. This clarifies intent and updates the `pipe_io_contracts` wire field names.

- **Refactors**
  - `PipeInputContract.concept_ref` and `PipeOutputContract.concept_ref` replace `concept_code` in `pipe_io_contracts`.
  - Builders now populate concept refs from `concept.concept_ref`; tests updated.
  - In `dry_run_pipeline` and input ops, locals `main_pipe_code` → `main_pipe_ref`; comments and return docs clarified.

- **Migration**
  - If you consume `pipe_io_contracts`, read `concept_ref` instead of `concept_code`.
  - No changes to runner inputs or other `*_code` fields; keep passing `pipe_code` where applicable.

<sup>Written for commit 6a1830ddc4be24289083155a3f9bb48e4fbb7c43. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Pipelex/pipelex/pull/990?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

