### PR TITLE
fix(core): resolve a shaped value's structure class through the injected provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- **Input shaping honors its injected concept provider (Breaking)**: `InputShaper` took a `ConceptProviderAbstract` and consulted it for concept resolution and compatibility, then resolved each value's structure class from the process-global class registry anyway — the ambient lookup the provider parameter exists to replace. It now resolves the class through the provider and hands the resolved type down, so a caller that supplies its own provider can shape inputs without a loaded library. Breaking on one failure path: a declared structure class that does not resolve now raises `ConceptStructureClassNotFoundError` instead of arriving as a `StructureValidationError` about the value, which pointed the author at their input rather than at the concept.
+
 ## [v0.42.0] - 2026-08-01
 
 ### Added

--- a/pipelex/core/memory/input_shaper.py
+++ b/pipelex/core/memory/input_shaper.py
@@ -536,9 +536,30 @@ class InputShaper:
         stuff_spec: StuffSpec,
         variable_name: str,
     ) -> StuffContent:
-        """Delegate to ``StuffContentFactory``, wrapping a build failure as a D4 structure error."""
+        """Delegate to ``StuffContentFactory``, wrapping a build failure as a D4 structure error.
+
+        The structure class is resolved through the **injected provider**, then handed down as a
+        resolved type — the shape ``hub-layering.md`` prescribes for exactly this ("rendering takes
+        the resolved class, not the name"), and the one ``StuffSpec.render_stuff_spec`` already
+        follows. The registry-resolving overload
+        (``make_stuff_content_from_concept_required``) stays for the bottom-up callers that hold no
+        provider; a caller that *has* one must not reach past it into ambient state, which is what
+        the provider parameter exists to avoid.
+
+        Two things follow, and neither is incidental. A shaper that resolved names from the process
+        registry could not run without a loaded library at all — the registry is empty outside a
+        booted process, so `shape_inputs` was un-callable by any programmatic caller that built its
+        own provider, despite taking one explicitly for that purpose. And a name that should have
+        resolved and did not now raises ``ConceptStructureClassNotFoundError`` (uncaught here,
+        deliberately) rather than arriving as a ``StructureValidationError``: an unresolvable
+        declared class is not a malformed *value*, and reporting it as one pointed the author at
+        their input instead of at the concept.
+        """
         try:
-            return StuffContentFactory.make_stuff_content_from_concept_required(concept=concept, value=value)
+            return StuffContentFactory.make_content_from_value(
+                stuff_content_subclass=concept_provider.get_structure_class(concept=concept),
+                value=value,
+            )
         except (ValidationError, StuffContentFactoryError) as exc:
             raise StructureValidationError.make(
                 variable_name=variable_name,

--- a/tests/unit/pipelex/core/memory/input_shaper/test_provider_injection.py
+++ b/tests/unit/pipelex/core/memory/input_shaper/test_provider_injection.py
@@ -13,15 +13,28 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from pipelex.core.concepts.concept_factory import ConceptFactory
 from pipelex.core.concepts.concept_provider_abstract import ConceptProviderAbstract
 from pipelex.core.concepts.native.concept_native import NativeConceptCode
 from pipelex.core.memory.input_shaper import InputKind, InputShaper
+from pipelex.core.pipes.inputs.input_stuff_specs import InputStuffSpecs
+from pipelex.core.pipes.stuff_spec.stuff_spec import StuffSpec
+from pipelex.core.stuffs.text_content import TextContent
 from pipelex.interpreter_hub import get_concept_library
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
     from pipelex.core.concepts.concept import Concept
+
+
+class UnregisteredNote(TextContent):
+    """A structure class that exists as a type but is deliberately never registered.
+
+    The whole discriminating power of the content-building test below rests on this: the ambient
+    class registry cannot resolve the name `UnregisteredNote`, so a build that succeeds proves the
+    class came from the injected provider and from nowhere else.
+    """
 
 
 class TestConceptProviderInjection:
@@ -51,3 +64,51 @@ class TestConceptProviderInjection:
         assert InputShaper.resolve_input_kind(text_concept, concept_provider=stub) is InputKind.NUMBER
         assert stub.is_compatible.called
         assert stub.get_native_concept.called
+
+    def test_building_a_value_resolves_the_structure_class_through_the_injected_provider(self, mocker: MockerFixture) -> None:
+        """Content building takes the class from the provider, not from the ambient class registry.
+
+        The provider was consulted for *resolution* and for *compatibility* long before it was
+        consulted for this: `_make_content` handed the whole job to
+        `StuffContentFactory.make_stuff_content_from_concept_required`, which resolves the declared
+        `structure_class_name` through `get_class_registry()`. That is the regression shape this
+        module's docstring describes — a parameter accepted and then bypassed — and it is invisible
+        to every other test here, because the real library and the ambient registry agree on every
+        name the suite uses.
+
+        So the stub is made to *disagree*: the concept declares `TextContent`, which the registry
+        resolves perfectly well, while the provider answers `UnregisteredNote`. Whichever of the two
+        the shaper actually asked is then readable off the built content's exact type.
+
+        Beyond pinning the seam, this is the property a caller with no loaded library depends on:
+        the registry is empty outside a booted process, so a shaper that reaches it cannot run there
+        at all — `is_compatible` is left on the real library here precisely so the failure this
+        catches is class resolution and nothing else.
+        """
+        library = get_concept_library()
+        note_concept = ConceptFactory.make(
+            concept_code="Note",
+            domain_code="injection_probe",
+            description="A note the ambient registry and the injected provider deliberately disagree about",
+            structure_class_name=TextContent.__name__,
+            refines=NativeConceptCode.TEXT.concept_ref,
+        )
+
+        stub = mocker.Mock(spec=ConceptProviderAbstract)
+        stub.get_native_concept.side_effect = library.get_native_concept
+        stub.is_compatible.side_effect = library.is_compatible
+        stub.get_structure_class.return_value = UnregisteredNote
+
+        memory = InputShaper.shape(
+            {"note": "shaped through the provider"},
+            concept_provider=stub,
+            input_specs=InputStuffSpecs(root={"note": StuffSpec(concept=note_concept)}),
+        )
+
+        stuff = memory.get_stuff(name="note")
+        # `is` rather than `isinstance`: `UnregisteredNote` subclasses `TextContent`, so the registry's
+        # answer would satisfy an isinstance check against the base and pass a broken implementation.
+        assert type(stuff.content) is UnregisteredNote
+        assert stuff.content.text == "shaped through the provider"
+        assert stuff.concept.concept_ref == "injection_probe.Note"
+        assert stub.get_structure_class.called


### PR DESCRIPTION
## What

`InputShaper` takes a `ConceptProviderAbstract` so `core/`'s data-model half states its dependency rather than reaching a process global. It consulted that provider for concept resolution and for compatibility — and then handed content building to `StuffContentFactory.make_stuff_content_from_concept_required`, which resolves the declared `structure_class_name` through `get_class_registry()`.

One call site changes: `_make_content` now resolves the class through the provider and passes the resolved type down, the shape `StuffSpec.render_stuff_spec` already follows.

```diff
-return StuffContentFactory.make_stuff_content_from_concept_required(concept=concept, value=value)
+return StuffContentFactory.make_content_from_value(
+    stuff_content_subclass=concept_provider.get_structure_class(concept=concept),
+    value=value,
+)
```

## Why this is a defect and not a preference

`docs/contribute/hub-layering.md` already forbids it in as many words:

> When you add a core data-model function that needs a concept — or a concept's structure class — add a `concept_provider` parameter. Do not add a hub import, and **do not reach for `get_class_registry()`**.

`tests/unit/pipelex/core/memory/input_shaper/test_provider_injection.py` was written to catch precisely this regression shape — *"a regression that took the provider and then reached for the hub anyway would produce the same answers everywhere and fail nothing"* — and it did not look at content building. The golden-set guard that pins the rule (`test_concept_registry_boundary.py`) walks `pipelex/core/concepts/` only, so the leak sat one directory over, where nothing could see it.

## What it unblocks

The class registry is **empty outside a booted process** — even `TextContent` is absent. So any caller that built its own provider was blocked on the first value it shaped, despite the parameter existing for exactly that case. Measured before/after with a static provider and no boot: before, `ClassRegistryNotFoundError` on the first input; after, three inputs shape correctly, each under its **declared** concept with its **projected** class (a text-refining concept lands as `flow.Note`/`Note`, not `native.Text`/`TextContent`).

Found while building a compiled-method prototype that supplies its own provider, but it stands on its own: it is the documented rule, restored where the rule is stated.

## Test

The new test makes the two sources **disagree** — the concept declares `TextContent`, which the registry resolves perfectly well, while the provider answers a never-registered subclass — so whichever one was consulted is readable off the built content's exact type. Red before the change (`assert <class 'TextContent'> is UnregisteredNote`), green after. `is` rather than `isinstance`, because the probe class subclasses `TextContent` and an isinstance check would pass a broken implementation.

## Breaking

One failure path. A declared structure class that does not resolve now raises `ConceptStructureClassNotFoundError` instead of arriving as a `StructureValidationError` about the value. "Unknown" and "malformed" are different answers, and reporting the first as the second pointed the author at their input rather than at the concept — the same distinction `ConceptLibrary.is_compatible` was already corrected for.

## Deliberately out of scope

`stuff_factory.py` has six more registry reads inside methods that **do** hold a provider (the bottom-up envelope arm) — same defect, worth the same fix, but each carries its own error-message semantics on the not-found path, so it belongs in its own change. Two further reads (`combine_stuffs`, `working_memory_factory`) hold no provider at all and are a different question: whether to thread one in.

## Checks

`make agent-check` ✅ (pyright 0, mypy 2398 files, keyword-only, hub-layering) · `make agent-test` ✅ full suite · independent of the kernel stack — this sits below `pipelex.kernel.memory_ops.shape_inputs`, which does not exist on `dev` yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dn8QL3hjv1oyAubhPdpurf

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolve structure classes through the injected `ConceptProviderAbstract` in `InputShaper`, not the process-global registry. This fixes provider bypass and enables shaping inputs without a booted library.

- **Bug Fixes**
  - Use `concept_provider.get_structure_class(...)` and build via `StuffContentFactory.make_content_from_value`.
  - Follow hub-layering (no `get_class_registry()` in this path).
  - Added a test that forces provider vs registry disagreement to ensure the provider is used.

- **Migration**
  - An unresolvable declared structure class now raises `ConceptStructureClassNotFoundError` (was `StructureValidationError`). Update error handling if you rely on the previous exception.

<sup>Written for commit 179b665866f5cf27729e99bf2f240e0939e0fae8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Pipelex/pipelex/pull/1086?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

