### PR TITLE
ci-cd: move tests-full + dependency-canary off Azure (shard the gate)

### DIFF
--- a/.github/workflows/dependency-canary.yml
+++ b/.github/workflows/dependency-canary.yml
@@ -33,12 +33,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install uv (with cache)
-        uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: true
-          cache-dependency-glob: "uv.lock"
-
       - name: Install
         run: PYTHON_VERSION=${{ matrix.python-version }} make install
 
@@ -68,12 +62,6 @@ jobs:
       PIPELEX_NO_DECK_NOTICE: "1"
     steps:
       - uses: actions/checkout@v4
-
-      - name: Install uv (with cache)
-        uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: true
-          cache-dependency-glob: "uv.lock"
 
       - name: Install
         run: make install

--- a/.github/workflows/dependency-canary.yml
+++ b/.github/workflows/dependency-canary.yml
@@ -21,20 +21,23 @@ jobs:
   #    breakage from any floor-only / uncapped dependency the moment it releases.
   latest-within-ranges:
     name: Latest deps within ranges (py${{ matrix.python-version }})
-    runs-on: [aca-runner-test]
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.11", "3.13"]
-    permissions:
-      contents: read
-      id-token: write
     env:
       VIRTUAL_ENV: ${{ github.workspace }}/.venv
       ENV: dev
       PIPELEX_NO_DECK_NOTICE: "1"
     steps:
       - uses: actions/checkout@v4
+
+      - name: Install uv (with cache)
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
 
       - name: Install
         run: PYTHON_VERSION=${{ matrix.python-version }} make install
@@ -58,16 +61,19 @@ jobs:
   #    the cap on purpose.
   beyond-typer-cap:
     name: Beyond typer cap (real CLI)
-    runs-on: [aca-runner-test]
-    permissions:
-      contents: read
-      id-token: write
+    runs-on: ubuntu-latest
     env:
       VIRTUAL_ENV: ${{ github.workspace }}/.venv
       ENV: dev
       PIPELEX_NO_DECK_NOTICE: "1"
     steps:
       - uses: actions/checkout@v4
+
+      - name: Install uv (with cache)
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
 
       - name: Install
         run: make install

--- a/.github/workflows/tests-full-check.yml
+++ b/.github/workflows/tests-full-check.yml
@@ -1,16 +1,14 @@
 name: Tests full (pre-main gate)
 
-# The full Python matrix. Feature PRs (to dev) run the floor version only,
-# sharded, in `tests-check.yml`; this is the gate on PRs targeting main (the
-# release PRs, dev -> main) where every supported version gets exercised.
+# The full Python matrix, sharded. Feature PRs (to dev) run the floor version
+# only, sharded, in `tests-check.yml`; this is the gate on PRs targeting main
+# (the release PRs, dev -> main) where every supported version gets exercised.
 #
-# Why not on every PR: the suite is CPU-bound pytest per version, so a
-# 4-version matrix on every push of every feature PR was the bulk of the CI
-# bill, for a signal that almost never differs between versions. Running it as
-# a release gate means no version-specific break can reach main, without paying
-# it on day-to-day feature work.
-#
-# Same shape as `lint-fresh-check.yml`: fast on feature PRs, definitive before main.
+# Sharded across free GitHub-hosted runners: 4 versions x 8 shards = 32 jobs,
+# balanced by the committed .test_durations file, all in parallel. Wall clock
+# ~4 min (faster than the old 8-core Azure box) at zero cost. The single
+# required check is the aggregator `Tests full (all)` — so shard count or
+# Python versions can change without ever touching the branch ruleset.
 
 on:
   pull_request:
@@ -28,19 +26,17 @@ concurrency:
 
 jobs:
   matrix-test-full:
-    name: Tests full (py${{ matrix.python-version }})
-    runs-on: [aca-runner-test]
+    name: Tests full (py${{ matrix.python-version }}, shard ${{ matrix.group }}/8)
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.11", "3.12", "3.13", "3.14"]
-    permissions:
-      contents: read
-      id-token: write
+        group: [1, 2, 3, 4, 5, 6, 7, 8]
     env:
       VIRTUAL_ENV: ${{ github.workspace }}/.venv
       ENV: dev
-      PIPELEX_HANG_DUMP_DIR: /tmp/pipelex-hang-dumps-${{ github.run_id }}-py${{ matrix.python-version }}
+      PIPELEX_HANG_DUMP_DIR: /tmp/pipelex-hang-dumps-${{ github.run_id }}-py${{ matrix.python-version }}-shard${{ matrix.group }}
     steps:
       # On a pull_request this checks out the merge ref (dev merged into main),
       # which is exactly what must be gated. workflow_dispatch can override.
@@ -48,14 +44,17 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.sha }}
 
+      - name: Install uv (with cache)
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
       - name: Install dependencies
         run: PYTHON_VERSION=${{ matrix.python-version }} make install
 
-      - name: Boot test
-        run: make tp TEST=TestFundamentals
-
-      - name: Run tests
-        run: make gha-tests
+      - name: Run tests (py${{ matrix.python-version }}, shard ${{ matrix.group }}/8)
+        run: SPLITS=8 GROUP=${{ matrix.group }} make gha-tests
 
       - name: Show hang dumps
         if: failure()
@@ -69,3 +68,22 @@ jobs:
           else
             echo "No hang dumps were produced."
           fi
+
+# --------------------------------------------------------------------------
+#  Aggregator — the single required status check for the full-matrix gate.
+#  Green only if all 32 shards across all 4 versions pass.
+# --------------------------------------------------------------------------
+  tests-full-all:
+    name: Tests full (all)
+    runs-on: ubuntu-latest
+    needs: [matrix-test-full]
+    if: always()
+
+    steps:
+      - name: Fail unless every version and shard passed
+        run: |
+          if [ "${{ needs.matrix-test-full.result }}" != "success" ]; then
+            echo "::error::At least one full-matrix shard failed."
+            exit 1
+          fi
+          echo "All full-matrix shards passed."


### PR DESCRIPTION
Shards the full-matrix pre-main gate onto free runners (4 versions × 8 shards = 32 jobs, ~4 min, faster than the old 8-core Azure box) with a `Tests full (all)` aggregator. Moves `dependency-canary` to `ubuntu-latest` too.

After this merges, **no workflow references `aca-runner-test`** — the Azure runner infra can be destroyed. The main ruleset's required check switches from the four `Tests full (py3.X)` legs to `Tests full (all)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the full test gate and dependency canary off Azure to GitHub-hosted `ubuntu-latest`, sharding the matrix to ~4 minutes total runtime. Added a single `Tests full (all)` aggregator as the required check.

- **Refactors**
  - Shard full test gate: 4 Python versions × 8 shards (32 jobs) on `ubuntu-latest` (~4 min).
  - Replace per-version required checks with a single `Tests full (all)` aggregator.
  - Move `dependency-canary` to `ubuntu-latest`; remove all `aca-runner-test` references.

- **Dependencies**
  - Use `astral-sh/setup-uv@v7` with caching (`uv.lock`) in the tests gate.
  - Drop uv cache from `dependency-canary` so it resolves newer-than-locked deps; `make install` bootstraps uv.

<sup>Written for commit 0f5fe46dd1463388fac5274890fbfda318352f8c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Pipelex/pipelex/pull/1055?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

