### PR TITLE
fix(pipe-run): make batch_max_concurrency required, not defaulted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- **`PipeRunParams.batch_max_concurrency` is required (Breaking)**: The fan-out bound has no default any more, joining `run_mode` and `pipe_stack_limit` as a field whose omission fails loud. `None` is not only what a default would give — it is also what an authored `max_concurrency = "unbounded"` resolves to, so a default made "never written" indistinguishable from "authored unbounded", and pointed the omission at the dangerous direction: launch every branch at once. Breaking for code constructing `PipeRunParams` directly or decoding a payload that predates the field; build through `PipeRunParamsFactory.make_run_params`, the single writer of all three fields.
+
 ## [v0.43.0] - 2026-08-12
 
 ### Highlights

--- a/docs/under-the-hood/pipe-routing-and-execution.md
+++ b/docs/under-the-hood/pipe-routing-and-execution.md
@@ -51,6 +51,9 @@ The `PipeJob` is the universal unit of execution. It carries everything needed t
 
 `PipeJob` is created by `pipeline_run_setup()`, which handles library loading, pipe resolution, working memory initialization, and telemetry setup. For distributed dispatch, a transport-prep step outside open core moves `working_memory` to `working_memory_raw` (deferred hydration) and ensures the crate is attached.
 
+!!! warning "Build `PipeRunParams` through its factory"
+    `PipeRunParamsFactory.make_run_params()` is the single writer of the fields that carry a run-scoped invariant: `run_mode`, `pipe_stack_limit` and `batch_max_concurrency`. None of the three has a default — for each, a silently-defaulted value would point at the dangerous direction (real spend, an unbounded pipe stack, a fan-out that launches every branch at once), and for `batch_max_concurrency` the would-be default `None` is *also* the resolved value of an authored `max_concurrency = "unbounded"`, so "never written" and "authored unbounded" would be indistinguishable. Constructing `PipeRunParams` by hand and omitting any of them raises a `ValidationError` — at the constructor and at the wire boundary alike.
+
 ---
 
 ## Library Loading

--- a/pipelex/pipe_run/pipe_run_params.py
+++ b/pipelex/pipe_run/pipe_run_params.py
@@ -152,12 +152,17 @@ class PipeRunParams(BaseModel):
     # once at construction (`PipeRunParamsFactory.make_run_params`). `None` means unbounded —
     # `gather_bounded`'s own no-bound sentinel, so the field is passed straight through.
     #
+    # REQUIRED (no default), for the same reason as `run_mode` above: `None` is *also* the
+    # resolved value of an authored `max_concurrency = "unbounded"`, so a default would make
+    # "never written" indistinguishable from "authored unbounded" — and would point the omission
+    # at the dangerous direction, launching every branch at once. An omission must fail loud.
+    #
     # Frozen and payload-borne rather than read live at fan-out time: the bound is PipeBatch's
     # chunk size, and chunk size determines where a distributed backend's task boundaries fall
     # between branch dispatches. Read from live worker config, a redeploy that changed the
     # setting mid-run would make a replay emit a different command grouping than the recorded
     # history. Carried in the payload, the fan-out shape is a pure function of the run.
-    batch_max_concurrency: int | None = Field(default=None, frozen=True)
+    batch_max_concurrency: int | None = Field(frozen=True)
 
     final_stuff_code: str | None = None
     output_multiplicity: VariableMultiplicity | None = None

--- a/tests/integration/pipelex/fixtures/pipe_job_helpers.py
+++ b/tests/integration/pipelex/fixtures/pipe_job_helpers.py
@@ -10,12 +10,32 @@ from pipelex.mthds_parsing.parser import MthdsParser
 from pipelex.pipe_machinery.pipe_abstract import PipeAbstract
 from pipelex.pipe_run.pipe_job import PipeJob
 from pipelex.pipe_run.pipe_job_factory import PipeJobFactory
+from pipelex.pipe_run.pipe_run_params import PipeRunParams
 from pipelex.pipe_run.pipe_run_params_factory import PipeRunParamsFactory
 from pipelex.system.job_metadata import JobMetadata, SpecialPipelineId
 from pipelex.system.pipe_run_mode import PipeRunMode
 from pipelex.system.telemetry.otel_constants import OTelConstants
 
 PIPE_JOB_HELPERS_PIPELINE_RUN_ID_PREFIX = "pipe_job_helpers_test"
