### PR TITLE
docs: fix drift on building-methods pipes/ pages (Drift Hunt S2-1)

### DIFF
--- a/docs/building-methods/pipes/csv-input-and-output.md
+++ b/docs/building-methods/pipes/csv-input-and-output.md
@@ -16,7 +16,8 @@ A concept used with CSV must be **flat**: every field is a scalar. The accepted 
 - `integer` → `int`
 - `number` → `float`
 - `boolean` → `bool`
-- `date` → `datetime.datetime` (an ISO `YYYY-MM-DD` value is accepted and parsed as midnight)
+- `date` → `datetime.date` (an ISO `YYYY-MM-DD` value)
+- `datetime` → `datetime.datetime` (an ISO `YYYY-MM-DDTHH:MM:SS` value)
 
 Optional fields are allowed, and so are choice-constrained scalars — but only **string-valued** ones (a `text`-typed `choices` field, a string `Literal`, or a `StrEnum`). A non-string choice such as `Literal[1, 2, 3]` or an `IntEnum` is rejected: it would serialize to a CSV string but cannot coerce back from one, so accepting it would break the round trip. Any nested concept, list, dict, union, or `Any`-typed field is likewise rejected with a clear error that names the offending field — a CSV cell has no room for nested structure, so you must project to a flat concept first.
 

--- a/docs/building-methods/pipes/executing-pipelines.md
+++ b/docs/building-methods/pipes/executing-pipelines.md
@@ -29,16 +29,19 @@ pipelex run bundle path/to/my_bundle.mthds --inputs inputs.json
 ### Using Python
 
 ```python
+from pathlib import Path
+
 from pipelex.pipelex import Pipelex
 from pipelex.pipeline.runner import PipelexMTHDSProtocol
 
 Pipelex.make()
 
+bundle_content = Path("path/to/my_bundle.mthds").read_text(encoding="utf-8")
+
 # Run the bundle's main_pipe
-runner = PipelexMTHDSProtocol(
-    bundle_uri="path/to/my_bundle.mthds",
-)
+runner = PipelexMTHDSProtocol()
 response = await runner.execute(
+    mthds_contents=[bundle_content],
     # Provide values directly — each is interpreted against the pipe's declared input signature.
     inputs={
         "my_input": "Hello world",
@@ -47,10 +50,8 @@ response = await runner.execute(
 pipe_output = response.pipe_output
 
 # Or run a specific pipe from the bundle
-runner = PipelexMTHDSProtocol(
-    bundle_uri="path/to/my_bundle.mthds",
-)
 response = await runner.execute(
+    mthds_contents=[bundle_content],
     pipe_code="my_specific_pipe",
     inputs={...},
 )
@@ -60,7 +61,7 @@ pipe_output = response.pipe_output
 !!! info "How `main_pipe` Works"
     When you run a bundle without specifying a `pipe_code`, Pipelex executes the bundle's `main_pipe` (declared at the top of the `.mthds` file). If no `main_pipe` is defined and no `pipe_code` is provided, an error is raised.
 
-    If you provide both `bundle_uri` and `pipe_code`, the explicit `pipe_code` takes priority over `main_pipe`.
+    If you provide both `mthds_contents` and `pipe_code`, the explicit `pipe_code` takes priority over `main_pipe`.
 
 See the [Pipelex Bundle Specification](../pipelex-bundle-specification.md) for more about the `main_pipe` property.
 
@@ -84,9 +85,11 @@ When using `PipelexMTHDSProtocol`, you can control library behavior with these p
 
 - **`library_id`**: A unique identifier for the library instance. If not specified, it defaults to the `pipeline_run_id` (a unique ID generated for each pipeline execution).
 
-- **`library_dirs`**: A list of directory paths to load pipe definitions from. **These directories must contain both your `.mthds` files AND any Python files defining `StructuredContent` classes** (e.g., `*_struct.py` files). If not specified, Pipelex falls back to the `PIPELEXPATH` environment variable, then to the current working directory.
+- **`library_dirs`**: A list of directory paths to load pipe definitions from. **These directories must contain both your `.mthds` files AND any Python files defining `StructuredContent` classes** (e.g., `*_struct.py` files). If not specified, Pipelex falls back to the default library directories passed to `Pipelex.make(library_dirs=...)`, then to the `PIPELEXPATH` environment variable; if none of these are set, no library directories are loaded.
 
-- **`mthds_contents`**: When provided to `PipelexMTHDSProtocol.execute()`, Pipelex will load only this content into the library, bypassing directory scanning. This is useful for dynamic pipeline execution without file-based definitions.
+- **`mthds_contents`**: When provided to `PipelexMTHDSProtocol.execute()`, Pipelex parses these strings and loads them into the library in addition to any resolved library directories. To run with only this content, disable directory loading explicitly (e.g. `library_dirs=[]`). This is useful for dynamic pipeline execution without file-based definitions.
+
+- **`bundle_uris`**: Optional file paths identifying the bundles passed as `mthds_contents` (matched by position). When a URI matches a bundle already loaded from the library directories, that content is skipped instead of being loaded twice. Without `bundle_uris`, every `mthds_contents` entry is loaded unconditionally — so passing content that duplicates a directory-loaded bundle raises a duplicate-declaration error.
 
 !!! info "Python Structure Classes"
     If your concepts use Python `StructuredContent` classes instead of inline structures, those Python files must be in the directories specified by `library_dirs`. Pipelex auto-discovers and registers these classes during library loading. Learn more about [Python StructuredContent Classes](../concepts/python-classes.md).
@@ -101,14 +104,15 @@ When using `PipelexMTHDSProtocol`, you can control library behavior with these p
 
 This approach loads pipe definitions from directories and executes a specific pipe by its code.
 
-**Basic usage** (loads from current working directory):
+**Basic usage** (default library directories set at initialization):
 
 ```python
 from pipelex.pipelex import Pipelex
 from pipelex.pipeline.runner import PipelexMTHDSProtocol
 
