### PR TITLE
test thomas

### DIFF
--- a/pipelex/errors/error_pages_generator.py
+++ b/pipelex/errors/error_pages_generator.py
@@ -84,7 +84,7 @@ def _force_load_all_error_modules() -> None:
         name = path.name
         if name != "exceptions.py" and not name.endswith("_exceptions.py"):
             continue
-        rel = path.relative_to(_PIPELEX_ROOT.parent).with_suffix("")
+        rel= path.relative_to(_PIPELEX_ROOT.parent).with_suffix("")
         dotted = ".".join(rel.parts)
         try:
             importlib.import_module(dotted)


### PR DESCRIPTION
### 🔗 Related Issues

### 📝 Description

### 🔄 Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🧹 Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update

### 🧪 Tests

### 📋 Checklist

- [ ] Linting / type-checking / unit tests pass locally with my changes
- [ ] I've added tests that prove my fix is effective or that my feature works
- [ ] My code follows the style guidelines of this project
- [ ] I've made corresponding changes to the documentation
- [ ] My changes generate no new warnings


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Small style tweak in `pipelex/errors/error_pages_generator.py`: adjusted the `rel` assignment in `_force_load_all_error_modules` while building the dotted module path. No functional change.

<sup>Written for commit 5c6e998412a660394182850fce2c3eac66847370. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Pipelex/pipelex/pull/1053?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