+
+
+def make_mode_guarded_run_params(*, pipe_run_mode: PipeRunMode = PipeRunMode.LIVE) -> PipeRunParams:
+    """Run params built through the factory, with the requested run mode guarded.
+
+    A fixture builds through the factory rather than hand-building params because the factory is the
+    single writer of the three fields that carry a run-scoped invariant — `run_mode`,
+    `pipe_stack_limit` and `batch_max_concurrency`. What the factory adds in exchange is the
+    keyless-boot coercion: under `needs_inference=False` a requested LIVE comes back DRY. For a
+    fixture whose whole point is *which controller path* runs, that would swap the path under the
+    test while every assertion still passed, so assert the requested mode survived.
+    """
+    run_params = PipeRunParamsFactory.make_run_params(pipe_run_mode=pipe_run_mode)
+    match pipe_run_mode:
+        case PipeRunMode.LIVE:
+            assert run_params.run_mode.is_live, "This test must run the live path — the boot coerced the run mode to DRY"
+        case PipeRunMode.DRY:
+            assert run_params.run_mode.is_dry, "This test must run the dry path — the boot returned a run mode other than DRY"
+    return run_params
 
 
 def build_pipe_job(

--- a/tests/integration/pipelex/pipeline/test_optional_method_inputs.py
+++ b/tests/integration/pipelex/pipeline/test_optional_method_inputs.py
@@ -18,11 +18,11 @@ from pipelex.core.stuffs.text_content import TextContent
 from pipelex.pipe_machinery.pipe_factory import PipeFactory
 from pipelex.pipe_operators.func.pipe_func import PipeFunc
 from pipelex.pipe_operators.func.pipe_func_blueprint import PipeFuncBlueprint
-from pipelex.pipe_run.pipe_run_params_factory import PipeRunParamsFactory
 from pipelex.pipeline.execution_seams import prepare_pipe_job
 from pipelex.system.job_metadata import JobMetadata
 from pipelex.system.pipe_run_mode import PipeRunMode
 from pipelex.system.registries.func_registry import func_registry
+from tests.integration.pipelex.fixtures.pipe_job_helpers import make_mode_guarded_run_params
 
 
 def optionals_method_report(working_memory: WorkingMemory) -> TextContent:
@@ -150,7 +150,7 @@ class TestOptionalMethodInputs:
         """
         load_empty_library()
         pipe = _make_method_pipe()
-        run_params = PipeRunParamsFactory.make_run_params(pipe_run_mode=PipeRunMode.LIVE)
+        run_params = make_mode_guarded_run_params(pipe_run_mode=PipeRunMode.LIVE)
 
         with pytest.raises(PipeRunInputsError) as exc_info:
             await pipe.run_pipe(

--- a/tests/integration/pipelex/pipeline/test_optional_method_inputs.py
+++ b/tests/integration/pipelex/pipeline/test_optional_method_inputs.py
@@ -18,7 +18,7 @@ from pipelex.core.stuffs.text_content import TextContent
 from pipelex.pipe_machinery.pipe_factory import PipeFactory
 from pipelex.pipe_operators.func.pipe_func import PipeFunc
 from pipelex.pipe_operators.func.pipe_func_blueprint import PipeFuncBlueprint
-from pipelex.pipe_run.pipe_run_params import PipeRunParams
+from pipelex.pipe_run.pipe_run_params_factory import PipeRunParamsFactory
 from pipelex.pipeline.execution_seams import prepare_pipe_job
 from pipelex.system.job_metadata import JobMetadata
 from pipelex.system.pipe_run_mode import PipeRunMode
@@ -150,7 +150,7 @@ class TestOptionalMethodInputs:
         """
         load_empty_library()
         pipe = _make_method_pipe()
-        run_params = PipeRunParams(run_mode=PipeRunMode.LIVE, pipe_stack_limit=get_config().pipelex.pipe_run_config.pipe_stack_limit)
+        run_params = PipeRunParamsFactory.make_run_params(pipe_run_mode=PipeRunMode.LIVE)
 
         with pytest.raises(PipeRunInputsError) as exc_info:
             await pipe.run_pipe(

--- a/tests/integration/pipelex/pipes/controller/pipe_batch/test_pipe_batch_compaction.py
+++ b/tests/integration/pipelex/pipes/controller/pipe_batch/test_pipe_batch_compaction.py
@@ -26,10 +26,11 @@ from pipelex.pipe_machinery.pipe_factory import PipeFactory
 from pipelex.pipe_operators.func.pipe_func import PipeFunc
 from pipelex.pipe_operators.func.pipe_func_blueprint import PipeFuncBlueprint
 from pipelex.pipe_run.pipe_run_params import PipeRunParams
-from pipelex.pipe_run.pipe_run_params_factory import PipeRunParamsFactory, resolve_batch_max_concurrency
+from pipelex.pipe_run.pipe_run_params_factory import resolve_batch_max_concurrency
 from pipelex.system.job_metadata import JobMetadata
 from pipelex.system.pipe_run_mode import PipeRunMode
 from pipelex.system.registries.func_registry import func_registry
+from tests.integration.pipelex.fixtures.pipe_job_helpers import make_mode_guarded_run_params
 
 _DOMAIN_CODE = "test_optionals_batch"
 
@@ -48,7 +49,7 @@ def _make_live_run_params() -> PipeRunParams:
     exercising the setting in the one test suite where the bound changes behavior. The field is
     required now, so the omission cannot recur silently — the factory is the single writer.
     """
-    return PipeRunParamsFactory.make_run_params(pipe_run_mode=PipeRunMode.LIVE)
+    return make_mode_guarded_run_params(pipe_run_mode=PipeRunMode.LIVE)
 
 
 def _build_compacting_batch() -> PipeBatch:

--- a/tests/integration/pipelex/pipes/controller/pipe_batch/test_pipe_batch_compaction.py
+++ b/tests/integration/pipelex/pipes/controller/pipe_batch/test_pipe_batch_compaction.py
@@ -26,6 +26,7 @@ from pipelex.pipe_machinery.pipe_factory import PipeFactory
 from pipelex.pipe_operators.func.pipe_func import PipeFunc
 from pipelex.pipe_operators.func.pipe_func_blueprint import PipeFuncBlueprint
 from pipelex.pipe_run.pipe_run_params import PipeRunParams
+from pipelex.pipe_run.pipe_run_params_factory import PipeRunParamsFactory, resolve_batch_max_concurrency
 from pipelex.system.job_metadata import JobMetadata
 from pipelex.system.pipe_run_mode import PipeRunMode
 from pipelex.system.registries.func_registry import func_registry
@@ -41,7 +42,13 @@ _TEST_FUNCS = [optionals_batch_shout_item]
 
 
 def _make_live_run_params() -> PipeRunParams:
-    return PipeRunParams(run_mode=PipeRunMode.LIVE, pipe_stack_limit=get_config().pipelex.pipe_run_config.pipe_stack_limit)
+    """Build through the factory so the batch fans out under the *configured* bound.
+
+    Hand-built params used to omit `batch_max_concurrency` and fan out unbounded, quietly not
+    exercising the setting in the one test suite where the bound changes behavior. The field is
+    required now, so the omission cannot recur silently — the factory is the single writer.
+    """
+    return PipeRunParamsFactory.make_run_params(pipe_run_mode=PipeRunMode.LIVE)
 
 
 def _build_compacting_batch() -> PipeBatch:
@@ -115,10 +122,15 @@ class TestPipeBatchCompaction:
         )
         working_memory = WorkingMemoryFactory.make_from_single_stuff(items_stuff)
 
+        run_params = _make_live_run_params()
+        # Guard the fixture, not the factory: this is the suite where an accidentally-unbounded
+        # fan-out would change behavior without failing anything.
+        assert run_params.batch_max_concurrency == resolve_batch_max_concurrency(get_config().pipelex.pipeline_execution_config.max_concurrency)
+
         pipe_output = await batch.run_pipe(
             job_metadata=job_metadata,
             working_memory=working_memory,
-            pipe_run_params=_make_live_run_params(),
+            pipe_run_params=run_params,
         )
 
         list_content = pipe_output.main_stuff.content

--- a/tests/integration/pipelex/pipes/controller/pipe_condition/test_pipe_condition_continue_delivery.py
+++ b/tests/integration/pipelex/pipes/controller/pipe_condition/test_pipe_condition_continue_delivery.py
@@ -11,7 +11,6 @@ from typing import Callable
 
 import pytest
 
-from pipelex.config import get_config
 from pipelex.core.concepts.concept_factory import ConceptFactory
 from pipelex.core.concepts.native.concept_native import NativeConceptCode
 from pipelex.core.domains.domain import SpecialDomain
@@ -25,6 +24,7 @@ from pipelex.pipe_controllers.condition.pipe_condition_blueprint import PipeCond
 from pipelex.pipe_controllers.condition.special_outcome import SpecialOutcome
 from pipelex.pipe_machinery.pipe_factory import PipeFactory
 from pipelex.pipe_run.pipe_run_params import PipeRunParams
+from pipelex.pipe_run.pipe_run_params_factory import PipeRunParamsFactory
 from pipelex.system.job_metadata import JobMetadata
 from pipelex.system.pipe_run_mode import PipeRunMode
 
@@ -55,9 +55,12 @@ def _make_input_text_stuff():
 
 
 def _make_run_params(run_mode: PipeRunMode) -> PipeRunParams:
-    # Constructed directly (not via the factory) so a keyless boot's forced-DRY coercion cannot
-    # silently swap which controller code path (live vs dry) the test exercises.
-    return PipeRunParams(run_mode=run_mode, pipe_stack_limit=get_config().pipelex.pipe_run_config.pipe_stack_limit)
+    run_params = PipeRunParamsFactory.make_run_params(pipe_run_mode=run_mode)
+    # The factory is the single writer of the run-mode and fan-out-bound fields, so the fixture goes
+    # through it rather than hand-building params. Assert the mode survived: under a keyless boot the
+    # factory coerces LIVE to DRY, which would silently swap which controller path the test exercises.
+    assert run_params.run_mode == run_mode, f"This test must run the {run_mode} controller path — the boot coerced it to {run_params.run_mode}"
+    return run_params
 
 
 @pytest.mark.asyncio(loop_scope="class")

--- a/tests/integration/pipelex/pipes/controller/pipe_condition/test_pipe_condition_continue_delivery.py
+++ b/tests/integration/pipelex/pipes/controller/pipe_condition/test_pipe_condition_continue_delivery.py
@@ -59,7 +59,11 @@ def _make_run_params(run_mode: PipeRunMode) -> PipeRunParams:
     # The factory is the single writer of the run-mode and fan-out-bound fields, so the fixture goes
     # through it rather than hand-building params. Assert the mode survived: under a keyless boot the
     # factory coerces LIVE to DRY, which would silently swap which controller path the test exercises.
-    assert run_params.run_mode == run_mode, f"This test must run the {run_mode} controller path — the boot coerced it to {run_params.run_mode}"
+    match run_mode:
+        case PipeRunMode.LIVE:
+            assert run_params.run_mode.is_live, f"This test must run the live controller path — the boot coerced it to {run_params.run_mode}"
+        case PipeRunMode.DRY:
+            assert run_params.run_mode.is_dry, f"This test must run the dry controller path — the boot coerced it to {run_params.run_mode}"
     return run_params
 
 

--- a/tests/integration/pipelex/pipes/controller/pipe_condition/test_pipe_condition_continue_delivery.py
+++ b/tests/integration/pipelex/pipes/controller/pipe_condition/test_pipe_condition_continue_delivery.py
@@ -24,9 +24,9 @@ from pipelex.pipe_controllers.condition.pipe_condition_blueprint import PipeCond
 from pipelex.pipe_controllers.condition.special_outcome import SpecialOutcome
 from pipelex.pipe_machinery.pipe_factory import PipeFactory
 from pipelex.pipe_run.pipe_run_params import PipeRunParams
-from pipelex.pipe_run.pipe_run_params_factory import PipeRunParamsFactory
 from pipelex.system.job_metadata import JobMetadata
 from pipelex.system.pipe_run_mode import PipeRunMode
+from tests.integration.pipelex.fixtures.pipe_job_helpers import make_mode_guarded_run_params
 
 
 def _make_continue_only_condition() -> PipeCondition:
@@ -55,16 +55,7 @@ def _make_input_text_stuff():
 
 
 def _make_run_params(run_mode: PipeRunMode) -> PipeRunParams:
-    run_params = PipeRunParamsFactory.make_run_params(pipe_run_mode=run_mode)
-    # The factory is the single writer of the run-mode and fan-out-bound fields, so the fixture goes
-    # through it rather than hand-building params. Assert the mode survived: under a keyless boot the
-    # factory coerces LIVE to DRY, which would silently swap which controller path the test exercises.
-    match run_mode:
-        case PipeRunMode.LIVE:
-            assert run_params.run_mode.is_live, f"This test must run the live controller path — the boot coerced it to {run_params.run_mode}"
-        case PipeRunMode.DRY:
-            assert run_params.run_mode.is_dry, f"This test must run the dry controller path — the boot coerced it to {run_params.run_mode}"
-    return run_params
+    return make_mode_guarded_run_params(pipe_run_mode=run_mode)
 
 
 @pytest.mark.asyncio(loop_scope="class")

--- a/tests/integration/pipelex/pipes/controller/pipe_parallel/test_pipe_parallel_absence.py
+++ b/tests/integration/pipelex/pipes/controller/pipe_parallel/test_pipe_parallel_absence.py
@@ -34,11 +34,11 @@ from pipelex.pipe_machinery.pipe_factory import PipeFactory
 from pipelex.pipe_operators.func.pipe_func import PipeFunc
 from pipelex.pipe_operators.func.pipe_func_blueprint import PipeFuncBlueprint
 from pipelex.pipe_run.pipe_run_params import PipeRunParams
-from pipelex.pipe_run.pipe_run_params_factory import PipeRunParamsFactory
 from pipelex.runtime_hub import get_class_registry
 from pipelex.system.job_metadata import JobMetadata
 from pipelex.system.pipe_run_mode import PipeRunMode
 from pipelex.system.registries.func_registry import func_registry
+from tests.integration.pipelex.fixtures.pipe_job_helpers import make_mode_guarded_run_params
 
 _DOMAIN_CODE = "test_optionals_par"
 
@@ -69,7 +69,7 @@ _TEST_FUNCS = [optionals_par_echo_source, optionals_par_echo_topic]
 
 
 def _make_live_run_params() -> PipeRunParams:
-    return PipeRunParamsFactory.make_run_params(pipe_run_mode=PipeRunMode.LIVE)
+    return make_mode_guarded_run_params(pipe_run_mode=PipeRunMode.LIVE)
 
 
 def _build_parallel(*, output_ref: str, structure_class_names: list[str], add_each_output: bool = False) -> PipeParallel:

--- a/tests/integration/pipelex/pipes/controller/pipe_parallel/test_pipe_parallel_absence.py
+++ b/tests/integration/pipelex/pipes/controller/pipe_parallel/test_pipe_parallel_absence.py
@@ -16,7 +16,6 @@ from typing import Callable
 import pytest
 from pydantic import Field
 
-from pipelex.config import get_config
 from pipelex.core.concepts.concept_factory import ConceptFactory
 from pipelex.core.memory.absence import AbsenceKind, AbsenceRecord
 from pipelex.core.memory.working_memory import WorkingMemory
@@ -35,6 +34,7 @@ from pipelex.pipe_machinery.pipe_factory import PipeFactory
 from pipelex.pipe_operators.func.pipe_func import PipeFunc
 from pipelex.pipe_operators.func.pipe_func_blueprint import PipeFuncBlueprint
 from pipelex.pipe_run.pipe_run_params import PipeRunParams
+from pipelex.pipe_run.pipe_run_params_factory import PipeRunParamsFactory
 from pipelex.runtime_hub import get_class_registry
 from pipelex.system.job_metadata import JobMetadata
 from pipelex.system.pipe_run_mode import PipeRunMode
@@ -69,7 +69,7 @@ _TEST_FUNCS = [optionals_par_echo_source, optionals_par_echo_topic]
 
 
 def _make_live_run_params() -> PipeRunParams:
-    return PipeRunParams(run_mode=PipeRunMode.LIVE, pipe_stack_limit=get_config().pipelex.pipe_run_config.pipe_stack_limit)
+    return PipeRunParamsFactory.make_run_params(pipe_run_mode=PipeRunMode.LIVE)
 
 
 def _build_parallel(*, output_ref: str, structure_class_names: list[str], add_each_output: bool = False) -> PipeParallel:

--- a/tests/integration/pipelex/pipes/optionals/test_lift_sequence.py
+++ b/tests/integration/pipelex/pipes/optionals/test_lift_sequence.py
@@ -23,11 +23,11 @@ from pipelex.pipe_machinery.pipe_factory import PipeFactory
 from pipelex.pipe_operators.func.pipe_func import PipeFunc
 from pipelex.pipe_operators.func.pipe_func_blueprint import PipeFuncBlueprint
 from pipelex.pipe_run.pipe_run_params import PipeRunParams
-from pipelex.pipe_run.pipe_run_params_factory import PipeRunParamsFactory
 from pipelex.pipeline.execution_seams import prepare_pipe_job
 from pipelex.system.job_metadata import JobMetadata
 from pipelex.system.pipe_run_mode import PipeRunMode
 from pipelex.system.registries.func_registry import func_registry
+from tests.integration.pipelex.fixtures.pipe_job_helpers import make_mode_guarded_run_params
 
 _DOMAIN_CODE = "test_optionals_seq"
 
@@ -52,7 +52,7 @@ _TEST_FUNCS = [optionals_seq_echo_source, optionals_seq_echo_a_out, optionals_se
 
 
 def _make_live_run_params() -> PipeRunParams:
-    return PipeRunParamsFactory.make_run_params(pipe_run_mode=PipeRunMode.LIVE)
+    return make_mode_guarded_run_params(pipe_run_mode=PipeRunMode.LIVE)
 
 
 def _build_lift_sequence() -> PipeSequence:

--- a/tests/integration/pipelex/pipes/optionals/test_lift_sequence.py
+++ b/tests/integration/pipelex/pipes/optionals/test_lift_sequence.py
@@ -23,6 +23,7 @@ from pipelex.pipe_machinery.pipe_factory import PipeFactory
 from pipelex.pipe_operators.func.pipe_func import PipeFunc
 from pipelex.pipe_operators.func.pipe_func_blueprint import PipeFuncBlueprint
 from pipelex.pipe_run.pipe_run_params import PipeRunParams
+from pipelex.pipe_run.pipe_run_params_factory import PipeRunParamsFactory
 from pipelex.pipeline.execution_seams import prepare_pipe_job
 from pipelex.system.job_metadata import JobMetadata
 from pipelex.system.pipe_run_mode import PipeRunMode
@@ -51,7 +52,7 @@ _TEST_FUNCS = [optionals_seq_echo_source, optionals_seq_echo_a_out, optionals_se
 
 
 def _make_live_run_params() -> PipeRunParams:
-    return PipeRunParams(run_mode=PipeRunMode.LIVE, pipe_stack_limit=get_config().pipelex.pipe_run_config.pipe_stack_limit)
+    return PipeRunParamsFactory.make_run_params(pipe_run_mode=PipeRunMode.LIVE)
 
 
 def _build_lift_sequence() -> PipeSequence:

--- a/tests/integration/pipelex/pipes/optionals/test_lift_skip_trichotomy.py
+++ b/tests/integration/pipelex/pipes/optionals/test_lift_skip_trichotomy.py
@@ -10,7 +10,6 @@ from typing import Callable, cast
 import pytest
 from pytest_mock import MockerFixture
 
-from pipelex.config import get_config
 from pipelex.core.concepts.concept_factory import ConceptFactory
 from pipelex.core.concepts.native.concept_native import NativeConceptCode
 from pipelex.core.memory.absence import AbsenceKind, AbsenceRecord
@@ -25,6 +24,7 @@ from pipelex.pipe_machinery.pipe_factory import PipeFactory
 from pipelex.pipe_operators.func.pipe_func import PipeFunc
 from pipelex.pipe_operators.func.pipe_func_blueprint import PipeFuncBlueprint
 from pipelex.pipe_run.pipe_run_params import PipeRunParams
+from pipelex.pipe_run.pipe_run_params_factory import PipeRunParamsFactory
 from pipelex.system.job_metadata import JobMetadata
 from pipelex.system.pipe_run_mode import PipeRunMode
 from pipelex.system.registries.func_registry import func_registry
@@ -83,9 +83,12 @@ def _make_seeded_absence() -> AbsenceRecord:
 
 
 def _make_live_run_params() -> PipeRunParams:
-    # Constructed directly (not via the factory) so a keyless boot's forced-DRY coercion cannot
-    # silently swap which code path (live vs dry) the test exercises.
-    return PipeRunParams(run_mode=PipeRunMode.LIVE, pipe_stack_limit=get_config().pipelex.pipe_run_config.pipe_stack_limit)
+    run_params = PipeRunParamsFactory.make_run_params(pipe_run_mode=PipeRunMode.LIVE)
+    # The factory is the single writer of the run-mode and fan-out-bound fields, so the fixture goes
+    # through it rather than hand-building params. Assert the mode survived: under a keyless boot the
+    # factory coerces LIVE to DRY, which would silently swap which code path the test exercises.
+    assert run_params.run_mode.is_live, "This test must run the live controller path — the boot coerced it to DRY"
+    return run_params
 
 
 @pytest.mark.asyncio(loop_scope="class")

--- a/tests/integration/pipelex/pipes/optionals/test_lift_skip_trichotomy.py
+++ b/tests/integration/pipelex/pipes/optionals/test_lift_skip_trichotomy.py
@@ -24,10 +24,10 @@ from pipelex.pipe_machinery.pipe_factory import PipeFactory
 from pipelex.pipe_operators.func.pipe_func import PipeFunc
 from pipelex.pipe_operators.func.pipe_func_blueprint import PipeFuncBlueprint
 from pipelex.pipe_run.pipe_run_params import PipeRunParams
-from pipelex.pipe_run.pipe_run_params_factory import PipeRunParamsFactory
 from pipelex.system.job_metadata import JobMetadata
 from pipelex.system.pipe_run_mode import PipeRunMode
 from pipelex.system.registries.func_registry import func_registry
+from tests.integration.pipelex.fixtures.pipe_job_helpers import make_mode_guarded_run_params
 from tests.unit.pipelex.graph.conftest import make_trace_context
 
 
@@ -83,12 +83,7 @@ def _make_seeded_absence() -> AbsenceRecord:
 
 
 def _make_live_run_params() -> PipeRunParams:
-    run_params = PipeRunParamsFactory.make_run_params(pipe_run_mode=PipeRunMode.LIVE)
-    # The factory is the single writer of the run-mode and fan-out-bound fields, so the fixture goes
-    # through it rather than hand-building params. Assert the mode survived: under a keyless boot the
-    # factory coerces LIVE to DRY, which would silently swap which code path the test exercises.
-    assert run_params.run_mode.is_live, "This test must run the live controller path — the boot coerced it to DRY"
-    return run_params
+    return make_mode_guarded_run_params(pipe_run_mode=PipeRunMode.LIVE)
 
 
 @pytest.mark.asyncio(loop_scope="class")

--- a/tests/integration/pipelex/pipes/optionals/test_lifted_parallel_companion_slots.py
+++ b/tests/integration/pipelex/pipes/optionals/test_lifted_parallel_companion_slots.py
@@ -8,7 +8,6 @@ from typing import Callable, cast
 
 import pytest
 
-from pipelex.config import get_config
 from pipelex.core.memory.absence import AbsenceKind, AbsenceRecord
 from pipelex.core.memory.working_memory import WorkingMemory
 from pipelex.core.memory.working_memory_factory import WorkingMemoryFactory
@@ -25,6 +24,7 @@ from pipelex.pipe_machinery.pipe_factory import PipeFactory
 from pipelex.pipe_operators.func.pipe_func import PipeFunc
 from pipelex.pipe_operators.func.pipe_func_blueprint import PipeFuncBlueprint
 from pipelex.pipe_run.pipe_run_params import PipeRunParams
+from pipelex.pipe_run.pipe_run_params_factory import PipeRunParamsFactory
 from pipelex.system.job_metadata import JobMetadata
 from pipelex.system.pipe_run_mode import PipeRunMode
 from pipelex.system.registries.func_registry import func_registry
@@ -51,7 +51,7 @@ _TEST_FUNCS = [optionals_comp_find, optionals_comp_find_many, optionals_comp_sin
 
 
 def _make_live_run_params() -> PipeRunParams:
-    return PipeRunParams(run_mode=PipeRunMode.LIVE, pipe_stack_limit=get_config().pipelex.pipe_run_config.pipe_stack_limit)
+    return PipeRunParamsFactory.make_run_params(pipe_run_mode=PipeRunMode.LIVE)
 
 
 def _build_sequence_with_liftable_parallel() -> PipeSequence:

--- a/tests/integration/pipelex/pipes/optionals/test_lifted_parallel_companion_slots.py
+++ b/tests/integration/pipelex/pipes/optionals/test_lifted_parallel_companion_slots.py
@@ -24,10 +24,10 @@ from pipelex.pipe_machinery.pipe_factory import PipeFactory
 from pipelex.pipe_operators.func.pipe_func import PipeFunc
 from pipelex.pipe_operators.func.pipe_func_blueprint import PipeFuncBlueprint
 from pipelex.pipe_run.pipe_run_params import PipeRunParams
-from pipelex.pipe_run.pipe_run_params_factory import PipeRunParamsFactory
 from pipelex.system.job_metadata import JobMetadata
 from pipelex.system.pipe_run_mode import PipeRunMode
 from pipelex.system.registries.func_registry import func_registry
+from tests.integration.pipelex.fixtures.pipe_job_helpers import make_mode_guarded_run_params
 
 _DOMAIN_CODE = "test_optionals_companion"
 
@@ -51,7 +51,7 @@ _TEST_FUNCS = [optionals_comp_find, optionals_comp_find_many, optionals_comp_sin
 
 
 def _make_live_run_params() -> PipeRunParams:
-    return PipeRunParamsFactory.make_run_params(pipe_run_mode=PipeRunMode.LIVE)
+    return make_mode_guarded_run_params(pipe_run_mode=PipeRunMode.LIVE)
 
 
 def _build_sequence_with_liftable_parallel() -> PipeSequence:

--- a/tests/integration/pipelex/pipes/optionals/test_optional_gate_tolerates_missing.py
+++ b/tests/integration/pipelex/pipes/optionals/test_optional_gate_tolerates_missing.py
@@ -9,7 +9,6 @@ from typing import Callable
 
 import pytest
 
-from pipelex.config import get_config
 from pipelex.core.memory.working_memory_factory import WorkingMemoryFactory
 from pipelex.core.stuffs.stuff_factory import StuffFactory
 from pipelex.interpreter_hub import get_pipe_library
@@ -22,6 +21,7 @@ from pipelex.pipe_machinery.pipe_factory import PipeFactory
 from pipelex.pipe_operators.compose.pipe_compose import PipeCompose
 from pipelex.pipe_operators.compose.pipe_compose_blueprint import PipeComposeBlueprint
 from pipelex.pipe_run.pipe_run_params import PipeRunParams
+from pipelex.pipe_run.pipe_run_params_factory import PipeRunParamsFactory
 from pipelex.system.job_metadata import JobMetadata
 from pipelex.system.pipe_run_mode import PipeRunMode
 
@@ -29,7 +29,7 @@ _DOMAIN_CODE = "test_optionals_gate"
 
 
 def _make_live_run_params() -> PipeRunParams:
-    return PipeRunParams(run_mode=PipeRunMode.LIVE, pipe_stack_limit=get_config().pipelex.pipe_run_config.pipe_stack_limit)
+    return PipeRunParamsFactory.make_run_params(pipe_run_mode=PipeRunMode.LIVE)
 
 
 def _register_guarded_compose() -> None:

--- a/tests/integration/pipelex/pipes/optionals/test_optional_gate_tolerates_missing.py
+++ b/tests/integration/pipelex/pipes/optionals/test_optional_gate_tolerates_missing.py
@@ -21,15 +21,15 @@ from pipelex.pipe_machinery.pipe_factory import PipeFactory
 from pipelex.pipe_operators.compose.pipe_compose import PipeCompose
 from pipelex.pipe_operators.compose.pipe_compose_blueprint import PipeComposeBlueprint
 from pipelex.pipe_run.pipe_run_params import PipeRunParams
-from pipelex.pipe_run.pipe_run_params_factory import PipeRunParamsFactory
 from pipelex.system.job_metadata import JobMetadata
 from pipelex.system.pipe_run_mode import PipeRunMode
+from tests.integration.pipelex.fixtures.pipe_job_helpers import make_mode_guarded_run_params
 
 _DOMAIN_CODE = "test_optionals_gate"
 
 
 def _make_live_run_params() -> PipeRunParams:
-    return PipeRunParamsFactory.make_run_params(pipe_run_mode=PipeRunMode.LIVE)
+    return make_mode_guarded_run_params(pipe_run_mode=PipeRunMode.LIVE)
 
 
 def _register_guarded_compose() -> None:

--- a/tests/unit/pipelex/pipe_operators/pipe_func/test_direct_executor_workdir.py
+++ b/tests/unit/pipelex/pipe_operators/pipe_func/test_direct_executor_workdir.py
@@ -64,7 +64,7 @@ class TestDirectExecutorWorkdir:
             pipe_code="missing_pipe",
             function_name="missing_func",
             job_metadata=JobMetadata(user_id="user", pipeline_run_id="run"),
-            pipe_run_params=PipeRunParams(run_mode=PipeRunMode.DRY, pipe_stack_limit=10),
+            pipe_run_params=PipeRunParams(run_mode=PipeRunMode.DRY, pipe_stack_limit=10, batch_max_concurrency=None),
         )
 
         with scoped_current_library(library_id=direct_pipe_func_executor._TRANSPORTED_LIBRARY_ID):  # noqa: SLF001 # pyright: ignore[reportPrivateUsage]
@@ -89,7 +89,7 @@ class TestDirectExecutorWorkdir:
             pipe_code="missing_pipe",
             function_name="missing_func",
             job_metadata=JobMetadata(user_id="user", pipeline_run_id="run"),
-            pipe_run_params=PipeRunParams(run_mode=PipeRunMode.DRY, pipe_stack_limit=10),
+            pipe_run_params=PipeRunParams(run_mode=PipeRunMode.DRY, pipe_stack_limit=10, batch_max_concurrency=None),
         )
 
         with scoped_current_library(library_id=direct_pipe_func_executor._TRANSPORTED_LIBRARY_ID):  # noqa: SLF001 # pyright: ignore[reportPrivateUsage]
@@ -139,7 +139,7 @@ class TestDirectExecutorWorkdir:
             pipe_code="greet",
             function_name="greet_it",
             job_metadata=JobMetadata(user_id="user", pipeline_run_id="run"),
-            pipe_run_params=PipeRunParams(run_mode=PipeRunMode.DRY, pipe_stack_limit=10),
+            pipe_run_params=PipeRunParams(run_mode=PipeRunMode.DRY, pipe_stack_limit=10, batch_max_concurrency=None),
         )
 
         with scoped_current_library(library_id=direct_pipe_func_executor._TRANSPORTED_LIBRARY_ID):  # noqa: SLF001 # pyright: ignore[reportPrivateUsage]

--- a/tests/unit/pipelex/pipe_operators/pipe_func/test_pipe_func_execution_transport.py
+++ b/tests/unit/pipelex/pipe_operators/pipe_func/test_pipe_func_execution_transport.py
@@ -47,6 +47,6 @@ class TestPipeFuncExecutionTransport:
                 pipe_code="my_pipe",
                 function_name="my_func",
                 job_metadata=JobMetadata(user_id="user", pipeline_run_id="run"),
-                pipe_run_params=PipeRunParams(run_mode=PipeRunMode.DRY, pipe_stack_limit=10),
+                pipe_run_params=PipeRunParams(run_mode=PipeRunMode.DRY, pipe_stack_limit=10, batch_max_concurrency=None),
                 timeout_seconds=float("inf"),
             )

--- a/tests/unit/pipelex/pipe_operators/pipe_func/test_pipe_func_hosted_mode.py
+++ b/tests/unit/pipelex/pipe_operators/pipe_func/test_pipe_func_hosted_mode.py
@@ -90,7 +90,7 @@ class TestPipeFuncHostedMode:
         pipe_output = await pipe_func._dry_run_operator_pipe(  # noqa: SLF001 # pyright: ignore[reportPrivateUsage]
             job_metadata=JobMetadata(user_id="user", pipeline_run_id="run"),
             working_memory=WorkingMemoryFactory.make_empty(),
-            pipe_run_params=PipeRunParams(run_mode=PipeRunMode.DRY, pipe_stack_limit=10),
+            pipe_run_params=PipeRunParams(run_mode=PipeRunMode.DRY, pipe_stack_limit=10, batch_max_concurrency=None),
         )
 
         content = pipe_output.working_memory.get_main_stuff().content

--- a/tests/unit/pipelex/pipe_operators/pipe_llm/test_prompt_rendering_purity.py
+++ b/tests/unit/pipelex/pipe_operators/pipe_llm/test_prompt_rendering_purity.py
@@ -144,7 +144,7 @@ class TestPromptRenderingPurity:
         await pipe_llm._dry_run_operator_pipe(  # noqa: SLF001 # pyright: ignore[reportPrivateUsage]
             job_metadata=JobMetadata(user_id="pytest", pipeline_run_id="test_prompt_rendering_purity"),
             working_memory=_make_working_memory(),
-            pipe_run_params=PipeRunParams(run_mode=PipeRunMode.DRY, pipe_stack_limit=10),
+            pipe_run_params=PipeRunParams(run_mode=PipeRunMode.DRY, pipe_stack_limit=10, batch_max_concurrency=None),
         )
 
         assert pipe_llm.model_dump() == snapshot

--- a/tests/unit/pipelex/pipe_run/test_batch_max_concurrency.py
+++ b/tests/unit/pipelex/pipe_run/test_batch_max_concurrency.py
@@ -1,16 +1,19 @@
-"""`batch_max_concurrency`: resolved from config once, at run-params construction, then frozen.
+"""`batch_max_concurrency`: required, resolved from config once at run-params construction, then frozen.
 
 The bound is PipeBatch's fan-out chunk size. Read live at fan-out time it would let a config
 redeploy reshape an in-flight run's dispatch grouping; carried in the payload it cannot. These
-tests pin the resolution table and the write-once discipline. (The field is `frozen=True`, so a
-post-construction write is a *type* error — no runtime test needed for what the checkers block.)
+tests pin the resolution table, the write-once discipline, and the no-default rule. (The field is
+`frozen=True`, so a post-construction write is a *type* error — no runtime test needed for what the
+checkers block.)
 """
 
 from typing import Literal
 
 import pytest
+from pydantic import ValidationError
 
 from pipelex.config import get_config
+from pipelex.pipe_run.pipe_run_params import PipeRunParams
 from pipelex.pipe_run.pipe_run_params_factory import PipeRunParamsFactory, resolve_batch_max_concurrency
 from pipelex.system.pipe_run_mode import PipeRunMode
 
@@ -36,6 +39,22 @@ class TestBatchMaxConcurrency:
         string straight into gather_bounded, which would raise TypeError on its `max_concurrency < 1` check.
         """
         assert resolve_batch_max_concurrency(max_concurrency_setting) == expected_bound
+
+    def test_omitting_the_bound_fails_loud_on_the_constructor(self) -> None:
+        """No default: `None` also means an authored `max_concurrency = "unbounded"`, so a defaulted
+        field would make "never written" indistinguishable from "authored unbounded" — and would
+        point the omission at the dangerous direction (every branch at once). Same discipline as
+        `run_mode` and `pipe_stack_limit`, which are required for the same reason.
+        """
+        with pytest.raises(ValidationError, match="batch_max_concurrency"):
+            PipeRunParams(run_mode=PipeRunMode.DRY, pipe_stack_limit=20)  # type: ignore[call-arg] # pyright: ignore[reportCallIssue] # the static error is the runtime contract under test
+
+    def test_omitting_the_bound_fails_loud_on_a_decoded_payload(self) -> None:
+        """The wire boundary too: `PipeRunParams` rides a distributed backend's payloads, so a
+        decode that drops the key must raise rather than silently resume unbounded.
+        """
+        with pytest.raises(ValidationError, match="batch_max_concurrency"):
+            PipeRunParams.model_validate({"run_mode": PipeRunMode.DRY, "pipe_stack_limit": 20})
 
     def test_factory_freezes_the_live_config_value(self) -> None:
         execution_config = get_config().pipelex.pipeline_execution_config

--- a/tests/unit/pipelex/pipe_run/test_cogt_run_params_carrier.py
+++ b/tests/unit/pipelex/pipe_run/test_cogt_run_params_carrier.py
@@ -19,7 +19,7 @@ from pipelex.system.pipe_run_mode import PipeRunMode
 class TestCogtRunParamsCarrier:
     def test_cogt_run_params_derives_from_run_mode_fields(self) -> None:
         """The carrier is minted from the stored fields — one copy of the facts."""
-        run_params = PipeRunParams(run_mode=PipeRunMode.DRY, is_mock_usage=True, pipe_stack_limit=20)
+        run_params = PipeRunParams(run_mode=PipeRunMode.DRY, is_mock_usage=True, pipe_stack_limit=20, batch_max_concurrency=None)
 
         cogt_run_params = run_params.cogt_run_params
         assert cogt_run_params.run_mode.is_dry
@@ -64,22 +64,23 @@ class TestCogtRunParamsCarrier:
     def test_stale_cogt_run_params_kwarg_fails_loudly(self) -> None:
         """cogt_run_params is a derived property, not a field: passing it as a kwarg must raise.
 
-        run_mode is supplied so the ONLY thing that can raise is the forbidden extra — without
-        it the test would pass on the missing-required-field error even if extra="forbid" were
-        dropped.
+        Every required field is supplied so the ONLY thing that can raise is the forbidden extra —
+        without them the test would pass on a missing-required-field error even if extra="forbid"
+        were dropped.
         """
         with pytest.raises(ValidationError, match="cogt_run_params"):
             PipeRunParams(
                 run_mode=PipeRunMode.DRY,
                 cogt_run_params=CogtRunParams(run_mode=PipeRunMode.DRY),  # type: ignore[call-arg] # pyright: ignore[reportCallIssue]
                 pipe_stack_limit=20,
+                batch_max_concurrency=None,
             )
 
     def test_run_mode_fields_are_frozen(self) -> None:
         """A post-construction DRY→LIVE flip (or mock-usage flip) must raise — it would bypass
         the construction validator and flow into real provider spend via the derived carrier.
         """
-        run_params = PipeRunParams(run_mode=PipeRunMode.DRY, pipe_stack_limit=20)
+        run_params = PipeRunParams(run_mode=PipeRunMode.DRY, pipe_stack_limit=20, batch_max_concurrency=None)
 
         with pytest.raises(ValidationError, match="frozen"):
             run_params.run_mode = PipeRunMode.LIVE  # type: ignore[misc]  # the static read-only error is the runtime contract under test
@@ -89,7 +90,7 @@ class TestCogtRunParamsCarrier:
     def test_mock_usage_requires_dry_on_pipe_run_params(self) -> None:
         """is_mock_usage is a sub-flag of DRY: setting it on a LIVE PipeRunParams is a contract violation."""
         with pytest.raises(ValidationError, match="is_mock_usage"):
-            PipeRunParams(run_mode=PipeRunMode.LIVE, is_mock_usage=True, pipe_stack_limit=20)
+            PipeRunParams(run_mode=PipeRunMode.LIVE, is_mock_usage=True, pipe_stack_limit=20, batch_max_concurrency=None)
 
     def test_mock_usage_requires_dry_on_carrier(self) -> None:
         """The wire carrier enforces the same rule at its own boundary (assignments cross the wire)."""

--- a/tests/unit/pipelex/pipe_run/test_pipe_run_params_isolation.py
+++ b/tests/unit/pipelex/pipe_run/test_pipe_run_params_isolation.py
@@ -9,7 +9,7 @@ class TestPipeRunParamsIsolation:
 
     def test_make_deep_copy_isolates_pipe_stack(self) -> None:
         """A deep copy's pipe_stack is an independent list — a push on one branch does not leak into the other."""
-        original = PipeRunParams(run_mode=PipeRunMode.LIVE, pipe_stack_limit=20, pipe_stack=["root"])
+        original = PipeRunParams(run_mode=PipeRunMode.LIVE, pipe_stack_limit=20, batch_max_concurrency=None, pipe_stack=["root"])
 
         branch = original.make_deep_copy()
         assert branch.pipe_stack is not original.pipe_stack, "a deep copy must not share the pipe_stack list object"

--- a/wip/pr-1093-review-notes.md
+++ b/wip/pr-1093-review-notes.md
@@ -10,7 +10,7 @@ Both were verified against the code. **Neither is a live bug** — one is a fals
 
 > **Status (2026-08-12): done in `pipelex`, on `fix/batch-max-concurrency-required`.** The field is required, the integration fixtures route through `PipeRunParamsFactory.make_run_params`, both omission paths (constructor and `model_validate`) have `ValidationError` coverage, and the mutation check was run — restoring `default=None` turns both new tests red and nothing else. The compaction fixture builds through the factory and asserts the configured bound.
 >
-> **Still open — the cross-repo wire test, and it *is* gated.** `pipelex-server/temporal/tests/integration/pipelex_temporal/data_converter/test_data_conv_pipe_run_params.py` round-trips `PipeRunParams` without the field, so it asserts `None == None` and would not catch the bound being dropped on the wire. It cannot be fixed ahead of the pin: `pipelex-server` pins `pipelex==0.42.0`, which predates the field entirely, and `PipeRunParams` is `extra="forbid"` — passing `batch_max_concurrency` there today fails. When the pin moves to ≥ the release carrying this change, make that test round-trip a real int bound.
+> **Still open — the cross-repo wire test, and it *is* gated.** Our Temporal plugin's payload-converter test round-trips `PipeRunParams` without the field, so it asserts `None == None` and would not catch the bound being dropped on the wire. It cannot be fixed ahead of the pin: that side pins a `pipelex` version predating the field entirely, and `PipeRunParams` is `extra="forbid"` — passing `batch_max_concurrency` there today fails. When the pin moves to ≥ the release carrying this change, make that test round-trip a real int bound. Path and pin live in the workspace-level private notes.
 
 - **Origin:** surfaced while verifying Codex's second P1 on `pipelex/pipe_run/pipe_run_params.py:160`. It is *not* the defect Codex described (see "Not deferred" below for why that one is a false positive) — it is the weakness underneath it.
 - **Where:** `pipelex/pipe_run/pipe_run_params.py`, the `batch_max_concurrency: int | None = Field(default=None, frozen=True)` field.
@@ -51,14 +51,14 @@ Keeps `int | None`, so authored `"unbounded"` still resolves to `None`; keeps `f
 
 ### Why it was deferred rather than done here
 
-The source change is one word, but the fixtures are not: ~19 direct constructions in this repo plus one in `pipelex-server` must supply the field. The integration fixtures should route through `PipeRunParamsFactory.make_run_params` instead — a net simplification, since they already hand-duplicate the factory's config read — but that is a ~20-file change with a cross-repo tail, landing on a release branch whose CI is green and which is about to merge to `main`. It belongs on `dev` immediately after the promotion.
+The source change is one word, but the fixtures are not: ~19 direct constructions in this repo plus one on the plugin side must supply the field. The integration fixtures should route through `PipeRunParamsFactory.make_run_params` instead — a net simplification, since they already hand-duplicate the factory's config read — but that is a ~20-file change with a cross-repo tail, landing on a release branch whose CI is green and which is about to merge to `main`. It belongs on `dev` immediately after the promotion.
 
 ### Execution notes for the follow-up
 
 - **Tests:** add `pytest.raises(ValidationError)` coverage for both the constructor and `model_validate({...})` with the key absent, mirroring the required-`run_mode` coverage already in `tests/unit/pipelex/pipe_run/test_cogt_run_params_carrier.py:72-92`.
 - **Mutation-check it.** Temporarily restore `default=None` and confirm the new test goes red. A test green on first run proves nothing here.
 - **Fix the compaction fixture** to build via the factory and assert the observed bound — that is the one place where an accidentally-unbounded fan-out actually changes behavior.
-- **Cross-repo, gated on the `pipelex` pin moving:** `pipelex-server/temporal/tests/integration/pipelex_temporal/data_converter/test_data_conv_pipe_run_params.py:22` round-trips `None`, so it asserts `None == None` and would not catch the field being dropped on the wire. Make it round-trip a real int bound.
+- **Cross-repo, gated on the `pipelex` pin moving:** our Temporal plugin's payload-converter test round-trips `None`, so it asserts `None == None` and would not catch the field being dropped on the wire. Make it round-trip a real int bound.
 - **Honest caveat to keep in view:** making the field required converts a legacy-history decode into a `ValidationError`, and a workflow-task converter exception retries forever — it hangs rather than fails. Both states are non-events while Temporal is pre-production, and neither is fixed by a field default. It reconfirms that deploy discipline, not this field, is the real control over version skew under live histories.
 
 ## Not deferred — the two P1s as Codex reported them
@@ -71,7 +71,7 @@ Codex argued that `Pipelex.make` given a router that satisfies `PipeRouterProtoc
 
 The language claim is correct. Everything downstream of it is not:
 
-- **No such router exists.** Every implementer in the workspace inherits nominally — `PipeRouter` (`pipelex/pipe_run/pipe_router.py`), `TemporalPipeRouter` in `pipelex-server/temporal/`, `MistralWorkflowsPipeRouter`, and every test stub. `pipelex-api` and `pipelex-server/transport/` contain no router at all.
+- **No such router exists.** Every implementer in the workspace inherits nominally — `PipeRouter` (`pipelex/pipe_run/pipe_router.py`), the routers in our Temporal and Mistral Workflows plugins, and every test stub. `pipelex-api` and the transport layer that is not open core contain no router at all.
 - **The failure mode is static, not runtime.** The protocol is not `@runtime_checkable`, and injection performs no isinstance check — but pyright rejects a structural non-conformer at the injection boundary with `"run_batch_branch" is not present (reportArgumentType)`. Every consumer in this workspace is type-checked.
 - **Structural conformance was never viable here.** `PipeRouterProtocol` declares an attribute, three concrete observer hooks, a concrete template-method `run`, and an `@abstractmethod _run_pipe_job`. Conforming without inheriting would mean reimplementing `run`'s entire error-wrapping template. Inheritance is not one supported pattern — it is the only one.
 - **The cited convention says the opposite.** Codex referenced `AGENTS.md:255-258`; that section actually reads *"When extending the `Protocol`, also update every implementation (including no-op / null implementations) so structural typing is satisfied"* — a rule pointing away from the claim it was cited for.
@@ -86,11 +86,11 @@ No test was added either. A test injecting a non-inheriting router would assert 
 
 Codex argued that a worker resuming a `PipeRunParams` serialized before `batch_max_concurrency` existed would decode it as `None`, read as unbounded, changing both concurrency and replay grouping mid-flight.
 
-The mechanism is real: `PipeRunParams` does ride a Temporal workflow argument (`pipelex-server/temporal/pipelex_temporal/tprl_pipe/wf_pipe_router.py:204`), workflow arguments are recorded in history and re-decoded on replay, and `gather_bounded`'s chunk size does determine command grouping — which `pipelex-server/temporal/docs/temporal-replay-determinism.md` places on the replay-unsafe side of its own table.
+The mechanism is real: `PipeRunParams` does ride a Temporal workflow argument in our Temporal plugin's router workflow, workflow arguments are recorded in history and re-decoded on replay, and `gather_bounded`'s chunk size does determine command grouping — which that plugin's own replay-determinism notes place on the replay-unsafe side of their table.
 
 The scenario is not:
 
-- **The Temporal integration is not in this package.** `pipelex/temporal/**` was removed in *Refactor/plugins 5* (#1006) and lives in the private `pipelex-server/temporal/` plugin; `pyproject.toml` carries no `temporalio` dependency. No OSS consumer of `pipelex` can have an in-flight durable batch.
+- **The Temporal integration is not in this package.** It lives in our Temporal plugin, and `pyproject.toml` carries no `temporalio` dependency. No OSS consumer of `pipelex` can have an in-flight durable batch.
 - **The only exposed party is our own hosted plane, which is pre-production.** Temporal has never shipped to prod.
 - **A field default cannot fix the general case.** Bumping `pipelex` on a Temporal worker is a workflow-code change, and this same release lands the kernel extraction and the plugin entry-point-group split. There is no `workflow.patched` or worker-versioning machinery. Hot-swapping any pipelex version under live histories is unsafe with or without this field; the control is deploy discipline (drain, build IDs).
 - **The remedy is what the workspace rules out.** "No backward compatibility… no deprecation transition period." A legacy-payload sentinel is exactly the speculative back-compat machinery that policy exists to prevent, and the change is already recorded as breaking in the changelog.

--- a/wip/pr-1093-review-notes.md
+++ b/wip/pr-1093-review-notes.md
@@ -8,6 +8,10 @@ Both were verified against the code. **Neither is a live bug** — one is a fals
 
 ## Deferred — `batch_max_concurrency` should be required, not defaulted
 
+> **Status (2026-08-12): done in `pipelex`, on `fix/batch-max-concurrency-required`.** The field is required, the integration fixtures route through `PipeRunParamsFactory.make_run_params`, both omission paths (constructor and `model_validate`) have `ValidationError` coverage, and the mutation check was run — restoring `default=None` turns both new tests red and nothing else. The compaction fixture builds through the factory and asserts the configured bound.
+>
+> **Still open — the cross-repo wire test, and it *is* gated.** `pipelex-server/temporal/tests/integration/pipelex_temporal/data_converter/test_data_conv_pipe_run_params.py` round-trips `PipeRunParams` without the field, so it asserts `None == None` and would not catch the bound being dropped on the wire. It cannot be fixed ahead of the pin: `pipelex-server` pins `pipelex==0.42.0`, which predates the field entirely, and `PipeRunParams` is `extra="forbid"` — passing `batch_max_concurrency` there today fails. When the pin moves to ≥ the release carrying this change, make that test round-trip a real int bound.
+
 - **Origin:** surfaced while verifying Codex's second P1 on `pipelex/pipe_run/pipe_run_params.py:160`. It is *not* the defect Codex described (see "Not deferred" below for why that one is a false positive) — it is the weakness underneath it.
 - **Where:** `pipelex/pipe_run/pipe_run_params.py`, the `batch_max_concurrency: int | None = Field(default=None, frozen=True)` field.
 


### PR DESCRIPTION
The one real finding from the #1093 review, spec'd end-to-end in `wip/pr-1093-review-notes.md` and deferred off the release branch. `dev` is the right place for it.

## The defect

`None` was not only `batch_max_concurrency`'s default — it is also what an authored `max_concurrency = "unbounded"` resolves to. So **"never written" and "authored unbounded" were indistinguishable**, and the default pointed the omission at the dangerous direction: launch every branch at once. That contradicted the discipline the file states two fields above, on `run_mode` ("a payload missing the run mode must fail loud…"); `pipe_stack_limit` is required for the same reason. `batch_max_concurrency` was the odd one out.

The trap had already been sprung: the **PipeBatch compaction fixture** hand-built its params and silently fanned out unbounded — in the one suite where the bound actually changes behavior. The tell was in the same expression: it bothered to read `pipe_stack_limit` from config *because that field is required*, and dropped the one that wasn't.

## The change

```python
batch_max_concurrency: int | None = Field(frozen=True)
```

One word deleted. Keeps `int | None` (authored `"unbounded"` still resolves to `None`), keeps `frozen=True`, keeps the factory as single writer, turns any omission — constructor or payload — into a loud `ValidationError`. The `run_mode` rationale is carried into the field comment so the three invariant-bearing fields read as one convention. The sentinel the bot proposed stays rejected: a third state in a two-state domain, serving a migration story workspace policy rules out.

## Construction sites

All direct constructions now supply the field:

- The **integration fixtures route through `PipeRunParamsFactory.make_run_params`** instead of hand-duplicating its config read — a net simplification.
- Two of them bypassed the factory *deliberately*, with a comment: direct construction dodged a keyless boot's forced-DRY coercion. Routing them through the factory would have silently dropped that guard, so they now **assert the resolved mode** — a keyless boot fails loud instead of quietly swapping which code path the test exercises.
- The unit tests that deliberately hardcode limits pass `batch_max_concurrency=None` explicitly.

## Coverage, and the mutation check

Both omission boundaries are covered in `test_batch_max_concurrency.py` — the constructor and `model_validate({...})` with the key absent, mirroring the required-`run_mode` coverage next door.

**Mutation-checked, because a test green on first run proves nothing here.** Restoring `default=None` turned exactly those two red (`DID NOT RAISE`) and left the rest green. The compaction fixture's bound assertion was mutation-checked the same way: reverting it to hand-built unbounded params fires it (`assert None == 8`).

## Not in this PR — the cross-repo wire test, and it is harder-gated than the notes assumed

`pipelex-server/temporal/…/test_data_conv_pipe_run_params.py` round-trips `PipeRunParams` without the field, so it asserts `None == None` and would not catch the bound being dropped on the wire. It **cannot** be fixed ahead of the pin: `pipelex-server` pins `pipelex==0.42.0`, which predates the field entirely, and `PipeRunParams` is `extra="forbid"` — passing `batch_max_concurrency` there today fails. Recorded in the review notes; do it when the pin moves.

## Verification

- `make agent-check` clean (ruff, plxt, pyright, mypy, keyword-only, hub-layering)
- `make drift-check` passed
- full `make agent-test` green

Docs: a warning box on the run-params factory in `docs/under-the-hood/pipe-routing-and-execution.md` (the orchestrator-SPI audience is who constructs these by hand). Changelog: a breaking `[Unreleased]` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QqbG1R3uaghExhgh8dL3oq

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require PipeRunParams.batch_max_concurrency to prevent silent unbounded fan‑out. Previously omitting the field defaulted to None (same as authored "unbounded"); now omission raises ValidationError at construction and on model_validate. Explicit None still means unbounded.

- Field stays int | None and frozen. Tests that set limits now pass batch_max_concurrency=None explicitly.
- Integration fixtures now build via PipeRunParamsFactory.make_run_params. A shared helper make_mode_guarded_run_params asserts the requested run mode survives factory coercion; all affected suites use it. The compaction suite also asserts the configured bound via resolve_batch_max_concurrency.
- Docs add a factory warning; changelog marks this as breaking.

**Migration**
- When constructing PipeRunParams, use PipeRunParamsFactory.make_run_params or pass batch_max_concurrency explicitly (int or None).
- Any downstream that forbids extras and is pinned to a version predating this field will reject payloads with it; bump the dependency and update wire tests/payloads after upgrading.

<sup>Written for commit ea29532a58731c58940518f990fa356a513fd2cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Pipelex/pipelex/pull/1097?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