-# First, initialize Pipelex (this loads all pipeline definitions)
-Pipelex.make()
+# First, initialize Pipelex with default library directories
+# (used by every run unless overridden per call)
+Pipelex.make(library_dirs=["./pipelines"])
 
 # Execute the pipeline and wait for the result
 runner = PipelexMTHDSProtocol()
@@ -165,7 +169,7 @@ You can directly pass MTHDS content as a string to `PipelexMTHDSProtocol.execute
 from pipelex.pipelex import Pipelex
 from pipelex.pipeline.runner import PipelexMTHDSProtocol
 
-my_pipe_content = """
+my_pipe_content = '''
 domain = "marketing"
 description = "Marketing content generation domain"
 main_pipe = "generate_tagline"
@@ -179,12 +183,12 @@ type = "PipeLLM"
 description = "Generate a catchy tagline for a product"
 inputs = { description = "ProductDescription" }
 output = "Tagline"
-prompt = "
+prompt = """
 Product Description: $description
 
 Generate a catchy tagline based on the above description. The tagline should be memorable, concise, and highlight the key benefit.
-"
 """
+'''
 
 Pipelex.make()
 
@@ -199,7 +203,7 @@ pipe_output = response.pipe_output
 ```
 
 !!! note "Pipe Code Resolution"
-    When using `mthds_content`:
+    When using `mthds_contents`:
 
     - If the content has a `main_pipe` property and you don't provide `pipe_code`, the `main_pipe` is executed
     - If you provide `pipe_code`, it overrides `main_pipe`

