### PR TITLE
Drift Hunt S2-2: fix building-methods concepts + top-level docs drift

### DIFF
--- a/docs/building-methods/adapt-to-llm-prompting-style-openai-anthropic-mistral.md
+++ b/docs/building-methods/adapt-to-llm-prompting-style-openai-anthropic-mistral.md
@@ -11,8 +11,8 @@ The `PromptingConfig` class controls how Pipelex handles prompting styles for di
 
 ```python
 class PromptingConfig(ConfigModel):
-    default_prompting_style: PromptingStyle
-    prompting_styles: Dict[str, PromptingStyle]
+    default_prompting_style: TemplatingStyle
+    prompting_styles: dict[str, TemplatingStyle]
 ```
 
 ### Fields
@@ -28,12 +28,13 @@ Each prompting style defines how prompts are formatted and presented to the LLM.
 
 ```toml
 [pipelex.prompting_config]
-default_prompting_style = "chat"
+default_prompting_style = { tag_style = "xml" }
 
 [pipelex.prompting_config.prompting_styles]
-gpt4 = "chat"
-claude = "instruction"
-llama = "completion"
+openai = { tag_style = "ticks" }
+anthropic = { tag_style = "xml" }
+mistral = { tag_style = "square_brackets" }
+gemini = { tag_style = "xml" }
 ```
 
 ## Usage
@@ -41,11 +42,10 @@ llama = "completion"
 The configuration provides a method to get the appropriate prompting style:
 
 ```python
-def get_prompting_style(self, prompting_target: Optional[LLMPromptingTarget] = None) -> Optional[PromptingStyle]:
+def get_prompting_style(self, prompting_target: PromptingTarget | None = None) -> TemplatingStyle | None:
     if prompting_target:
         return self.prompting_styles.get(prompting_target, self.default_prompting_style)
-    else:
-        return None
+    return None
 ```
 
 This allows for:

--- a/docs/building-methods/concepts/define_your_concepts.md
+++ b/docs/building-methods/concepts/define_your_concepts.md
@@ -147,7 +147,7 @@ The refined concept inherits the structure of the base concept while adding sema
 
 ## Native Concepts
 
-Pipelex includes these built-in native concepts: `Text`, `Image`, `Document`, `Html`, `TextAndImages`, `Number`, `Page`, `Dynamic`, `JSON`, `SearchResult`, and `Anything`.
+Pipelex includes these built-in native concepts: `Text`, `Image`, `Document`, `TextAndImages`, `Number`, `YesNo`, `Date`, `Time`, `Page`, `Dynamic`, `JSON`, `Html`, `SearchResult`, `Composite`, and `Anything`.
 
 These concepts are automatically available in all pipelines—no setup required. You can use them directly in your pipes or refine them to create more specific concepts.
 

--- a/docs/building-methods/concepts/inline-structures.md
+++ b/docs/building-methods/concepts/inline-structures.md
@@ -81,9 +81,9 @@ email = { type = "text", description = "Email address" }
     
     - **type**: `text`
     - **description**: The string you provided
+    - **required**: `true`
     
-    This is a shorthand for the most common case: text fields.
-    This will put the field as optional by default, and not required.
+    This is a shorthand for the most common case: required text fields. To make a text field optional, use the explicit form instead, e.g. `email = { type = "text", description = "Email address" }`.
 
 ### integer
 
