### PR TITLE
Release v0.43.0 — publish fix

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -19,6 +19,24 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # A manual run can target any ref that contains this workflow, and every
+      # job below builds and publishes whatever it checks out — so an unguarded
+      # dispatch could push a feature branch to production PyPI and tag it.
+      # guard-branches.yml cannot help: it only runs on pull_request_target.
+      # Restrict manual runs to the refs a publish can legitimately come from;
+      # pull_request runs are already constrained by their base branch.
+      - name: Verify the dispatched ref may publish
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          REF: ${{ github.ref }}
+        run: |
+          echo "Dispatched from $REF"
+          if [[ "$REF" != "refs/heads/main" ]] \
+            && [[ ! "$REF" =~ ^refs/heads/release/v[0-9]+\.[0-9]+\.[0-9]+$ ]] \
+            && [[ ! "$REF" =~ ^refs/heads/pre-release/v ]]; then
+            echo "::error::Manual publish is allowed only from main, release/vX.Y.Z or pre-release/v*. Got: $REF"
+            exit 1
+          fi
       - uses: actions/checkout@v4
         with:
           persist-credentials: false

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -6,11 +6,16 @@ on:
     branches:
       - main
       - "pre-release/v*"
+  # Manual retry. A publish that fails after the merge (a rejected upload, an
+  # expired token) is otherwise unrecoverable: re-running a run replays the
+  # workflow file it started with, and the only other trigger is merging a PR
+  # into main — which the branch guard restricts to release/vX.Y.Z branches.
+  workflow_dispatch:
 
 jobs:
   build:
     name: Build distribution 📦
-    if: github.event.pull_request.merged == true
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
 
     steps:
@@ -38,7 +43,7 @@ jobs:
   publish-to-pypi:
     name: >-
       Publish Python 🐍 distribution 📦 to PyPI
-    if: github.event.pull_request.merged == true
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     needs:
       - build
     runs-on: ubuntu-latest
@@ -55,12 +60,15 @@ jobs:
           name: python-package-distributions
           path: dist/
       - name: Publish distribution 📦 to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        # v1.13.0+ bundles Twine 7, which accepts core metadata 2.5. The
+        # previous pin did not, so the first v0.43.0 upload was rejected on a
+        # wheel hatchling had built correctly.
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
 
   github-release:
     name: >-
       Create GitHub Release with Changelog
-    if: github.event.pull_request.merged == true
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     needs:
       - build
       - publish-to-pypi


### PR DESCRIPTION
## Why

The v0.43.0 publish failed after #1093 merged, so **the release never shipped**: PyPI still serves 0.42.0, and there is no `v0.43.0` tag or GitHub release.

```
Checking dist/pipelex-0.43.0-py3-none-any.whl:
ERROR InvalidDistribution: Invalid distribution metadata:
      '2.5' is not a valid metadata version
```

The wheel was fine. `hatchling` is unpinned and now emits core metadata 2.5, while `pypa/gh-action-pypi-publish` was pinned to a SHA whose bundled Twine predates support for it. `publish-to-pypi` failed → `github-release` (which `needs` it) was skipped → no tag, no release notes.

## What

- Bump the action pin to **v1.14.2** (`dc37677`), which bundles Twine 7 and accepts core metadata 2.5. Pinning `hatchling` instead would only hide the drift.
- Add **`workflow_dispatch`**. Recovering from this was harder than it should have been: re-running a run replays the workflow file it started with, so the fix cannot take effect that way, and the only other trigger is merging a PR into `main` — which the branch guard restricts to `release/vX.Y.Z` branches. A failed publish should be retryable without inventing a release.

## Effect of merging

`pyproject.toml` is still at `0.43.0`, so merging this re-runs the publish with the fixed pin and ships **0.43.0** to PyPI, then creates the `v0.43.0` tag and GitHub release. No version bump needed.

CI-only change — no runtime code, so the changelog entry for v0.43.0 is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QqbG1R3uaghExhgh8dL3oq

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unblocks the v0.43.0 release by bumping `pypa/gh-action-pypi-publish` to v1.14.2 (Twine 7) and adding a guarded manual retry. Before: Twine rejected core metadata 2.5 with no safe retry path; after: uploads succeed and manual runs are limited to release refs.

- Adds `workflow_dispatch` and verifies the dispatched ref; manual runs allowed only from `main`, `release/vX.Y.Z`, and `pre-release/v*`; jobs run on manual trigger or merged PRs.
- Pins `pypa/gh-action-pypi-publish` to v1.14.2; keeps `hatchling` unpinned.
- No runtime changes; branch synced with `main`. Merging publishes 0.43.0 and creates the GitHub release; no version bump or migrations.

<sup>Written for commit 765c1600e375abb25245b81395118d138d893c46. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Pipelex/pipelex/pull/1094?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