--- a/docs/building-methods/pipes/executing-pipelines.md
+++ b/docs/building-methods/pipes/executing-pipelines.md
@@ -58,6 +58,9 @@ response = await runner.execute(
 pipe_output = response.pipe_output
 ```
 
+!!! tip "Already loading libraries elsewhere?"
+    If a `PIPELEXPATH` environment variable or `Pipelex.make(library_dirs=...)` already loads this same bundle from disk, passing its content again via `mthds_contents` loads it twice and raises a duplicate-declaration error. See [Advanced: Using Library Directories](#advanced-using-library-directories) for `bundle_uris` (deduplication) and `library_dirs=[]` (run with only the provided content).
+
 !!! info "How `main_pipe` Works"
     When you run a bundle without specifying a `pipe_code`, Pipelex executes the bundle's `main_pipe` (declared at the top of the `.mthds` file). If no `main_pipe` is defined and no `pipe_code` is provided, an error is raised.
 

--- a/docs/building-methods/pipes/index.md
+++ b/docs/building-methods/pipes/index.md
@@ -73,11 +73,11 @@ The tagline should be memorable, concise, and highlight the key benefit.
 """
 ```
 
-This defines a single-step pipeline. The pipe `generate_tagline` takes a `ProductDescription` as input and outputs a `Tagline` (both are native Text concepts, see more about native concepts [here](../concepts/native-concepts.md)).
+This defines a single-step pipeline. The pipe `generate_tagline` takes a `ProductDescription` as input and outputs a `Tagline` (both are custom concepts defined by a simple description, so they are Text-based by default — see more about native concepts [here](../concepts/native-concepts.md)).
 
 The inputs specified will be required before the pipe is executed. Those inputs should be stored in the [Working Memory](working-memory.md).
 
-The output concept is very important. Indeed, the output of your pipe will be corresponding to the concept you specify. If the concept is structured, the output will be a structured object. If the concept is native, the output will be a string.
+The output concept is very important. Indeed, the output of your pipe will be corresponding to the concept you specify. If the concept is structured, the output will be a structured object. If the concept is Text-based — like `Tagline` here — the output is text. Other native concepts produce their corresponding content type (an `Image` output is an image, a `Number` output is a number, and so on).
 
 ### Understanding the Pipe Contract
 
@@ -103,6 +103,7 @@ description = "Marketing content generation domain"
 [concept]
 ProductDescription = "A description of a product's features and benefits"
 Tagline = "A catchy marketing tagline"
+Keyword = "A marketing keyword extracted from text"
 
 # 2. Define the first step of your pipe
 [pipe.generate_tagline]
@@ -132,11 +133,11 @@ Extract the most relevant keywords from the following tagline. Focus on features
 """
 
 # 4. Define the controller that orchestrates the two steps
-[pipe.description_to_tagline]
+[pipe.description_to_keywords]
 type = "PipeSequence"
-description = "From product description to tagline"
+description = "From product description to tagline keywords"
 inputs = { description = "ProductDescription" }
-output = "Tagline"
+output = "Keyword[]"
 steps = [
     { pipe = "generate_tagline", result = "tagline" },
     { pipe = "extract_keywords_from_tagline", result = "keywords" },
@@ -147,7 +148,7 @@ steps = [
     The `[]` bracket notation in `output = "Keyword[]"` allows the LLM to generate as many keywords as it finds relevant. For a comprehensive guide on controlling how many items pipes produce or accept, see [Understanding Multiplicity](./understanding-multiplicity.md).
 
 
-This defines a two-step pipeline. The `PipeSequence` controller `description_to_tagline` takes a `ProductDescription` as input and outputs a `Tagline`. The first step is `generate_tagline` which generates a `Tagline` from the `ProductDescription`. The second step is `extract_keywords_from_tagline` which extracts keywords from the `Tagline`.
+This defines a two-step pipeline. The `PipeSequence` controller `description_to_keywords` takes a `ProductDescription` as input and outputs a list of `Keyword`s — a sequence's declared `output` must match what its last step yields. The first step is `generate_tagline` which generates a `Tagline` from the `ProductDescription`. The second step is `extract_keywords_from_tagline` which extracts keywords from the `Tagline`.
 
 See here all the different operators, see [Pipe Operators](./pipe-operators/index.md).
 See here all the different controllers, see [Pipe Controllers](./pipe-controllers/index.md).

--- a/docs/building-methods/pipes/pipe-controllers/PipeBatch.md
+++ b/docs/building-methods/pipes/pipe-controllers/PipeBatch.md
@@ -47,14 +47,8 @@ This is the batch arm of the "route or skip" pattern: batch over items with a co
 | `inputs`           | dictionary   | The input concept(s) for the batch operation, as a dictionary mapping input names to concept codes.                                                     | Yes       |
 | `output`           | string       | The output concept produced by the batch operation.                                                | Yes      |
 | `branch_pipe_code` | string       | The name of the single pipe to execute for each item in the input list.                                                                          | Yes      |
-| `batch_params`     | table (dict) | An optional table to provide more specific names for the batch operation.                                                                        | No       |
-
-### Batch Parameters (`batch_params`)
-
-| Key                     | Type   | Description                                                                                                                           | Required |
-| ----------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| `input_list_stuff_name` | string | The name of the list in the `WorkingMemory` to iterate over. If not provided, it defaults to the name of the `PipeBatch`'s main `input`. | No       |
-| `input_item_stuff_name` | string | The name that an individual item from the list will have inside its execution branch. This is how the branch pipe finds its input.   | Yes      |
+| `input_list_name`  | string       | The name of the input list to iterate over. Must match one of the keys in `inputs`. Typically a plural noun (e.g. `articles`).                   | Yes      |
+| `input_item_name`  | string       | The name that an individual item from the list will have inside its execution branch — this is how the branch pipe finds its input. Must differ from `input_list_name` and from every key in `inputs`. Typically the singular form of the list name (e.g. `article`). | Yes      |
 
 ### Example: Summarizing a list of articles
 
@@ -67,26 +61,26 @@ type = "PipeLLM"
 description = "Summarize a single article"
 inputs = { article = "ArticleText" }
 output = "ArticleSummary"
-prompt = "Please provide a one-sentence summary of the following article:\n\n@article_text"
+prompt = "Please provide a one-sentence summary of the following article:\n\n@article"
 
 # The PipeBatch definition
 [pipe.summarize_all_articles]
 type = "PipeBatch"
 description = "Summarize a batch of articles in parallel"
-inputs = { articles = "ArticleList" }  # This is the list to iterate over
-output = "SummaryList" # This will be the list of summaries
+inputs = { articles = "ArticleText[]" }  # This is the list to iterate over
+output = "ArticleSummary[]" # This will be the list of summaries
 branch_pipe_code = "summarize_one_article"
-
-input_item_name = "ArticleText" # Name of an item within the branch
+input_list_name = "articles" # Name of the input list to iterate over
+input_item_name = "article" # Name of an item within the branch
 ```
 
 How this works:
-1.  The `summarize_all_articles` pipe receives an `ArticleList`. Let's say it contains 10 articles.
+1.  The `summarize_all_articles` pipe receives a list of `ArticleText` items under the name `articles`. Let's say it contains 10 articles.
 2.  `PipeBatch` creates 10 parallel branches.
-3.  In branch #1, it takes the first article from `ArticleList`, puts it into the branch's isolated working memory, and gives it the name `ArticleText` (as specified by `input_item_name`).
-4.  The `summarize_one_article` pipe is then executed in branch #1. It looks for an input named `ArticleText`, finds the injected article, and produces a summary.
+3.  In branch #1, it takes the first article from the `articles` list, puts it into the branch's isolated working memory, and gives it the name `article` (as specified by `input_item_name`).
+4.  The `summarize_one_article` pipe is then executed in branch #1. It looks for an input named `article`, finds the injected article, and produces a summary.
 5.  Steps 3 and 4 run concurrently across branches, up to `max_concurrency` at a time (8 by default), until all 10 articles are processed.
-6.  Once all `summarize_one_article` pipes are done, `PipeBatch` collects the 10 `ArticleSummary` outputs and bundles them into a single `SummaryList`. This list is the final result.
+6.  Once all `summarize_one_article` pipes are done, `PipeBatch` collects the 10 `ArticleSummary` outputs and bundles them into a single `ArticleSummary[]` list. This list is the final result.
 
 ## Related Documentation
 

--- a/docs/building-methods/pipes/pipe-controllers/PipeCondition.md
+++ b/docs/building-methods/pipes/pipe-controllers/PipeCondition.md
@@ -31,7 +31,7 @@ The `PipeCondition` controller adds branching logic to your pipelines. It evalua
 | `expression_template`            | string         | A full Jinja2 template string. Use this for more complex logic, like `{% if my_var.value > 10 %}high{% else %}low{% endif %}`.                           | Yes (or `expression`)          |
 | `outcomes`                     | table (dict)   | A mapping where keys are the possible string results of the expression, and values are the names of the pipes to execute — or the special outcomes `continue` / `fail`.                                  | Yes                            |
 | `default_outcome`            | string         | The outcome used when the expression result does not match any key in `outcomes`: a pipe name, `continue`, or `fail`.                                                             | Yes                             |
-| `add_alias_from_expression_to` | string         | An advanced feature. If provided, the string result of the expression evaluation is added to the working memory as an alias with this name.               | No                             |
+| `add_alias_from_expression_to` | string         | An advanced feature. If provided, an alias named after the string result of the expression evaluation is added to the working memory, pointing to the existing entry named by this value (which must already be in the working memory).               | No                             |
 
 !!! important "Output Concept Matching"
     The output concept of the `PipeCondition` has to match the output of all the pipes in the `outcomes`.
@@ -44,8 +44,11 @@ Here's a basic example showing how PipeCondition routes based on input data:
 domain = "routing_example"
 description = "Example of PipeCondition routing"
 
-[concept]
-CategoryInput = "Input with a category field"
+[concept.CategoryInput]
+description = "Input with a category field"
+
+[concept.CategoryInput.structure]
+category = "The category of the input"
 
 # Define the PipeCondition first
 [pipe.route_by_category]

--- a/docs/building-methods/pipes/pipe-controllers/PipeParallel.md
+++ b/docs/building-methods/pipes/pipe-controllers/PipeParallel.md
@@ -42,7 +42,7 @@ A branch result may legitimately be **absent** at run time: the branch pipe decl
 | ----------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------- |
 | `type`            | string        | The type of the pipe: `PipeParallel`                                                                          | Yes      |
 | `description`     | string        | A description of the parallel operation.                                                                           | Yes      |
-| `inputs`    | dictionary  | The input concept(s) for the parallel operation, as a dictionary mapping input names to concept codes.                                                     | Yes       |
+| `inputs`    | dictionary  | The input concept(s) for the parallel operation, as a dictionary mapping input names to concept codes.                                                     | No       |
 | `output`   | string          | The concept the branch results are combined into: `Composite` or a structured concept whose fields match the branch `result` names.                                                | Yes      |
 | `branches`        | array of tables| An array defining the pipes to run in parallel. Each table is a sub-pipe definition.                                                                                           | Yes      |
 | `add_each_output` | boolean       | If `true`, also adds the output of each parallel pipe to the working memory individually under its `result` name. Defaults to `false`.                                                                       | No       |
@@ -61,12 +61,24 @@ Each entry in the `branches` array is a table with the following keys:
 Imagine you have a product description and you want to extract the product features and the product sentiment at the same time.
 
 ```toml
+[concept.ProductDescription]
+description = "A product description"
+refines = "Text"
+
+[concept.ProductFeatures]
+description = "The features of a product"
+refines = "Text"
+
+[concept.ProductSentiment]
+description = "The sentiment expressed about a product"
+refines = "Text"
+
 [concept.ProductAnalysis]
 description = "Combined product analysis"
 
 [concept.ProductAnalysis.structure]
-features  = { type = "text", description = "Product features", required = true }
-sentiment = { type = "text", description = "Product sentiment", required = true }
+features  = { type = "concept", concept_ref = "ProductFeatures", description = "Product features", required = true }
+sentiment = { type = "concept", concept_ref = "ProductSentiment", description = "Product sentiment", required = true }
 
 [pipe.extract_features]
 type = "PipeLLM"

--- a/docs/building-methods/pipes/pipe-controllers/PipeSequence.md
+++ b/docs/building-methods/pipes/pipe-controllers/PipeSequence.md
@@ -35,7 +35,11 @@ Each entry in the `steps` array is a table with the following keys:
 | Key      | Type   | Description                                                        | Required |
 | -------- | ------ | ------------------------------------------------------------------ | -------- |
 | `pipe`   | string | The name of the pipe to execute for this step.                     | Yes      |
-| `result` | string | The name to give to the output of this step in the working memory. | Yes      |
+| `result` | string | The name to give to the output of this step in the working memory. When omitted, the step's output is stored only as the anonymous main stuff, so subsequent steps cannot refer to it by a dedicated name. | No       |
+| `nb_output` | integer | Request a fixed number of outputs from this step's pipe. Cannot be combined with `multiple_output`. | No       |
+| `multiple_output` | boolean | Request a variable number of outputs from this step's pipe (the model decides how many). Cannot be combined with `nb_output`. | No       |
+| `batch_over` | string | The name of a list in the working memory to batch this step over, running the pipe once per item. Must be provided together with `batch_as`. See [Understanding Multiplicity](../understanding-multiplicity.md). | No       |
+| `batch_as` | string | The name each item takes in the working memory during a `batch_over` run. Must differ from `batch_over` (e.g. `batch_over = "items"`, `batch_as = "item"`). | No       |
 
 !!! important "Output Concept Matching"
     The output concept of the `PipeSequence` has to match the output of the last pipe in the sequence.
@@ -48,27 +52,28 @@ Let's imagine a pipeline that first extracts text from an image, then summarizes
 [pipe.extract_text_from_image]
 type = "PipeExtract"
 description = "Extract text from an image"
-output = "Text"
-model = "mistral-ocr"
+inputs = { image = "Image" }
+output = "Page[]"
+model = "@default-extract-image"
 
 [pipe.summarize_text]
 type = "PipeLLM"
 description = "Summarize text"
-inputs = { text = "Text" }
+inputs = { extracted_text = "Page" }
 output = "Text"
 
 [pipe.translate_to_french]
 type = "PipeLLM"
 description = "Translate text to French"
-inputs = { text = "Text" }
+inputs = { english_summary = "Text" }
 output = "Text"
 
 
 [pipe.image_to_french_summary]
 type = "PipeSequence"
 description = "Extract, summarize, and translate text from an image"
-inputs = { image = "source.Image" }
-output = "target.FrenchText"
+inputs = { image = "Image" }
+output = "Text"
 steps = [
     { pipe = "extract_text_from_image", result = "extracted_text" },
     { pipe = "summarize_text", result = "english_summary" },

--- a/docs/building-methods/pipes/pipe-controllers/PipeSequence.md
+++ b/docs/building-methods/pipes/pipe-controllers/PipeSequence.md
@@ -35,7 +35,7 @@ Each entry in the `steps` array is a table with the following keys:
 | Key      | Type   | Description                                                        | Required |
 | -------- | ------ | ------------------------------------------------------------------ | -------- |
 | `pipe`   | string | The name of the pipe to execute for this step.                     | Yes      |
-| `result` | string | The name to give to the output of this step in the working memory. When omitted, the step's output is stored only as the anonymous main stuff, so subsequent steps cannot refer to it by a dedicated name. | No       |
+| `result` | string | The name to give to this step's output in the working memory. When omitted, the output is stored only in the unnamed `main_stuff` slot (the default output), so later steps can pick it up as their implicit input but cannot reference it by a dedicated name. | No       |
 | `nb_output` | integer | Request a fixed number of outputs from this step's pipe. Cannot be combined with `multiple_output`. | No       |
 | `multiple_output` | boolean | Request a variable number of outputs from this step's pipe (the model decides how many). Cannot be combined with `nb_output`. | No       |
 | `batch_over` | string | The name of a list in the working memory to batch this step over, running the pipe once per item. Must be provided together with `batch_as`. See [Understanding Multiplicity](../understanding-multiplicity.md). | No       |
@@ -59,7 +59,7 @@ model = "@default-extract-image"
 [pipe.summarize_text]
 type = "PipeLLM"
 description = "Summarize text"
-inputs = { extracted_text = "Page" }
+inputs = { extracted_text = "Page[]" }
 output = "Text"
 
 [pipe.translate_to_french]

--- a/docs/building-methods/pipes/pipe-controllers/index.md
+++ b/docs/building-methods/pipes/pipe-controllers/index.md
@@ -20,12 +20,12 @@ Here are the primary pipe controllers available in Pipelex:
 
 ## Overview
 
-Pipelex provides the following pipe operators:
+Pipelex provides the following pipe controllers:
 
 - `PipeSequence`: For chaining multiple pipes in sequence
 - `PipeParallel`: For running different pipes in parallel
 - `PipeBatch`: For running one pipe over a batch of inputs
-- `PipeCondition`: For conditional execution based on input validation
+- `PipeCondition`: For conditional execution based on an evaluated expression
 
 ## PipeSequence
 
@@ -40,12 +40,11 @@ Run multiple pipes in sequence.
 
 ## PipeCondition
 
-Enables conditional execution based on input validation.
+Enables conditional execution based on an evaluated expression.
 
 ### Key Features
 
 - Expression-based routing
 - Default fallback paths
 - Jinja2 template support
-- Input validation
 - Error handling

--- a/docs/building-methods/pipes/pipe-operators/PipeCompose.md
+++ b/docs/building-methods/pipes/pipe-operators/PipeCompose.md
@@ -32,8 +32,8 @@ The Jinja2 template has access to all the "stuffs" currently in the working memo
 | --------------- | ----------------- | --------------------------------------------------------------------------- | -------- |
 | `type`          | string            | The type of the pipe: `PipeCompose`                                         | Yes      |
 | `description`   | string            | A description of the operation                                              | Yes      |
-| `inputs`        | table             | Input variables needed for the template                                     | Yes      |
-| `output`        | string            | The concept for the output                                                  | No       |
+| `inputs`        | table             | Input variables needed for the template                                     | No       |
+| `output`        | string            | The concept for the output                                                  | Yes      |
 | `template`      | string or section | An inline template string, or a `[pipe.name.template]` section (see below)  | Yes*     |
 
 *Template mode requires `template`. When using the rich form (`[pipe.name.template]` section), the following sub-fields are available:
@@ -121,7 +121,7 @@ Instead of rendering a template, construct mode creates a structured object by s
 | ------------- | ------ | --------------------------------------------------------- | -------- |
 | `type`        | string | The type of the pipe: `PipeCompose`                       | Yes      |
 | `description` | string | A description of the operation                            | Yes      |
-| `inputs`      | table  | Input variables needed for the construct                  | Yes      |
+| `inputs`      | table  | Input variables needed for the construct                  | No       |
 | `output`      | string | The structured concept to output                          | Yes      |
 | `construct`   | section| Field mappings (see below)                                | Yes*     |
 

--- a/docs/building-methods/pipes/pipe-operators/PipeExtract.md
+++ b/docs/building-methods/pipes/pipe-operators/PipeExtract.md
@@ -58,7 +58,7 @@ Extraction presets are defined in your model deck configuration and can include 
 | `output`                    | string  | The output concept produced by the extraction operation. Use `Page[]`.                                  | Yes      |
 | `max_page_images`           | integer or null | Maximum number of images to extract from pages: `null` (or omit) for unlimited, `0` for no images, or a positive integer to limit. Defaults to the value in your Extract model preset. | No       |
 | `page_views`                | boolean | If `true`, a high-fidelity image of each page will be included in the `page_view` field. Defaults to `false`.                              | No       |
-| `page_views_dpi`            | integer | The resolution (in Dots Per Inch) for the generated page views when processing a PDF. Defaults to `150`.                                 | No       |
+| `page_views_dpi`            | integer | The resolution (in Dots Per Inch) for the generated page views when processing a PDF. Defaults to `72`.                                 | No       |
 | `page_image_captions`       | boolean | If `true`, the OCR service may attempt to generate captions for the images found. *Note: This feature depends on the OCR provider.*        | No       |
 | `render_js`                 | boolean | For web-page extraction: if `true`, the extraction backend renders JavaScript before fetching the page content. Defaults to `false`. *Note: Only honored by backends that support headless rendering.* | No       |
 | `include_raw_html`          | boolean | For web-page extraction: if `true`, the extracted `Page` populates its `raw_html` field with the fetched page's HTML. Defaults to `false`. | No       |
@@ -102,7 +102,7 @@ output      = "Page[]"
 model       = "@default-extract-web-page"
 ```
 
-Pass a web URL as the `document_uri` when running the pipe. PipeExtract fetches the page and extracts its content into `Page` objects, following the same pattern as document extraction.
+Pass a web URL as the `article_url` input when running the pipe. PipeExtract fetches the page and extracts its content into `Page` objects, following the same pattern as document extraction.
 
 ## Related Documentation
 

--- a/docs/building-methods/pipes/pipe-operators/PipeFunc.md
+++ b/docs/building-methods/pipes/pipe-operators/PipeFunc.md
@@ -23,7 +23,7 @@ For a function to be automatically registered and available to `PipeFunc`, it **
 !!! warning "Function Eligibility Requirements"
 
 - **Must be decorated with** `@pipe_func()` (required since v0.12.0)
-- **Must be an async function** (defined with `async def`)
+- **Can be async or sync**: `async def` functions are awaited directly; plain `def` functions run in a worker thread (via `asyncio.to_thread`) so they don't block the pipeline
 - **Must have exactly 1 parameter** named `working_memory`
 - **Parameter type must be** `WorkingMemory`
 - **Return type must be** a subclass of `StuffContent` (or a generic type like `ListContent[SomeType]`)
@@ -31,7 +31,7 @@ For a function to be automatically registered and available to `PipeFunc`, it **
 
 ### Return values
 
-Your async Python function can return:
+Your Python function can return:
 
 -   A `StuffContent` object (e.g., `TextContent`, `ImageContent`, or a custom `StructuredContent` model).
 -   A `ListContent` containing `StuffContent` objects.

--- a/docs/building-methods/pipes/pipe-operators/PipeImgGen.md
+++ b/docs/building-methods/pipes/pipe-operators/PipeImgGen.md
@@ -58,9 +58,11 @@ PipeImgGen uses the unified inference backend system to manage image generation 
 
 Common image generation model handles:
 
-- `base-img-gen`: Base image generation model (alias for flux-pro/v1.1)
-- `best-img-gen`: Best quality image generation model (alias for flux-pro/v1.1-ultra)
-- `fast-img-gen`: Fast image generation model (alias for fast-lightning-sdxl)
+- `default-general`: General-purpose image generation model (alias for nano-banana)
+- `default-premium`: Premium image generation model (alias for nano-banana-2)
+- `default-small`: Small, fast image generation model (alias for gpt-image-1-mini)
+- `best-gpt`: Best OpenAI image generation model (alias for gpt-image-2)
+- `best-gemini`: Best Gemini image generation model (alias for nano-banana-2)
 
 Image generation presets are defined in your model deck configuration and can include parameters like `quality`, `guidance_scale`, and `safety_tolerance`.
 

--- a/docs/building-methods/pipes/pipe-operators/PipeLLM.md
+++ b/docs/building-methods/pipes/pipe-operators/PipeLLM.md
@@ -130,7 +130,9 @@ description = "Summarize a document"
 inputs = { document = "Document" }
 output = "DocumentSummary"
 prompt = """
-Summarize the key points from this document: @document
+Summarize the key points from this document:
+
+@document
 """
 ```
 

--- a/docs/building-methods/pipes/pipe-operators/PipeLLM.md
+++ b/docs/building-methods/pipes/pipe-operators/PipeLLM.md
@@ -234,7 +234,7 @@ When `model` is specified as a table (inline LLM setting), it accepts the follow
 | `model` | string | Model name or alias (e.g., `"claude-4.5-sonnet"`, `"@default-premium"`) |
 | `temperature` | float | Sampling temperature (0.0 – 1.0) |
 | `max_tokens` | integer | Maximum output tokens |
-| `reasoning_effort` | string | Reasoning depth: `"none"`, `"minimal"`, `"low"`, `"medium"`, `"high"`, `"max"`. Not supported for structured generation. |
+| `reasoning_effort` | string | Reasoning depth: `"none"`, `"minimal"`, `"low"`, `"medium"`, `"high"`, `"xhigh"`, `"max"`. Not supported for structured generation. |
 | `reasoning_budget` | integer | Explicit token budget for reasoning. Mutually exclusive with `reasoning_effort`. Supported by Anthropic and Google only. |
 | `description` | string | Human-readable description (for presets) |
 

--- a/docs/building-methods/pipes/pipe-operators/PipeStructure.md
+++ b/docs/building-methods/pipes/pipe-operators/PipeStructure.md
@@ -101,7 +101,8 @@ description = "Read the invoice PDF and produce a faithful textual transcript"
 inputs = { invoice_pdf = "Document" }
 output = "Text"
 prompt = """
-Read this invoice and produce a faithful textual transcript of every line item, total, and metadata: @invoice_pdf
+Read this invoice and produce a faithful textual transcript of every line item, total, and metadata:
+@invoice_pdf
 """
 
 [pipe.structure_invoice]

--- a/docs/building-methods/pipes/pipe-operators/index.md
+++ b/docs/building-methods/pipes/pipe-operators/index.md
@@ -16,7 +16,8 @@ Each operator specializes in a specific kind of action, from interacting with La
 Here are the primary pipe operators available in Pipelex:
 
 -   [**`PipeLLM`**](./PipeLLM.md): The core operator for all interactions with Large Language Models (LLMs), including text generation, structured data extraction, and vision tasks.
--   [**`PipeExtract`**](./PipeExtract.md): Performs Optical Character Recognition (OCR) on images and PDF documents to extract text and embedded images.
+-   [**`PipeStructure`**](./PipeStructure.md): Turns free-form text into structured, typed data via a single LLM call — ideal when the text comes from an upstream extraction, search, or generation step.
+-   [**`PipeExtract`**](./PipeExtract.md): Performs Optical Character Recognition (OCR) on images and PDF documents to extract text and embedded images, and fetches and extracts content from web pages.
 -   [**`PipeImgGen`**](./PipeImgGen.md): Generates images from a text prompt using models like GPT Image, Flux, or other image generation models.
 -   [**`PipeSearch`**](./PipeSearch.md): Searches the web using a configurable search provider and returns structured results with an answer and source citations.
 -   [**`PipeFunc`**](./PipeFunc.md): An escape hatch that allows you to execute any custom Python function, giving you maximum flexibility.
@@ -27,10 +28,12 @@ Here are the primary pipe operators available in Pipelex:
 Pipelex provides the following pipe operators:
 
 - `PipeLLM`: For LLM-based text generation and processing
+- `PipeCompose`: For rendering Jinja2 templates from working memory data
 - `PipeExtract`: For optical character recognition and document processing
 - `PipeFunc`: For executing custom functions
 - `PipeImgGen`: For AI-powered image generation
 - `PipeSearch`: For web search with structured results
+- `PipeStructure`: For turning free-form text into structured data
 
 ## PipeLLM
 
@@ -44,16 +47,9 @@ Core operator for LLM-based text generation and processing.
 - System prompt customization
 - LLM configuration
 
-### Key Features
-
-- Sequential execution
-- Working memory management
-- Sub-pipe handling
-- Pipeline composition
-
 ## PipeExtract
 
-Processes images and PDFs using Optical Character Recognition.
+Processes images and PDFs using Optical Character Recognition, and fetches and extracts content from web pages.
 
 ### Key Features
 

--- a/docs/building-methods/pipes/run-modes-and-backends.md
+++ b/docs/building-methods/pipes/run-modes-and-backends.md
@@ -33,7 +33,7 @@ One job type deliberately opts out of this fan-out: a **validation sweep** submi
 
 ## The Matrix
 
-All cells below describe **pipeline runs** — `pipelex run ...` or `PipelexRunner.execute_pipeline()`. Validation sweeps have their own distribution shape, covered in the next section.
+All cells below describe **pipeline runs** — `pipelex run ...` or `PipelexMTHDSProtocol.execute()`. Validation sweeps have their own distribution shape, covered in the next section.
 
 | Run mode \ Backend | Direct (in-process) | Temporal |
 |---|---|---|
@@ -57,14 +57,15 @@ pipelex run bundle my_bundle.mthds --orchestrator temporal --dry-run --mock-inpu
 From Python, the same knobs live on the runner — the backend comes from config:
 
 ```python
-from pipelex.pipe_run.pipe_run_mode import PipeRunMode
-from pipelex.pipeline.runner import PipelexRunner
+from pathlib import Path
 
-runner = PipelexRunner(
-    bundle_uri="path/to/my_bundle.mthds",
-    pipe_run_mode=PipeRunMode.DRY,
+from pipelex.pipe_run.pipe_run_mode import PipeRunMode
+from pipelex.pipeline.runner import PipelexMTHDSProtocol
+
+runner = PipelexMTHDSProtocol(pipe_run_mode=PipeRunMode.DRY)
+response = await runner.execute(
+    mthds_contents=[Path("path/to/my_bundle.mthds").read_text(encoding="utf-8")],
 )
-response = await runner.execute_pipeline()
 ```
 
 ## Validation Sweeps

--- a/docs/building-methods/pipes/understanding-multiplicity.md
+++ b/docs/building-methods/pipes/understanding-multiplicity.md
@@ -23,7 +23,7 @@ A concept represents a semantic entity—a meaningful piece of knowledge with cl
 [concept]
 Keyword = "A significant word or term extracted from text"
 ProductIdea = "A concept for a new product or service"
-Document = "A written or printed record containing information"
+SourceDocument = "A written or printed record containing information"
 ```
 
 Each of these definitions describes a single, coherent entity. The essence of what makes something a "Keyword" doesn't change whether you have one keyword or a hundred.
@@ -34,7 +34,7 @@ The number of items you're working with is a circumstantial detail of your metho
 
 - A pipe that extracts keywords from text might find 3 keywords or 30—but each is still a `Keyword`
 - A pipe that generates product ideas might produce 5 ideas or 10—but each remains a `ProductIdea`
-- A pipe that processes documents might handle 1 document or a batch of 100—but each is still a `Document`
+- A pipe that processes documents might handle 1 document or a batch of 100—but each is still a `SourceDocument`
 
 By keeping concepts singular and using multiplicity to express quantity, Pipelex maintains a clean semantic model that's both flexible and intuitive.
 
@@ -71,8 +71,8 @@ This is the default behavior and represents the most common case.
 Use empty brackets in the output to let the LLM decide how many items to generate:
 
 ```toml
-[concept]
-LineItem = "A single line item from an invoice"
+[concept.LineItem]
+description = "A single line item from an invoice"
 
 [concept.LineItem.structure]
 description = "Description of the item or service"
@@ -185,13 +185,13 @@ Use empty brackets `[]` to specify that the pipe expects a list with an indeterm
 
 ```toml
 [concept]
-Document = "A written or printed record"
+SourceDocument = "A written or printed record"
 Summary = "A concise overview of multiple documents"
 
 [pipe.summarize_all_documents]
 type = "PipeLLM"
 description = "Create a unified summary of multiple documents"
-inputs = { documents = "Document[]" }
+inputs = { documents = "SourceDocument[]" }
 output = "Summary"
 prompt = """
 Analyze all of these documents:
@@ -216,7 +216,6 @@ Use a number in brackets `[N]` to specify that the pipe expects exactly that man
 
 ```toml
 [concept]
-Image = "A visual image file"
 Comparison = "A detailed comparison analysis"
 
 [pipe.compare_two_images]
@@ -259,7 +258,7 @@ Extract all fields from this invoice:
 type = "PipeSequence"
 description = "Process multiple invoices"
 inputs = { invoice_images = "InvoiceImage[]" }
-output = "InvoiceData"
+output = "InvoiceData[]"
 steps = [
     { pipe = "extract_single_invoice", batch_over = "invoice_images", batch_as = "invoice_image", result = "all_invoice_data" }
 ]
@@ -278,8 +277,7 @@ SubjectLine = "An email subject line"
 type = "PipeLLM"
 description = "Generate 3 subject line options"
 inputs = { email_body = "EmailContent" }
-output = "SubjectLine"
-nb_output = 3
+output = "SubjectLine[3]"
 prompt = """
 Email content:
 @email_body


### PR DESCRIPTION
## Summary

Stage-2 batch **S2-1** of the Drift Hunt campaign: fixes all confirmed code↔doc drift on the `docs/building-methods/pipes/` pages (the Stage-1 findings for this page set), plus fix-time drift found on the same pages and adversarially verified before fixing. Docs-only.

**Verification discipline applied to every fix:**

- Every finding was re-verified against the current code at fix time (the finding is the pointer, the code is the authority); none was rejected.
- Every changed `.mthds`/TOML example was re-validated against the real parser (`pipelex validate bundle`, including dry-run) — broken teaching examples were restructured until they genuinely validate.
- Every changed Python snippet was checked against live signatures, and the run-a-bundle snippets were executed end-to-end in dry-run mode.
- A blind post-fix review (two no-context reviewers on the batch commit) re-verified all changed claims; its two catches are folded in.

**Main fix classes:**

- Bundle examples that failed validation verbatim: PipeSequence (PipeExtract step output/inputs + dead model handle), PipeBatch (fabricated `batch_params` table → real flat `input_list_name`/`input_item_name`), PipeParallel (combine type-mismatch → concept-typed structure fields), PipeCondition (unstructured routed-on concept), understanding-multiplicity (top-level `nb_output` → `SubjectLine[3]` bracket notation; native `Document`/`Image` redeclarations; batch output multiplicity), pipes/index (undeclared `Keyword` concept + sequence output), executing-pipelines (TOML multi-line string).
- Renamed Python API never propagated: `PipelexRunner` → `PipelexMTHDSProtocol`, `bundle_uri` → `bundle_uris`, `execute_pipeline()` → `execute()` — and the run-a-bundle snippets rewritten to a pattern that actually runs (`mthds_contents`; `bundle_uris` alone never loads content).
- Parameter tables aligned with the blueprints (required/optional flags on `inputs`/`output`/`result`; PipeSequence step keys completed from `SubPipeBlueprint`).
- Stale enumerations: `reasoning_effort` gains `xhigh`; operator rosters gain PipeStructure/PipeCompose; CSV accepted types gain `datetime`; dead img-gen handles replaced with the current deck aliases.
- Wrong defaults/behavioral claims: `page_views_dpi` 150→72, PipeFunc sync-function support, `library_dirs` resolution order (no cwd fallback), `PipeCondition.add_alias_from_expression_to` semantics, PipeCondition "input validation" → expression routing.

Also carries this page set's previously-unshipped Stage-0 fix (understanding-multiplicity), keeping the PR self-contained on dev.

Full audit trail (per-finding evidence, fix-time additions, refuted candidates, deferred code findings): `wip/drift-hunt/findings/building-methods.md` on the campaign branch `docs/Drift-hunt`.

## Test plan

- [x] `mkdocs build --strict` clean on this branch's state
- [x] `make check` green on the campaign branch carrying the same content
- [x] Every changed bundle example passes `pipelex validate bundle` (incl. dry-run); runner snippets executed live in dry-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes code↔doc drift across docs/building-methods/pipes/* for Drift Hunt S2‑1. All TOML bundles validate, Python snippets match the current runner API, and examples are type‑consistent and parser‑accurate.

- **Bug Fixes**
  - Updated runner usage and names: `PipelexRunner`/`execute_pipeline`/`bundle_uri` → `PipelexMTHDSProtocol`/`execute`/`mthds_contents`; added `bundle_uris` dedup and a tip to avoid duplicate loads; clarified `library_dirs` fallback (`Pipelex.make(library_dirs=...)` → `PIPELEXPATH`; no cwd fallback).
  - Fixed broken examples so they parse and type‑check: `PipeSequence` (e.g., `Page[]` flow; optional `result` writes to unnamed `main_stuff`), `PipeBatch` (`input_list_name`/`input_item_name`), `PipeParallel` (concept‑typed combine fields), `PipeCondition` (expression routing and alias semantics), `pipes/index` sequence (`Keyword[]`), TOML multi‑line strings, and `PipeLLM` templates (`@document` on its own line).
  - Aligned parameter tables with blueprints: optional `inputs` for `PipeParallel`/`PipeCompose`, required `output` for `PipeCompose`; new step keys `nb_output`, `multiple_output`, `batch_over`, `batch_as`; clarified optional `result`.
  - Refreshed defaults/enums/rosters: `page_views_dpi` 72; `reasoning_effort` adds `xhigh`; operator/controller lists include `PipeStructure`/`PipeCompose`; CSV adds `datetime` (and maps `date` → `datetime.date`); image‑gen handles updated.
  - Corrected API/field names and claims: `PipeFunc` supports sync functions; `PipeExtract` web input is `article_url`; clarified native concept outputs.

- **Migration**
  - Use `PipelexMTHDSProtocol().execute(mthds_contents=[...])`; pass `bundle_uris` to dedupe against libraries; set defaults via `Pipelex.make(library_dirs=...)`, or pass `library_dirs=[]` to load only provided content.
  - Replace `batch_params` with top‑level `input_list_name` and `input_item_name`; declare list inputs/outputs with `[]` (e.g., `ArticleText[]` → `ArticleSummary[]`), or `[N]` for fixed counts.
  - If validating config, allow `"xhigh"` for `reasoning_effort`; note the default `page_views_dpi` is now 72.

<sup>Written for commit b34c6a22b465ec48fedefb8c7ba5aec4d5bd1b86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Pipelex/pipelex/pull/1043?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