@@ -250,7 +250,7 @@ status = { choices = ["todo", "in_progress", "done"], description = "Current sta
 
 ## Required Fields
 
-By default, **all fields are optional** (`required = false`). To make a field mandatory, explicitly set `required = true`:
+Fields declared with the explicit inline-table form are **optional by default** (`required = false`). To make one mandatory, explicitly set `required = true`. Note that fields declared with the shorthand string syntax (`field_name = "description"`) are **required**:
 
 ```toml
 [concept.User.structure]

--- a/docs/building-methods/concepts/native-concepts.md
+++ b/docs/building-methods/concepts/native-concepts.md
@@ -304,7 +304,11 @@ type = "PipeLLM"
 description = "Analyze a document"
 inputs = { document = "Document" }
 output = "Text"
-prompt = "Analyze this document and provide a summary"
+prompt = """
+Analyze this document and provide a summary:
+
+@document
+"""
 ```
 
 ### In Pipe Outputs
@@ -315,7 +319,7 @@ type = "PipeLLM"
 description = "Describe an image"
 inputs = { photo = "Image" }
 output = "Text"
-prompt = "Describe what you see in this image"
+prompt = "Describe what you see in this image: $photo"
 ```
 
 ### With Page Content
@@ -327,7 +331,7 @@ The `Page` concept is particularly useful with `PipeExtract`:
 type = "PipeExtract"
 description = "Extract content from a document"
 inputs = { document = "Document" }
-output = "Page"
+output = "Page[]"
 ```
 
 This extracts each page with both its text/images and a visual representation.
@@ -379,7 +383,11 @@ type = "PipeLLM"
 description = "Summarize any text"
 inputs = { content = "Text" }
 output = "Text"
-prompt = "Summarize this content: @content"
+prompt = """
+Summarize this content:
+
+@content
+"""
 ```
 
 ### Document Extraction
@@ -391,10 +399,10 @@ description = "Extract content from a document"
 inputs = { document = "Document" }
 output = "Page[]"
 
-[pipe.analyze_page]
+[pipe.analyze_pages]
 type = "PipeLLM"
-description = "Analyze a page"
-inputs = { page = "Page[]" }
+description = "Analyze pages"
+inputs = { pages = "Page[]" }
 output = "Text"
 prompt = """Analyze those pages: 
 @pages
@@ -419,9 +427,11 @@ type = "PipeLLM"
 description = "Analyze image with text context"
 inputs = { image = "Image", context = "Text" }
 output = "Text"
-prompt = "Given this context: $context
+prompt = """
+Given this context: $context
 
-Analyze this image: $image"
+Analyze this image: $image
+"""
 ```
 
 ### Web Search

--- a/docs/building-methods/concepts/python-classes.md
+++ b/docs/building-methods/concepts/python-classes.md
@@ -106,7 +106,7 @@ This generates a single stamped `structures.py` module from your inline definiti
 
 If you need custom validation or computed properties, you have two options:
 
-1. **Generate then copy**: Run `pipelex build structures`, then copy the generated class into your own module and customize it there
+1. **Generate then subclass**: Run `pipelex build structures`, then subclass the generated class in a sibling module and add your custom logic there — never copy or edit the generated file; a subclass survives regeneration and stays in sync with the source concept
 2. **Write from scratch**: Create a Python class manually with your custom logic
 
 ### Example: Adding Custom Validation
@@ -129,21 +129,21 @@ age = { type = "integer", description = "User's age", required = false }
 pipelex build structures ./my_pipeline.mthds -o ./structures/
 ```
 
-**Step 3: Add custom validation**
+**Step 3: Subclass the generated class in a sibling module**
 
-Copy the generated class into your own module (never edit the generated file — it is overwritten on regeneration) and add your validation:
+Never copy or edit the generated file — it is overwritten on regeneration. A subclass in a sibling module survives regeneration and inherits all the generated fields, so you only write the custom logic:
 
 ```python
-from pipelex.core.stuffs.structured_content import StructuredContent
-from pydantic import Field, field_validator
+# structures/user_profile_ext.py
 import re
 
-class UserProfile(StructuredContent):
-    """A user profile with validation."""
+from pydantic import field_validator
 
-    username: str = Field(description="The user's username")
-    email: str = Field(description="The user's email address")
-    age: int | None = Field(default=None, description="User's age")
+from .structures import UserProfile
+
+
+class ValidatedUserProfile(UserProfile):
+    """A user profile with email validation."""
 
     @field_validator('email')
     @classmethod
@@ -155,20 +155,15 @@ class UserProfile(StructuredContent):
         return v
 ```
 
-**Step 4: Update your .mthds file**
+**Step 4: Keep the inline structure in your `.mthds` file**
 
-```toml
-[concept]
-UserProfile = "A user profile"  # Structure now defined in Python
-```
-
-The Python class is automatically discovered and registered.
+The inline structure remains the source of truth: on the next regeneration the base class is rewritten from it and your subclass picks up the changes automatically. The subclass is discovered and registered like any other `StructuredContent` class. At pipeline time the concept still resolves to the structure declared inline — apply your custom logic by validating with the subclass wherever your own code consumes the result (e.g. `ValidatedUserProfile.model_validate(profile.model_dump())`). If Pipelex itself must enforce the validation when producing the concept, move the structure to a hand-written class instead (see the [Migration Guide](#migration-guide) below).
 
 ## Migration Guide
 
 ### From Inline Structure to Python Class
 
-The easiest migration path is to use `pipelex build structures` to generate the Python class, then copy it into your own module and customize it there:
+Before migrating, check whether you need to migrate at all: if you only want custom logic on top of the structure, subclass the generated class in a sibling module (see above) and keep the inline structure as the source of truth. Migrate only when Pipelex itself must enforce your custom validation when producing the concept. In that case, write the Python class by hand — it becomes the source of truth:
 
 **1. You have this inline structure:**
 
@@ -185,13 +180,7 @@ price = { type = "number", description = "Product price", required = true }
 in_stock = { type = "boolean", description = "Stock availability", default_value = true }
 ```
 
-**2. Generate the Python class:**
-
-```bash
-pipelex build structures ./ecommerce.mthds -o ./structures/
-```
-
-**3. Copy the generated class into your own module** and add your custom logic:
+**2. Write the Python class in your own module** with your custom logic:
 
 ```python
 from pipelex.core.stuffs.structured_content import StructuredContent
@@ -221,7 +210,7 @@ class Product(StructuredContent):
         return f"${self.price:.2f}"
 ```
 
-**4. Update your `.mthds` file:**
+**3. Update your `.mthds` file:**
 
 ```toml
 domain = "ecommerce"
@@ -232,7 +221,7 @@ Product = "A product in the catalog"
 # Structure section removed - now defined in Python
 ```
 
-**5. Test your pipeline** - The behavior should be identical, plus your custom validation.
+**4. Test your pipeline** - The behavior should be identical, plus your custom validation.
 
 ## Recommendations
 

--- a/docs/building-methods/concepts/python-classes.md
+++ b/docs/building-methods/concepts/python-classes.md
@@ -157,7 +157,7 @@ class ValidatedUserProfile(UserProfile):
 
 **Step 4: Keep the inline structure in your `.mthds` file**
 
-The inline structure remains the source of truth: on the next regeneration the base class is rewritten from it and your subclass picks up the changes automatically. The subclass is discovered and registered like any other `StructuredContent` class. At pipeline time the concept still resolves to the structure declared inline — apply your custom logic by validating with the subclass wherever your own code consumes the result (e.g. `ValidatedUserProfile.model_validate(profile.model_dump())`). If Pipelex itself must enforce the validation when producing the concept, move the structure to a hand-written class instead (see the [Migration Guide](#migration-guide) below).
+The inline structure remains the source of truth: on the next regeneration the base class is rewritten from it and your subclass picks up the changes automatically. At pipeline time the concept still resolves to the structure declared inline — apply your custom logic by validating with the subclass wherever your own code consumes the result (e.g. `ValidatedUserProfile.model_validate(profile.model_dump())`). If Pipelex itself must enforce the validation when producing the concept, move the structure to a hand-written class instead (see the [Migration Guide](#migration-guide) below).
 
 ## Migration Guide
 

--- a/docs/building-methods/concepts/refining-concepts.md
+++ b/docs/building-methods/concepts/refining-concepts.md
@@ -82,16 +82,22 @@ output = "Analysis"
 ## Current Limitations
 
 !!! warning "No structure on refined concepts (For Now)"
-    When you refine a concept, you **cannot** add an inline structure or specify a `structure_class_name`. This limitation will be lifted in future releases.
+    When you refine a concept, you **cannot** also define a `structure` — neither by naming a structure class nor with an inline `[concept.X.structure]` table. The validator rejects the combination: a concept cannot have both `refines` and `structure`. This limitation will be lifted in future releases.
     
     **Not allowed:**
 ```toml
 [concept.Invoice]
 description = "A commercial invoice"
 refines = "Document"
-structure_class_name = "InvoiceModel"  # ❌ Not allowed
+structure = "InvoiceModel"  # ❌ Not allowed: refines and structure are mutually exclusive
+```
 
-[concept.Invoice.structure]  # ❌ Not allowed
+```toml
+[concept.Invoice]
+description = "A commercial invoice"
+refines = "Document"
+
+[concept.Invoice.structure]  # ❌ Not allowed: an inline table is the same structure field
 invoice_number = "Invoice ID"
 ```
 
@@ -146,7 +152,7 @@ description = "A screen capture image"
 refines = "Image"
 ```
 
-Each inherits `ImageContent` structure (url, caption, base_64, etc.) with specific semantic meaning.
+Each inherits `ImageContent` structure (url, caption, mime_type, etc.) with specific semantic meaning.
 
 ### Refining Text
 
@@ -234,6 +240,7 @@ description = "A weighted score result"
 [pipe.compute_weighted_score]
 type = "PipeLLM"
 description = "Compute a weighted score"
+inputs = { item = "Text" }
 output = "WeightedScore"
 prompt = "Compute a weighted score for: {{ item }}"
 ```
@@ -263,6 +270,7 @@ refines = "scoring_lib->scoring.WeightedScore"
 [pipe.compute_detailed_score]
 type = "PipeLLM"
 description = "Compute a detailed score"
+inputs = { item = "Text" }
 output = "DetailedScore"
 prompt = "Compute a detailed score for: {{ item }}"
 ```

--- a/docs/building-methods/configure-ai-llm-to-optimize-methods.md
+++ b/docs/building-methods/configure-ai-llm-to-optimize-methods.md
@@ -21,12 +21,12 @@ For complete details about the inference backend configuration system, see the [
 An LLM handle can be either:
 
 1. **A direct model name** (like "gpt-4o-mini", "claude-3-sonnet") - automatically available for all models loaded by the inference backend system
-2. **An alias** - user-defined shortcuts that map to model names, defined in the `[aliases]` section:
+2. **An alias** - user-defined shortcuts that map to model names, defined in the `[llm.aliases]` section:
 
 ### Example Alias Configurations
 
 ```toml
-[aliases]
+[llm.aliases]
 best-claude = "claude-4.1-opus"
 best-gemini = "gemini-2.5-pro"
 best-mistral = "mistral-large"
@@ -112,6 +112,8 @@ The Model Deck is your central configuration hub for all LLM-related settings. I
 - `1_llm_deck.toml`: LLM aliases and presets
 - `2_img_gen_deck.toml`: Image generation configuration
 - `3_extract_deck.toml`: Document extraction configuration
+- `4_search_deck.toml`: Search configuration
+- `x_custom_extract_deck.toml`: Custom extraction waterfalls/overrides (loaded last)
 - `x_custom_llm_deck.toml`: Custom LLM waterfalls/overrides (loaded last)
 
 ### Directory Structure
@@ -126,10 +128,12 @@ The Model Deck is your central configuration hub for all LLM-related settings. I
     │   ├── anthropic.toml
     │   └── ...
     └── deck/                      # Model deck configurations
-        ├── 1_llm_deck.toml           # LLM aliases & presets
-        ├── 2_img_gen_deck.toml       # Image generation config
-        ├── 3_extract_deck.toml       # Document extraction config
-        └── x_custom_llm_deck.toml    # Custom waterfalls/overrides
+        ├── 1_llm_deck.toml            # LLM aliases & presets
+        ├── 2_img_gen_deck.toml        # Image generation config
+        ├── 3_extract_deck.toml        # Document extraction config
+        ├── 4_search_deck.toml         # Search config
+        ├── x_custom_extract_deck.toml # Custom extraction waterfalls/overrides
+        └── x_custom_llm_deck.toml     # Custom LLM waterfalls/overrides
 ```
 
 

--- a/docs/building-methods/domain.md
+++ b/docs/building-methods/domain.md
@@ -159,7 +159,7 @@ Invoice = "A commercial document"
 type = "PipeLLM"
 inputs = { invoice = "Invoice" }    # Same domain, no prefix
 output = "Text"
-prompt = "Process this invoice: @invoice"
+prompt = "Process this invoice: $invoice"
 ```
 
 **Cross-domain references** (prefix required):
@@ -171,7 +171,7 @@ domain = "accounting"
 type = "PipeLLM"
 inputs = { invoice = "finance.Invoice" }    # Different domain, needs prefix
 output = "Report"
-prompt = "Reconcile this invoice: @invoice"
+prompt = "Reconcile this invoice: $invoice"
 ```
 
 ### In Python Code
@@ -201,7 +201,7 @@ type = "PipeLLM"
 # Automatically inherits the domain's system_prompt
 inputs = { record = "MedicalRecord" }
 output = "Diagnosis"
-prompt = "Extract the primary diagnosis: @record"
+prompt = "Extract the primary diagnosis: $record"
 ```
 
 Individual pipes can override the domain system prompt by defining their own `system_prompt` field.

--- a/docs/building-methods/libraries.md
+++ b/docs/building-methods/libraries.md
@@ -31,12 +31,11 @@ Libraries enforce specific uniqueness constraints to maintain consistency:
 | Component | Uniqueness Scope | Example |
 |-----------|-----------------|---------|
 | **Domains** | Unique per library | Each library can have one `marketing` domain |
-| **Pipes** | Unique per library* | Each library can have one `generate_tagline` pipe |
+| **Pipes** | Unique per domain | Each domain can have one `generate_tagline` pipe |
 | **Concepts** | Unique per domain | Each domain can have one `ProductDescription` concept |
 | **Domain.Concept** | Unique per library | `marketing.ProductDescription` is unique within a library |
 
-!!! info "Future Change"
-    *Pipe uniqueness will soon be scoped per domain instead of per library, allowing different domains within the same library to have pipes with the same code.
+Pipes are identified by their domain-qualified reference (e.g. `marketing.generate_tagline`), so different domains within the same library can have pipes with the same code.
 
 ## Local vs Remote Libraries
 
@@ -112,12 +111,14 @@ domain = "marketing"
 
 [concept]
 ProductDescription = "A product description"
+Tagline = "A catchy tagline for a product"
 
 [pipe.my_pipe]
 type = "PipeLLM"
+description = "Generate a tagline for a product"
 inputs = { desc = "ProductDescription" }
 output = "Tagline"
-prompt = "Generate a tagline for: @desc"
+prompt = "Generate a tagline for: $desc"
 """
 
 runner = PipelexMTHDSProtocol()
@@ -184,7 +185,7 @@ response = await runner.execute(
 )
 ```
 
-A temporary library will be created holding the Pipelex bundle, and the library_id will be pipeline_run_id.
+A temporary library will be created holding the Pipelex bundle, and the library_id will be pipeline_run_id. Since no `pipe_code` is passed, the generated content must declare `main_pipe` at the top of the bundle (e.g. `main_pipe = "my_pipe"`) so the runner knows which pipe to execute — otherwise pass `pipe_code=` explicitly.
 
 ### 3. Reuse Library IDs for Related Executions
 

--- a/docs/building-methods/pipelex-bundle-specification.md
+++ b/docs/building-methods/pipelex-bundle-specification.md
@@ -66,7 +66,7 @@ main_pipe = "extract_and_validate_invoice"
 - **`domain`** (required) - The unique identifier for this bundle's namespace
 - **`description`** (Optional) - A human-readable description of what this bundle does
 - **`system_prompt`** (Optional) - A system prompt that applies to all `PipeLLM` operators in this bundle
-- **`main_pipe`** (Optional) - The default pipe to execute when no specific pipe is requested when running the bundle (covered in section 2)
+- **`main_pipe`** (Optional) - The default pipe to execute when no specific pipe is requested when running the bundle (see "About `main_pipe`" below)
 
 **Why domains matter:**
 
@@ -84,12 +84,21 @@ When you define a `system_prompt` at the bundle level, it automatically applies 
 domain = "medical_records"
 system_prompt = "You are a medical records specialist with expertise in HIPAA compliance and clinical documentation."
 
+[concept]
+MedicalRecord = "A patient's medical record"
+Diagnosis = "A medical diagnosis extracted from a record"
+
 [pipe.extract_diagnosis]
 type = "PipeLLM"
 # This pipe will automatically use the bundle's system_prompt
+description = "Extract the primary diagnosis from a medical record"
 inputs = { record = "MedicalRecord" }
 output = "Diagnosis"
-prompt = "Extract the primary diagnosis from this medical record: @record"
+prompt = """
+Extract the primary diagnosis from this medical record:
+
+@record
+"""
 ```
 
 Individual pipes can override the bundle's system prompt by defining their own `system_prompt` field.
@@ -147,7 +156,7 @@ Pipes are the processing units that transform data. Like concepts, they're optio
 type = "PipeExtract"
 description = "Extract text and images from an invoice PDF"
 inputs = { document = "Document" }
-output = "Page"
+output = "Page[]"
 ```
 See more about designing pipes in [Designing Pipelines](./pipes/index.md).
 
@@ -171,7 +180,7 @@ type = "PipeLLM"
 description = "Validate invoice data"
 inputs = { invoice = "Invoice" }          # ✅ No prefix needed
 output = "ValidationResult"               # ✅ No prefix needed
-prompt = "Validate this invoice: @invoice"
+prompt = "Validate this invoice: $invoice"
 ```
 
 This is the most common case and keeps your code clean.
@@ -198,7 +207,11 @@ inputs = {
 }
 output = "ReconciliationReport"
 prompt = """
-Reconcile this payment with the invoice...
+Reconcile this payment with the invoice:
+
+@invoice
+
+@payment
 """
 ```
 


### PR DESCRIPTION
## What

Stage-2 batch **S2-2** of the Drift Hunt campaign: fixes all Stage-1 drift findings on the building-methods **concepts + top-level** pages (10 pages, docs-only). Sibling batches: S2-3 (#1042), S2-1 (#1043).

- **All 14 Stage-1 findings fixed, 0 rejected-at-fix-time** (F1–F3, F13–F16, F27–F28, F33–F36, F42): broken bundle examples (unused inputs, inline `@` sigils, a 3-pipe example with a prompt-var/pipe-ref mismatch), the fictional `structure_class_name` field replaced by the real `refines`/`structure` mutual-exclusion rule, the shorthand-field "optional by default" claim inverted to the real required-by-default, the stale "pipe uniqueness per library / future per-domain" claim replaced with shipped per-domain reality, `[aliases]` → `[llm.aliases]`, the deck-file enumerations completed, the native-concept list completed, and the copy-the-generated-class recommendation replaced with the generator's own subclass-in-a-sibling-module prescription.
- **+8 fix-time fixes** (D16, each adversarially verified before fixing): two more inline-`@` sigils, two `PipeExtract` outputs `Page` → `Page[]`, `reconcile_payment` unused inputs, the refining-concepts Full Example missing `item` inputs, the `execute()` `main_pipe`/`pipe_code` precondition on libraries.md, and a dangling "section 2" pointer. Six candidates were **refuted** by the verify gate (notably: the multi-line inline TOML tables are valid under the shipped tomli 2.4.1 — that refutation surfaced a real `tomli>=2.3.0` pin-floor gap, recorded as a deferred code finding).

## Verification

- Every changed `.mthds`/TOML example re-extracted from the pages and re-validated with `pipelex validate bundle` (cross-bundle ones via `-L` scaffolds); the libraries.md `execute()` pattern and the native-concepts Document Extraction sequence were **executed live in dry-run**.
- Blind post-fix review: two independent no-context reviewers on the batch commit — **zero defects**.
- Gates: `make docs-check` (strict) green on both this branch and the campaign branch; `make check` green.

## Notes

- Also carries this page set's previously-unshipped Stage-0 fixes (native-concepts triple-quoted prompt; adapt-to-llm-prompting-style config keys/signature), so the PR is self-contained on dev.
- Full fix-time record (incl. refuted candidates and two new code-side deferrals) lives in `wip/drift-hunt/findings/building-methods.md` on the campaign branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes drift across building-methods concept docs and top-level pages so examples and rules match current Pipelex behavior. Aligns prompts, validation rules, config keys, outputs, and structure guidance; adds missing inputs and clarifies execution defaults.

- **Bug Fixes**
  - Use `$var` in inline prompts and `@var` in block inserts; switch to triple-quoted blocks where needed.
  - Change `PipeExtract` output to `Page[]`; fix page-analysis pipe names and inputs.
  - Add missing inputs and drop unused ones (e.g., `item`, `reconcile_payment`).
  - Enforce mutual exclusion between `refines` and `structure`; remove `structure_class_name`.
  - Correct field defaults: shorthand string fields are required; inline-table fields are optional by default.
  - Scope pipe codes per domain and reference as `domain.pipe_code`.
  - Remove false auto-discovery claim for generated subclasses; subclasses aren’t auto-registered and should be applied in your code.

- **Refactors**
  - Rename `[aliases]` to `[llm.aliases]`; document `4_search_deck.toml` and `x_custom_extract_deck.toml`.
  - Expand native concepts list (`YesNo`, `Date`, `Time`, `Composite`) and fix ordering.
  - Update prompting docs: `TemplatingStyle`, `dict[str, ...]`, TOML `{ tag_style = ... }`, and new `get_prompting_style` signature.
  - Recommend subclassing generated structures instead of copying; keep inline structures as the source of truth unless Pipelex must enforce validation (then use a hand-written class).
  - Clarify `execute()` precondition: include `main_pipe` in the bundle or pass `pipe_code`.

<sup>Written for commit e82d36d07c97dc52d5fd67c54e3af5bd501fb1ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Pipelex/pipelex/pull/1044?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

