### PR TITLE
Release v0.39.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v0.39.1] - 2026-07-15
+
+### Changed
+
+- Bumped the `pipelex-tools-py` runtime dependency to `>=0.1.3` and the `pipelex-tools` dev dependency to `>=0.7.2`, picking up the latest MTHDS schema updates for `plxt` formatting and linting.
+
 ## [v0.39.0] - 2026-07-14
 
 ### Highlights

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pipelex"
-version = "0.39.0"
+version = "0.39.1"
 description = "Execute composable AI methods declared in the MTHDS open standard"
 authors = [{ name = "Evotis S.A.S.", email = "oss@pipelex.com" }]
 maintainers = [{ name = "Pipelex staff", email = "oss@pipelex.com" }]
@@ -36,7 +36,7 @@ dependencies = [
   "opentelemetry-semantic-conventions",
   "opentelemetry-sdk",
   "pillow>=12.1.1",
-  "pipelex-tools-py==0.1.1",
+  "pipelex-tools-py>=0.1.3",
   "polyfactory>=2.21.0",
   "portkey-ai>=2.1.0",
   "posthog>=6.7.0",
@@ -113,7 +113,7 @@ dev = [
   "jsonschema>=4.20.0",
   "moto[dynamodb,s3]>=5.0.0",
   "mypy==1.19.1",
-  "pipelex-tools>=0.6.0",
+  "pipelex-tools>=0.7.2",
   "pyright==1.1.410",
   "pylint==4.0.4",
   "pytest>=9.0.3",

--- a/uv.lock
+++ b/uv.lock
@@ -3242,7 +3242,7 @@ wheels = [
 
 [[package]]
 name = "pipelex"
-version = "0.39.0"
+version = "0.39.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },
@@ -3415,8 +3415,8 @@ requires-dist = [
     { name = "opentelemetry-sdk" },
     { name = "opentelemetry-semantic-conventions" },
     { name = "pillow", specifier = ">=12.1.1" },
-    { name = "pipelex-tools", marker = "extra == 'dev'", specifier = ">=0.6.0" },
-    { name = "pipelex-tools-py", specifier = "==0.1.1" },
+    { name = "pipelex-tools", marker = "extra == 'dev'", specifier = ">=0.7.2" },
+    { name = "pipelex-tools-py", specifier = ">=0.1.3" },
     { name = "polyfactory", specifier = ">=2.21.0" },
     { name = "portkey-ai", specifier = ">=2.1.0" },
     { name = "posthog", specifier = ">=6.7.0" },
@@ -3458,32 +3458,32 @@ provides-extras = ["anthropic", "bedrock", "docling", "fal", "gcp-storage", "goo
 
 [[package]]
 name = "pipelex-tools"
-version = "0.6.0"
+version = "0.7.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3c/87/e1316e7c3886ea6c6972c4fbca9a3800e52358bde1371d77835f623527a7/pipelex_tools-0.6.0.tar.gz", hash = "sha256:c4017a5b1a60c132b46b1bfabbcf0726dcc82428d551359534a8633bfe32e786", size = 167968, upload-time = "2026-05-31T23:15:06.367Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/01/ad82d2a4dd62c9375d0d6b8740bcda46344a1fcebcd8e3fc9a373d64e5b2/pipelex_tools-0.7.2.tar.gz", hash = "sha256:afcacadd5375db6dfd20d674b99ac260226d0688b2c3acd0b32e097c211cf371", size = 194940, upload-time = "2026-07-13T17:47:56.019Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6d/5e/3bf0831ebba9b22ca83ef71aa8a8d9e380f4af96be2b85604ead1c01de00/pipelex_tools-0.6.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:030d941060365367a510b6a128656163b450b6894263353bdab45499559263d3", size = 5156127, upload-time = "2026-05-31T23:14:54.974Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/86/a47fe8298d0bb77a0fb1bf89692186c03c3eee17a9f2b1f908fde3dc0552/pipelex_tools-0.6.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:1ffbb0eac120af063fdbe4226a90fffafc2afbf18af20556b8d0297ced5d96e4", size = 4915337, upload-time = "2026-05-31T23:14:56.684Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/32/a4e58781d9cbc6779e446c6a49ffe7df5892a338b00cf24c52541cc8287e/pipelex_tools-0.6.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c3efe5e208e5e1fb862d9307c9c909ea0fbc4ce13e80358a4eb1699d203415f3", size = 5031949, upload-time = "2026-05-31T23:14:58.187Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/df/fca17477a82327fa33bfe0f2c31bbe482c56027427b21028b86291e738cf/pipelex_tools-0.6.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ee67dcaf62b5ec10c24bd95f534a3cb3c2eb995f6aaccb1e19d4eb5cc6a0d1d9", size = 5261147, upload-time = "2026-05-31T23:14:59.678Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/d5/64f158aaf1d0c2fa81c45b407d9f478e7537a01f79d16de1d03928870442/pipelex_tools-0.6.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2d59d95934d13ac81092375f0299986461f9281ce8b7c397be2d0e00c23f46bd", size = 5290791, upload-time = "2026-05-31T23:15:01.262Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/01/361093296364c2da83ab5031688bb33d3471716a52df07cbd943090de165/pipelex_tools-0.6.0-py3-none-win32.whl", hash = "sha256:97d8560e7e0a70aceb63c13a899cefd333b2601ba299ba8950174e1bf3494df8", size = 4668464, upload-time = "2026-05-31T23:15:03.039Z" },
-    { url = "https://files.pythonhosted.org/packages/87/97/bb4a9034781e7f189d903b8940de837c723201d1733a71bb7072d0bcf309/pipelex_tools-0.6.0-py3-none-win_amd64.whl", hash = "sha256:56424ede9de3268c816af937f3525bf0b4c4fce8612bf6907e21f4ce078c3ead", size = 5471901, upload-time = "2026-05-31T23:15:04.587Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/5c/31a17a5ccc0528c24f9566b1274184608a3ac65e54463ba797647df4f222/pipelex_tools-0.7.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:8adbdabc3056cbe3fc235f1c0cf2d48e2d93afdc45867fb40f9f935177416aa1", size = 5177818, upload-time = "2026-07-13T17:47:41.012Z" },
+    { url = "https://files.pythonhosted.org/packages/74/5e/bb1804d0cb4f5a297e66214bff32094c972acd404597db9f6c390a1acadb/pipelex_tools-0.7.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:5884c135a9ac5af65ba1ae1033fa90319d6b2ebe5f54019e7386515f8624f70b", size = 4932368, upload-time = "2026-07-13T17:47:43.632Z" },
+    { url = "https://files.pythonhosted.org/packages/13/17/9259a1d84fa9a69332ccbc26e87c7fbdb069f6deec2e697471e4ca6b3045/pipelex_tools-0.7.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aa7014c83ffe694fef04090bf96a106669f95e07f3bd4adc330ed93a3c0f9862", size = 5004948, upload-time = "2026-07-13T17:47:45.598Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/26/406e3bd031cd29497f6c24a10c9e0d461821ae0c1a5f28fb512558d26abe/pipelex_tools-0.7.2-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ff5ef79de1945815bf2ff3686baa3e88c9cb62adaf58c23aef8fe16f7c232311", size = 5242365, upload-time = "2026-07-13T17:47:47.464Z" },
+    { url = "https://files.pythonhosted.org/packages/88/c1/ea8076deae82233dd29cebf45784970eea520316c8ada93969d55f146204/pipelex_tools-0.7.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5728f735cfe3acda6052aa64749cdac74161780db60ee6152aa8b8585c39c0f1", size = 5258268, upload-time = "2026-07-13T17:47:49.488Z" },
+    { url = "https://files.pythonhosted.org/packages/83/23/fe30a83212adcd30974a6f69a1c86e523112db95bf262731dd5120e61165/pipelex_tools-0.7.2-py3-none-win32.whl", hash = "sha256:a85c5b24c847c02f21f907badbc1659342bf04eeb0c7024166cc4e5ce7baa754", size = 4707280, upload-time = "2026-07-13T17:47:51.551Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/a9/9884212fa19e1a3272310d5de826a4d15799b10e88f2626e3990ed276c28/pipelex_tools-0.7.2-py3-none-win_amd64.whl", hash = "sha256:6b9df7166d69c5718974b1c1a7c14667c0e41943bf037ecfdf291cca71907b32", size = 5507110, upload-time = "2026-07-13T17:47:53.559Z" },
 ]
 
 [[package]]
 name = "pipelex-tools-py"
-version = "0.1.1"
+version = "0.1.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1c/7a/475d5314cf2c8a402ff646ebf435ccc9d51b9d4e3c52eb063b37130e6ee5/pipelex_tools_py-0.1.1.tar.gz", hash = "sha256:ec1f5e30fe666417f210a5bb1013394cef8b0c246d070037d78cf8dfcd086603", size = 114697, upload-time = "2026-06-29T10:23:00.415Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fd/a6/7ec8bb4b89c8f2c70d99a932c803a04f8dcd42c56c707e76f64f19d94004/pipelex_tools_py-0.1.3.tar.gz", hash = "sha256:f8f981fe9faf112095d41cea74e3a2945dd29321f61edc17e30621c328fa5a13", size = 122325, upload-time = "2026-07-13T17:44:38.936Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6b/51/701114de4b1744dbddf37ec172ab97649177d6c7c761d75689a4b1ea6788/pipelex_tools_py-0.1.1-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:69e930881da8787259cf3040eb33b669dfb4bd4ed13c8a68f082ee284f4fa3a7", size = 2490500, upload-time = "2026-06-29T10:22:48.96Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/4f/3f28ffe46d8a31760841f29a773519794b86c3e4a1d4eec70c9b74f97282/pipelex_tools_py-0.1.1-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:fe07dbf840deace1fa8bebe8154fef0abb4284177aae89961437edf9bddf3257", size = 2388577, upload-time = "2026-06-29T10:22:50.771Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/79/6d235117695c803946ae0fdcb5ad9410c11ed70f7182bf7a01460bf4d410/pipelex_tools_py-0.1.1-cp38-abi3-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:29b818d6af5af6510bf25505acbe7d3cdca309f1443cd95299c61b0b7fd0e180", size = 2717460, upload-time = "2026-06-29T10:22:52.446Z" },
-    { url = "https://files.pythonhosted.org/packages/43/aa/31f70c2ef5b7417d0b46c3b1079f797d3d42a2fc60ceaf176a8a9d52938f/pipelex_tools_py-0.1.1-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:902b69127df66a91f80d3b3158217ff29aa40c2ad86917b46de7e9640a6f81ab", size = 2505388, upload-time = "2026-06-29T10:22:53.902Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/4f/53f3e3e10391d3035bbc84966a80439277b04a9efc8cab09e890871a3cfe/pipelex_tools_py-0.1.1-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f89c17a9c58161ff0ff515bc7054bfc58710c9edec3d4dfc842d07966f239ba", size = 2629996, upload-time = "2026-06-29T10:22:55.713Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/72/4a68e0b3f3c758c0808a888db40299d46af1f79b23aa0c3fcc442f3a68de/pipelex_tools_py-0.1.1-cp38-abi3-win32.whl", hash = "sha256:b26e93fd975682b7dc15d0d300ddb540650cfdf9dff917a6e4880cc1283e83c8", size = 2396611, upload-time = "2026-06-29T10:22:57.173Z" },
-    { url = "https://files.pythonhosted.org/packages/98/16/aa4ad4790c29d2f7d0a9160e3fe2faf1b8be12d9dde081f989654038fc63/pipelex_tools_py-0.1.1-cp38-abi3-win_amd64.whl", hash = "sha256:a925bdc2e0ee00dde3adc9fe360e227f2968376b2ed0bbe4e14bb82014d9ac7e", size = 2633419, upload-time = "2026-06-29T10:22:58.875Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/d9/daf353eb2a5e33b215d9baae6f80a6ef5a194fda7a251378be337f3bd64c/pipelex_tools_py-0.1.3-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:b93257f98505d0dda936bcd23274e353d495a2f0673b315c13cc64cbd71e30d5", size = 2492434, upload-time = "2026-07-13T17:44:24.865Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/fb/b7eb60fc384e5a79eaaaf0e60c23a240e7c00cb0c889deef274de810ecd2/pipelex_tools_py-0.1.3-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:7c60923bc86a7bd65f47abd83a4fefade442d10e450e637fc64941373748149a", size = 2392193, upload-time = "2026-07-13T17:44:27.053Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/b1/39e00ce3ef90f300834e10ca134de94ce82e44e4a4aad6fb8508805a39ee/pipelex_tools_py-0.1.3-cp38-abi3-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:7b047b60ef003747225b31bf967e2635ba66f1b5c1a21044bb249dff41c1a000", size = 2708955, upload-time = "2026-07-13T17:44:28.975Z" },
+    { url = "https://files.pythonhosted.org/packages/60/22/d257d4a1ddb2d7a6ae03010f19512666f4352ebf66e05a30e4aaa7bd36cf/pipelex_tools_py-0.1.3-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dd835b69f607272848a21ed866dd48ec62f43bb1b90c256602450aa872cc9082", size = 2503927, upload-time = "2026-07-13T17:44:31.322Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/c3/3b175e5f2121175a1c7524449c948f08a2f71d55ecb72f4b72fbd6b9e6b1/pipelex_tools_py-0.1.3-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a63a23a0bde82ebb1fac8542a54ba4f18f61506628b4ad9c81c4f7376bd7ac22", size = 2624012, upload-time = "2026-07-13T17:44:33.497Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/0f/994bd53ae88062808c483785c3d2726bf0d16cad754357569f159b2fb263/pipelex_tools_py-0.1.3-cp38-abi3-win32.whl", hash = "sha256:1532b8c41b10d8177a1da015cabe9f734619f64b4c46e114e0a666fb76db8139", size = 2399074, upload-time = "2026-07-13T17:44:35.57Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/51/c9c9fdf3b0174787f1e0e1f38b9adf15919613104557018f46d93e30030b/pipelex_tools_py-0.1.3-cp38-abi3-win_amd64.whl", hash = "sha256:1cfd0fb2943fd3109d0ee1f88591965e619a2d9dd523510174585cfbc6727431", size = 2634894, upload-time = "2026-07-13T17:44:37.485Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Release v0.39.1

Bumps version from `0.39.0` to `0.39.1`.

### Changelog

## [v0.39.1] - 2026-07-15

### Changed

- Bumped the `pipelex-tools-py` runtime dependency to `>=0.1.3` and the `pipelex-tools` dev dependency to `>=0.7.2`, picking up the latest MTHDS schema updates for `plxt` formatting and linting.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Patch release v0.39.1 updates `pipelex-tools-py` and `pipelex-tools` to pick up the latest MTHDS schema. Keeps `plxt` formatting and linting in sync.

- **Dependencies**
  - Runtime: `pipelex-tools-py` to `>=0.1.3` (was `==0.1.1`)
  - Dev: `pipelex-tools` to `>=0.7.2` (was `>=0.6.0`)

<sup>Written for commit 51e0a385cc5b830affd3ed4f5ed5ca9adf696a75. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Pipelex/pipelex/pull/1049?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

