### PR TITLE
Per-request Gateway API keys: survey, Temporal design, and pipelex-server handoff (docs only)

### DIFF
--- a/wip/api_keys/gateway-per-request-key-under-temporal.md
+++ b/wip/api_keys/gateway-per-request-key-under-temporal.md
@@ -1,0 +1,125 @@
+# Per-request Gateway key under Temporal — the narrow design
+
+Companion to `sdk-per-request-key-survey.md`. That document surveys every SDK we ship. The hosted-plane half of what is designed here — the resolver plugin, the wire mapping, provisioning, IAM — is specified for `pipelex-server` in `pipelex-server-per-request-gateway-key-handoff.md`. This one deliberately narrows to a single scenario and does not look sideways: **only the SDKs that connect to the Pipelex Gateway**, and **only a solution that holds under distributed execution with our Temporal plugin**. Anything the survey says about other backends (Bedrock, HuggingFace, Linkup, Google structured output, endpoint overrides) is out of scope here and is not restated. Everything below about SDK behaviour was verified by executing the pinned versions in `.venv` (`openai` 2.34.0, `portkey-ai` 2.3.0, `instructor` as pinned) against an `httpx.MockTransport` that records the outbound headers.
+
+## 1. What "the Gateway" is, concretely
+
+The gateway plugin (`pipelex/providers/gateway/gateway_plugin.py`) registers six SDK handles, and every one of them authenticates the same way: the credential is the `x-portkey-api-key` header, and nothing else. There are exactly two client kinds behind those six handles.
+
+| Registered sdk | Family | Client object built by `get_or_create` | Worker | Per-request header seam that exists today |
+|---|---|---|---|---|
+| `gateway_completions` | LLM | `openai.AsyncOpenAI` (`GatewayCompletionsFactory.make_portkey_openai_client_for_completions`) | `OpenAICompletionsLLMWorker` | `make_extras` → `extra_headers` on both the text call and the `instructor` call |
+| `gateway_responses` | LLM | `openai.AsyncOpenAI` (`GatewayResponsesFactory.make_portkey_openai_client_for_responses`) | `OpenAIResponsesLLMWorker` | same, on both paths |
+| `gateway_completions` | IMG_GEN | `openai.AsyncOpenAI` | `OpenAICompletionsImgGenWorker` | `make_extras` → `extra_headers` |
+| `gateway_img_gen` | IMG_GEN | `AsyncPortkey` (`GatewayFactory.make_portkey_client`) | `GatewayImgGenWorker` | none — `with_options(config=…)` per call; the edits path goes through the vendored `portkey_client.openai_client.post(options={"headers": …})` |
+| `gateway_extract` | EXTRACT | `AsyncPortkey` | `GatewayExtractWorker` | `with_options(config=…)` per call; the base64 path additionally passes `headers=extra_headers` from `make_extras` |
+| `gateway_search` | SEARCH | `AsyncPortkey` | `GatewaySearchWorker` | none — `with_options(config=…)` per call |
+
+For the `AsyncOpenAI` kind the boot key is baked into `default_headers=createHeaders(api_key=…)` and the OpenAI `api_key` is the literal placeholder `"unused-auth-via-portkey-headers"`. For the `AsyncPortkey` kind the boot key is the client's `api_key`. Both are built once per process and cached in `SdkClientRegistry` under `ModelHandle.sdk_handle`, which has no caller dimension.
+
+In the hosted plane today there is **one gateway key per environment**: `PIPELEX_GATEWAY_API_KEY` is injected identically into the runner and the worker task definitions (`pipelex-server/infra/api/ecs/runner/ecs.tf`, `…/worker/ecs.tf`) and read through the backend's `api_key = "${PIPELEX_GATEWAY_API_KEY}"` placeholder. So "a different key per request" means: the same two client objects, the same Portkey endpoint, but the `x-portkey-api-key` value chosen per call from something the request carries.
+
+## 2. Verified override mechanics, per client kind
+
+The good news is that neither client kind needs a new client, a new `instructor` wrapper, or any change to the three model-keyed caches the survey worries about. The key can be swapped at the request. The details differ between the two kinds, and one of them has a trap.
+
+### `openai.AsyncOpenAI` (completions, responses, completions-img-gen)
+
+- `extra_headers={"x-portkey-api-key": key}` on the call **wins over** the boot `default_headers`. Verified: the boot key is sent when no extra header is given, the per-request key is sent when it is.
+- The same holds **through `instructor`**: `create_with_completion(..., extra_headers=…)` forwards the header to the underlying client on both the chat-completions and the responses adapters. Verified on the completions path with a recorded header of the per-request value.
+- `client.with_options(default_headers={...})` also works and the clone shares the same `httpx` pool (`clone._client is client._client` is `True`), but it is unnecessary here because the header seam already exists in `make_extras` on every `AsyncOpenAI` gateway path.
+- The SDK's transport retries (`max_retries` from `transport_max_retries`) reuse the same request options, so a retried call keeps the per-request key.
+
+Because `GatewayFactory.make_extras` is already called per request on all three of these workers and already reads `inference_job.job_metadata` to emit tracing headers, adding one more header there covers all three with no worker change.
+
+### `AsyncPortkey` (img-gen, extract, search)
+
+- `client.with_options(config=config_id, api_key=key)` sends the per-request key, and the clone **shares the connection pool** (`AsyncPortkey.copy` ends with `http_client=http_client or self._client`). The three workers already call `with_options(config=…)` on every request, so this is one added keyword argument at each call site.
+- **Trap: `post(..., headers={"x-portkey-api-key": key})` does not override the key.** Verified: the boot key is still what goes out. The Portkey base client merges its own auth headers over the per-call `headers` mapping, the opposite precedence from `openai`. This matters because `GatewayExtractWorker._extract_base64_url` currently passes `headers=extra_headers` from `make_extras` — so if the key were only added inside `make_extras`, the extract path would *look* wired and silently send the boot key. The `AsyncPortkey` workers must use `with_options(api_key=…)`, not the headers argument.
+- The image-edits path, which bypasses `AsyncPortkey.post` because of the upstream `files=` bug and calls the vendored `portkey_client.openai_client.post(..., options={"headers": {…}})`, **does** honour a per-request `x-portkey-api-key` in that `options["headers"]` mapping. Verified.
+
+The `SdkClientRegistry`, the `InferenceManager` worker cache, and the boot-time `InferenceBackend` all stay exactly as they are. Nothing is cached per credential, because nothing needs to be.
+
+## 3. The Temporal shape of the problem
+
+The request context that knows *whose* call this is dies at the runner and has to be reborn in a worker process that never saw the HTTP request. Tracing the path fixes what the design is allowed to rely on.
+
+1. The API Gateway authorizer stamps `X-Org-Id` from the token (`overwrite:header.X-Org-Id = $context.authorizer.org_id` in `apigateway_http.tf`) and the runner receives it.
+2. The runner builds `JobMetadata(user_id=…, pipeline_run_id=…, request_id=…, …)` once, in `pipelex/pipeline/execution_seams.py`, and hangs it on the `PipeJob`.
+3. Under the Temporal orchestrator the `PipeJob` **is the workflow input**, so `JobMetadata` is serialized by our pydantic data converter into workflow history. Child workflows carry it forward; `copy_with_update` is a deep `model_copy`, so any new field survives every hop unchanged.
+4. The activity granularity is one inference call: `act_llm_gen_text(llm_assignment: LLMAssignment)` is the whole activity body, and `LLMAssignment.job_metadata` is the same object. Inside the activity it becomes `LLMJob.job_metadata`, that is `InferenceJobAbstract.job_metadata`, and that is what `make_extras` and every gateway worker hold when they build the request. The same is true of the img-gen, extract and search assignments.
+5. Which worker executes a given activity is not knowable: the fleet polls one shared queue (`default_task_queue`, empty `activity_queues`), retries are `maximum_attempts = 3`, and a retry may land on a different process. Each worker boots Pipelex once (`worker_cmd.py`) and polls forever.
+
+Five consequences follow, and they are the constraints of the design rather than choices:
+
+- **The reference must ride on `JobMetadata`.** It is the only thing that provably arrives in the activity, on every attempt, on any worker. This is the payload-first rule applied; ContextVars, request-scoped globals and per-run singletons have no home in a process that hosts many runs of many tenants at once.
+- **The material must never ride on it.** `JobMetadata` is workflow history in plaintext. `StoragePayloadCodec` does not soften this: it is a size-threshold offload (1 MB default, shipped disabled), and a Portkey key is a short string that passes through untouched even with the codec on. Carry an opaque reference; resolve it in the worker.
+- **Resolution happens in the activity, never in workflow code.** Workflow code must be deterministic and side-effect-free on replay; a secrets lookup there is both a side effect and a replay hazard. Activities are exactly where I/O belongs, and the seam (`make_extras` / the `with_options` call) is already inside activity execution.
+- **Resolution must be repeatable and reachable from every worker.** Attempt two may run somewhere else, so any worker in the fleet must be able to turn any tenant's reference into that tenant's key. That is a blast-radius statement about worker IAM, not just a code one.
+- **Any cache is process-scoped, keyed on the reference, and needs a TTL.** A "per run" cache does not exist anywhere under Temporal: built per activity it is always empty, held per process it leaks across runs with no eviction signal. Keying on the reference gives a hit across every run of that tenant on that worker, and the TTL becomes the revocation latency, which then has to be a stated number.
+
+## 4. Proposed design
+
+Four small pieces, two of them in `pipelex` and two of them in the hosted plane. The OSS runtime gains a seam with a no-op default; the hosted plane gives the seam a real implementation.
+
+### 4.1 A reference field on `JobMetadata`
+
+Add one optional field, constrained at the wire boundary the same way `request_id` is (printable ASCII, bounded length), for example `gateway_key_ref: str | None = None`. It is opaque to `pipelex`: the runtime only carries it and hands it to the resolver. In the hosted plane the natural value for v1 is the org id the authorizer already injects, but the field should not be *named* org id, because the reference may later be a key id or a profile id (the BYOK inference-profile track) without touching the runtime.
+
+The runner stamps it where `JobMetadata` is built (`execution_seams.py`) from a field on the run request. In the hosted plane that field is set by the platform, which fronts every `/v1/*` route and already holds the authenticated org and user when it dispatches to the runner — the runner itself never sees `X-Org-Id` (see the handoff doc, §3 and §4.1). Nothing downstream needs to know: the workflow input, the child workflows and every activity payload carry it for free.
+
+### 4.2 A resolver protocol in `pipelex`, defaulting to today's behaviour
+
+Add a small `GatewayKeyResolver` protocol with one method, `resolve(gateway_key_ref: str) -> str`, and register it on the runtime hub the same way the secrets provider is (a default set at boot, replaceable by a plugin). The default resolver returns `backend.api_key`, so `pipelex` alone behaves exactly as today. Whether an *absent* reference falls back to the boot key or fails closed is a policy the hosted plane must be able to choose (see §6); the runtime should expose that as a switch rather than hard-code either.
+
+Put a single helper next to `make_extras`, say `GatewayFactory.resolve_request_key(inference_job=…) -> str | None`, that reads `inference_job.job_metadata.gateway_key_ref`, calls the resolver, and returns `None` when the boot key should be used. Both client kinds then consume that one helper.
+
+### 4.3 The two per-request seams
+
+- **`AsyncOpenAI` paths** (`gateway_completions` LLM and img-gen, `gateway_responses`): `GatewayFactory.make_extras` adds `extra_headers["x-portkey-api-key"] = key` when the helper returns a key. No worker changes; the header already flows into the text call and into `instructor` on both the completions and the responses workers.
+- **`AsyncPortkey` paths** (`gateway_img_gen`, `gateway_extract`, `gateway_search`): each `with_options(config=config_id)` becomes `with_options(config=config_id, api_key=key)` when a key is resolved, and the image-edits path adds the header to its `options["headers"]` mapping. Because of the trap in §2, the extract worker must **not** rely on the `headers=extra_headers` argument for the key even though it will now contain one; the header there is harmless but inert.
+
+Under Temporal each activity attempt re-runs the helper, so a retry on another worker resolves the same reference on that worker and gets the same key.
+
+### 4.4 The hosted resolver
+
+Lives in the hosted plane (`pipelex-server`), not in `pipelex`. It maps a reference to that tenant's Portkey key from wherever those keys are provisioned and stored, and wraps the lookup in a **process-scoped, bounded, TTL cache keyed on the reference**. That is the only cache this design introduces, it holds strings rather than clients, and it is one dictionary per worker process. It must not cache a failed lookup for long, so a freshly provisioned tenant is not locked out for a full TTL by a race between provisioning and first use.
+
+## 5. What this design does not touch
+
+- No credential dimension on `SdkClientRegistry`, `InferenceManager` or `ModelHandle`. One `AsyncOpenAI` and one `AsyncPortkey` per gateway model handle per process, as today.
+- No per-credential `instructor` wrappers.
+- `InferenceBackend` stays the boot-time singleton; the endpoint does not change per request. If a per-request *endpoint* is ever needed the survey's open question 5 applies and this document is the wrong one.
+- Non-gateway backends are untouched; the resolver is only consulted from the gateway plugin.
+- The Temporal plugin itself does not change: no new activity, no workflow edit, no data-converter change. The reference travels inside a model that already crosses the boundary.
+
+## 6. Cache, revocation and reachability under the worker fleet
+
+The process-scoped cache from §4.4 has three parameters that must be decided, not defaulted, because the worker outlives every run.
+
+- **TTL is the revocation SLA.** A rotated or revoked tenant key remains usable on a given worker until its entry expires or the process restarts. A short TTL costs one key-store round trip per (tenant, worker, TTL window), which is negligible at any realistic fleet size; a long TTL trades that for a longer window in which a revoked key still works. This needs a number.
+- **Bound the cache.** Key it on the reference, cap the entry count, evict least-recently-used. The material is small, but an unbounded map of tenant secrets in worker memory is still not something to ship.
+- **Every worker must be able to read every tenant's key.** With one shared queue there is no way to route a tenant to a subset of workers, so the read grant is fleet-wide. In the BYOK track the worker's decrypt path was explicitly *not* granted yet (deferred as a Phase 2d concern); this design needs it before it can run in the hosted plane. If a per-tenant Portkey key is provisioned server-side rather than supplied by the tenant, the store and the grant are simpler than BYOK's envelope scheme, but the reachability requirement is the same.
+
+Missing reference policy: in OSS and local development, no reference means the boot key, and the behaviour is unchanged. In the hosted plane a request that reaches the runner without an org id is already an authorizer failure upstream, so failing closed on a missing reference is cheap there and closes the "runs on the shared key by accident" hole. Recommend making it a hosted-side switch that defaults to fail-closed.
+
+## 7. Side benefits and a caution
+
+Portkey attributes usage to the API key that made the call, so per-tenant keys give per-tenant usage, budgets and rate limits at the gateway with no work on our side. That is a reason to prefer per-tenant Portkey *keys* over per-tenant Portkey *configs* or metadata headers as the mechanism.
+
+The caution is the same one the survey raises about `openai`'s callable `api_key`: do not be tempted to make the shared `AsyncOpenAI` refresh its own key from a callable, because `_refresh_api_key` writes to the shared client between two awaits and concurrent activities on the same worker would race. The header seam has no shared mutable state, which is why it is the right one under a worker that runs many tenants' activities concurrently.
+
+## 8. Tests worth writing before the code
+
+- For each of the six handles, a `MockTransport` test asserting the outbound `x-portkey-api-key` equals the per-request key when a reference is present and the boot key when it is not. The `AsyncPortkey` extract path needs its own test precisely because `post(headers=…)` would pass a naive review while sending the boot key.
+- One test that resolves two different references through the same cached client objects concurrently and asserts each request carried its own key, since the whole point of the design is that the shared client is safe.
+- A Temporal-level test with two activities carrying two references executing on one worker, asserting header attribution, and a resolver spy asserting a retry re-resolves rather than assuming.
+- A wire-boundary test that a `JobMetadata` with the new field round-trips through the pydantic data converter unchanged, and a guard that the field's constraint rejects a value that looks like key material (length and character-class are the cheap proxies).
+
+## 9. Open questions, narrowed to this scope
+
+1. **What is the reference in v1?** The org id is already available on every hosted request; a key id or profile id would need a second lookup. Recommendation: org id, under an opaque field name.
+2. **Where are per-tenant Portkey keys provisioned and stored?** Provisioned through the Portkey admin API on org creation, or on first use by the resolver? Stored beside the org record with envelope encryption, or in the secrets manager? This is a hosted-plane decision; only the resolver interface is fixed by this document.
+3. **TTL and bound for the worker cache.** Needs numbers, not defaults.
+4. **Fail-closed on a missing reference in the hosted plane?** Recommended yes; confirm.
+5. **Worker read access.** Which role gets the read grant and whether it is the shared task role or a worker-specific one, in line with the deferred task-role split from the BYOK track.

--- a/wip/api_keys/pipelex-server-per-request-gateway-key-handoff.html
+++ b/wip/api_keys/pipelex-server-per-request-gateway-key-handoff.html
@@ -1,0 +1,363 @@
+<title>Per-request Gateway key</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Newsreader:opsz,wght@6..72,500;6..72,600&family=IBM+Plex+Sans:wght@400;500;600&family=IBM+Plex+Mono:wght@400;500&display=swap">
+<style>
+  :root {
+    --bg: #F3F5F7;
+    --surface: #FFFFFF;
+    --ink: #18212B;
+    --muted: #5C6B79;
+    --rule: #D5DDE4;
+    --accent: #0E7A84;
+    --accent-soft: #DCEFF1;
+    --amber: #B07A1C;
+    --amber-soft: #F6ECD6;
+    --code-bg: #E9EEF2;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) {
+      --bg: #0F151B;
+      --surface: #171F27;
+      --ink: #E4E9EE;
+      --muted: #97A5B2;
+      --rule: #29343E;
+      --accent: #4EB5BE;
+      --accent-soft: #14343A;
+      --amber: #E0A93B;
+      --amber-soft: #3A2E15;
+      --code-bg: #1F2A34;
+    }
+  }
+  :root[data-theme="dark"] {
+    --bg: #0F151B;
+    --surface: #171F27;
+    --ink: #E4E9EE;
+    --muted: #97A5B2;
+    --rule: #29343E;
+    --accent: #4EB5BE;
+    --accent-soft: #14343A;
+    --amber: #E0A93B;
+    --amber-soft: #3A2E15;
+    --code-bg: #1F2A34;
+  }
+
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--ink);
+    font-family: "IBM Plex Sans", "Helvetica Neue", Arial, sans-serif;
+    font-size: 16px;
+    line-height: 1.55;
+    -webkit-font-smoothing: antialiased;
+  }
+  main {
+    max-width: 68ch;
+    margin: 0 auto;
+    padding: 56px 24px 72px;
+    display: flex;
+    flex-direction: column;
+    gap: 44px;
+  }
+  h1, h2, h3 {
+    font-family: "Newsreader", Georgia, "Times New Roman", serif;
+    font-weight: 500;
+    line-height: 1.15;
+    margin: 0;
+    text-wrap: balance;
+  }
+  h1 { font-size: 2.6rem; letter-spacing: -0.01em; }
+  h2 { font-size: 1.45rem; }
+  h3 { font-size: 1.1rem; font-weight: 600; }
+  p { margin: 0; }
+  a { color: var(--accent); text-decoration-thickness: 1px; text-underline-offset: 3px; }
+  a:focus-visible, button:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+  code {
+    font-family: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.86em;
+    background: var(--code-bg);
+    padding: 0.08em 0.35em;
+    border-radius: 3px;
+  }
+  .eyebrow {
+    font-size: 0.74rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--muted);
+    font-weight: 500;
+  }
+  header { display: flex; flex-direction: column; gap: 14px; }
+  .dek { font-size: 1.12rem; color: var(--muted); max-width: 60ch; }
+
+  .facts {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+    gap: 1px;
+    background: var(--rule);
+    border: 1px solid var(--rule);
+    border-radius: 6px;
+    overflow: hidden;
+    margin-top: 6px;
+  }
+  .facts div { background: var(--surface); padding: 12px 14px; display: flex; flex-direction: column; gap: 4px; }
+  .facts .k { font-size: 0.72rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted); }
+  .facts .v { font-size: 0.92rem; }
+  .facts code { font-size: 0.8rem; word-break: break-all; }
+
+  .pointer {
+    border-left: 3px solid var(--accent);
+    background: var(--accent-soft);
+    padding: 12px 16px;
+    border-radius: 0 6px 6px 0;
+    font-size: 0.95rem;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .pointer strong { font-weight: 600; }
+
+  section { display: flex; flex-direction: column; gap: 16px; }
+  section > p { max-width: 65ch; }
+
+  /* request path diagram */
+  .path-wrap { overflow-x: auto; padding-bottom: 6px; }
+  .path {
+    display: flex;
+    align-items: stretch;
+    gap: 0;
+    min-width: 640px;
+  }
+  .node {
+    flex: 1 1 0;
+    background: var(--surface);
+    border: 1px solid var(--rule);
+    border-radius: 6px;
+    padding: 10px 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    min-width: 0;
+  }
+  .node .who { font-weight: 600; font-size: 0.9rem; }
+  .node .what { font-size: 0.8rem; color: var(--muted); line-height: 1.4; }
+  .node.hot { border-color: var(--accent); background: var(--accent-soft); }
+  .node.hot .what { color: var(--ink); }
+  .arrow {
+    flex: 0 0 22px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--muted);
+  }
+  .arrow svg { width: 14px; height: 14px; }
+  .legend { font-size: 0.85rem; color: var(--muted); }
+  .legend .swatch {
+    display: inline-block; width: 10px; height: 10px; border-radius: 2px;
+    background: var(--accent-soft); border: 1px solid var(--accent); vertical-align: -1px; margin-right: 6px;
+  }
+
+  /* deliverables */
+  .rows { display: flex; flex-direction: column; border-top: 1px solid var(--rule); }
+  .row {
+    display: grid;
+    grid-template-columns: 11rem 1fr;
+    gap: 18px;
+    padding: 14px 0;
+    border-bottom: 1px solid var(--rule);
+  }
+  .row .where { display: flex; flex-direction: column; gap: 4px; }
+  .row .where strong { font-weight: 600; font-size: 0.95rem; }
+  .row .where code { font-size: 0.78rem; align-self: flex-start; }
+  .row ul { margin: 0; padding-left: 1.1em; display: flex; flex-direction: column; gap: 5px; font-size: 0.95rem; }
+  @media (max-width: 560px) { .row { grid-template-columns: 1fr; gap: 8px; } }
+
+  .contract { display: flex; flex-direction: column; gap: 10px; }
+  .contract li { font-size: 0.95rem; }
+  ul.plain { margin: 0; padding-left: 1.1em; display: flex; flex-direction: column; gap: 8px; }
+
+  .callout {
+    background: var(--surface);
+    border: 1px solid var(--rule);
+    border-radius: 6px;
+    padding: 16px 18px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    font-size: 0.95rem;
+  }
+  .callout p { max-width: none; }
+
+  /* decisions */
+  ol.decisions { margin: 0; padding: 0; list-style: none; display: flex; flex-direction: column; gap: 12px; counter-reset: d; }
+  ol.decisions li {
+    display: grid;
+    grid-template-columns: 2.6rem 1fr;
+    gap: 10px;
+    padding: 12px 14px;
+    background: var(--surface);
+    border: 1px solid var(--rule);
+    border-radius: 6px;
+    font-size: 0.95rem;
+  }
+  ol.decisions li::before {
+    counter-increment: d;
+    content: "§6." counter(d);
+    font-family: "IBM Plex Mono", ui-monospace, monospace;
+    font-size: 0.78rem;
+    color: var(--muted);
+    padding-top: 3px;
+  }
+  .decision { display: flex; flex-direction: column; gap: 6px; }
+  .decision .q { font-weight: 600; }
+  .chip {
+    display: inline-block;
+    font-size: 0.72rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    font-weight: 600;
+    color: var(--amber);
+    background: var(--amber-soft);
+    padding: 2px 8px;
+    border-radius: 999px;
+    align-self: flex-start;
+    margin-top: 2px;
+  }
+
+  ul.done { margin: 0; padding: 0; list-style: none; display: flex; flex-direction: column; gap: 8px; }
+  ul.done li { display: grid; grid-template-columns: 1.4rem 1fr; gap: 6px; font-size: 0.95rem; }
+  ul.done li::before {
+    content: "";
+    width: 14px; height: 14px; margin-top: 4px;
+    border: 1.5px solid var(--muted); border-radius: 3px;
+  }
+
+  footer {
+    border-top: 1px solid var(--rule);
+    padding-top: 20px;
+    font-size: 0.88rem;
+    color: var(--muted);
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  footer code { font-size: 0.8rem; }
+</style>
+
+<main>
+  <header>
+    <span class="eyebrow">Handoff · pipelex-server · hosted plane</span>
+    <h1>Per-request Gateway key</h1>
+    <p class="dek">Give every hosted run the Portkey key of the tenant who asked for it — on the runner or on any Temporal worker — instead of the one key the whole environment shares today.</p>
+    <div class="facts">
+      <div><span class="k">Status</span><span class="v">Spec written; five decisions open (below)</span></div>
+      <div><span class="k">Runtime side</span><span class="v"><code>pipelex</code> branch <code>feature/API-key-per-request</code></span></div>
+      <div><span class="k">Checked against</span><span class="v"><code>pipelex-server</code> dev <code>f0fd3d4</code>, 2026-08-18</span></div>
+    </div>
+    <div class="pointer">
+      <strong>This page is the skim.</strong>
+      <span>The full spec — contract, deliverables, tests, decisions with their trade-offs — is in this branch at <code>wip/api_keys/pipelex-server-per-request-gateway-key-handoff.md</code>. Section numbers below (§) point into it. The design and its rationale are beside it in <code>gateway-per-request-key-under-temporal.md</code>.</span>
+    </div>
+  </header>
+
+  <section>
+    <h2>The idea in one breath</h2>
+    <p>The platform stamps an opaque <code>gateway_key_ref</code> on each run it dispatches. The runtime carries it through Temporal on <code>JobMetadata</code> — a reference, never key material. A small hosted resolver plugin turns it into the tenant's Portkey key on whichever worker runs the inference call. Nothing is cached per credential; the shared SDK clients stay exactly as they are. Portkey then attributes usage, budgets and rate limits per tenant with no work on our side.</p>
+    <div class="path-wrap">
+      <div class="path" role="img" aria-label="Request path: API Gateway, then platform which stamps the reference, then runner which puts it on JobMetadata, then Temporal, then worker which resolves it, then Portkey gateway">
+        <div class="node"><span class="who">API Gateway</span><span class="what">authorizer; <code>/v1/*</code> → platform. Unchanged.</span></div>
+        <div class="arrow"><svg viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M2 7h10M8 3l4 4-4 4"/></svg></div>
+        <div class="node hot"><span class="who">platform</span><span class="what"><strong>stamps the reference</strong> from the authenticated org/user, on both runner hops</span></div>
+        <div class="arrow"><svg viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M2 7h10M8 3l4 4-4 4"/></svg></div>
+        <div class="node"><span class="who">runner</span><span class="what">opaque field → <code>JobMetadata</code></span></div>
+        <div class="arrow"><svg viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M2 7h10M8 3l4 4-4 4"/></svg></div>
+        <div class="node"><span class="who">Temporal</span><span class="what">rides on every workflow and activity payload</span></div>
+        <div class="arrow"><svg viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M2 7h10M8 3l4 4-4 4"/></svg></div>
+        <div class="node hot"><span class="who">worker</span><span class="what"><strong>resolver plugin</strong> → tenant's key, per call, TTL-cached</span></div>
+        <div class="arrow"><svg viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M2 7h10M8 3l4 4-4 4"/></svg></div>
+        <div class="node"><span class="who">Portkey</span><span class="what"><code>x-portkey-api-key</code> = that tenant's key</span></div>
+      </div>
+    </div>
+    <p class="legend"><span class="swatch"></span>Where pipelex-server does its work. Everything else is the runtime's job (§2).</p>
+  </section>
+
+  <section>
+    <h2>What pipelex-server builds</h2>
+    <div class="rows">
+      <div class="row">
+        <div class="where"><strong>Stamp the reference</strong><code>platform/</code></div>
+        <ul>
+          <li>Run dispatch: <code>payload["gateway_key_ref"]</code> in <code>services/pipeline_runner.py</code>, the same way the org-scoped storage plan carries <code>storage_scope</code>.</li>
+          <li>Tooling proxy: the platform <em>sets</em> <code>X-Gateway-Key-Ref</code> on <code>/build/*</code> hops in <code>runner_proxy.py</code>; a client-supplied value is never passed through.</li>
+          <li>Small matching change in public <code>pipelex-api</code>: a body field plus one trusted-proxy header, both opaque, threaded to <code>JobMetadata</code>. No API Gateway change. (§4.1)</li>
+        </ul>
+      </div>
+      <div class="row">
+        <div class="where"><strong>Resolve it</strong><code>gateway-keys/</code> (new member)</div>
+        <ul>
+          <li>A plugin lib like <code>temporal/</code> or <code>transport/</code>: pins <code>pipelex==X.Y.Z</code>, installed by <strong>both</strong> <code>api-hosted/</code> and <code>worker/</code>, contributes a <code>GatewayKeyResolver</code> via entry point.</li>
+          <li>Reads the tenant's key row with <code>boto3</code> directly (neither image installs <code>pipelex-shared</code>). Never provisions. Never logs the key.</li>
+          <li>One process-scoped cache keyed on the reference: positive TTL, shorter negative TTL, LRU cap. The positive TTL <em>is</em> the revocation SLA. On any failure it raises; the fallback decision belongs to the runtime's policy switch. (§4.2)</li>
+        </ul>
+      </div>
+      <div class="row">
+        <div class="where"><strong>Provision keys</strong><code>platform/</code> + order webhook</div>
+        <ul>
+          <li>Per-user Portkey keys already exist (<code>provision_gateway_key</code>, race-safe, shared) and now carry paid top-up credit. Provisioning stays where the Portkey admin credential is.</li>
+          <li>Because the platform fronts dispatch, it can provision-on-dispatch, so a fresh tenant never hits fail-closed. Which row holds the key depends on §6.1. (§4.3)</li>
+        </ul>
+      </div>
+      <div class="row">
+        <div class="where"><strong>Config, IAM, deploy</strong><code>api-hosted/</code> <code>worker/</code> <code>infra/</code></div>
+        <ul>
+          <li>Fail-closed missing-reference policy in both images' <code>.pipelex/pipelex_{env}.toml</code>; local stack keeps the fallback.</li>
+          <li>Read grant on <code>worker_task_role</code> and <code>api_task_role</code> for the key row (plus <code>kms:Decrypt</code> if the plaintext moves under envelope encryption). Every worker needs it — the shared queue can't route tenants.</li>
+          <li>Table env var on runner and worker; version bumps across <code>api-hosted</code>, <code>worker</code>, <code>platform</code> and the new member — <code>make deploy-plan</code> must select all three deployables. (§4.4)</li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h2>Built against — the runtime contract</h2>
+    <ul class="plain contract">
+      <li><code>JobMetadata.gateway_key_ref: str | None</code> — opaque, printable-ASCII, bounded; travels for free through every Temporal hop.</li>
+      <li><code>GatewayKeyResolver.resolve(gateway_key_ref) -> str</code> — plugin-contributed, consulted only by the gateway plugin, inside activity execution. Default returns the boot key.</li>
+      <li>A missing-reference policy switch: fall back to the boot key (OSS default) or fail the call (hosted).</li>
+      <li>All six gateway handles honour the resolved key per request; a retry re-resolves on whichever worker takes it. The hosted plane re-implements none of this. (§2)</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Two corrections to the design doc</h2>
+    <div class="callout">
+      <p><strong>The runner never sees <code>X-Org-Id</code>.</strong> Every <code>/v1/*</code> route goes to the platform, which handles <code>/start</code> and <code>/execute</code> itself and proxies the tooling routes, forwarding only <code>X-User-Id</code>. <code>api-hosted/</code> has no source of its own. So the reference is stamped by the platform, one hop later than the design assumed, and API Gateway is untouched.</p>
+      <p><strong>Per-tenant Portkey keys already exist — per user, and money-bearing.</strong> The credit top-up work that just merged lands purchased credit on the user's own Portkey key. That makes the "user or org?" question a product decision (see §6.1), not the technical afterthought the design treated it as.</p>
+    </div>
+  </section>
+
+  <section>
+    <h2>Decide before starting</h2>
+    <ol class="decisions">
+      <li><div class="decision"><span class="q">User or organization as the v1 reference?</span><span>Is hosted usage meant to consume the credit a user buys? Yes → user id, existing key, nothing new to provision. No → org id, a new per-org key beside the per-user one. The resolver is indifferent; the product is not.</span><span class="chip">Product call</span></div></li>
+      <li><div class="decision"><span class="q">Where the plaintext lives.</span><span>On the tenant's DynamoDB row as today, or behind envelope encryption now (which turns the read grant into a fleet-wide KMS decrypt grant).</span><span class="chip">Recommend: row for v1</span></div></li>
+      <li><div class="decision"><span class="q">Cache numbers.</span><span>Positive TTL, negative TTL, entry cap. The positive TTL is the revocation SLA — write it down as one.</span><span class="chip">Needs numbers</span></div></li>
+      <li><div class="decision"><span class="q">Fail-closed in the hosted plane?</span><span>Only shippable once <em>both</em> platform hops stamp and the legacy direct-to-runner routes are gone or accepted as failing.</span><span class="chip">Recommend: yes</span></div></li>
+      <li><div class="decision"><span class="q">Ride the org-scoped storage change?</span><span>It threads <code>storage_scope</code> through the same sites (<code>pipelex</code>, <code>pipelex-api</code>, platform, transport, temporal). Doing both at once saves a second runner/worker rebuild and a second <code>pipelex</code> version move.</span><span class="chip">Recommend: together</span></div></li>
+    </ol>
+  </section>
+
+  <section>
+    <h2>Done when</h2>
+    <ul class="done">
+      <li>Two tenants running the same method on the same worker fleet show two distinct Portkey attributions, and no run touched <code>PIPELEX_GATEWAY_API_KEY</code>.</li>
+      <li>A run that reaches the runner without a reference fails at the inference call, on the execute path and on the build path.</li>
+      <li>Revoking a tenant's key stops that tenant's runs within the stated TTL on every worker.</li>
+      <li>The local stack still runs end to end for a developer holding only the shared key.</li>
+    </ul>
+  </section>
+
+  <footer>
+    <span>Not touched by this work: <code>SdkClientRegistry</code>, <code>InferenceManager</code>, <code>ModelHandle</code>, the <code>instructor</code> wrappers, any Temporal workflow, activity or converter, any non-gateway backend, tenant-supplied keys.</span>
+    <span>Full spec: <code>wip/api_keys/pipelex-server-per-request-gateway-key-handoff.md</code> · design: <code>gateway-per-request-key-under-temporal.md</code> · SDK survey: <code>sdk-per-request-key-survey.md</code> — all on <code>feature/API-key-per-request</code>.</span>
+  </footer>
+</main>

--- a/wip/api_keys/pipelex-server-per-request-gateway-key-handoff.md
+++ b/wip/api_keys/pipelex-server-per-request-gateway-key-handoff.md
@@ -1,0 +1,100 @@
+# Per-request Gateway key — handoff spec for `pipelex-server`
+
+Companion to `gateway-per-request-key-under-temporal.md`, which is the design and the rationale. This document is the part of that design that has to be built **in the hosted plane** (`pipelex-server`, plus one small change in the public runner `pipelex-api`), written as a spec: what must exist, what contract it is built against, what it may assume, and what has to be decided before it starts. It does not restate the design's reasoning and it is not a phased plan. Where it disagrees with the design doc it is because the design doc assumed something about the hosted plane that turned out not to be true; those points are marked **(correction)**.
+
+Everything below about the hosted plane was checked against `pipelex-server` `dev` at `f0fd3d4` (2026-08-18, after the credit top-up, method-deletion and Temporal-erasure merges) and against `pipelex-api`.
+
+## 1. Scope
+
+In: everything needed for a hosted run — whether it executes in the runner process or on any Temporal worker — to call the Pipelex Gateway with a Portkey key that belongs to the tenant who made the request, instead of the environment-wide `PIPELEX_GATEWAY_API_KEY`.
+
+Out: the runtime seams themselves (they land in `pipelex` on `feature/API-key-per-request`, see §2), any non-gateway backend, per-request endpoints, and BYOK in the sense of tenant-supplied provider keys. The Portkey keys here are **ours**, provisioned per tenant in our Portkey workspace, exactly like the ones `POST /v1/gateway-api-key` already mints.
+
+## 2. The contract the runtime will expose
+
+The `pipelex` side of this feature adds three things. Names are the current proposal and the runtime owns them; the shapes are what the hosted plane must build against.
+
+- **`JobMetadata.gateway_key_ref: str | None`** — an opaque reference, constrained like `request_id` (printable ASCII, bounded length). It rides on the workflow input, every child workflow and every activity payload; the hosted plane never touches it after it is stamped. It must carry a reference, never key material: `JobMetadata` is Temporal history in plaintext.
+- **A `GatewayKeyResolver` with one method, `resolve(gateway_key_ref: str) -> str`**, contributed through the plugin registrar the same way a secrets provider is, and consulted only by the gateway plugin at request time (inside activity execution under Temporal). The default resolver returns the boot key, so an environment without the hosted plugin behaves as today.
+- **A missing-reference policy switch** in runtime config: fall back to the boot key, or fail the inference call. OSS defaults to fallback; the hosted plane sets it (see §4.4).
+
+Every gateway handle — completions, responses, completions-img-gen, img-gen, extract, search — honours the resolved key per request, and a Temporal retry re-resolves on whichever worker picks the attempt up. That is the runtime's guarantee; the hosted plane does not re-implement any of it.
+
+The way the reference enters the runner (§4.1) also needs a `pipelex`/`pipelex-api` surface, and it is the same one the org-scoped storage plan (`pipelex-server/docs/plans/org-scoped-storage-20260817.md`, ready to implement) is about to use for `storage_scope`: a field on the runner's run-request body (`PipelexPipeRunInput` in `pipelex/runtime_bridge/payloads.py`) threaded into `pipeline_run_setup` and onto `JobMetadata`. The two fields should be added the same way, ideally in the same change.
+
+## 3. What the hosted plane looks like today, and what that changes
+
+- **One key per environment.** `PIPELEX_GATEWAY_API_KEY` is injected identically into the runner and the worker task definitions (`infra/api/ecs/runner/ecs.tf`, `infra/api/ecs/worker/ecs.tf`) and read through `api_key = "${PIPELEX_GATEWAY_API_KEY}"` in `api-hosted/.pipelex/inference/backends.toml` and `worker/.pipelex/inference/backends.toml`. It stays as the boot key; after this work it is only what the fallback policy would use.
+- **The platform fronts every `/v1/*` route, including run dispatch (correction).** The design doc traces the request as "authorizer stamps `X-Org-Id` → the runner receives it and builds `JobMetadata`". That is not the topology. API Gateway sends `ANY /v1/{proxy+}` to `platform/`; only the legacy `/runner/v1/*` prefix and the two time-boxed `upload` / `resolve-storage-url` exceptions reach the runner ALB directly. The platform then reaches the runner over the internal ALB in two ways: `routers/v1/execution.py` handles `POST /start` and `POST /execute` itself, records the Run row, and calls `services/pipeline_runner.py`, which builds an explicit JSON payload and forwards exactly one identity header, `X-User-Id`; and `routers/v1/tooling_proxy.py` relays `/validate`, `/models` and `/build/*` through `services/runner_proxy.py`, whose header allowlist is `content-type`, `accept`, `x-user-id`, `x-request-id`. In both cases the platform holds the authenticated identity (`OrgScopedUserDep`: `user_id` and membership-validated `org_id`), and the runner (`pipelex-api`, `TRUST_FORWARDED_IDENTITY_HEADERS=true`, `AUTH_MODE=none`) sees only `X-User-Id`. So the reference is stamped by the platform, and API Gateway needs no change. `api-hosted/` has no source of its own — it is a composition around the public runner — so nothing can be stamped there either.
+- **Per-tenant Portkey keys already exist, per user, and now carry paid money.** `POST /v1/gateway-api-key` mints one Portkey key per user through `pipelex_shared.domain.gateway_key.provision_gateway_key` (extracted from the router in the credit top-up work so the LemonSqueezy order webhook can provision too) and stores `gateway_api_key_id`, `gateway_api_key_hash` and the plaintext `gateway_api_key` on the User row. Portkey holds that key's `credit_limit`; promo grants and, since `feat/credit-topup` merged, **paid top-ups** (`POST /v1/billing/credits/checkout` → order webhook → `apply_credit_grant`) are added to it under a per-key DynamoDB lock. Today those keys serve `pipelex login` clients calling the gateway directly; hosted runs do not use them. Subscriptions remain org-grain and plan-only, and the top-up plan states that credits are per user with `org_id` on the grant for reporting only. Portkey returns keys masked after creation, which is why the plaintext lives on our side.
+- **The Portkey admin credential is platform-only.** `PORTKEY_API_KEY` and `PORTKEY_WORKSPACE_ID` are wired into the platform task definition (`infra/api/ecs/platform/ecs.tf`) and the order-webhook Lambda. Provisioning must stay on those two.
+- **Neither the runner nor the worker installs `pipelex-shared`.** Both compose `pipelex[dynamodb,s3]` + `pipelex-temporal` + `pipelex-daytona-sandbox`. A resolver that reads a DynamoDB row cannot import the shared adapters without adding that dependency to both images; §4.2 asks for a small, dependency-light member instead.
+- **The worker already has its own task role.** `worker_task_role` (`infra/api/iam.tf`) is distinct from `api_task_role`, and today holds only the events-table DynamoDB policy and the app S3 policy. The read grant this feature needs (§4.4) is an addition to that role, not the deferred split the BYOK track was waiting on — that split exists.
+
+## 4. Deliverables
+
+### 4.1 The reference on the wire — platform, `pipelex-api`, and the runner hop
+
+The platform stamps the reference on every hop it makes to the runner, deriving it from the authenticated request context (`current_user.org_id` or `current_user.user_id`, per §6.1) and never from anything the client sent. Two hops, one mechanism each:
+
+- **Run dispatch** (`services/pipeline_runner.py`, used by `/start` and `/execute`): the reference rides in the explicit JSON payload as `payload["gateway_key_ref"]`, exactly as the org-scoped storage plan carries `storage_scope` — data the runner threads onto `JobMetadata`, not identity. On the `pipelex-api` side `PipelexPipeRunInput` gains the field and `ApiRunner` passes it to `pipeline_run_setup(gateway_key_ref=…)`.
+- **Tooling proxy** (`services/runner_proxy.py`, used by `/build/*`, `/validate`, `/models`): `/build/*` makes gateway calls through the kernel path, which builds its own `JobMetadata`. The reference reaches it as a trusted-proxy header, provisionally `X-Gateway-Key-Ref`, that the platform *sets* on the forwarded request (the allowlist must not merely pass a client-supplied one through), and that `pipelex-api` reads under the same `TRUST_FORWARDED_IDENTITY_HEADERS` gate as `X-User-Id` and threads into the kernel's metadata. Routes that never reach the gateway (`/validate`, `/models`) may carry it harmlessly.
+
+Either way the runner treats the value as opaque and validates it with the same constraint as the `JobMetadata` field, which keeps this a generic runner feature and not a hosted one. `compose/edge` (the local API Gateway emulator) needs nothing: the platform derives the reference itself. Legacy direct-to-runner routes (`/runner/v1/*`) get no reference and therefore run under the policy in §4.4; they are slated for deletion and should not be extended.
+
+### 4.2 The hosted resolver — a new plugin member
+
+A new workspace member, provisionally `pipelex-server/gateway-keys/` (distribution `pipelex-gateway-keys`), in the same class as `temporal/`, `transport/` and `daytona-sandbox/`: it states the exact `pipelex==X.Y.Z` it is built against, it is installed by **both** `api-hosted/` and `worker/` (the runner still executes gateway calls in-process for build and non-Temporal paths), and it contributes the resolver through a `pipelex.plugins.*` entry point.
+
+Behaviour:
+
+- `resolve(gateway_key_ref)` maps the reference to the tenant's Portkey key plaintext read from the store chosen in §6.2, using `boto3` directly rather than `pipelex-shared` (see §3). It never provisions: an unknown reference is a lookup failure, not a trigger to mint a key.
+- It wraps the lookup in one process-scoped cache, keyed on the reference, holding strings only: positive entries with a TTL, negative entries with a much shorter TTL, an entry cap with least-recently-used eviction. The TTL is the revocation latency and must be stated in the member's `docs/`. Proposed starting values, to be confirmed in §6.3: positive TTL of a few minutes, negative TTL of a few seconds, cap in the low thousands of entries.
+- Failure semantics: a store error or a missing row raises, and the runtime turns that into a failed inference call; the resolver never falls back to the boot key on its own — that decision belongs to the runtime's policy switch, not to the plugin.
+- Logging: the reference may be logged; the resolved key never is, in any log line, error message or exception field. Errors that quote the reference use the same printable-ASCII assumption the runtime enforces.
+- The lookup is synchronous or async to match what the runtime's protocol ends up requiring; the seam sits inside `make_extras` / the `with_options` calls, which are on the async request path.
+
+### 4.3 Per-tenant keys — store and provisioning
+
+Provisioning happens in `platform/` (and the order-webhook Lambda, which already shares `provision_gateway_key`) and nowhere else, because that is where `PortkeyService` and the Portkey admin credential live. Because the platform now fronts dispatch, it can also guarantee a key exists **before** forwarding a run — provision-on-dispatch through the shared, race-safe `provision_gateway_key` — so the worker never meets an unprovisioned tenant and fail-closed cannot fire on a fresh account. Depending on §6.1:
+
+- **User-grain reference.** The reference is the user id and the resolver reads the User row's existing `gateway_api_key`. Nothing new to provision beyond provision-on-dispatch for users who never opened the developer page. Hosted runs then draw down the same Portkey `credit_limit` that `pipelex login` usage, promo grants and paid top-ups land on — which is coherent if purchased credit is meant to pay for hosted usage, and a surprise otherwise. A user whose gateway key was revoked through the admin flow (`clear_gateway_api_key`) becomes unable to run hosted methods.
+- **Org-grain reference (the design doc's recommendation).** A new per-organization Portkey key, minted through the same `PortkeyService.create_api_key` at organization creation plus provision-on-dispatch as the backstop, stored on the Organization row with the same three fields the User row uses. Attribution then matches the org-grain subscription, but purchased per-user credit is not what hosted runs consume, and the two Portkey keys per person have to be explained on the developer page.
+
+Either way the plaintext must remain retrievable server-side. That conflicts with the standing intent to stop persisting the gateway key plaintext on the User row (the "masked preview only" direction recorded around the `GET /gateway-api-key` throttle work). The two must be reconciled explicitly: if the plaintext moves under envelope encryption, the resolver's read grant becomes a KMS decrypt grant on every worker, which is the reachability cost the design's §6 describes.
+
+### 4.4 Configuration, IAM and deploy
+
+- **Policy switch.** `api-hosted/.pipelex/pipelex_{dev,staging,prod}.toml` and `worker/.pipelex/pipelex_{dev,staging,prod}.toml` set the runtime's missing-reference policy to fail-closed. Every hosted call path that reaches the gateway goes through the platform after §4.1, so this closes the "ran on the shared key by accident" hole at no cost — but only once both hops in §4.1 stamp, and only once the legacy direct-to-runner routes are gone or accepted as failing.
+- **Read grant.** `worker_task_role` and `api_task_role` gain read access to the table and item class holding the per-tenant key (the users table named by `DYNAMODB_USERS_TABLE`, or the org rows if §6.1 goes org-grain), plus `kms:Decrypt` if §4.3 lands the plaintext under envelope encryption. Every worker in the fleet needs it; the shared task queue gives no way to route a tenant to a subset of workers.
+- **Environment.** Whatever the resolver reads to find its table (a `DYNAMODB_USERS_TABLE`-style variable, which the platform already receives) is added to both the runner and the worker task definitions, next to `PIPELEX_GATEWAY_API_KEY`, and to `compose/` and the `.env.example` files so the local stack keeps working. The local stack must keep working with the fallback policy too, so a developer without per-tenant keys is not blocked.
+- **Versions.** The new member is a shared library, so it bumps `api-hosted/` and `worker/` and itself, and the platform bumps for §4.1; `make deploy-plan ENV=<env> BASELINE=<sha>` must select all three deployables. The member's `pipelex==X.Y.Z` pin joins the multi-site edit that moving `pipelex` already requires (workspace `CLAUDE.md`, "Moving `pipelex`"), and its `docs/` say so.
+
+### 4.5 Tests owned by the hosted plane
+
+The per-handle header tests, the concurrent two-reference test and the wire-boundary round-trip live in `pipelex`. The hosted plane owns:
+
+- resolver unit tests: cache hit within TTL, miss after TTL, negative entry expiring faster than a positive one, eviction at the cap, and a store error raising rather than returning the boot key;
+- platform tests on both runner hops: the dispatch payload and the proxied `/build/*` request carry a reference derived from the authenticated context, and a client-supplied `gateway_key_ref` field or `X-Gateway-Key-Ref` header is ignored — the sibling of the existing rule that `X-Org-Id` is overwrite-only at the gateway;
+- an integration test in the local stack: two tenants, one worker process, one run each, and the outbound `x-portkey-api-key` observed per run at the gateway boundary (a recording transport or a stub gateway) — the assertion is attribution, not success;
+- a fail-closed test through the runner: a run request without a reference fails at the inference call with the runtime's policy error, on the execute path and on the build path.
+
+## 5. Non-goals
+
+- No change to `SdkClientRegistry`, `InferenceManager`, `ModelHandle`, `InferenceBackend`, the `instructor` wrappers, or any Temporal workflow, activity or converter. If the implementation finds it needs one, stop and reread the design.
+- No per-request endpoint, no per-request Portkey config; the key is the whole mechanism.
+- No tenant-supplied keys. That is the BYOK inference-profile track; this work is what it will later plug into, by changing what the reference points at.
+- No provisioning from the worker or the runner. The Portkey admin credential stays on the platform and the order-webhook Lambda.
+- No API Gateway change. The reference is minted one hop later, in the platform.
+
+## 6. Decisions to confirm before starting
+
+1. **Reference identity in v1: user or organization?** This is now a product question before it is a technical one: **is hosted usage meant to consume the credit a user buys through the new top-up flow?** If yes, the reference is the user id, the resolver reads the User row's existing key, provisioning is already race-safe and shared, and Portkey attribution lands where the money is. If hosted usage is instead covered by the org's plan, the reference is the org id and a per-org key has to be provisioned and explained beside the per-user one. The design doc recommends org-grain, written before the top-up work merged; the resolver is indifferent (opaque reference, different row), so the choice costs nothing on the runtime side and everything on the product side.
+2. **Store for the plaintext.** On the tenant's DynamoDB row as today, or moved behind envelope encryption now, given the standing intent to stop persisting it. Recommendation: keep it on the row for v1 with the read grant scoped to that item class, and take the envelope-encryption move as its own change with the KMS grant it implies.
+3. **Cache numbers.** Positive TTL, negative TTL and entry cap — proposals in §4.2; the positive TTL is the revocation SLA and should be written down as such.
+4. **Fail-closed in the hosted plane.** Recommended yes; confirm, and confirm that both platform hops (dispatch payload and tooling-proxy header) are in scope — fail-closed cannot ship with only one of them.
+5. **Coordination with the org-scoped storage plan.** That plan is threading `storage_scope` from the platform payload through `PipelexPipeRunInput` into `JobMetadata` and touches the same `pipelex`, `pipelex-api`, `platform`, `transport` and `temporal` sites. Decide whether `gateway_key_ref` rides in that change or follows it; doing them together avoids two runner/worker rebuilds and two `pipelex` version moves.
+
+## 7. Acceptance
+
+The work is done when, in a deployed environment, two tenants running the same method on the same worker fleet produce two distinct Portkey usage attributions with no run touching `PIPELEX_GATEWAY_API_KEY`; a run that reaches the runner without a reference fails at the inference call rather than running on the shared key; revoking a tenant's key stops that tenant's runs within the stated TTL on every worker; and the local stack still runs end to end for a developer holding only the shared key.

--- a/wip/api_keys/sdk-per-request-key-survey.md
+++ b/wip/api_keys/sdk-per-request-key-survey.md
@@ -1,0 +1,88 @@
+# Per-request API keys: where the key is bound today, and what each SDK lets us override
+
+Survey for `feature/API-key-per-request`. Two questions are in scope: **how do we decide to change the key, and how do we get it**, and **do the SDKs we ship let us override the key on the request rather than on the client**. Everything below about SDK behaviour was verified by reading and executing the versions actually pinned in `.venv` — versions are named at each claim, because several of these answers changed within the last few releases.
+
+## 1. Where the key is bound today
+
+The key travels through four stages, and every one of them happens exactly once, at boot.
+
+1. **Declared as a placeholder in TOML.** Each backend in `pipelex/kit/configs/inference/backends.toml` declares `api_key = "${OPENAI_API_KEY}"` (or the `${env:…|secret:…}` fallback form).
+2. **Substituted against the secrets provider.** `InferenceBackendLibrary.load()` binds a `substitute_vars` partial to the process-wide secrets provider (`backend_library.py:151`) and rewrites the whole blueprint dict. A backend whose variable will not resolve is *skipped* in lenient mode and *fatal* otherwise.
+3. **Frozen onto the backend model.** `InferenceBackendFactory.make_inference_backend()` stores the resolved string on `InferenceBackend.api_key` (`backend.py:44`). That object lives on the models manager for the life of the process.
+4. **Baked into an SDK client, which is then cached forever.** Each provider plugin calls `sdk_clients.get_or_create(handle=…, build=lambda: …Factory.make_…_client(backend=backend))`. The cache key is `ModelHandle.sdk_handle` — `"{sdk}@{backend}"` plus an optional variant (`model_handle.py:12`) — so it carries **no notion of who is asking**. `OpenAIClientFactory.make_openai_client` reads `backend.api_key` at construction (`openai_client_factory.py:45`) and never looks again.
+
+There is a fifth cache on top: `InferenceManager` memoises workers by bare model handle (`inference_manager.py:66`), and each worker also builds an `instructor` wrapper around the client in its `__init__`. So a single `openai@openai` client, and a single `instructor` wrapper over it, serve every caller in the process.
+
+**The consequence to design around:** three caches (`InferenceBackend`, `SdkClientRegistry`, `InferenceManager.*_workers`) are all keyed on *what model* is being called and none on *whose credentials*. Whatever mechanism we pick, either the key must ride on the request and bypass all three, or all three keys must grow a credential dimension.
+
+Two smaller irregularities worth knowing before designing:
+
+- **Linkup does not use `backend.api_key` at all.** Both Linkup workers call `get_secrets_provider().get_secret(secret_id="LINKUP_API_KEY")` directly in their own `__init__` (`linkup_extract_worker.py:44`, `linkup_search_worker.py:43`). Any backend-level design silently misses these two workers unless they are moved onto `backend.api_key` first.
+- **Gateway and Portkey do not authenticate with `api_key` at all.** Both build a plain `openai.AsyncOpenAI` whose `api_key` is the literal placeholder `"unused-auth-via-portkey-headers"`, and put the real credential in `default_headers` via `createHeaders(api_key=…)` (`gateway_completions_factory.py:130`). The credential is the `x-portkey-api-key` header. This turns out to be the single most convenient path to convert — see §4.
+
+## 2. How do we decide to change the key?
+
+The codebase already has the vehicle, and it already reaches the exact place a per-request key would need to land.
+
+Every worker call receives an `InferenceJobAbstract`, which carries `job_metadata: JobMetadata`. Both the Gateway and the Portkey factories already read that metadata per request and turn it into request headers: `make_extras(inference_model, inference_job=…, output_desc=…)` returns `(extra_headers, extra_body)`, which the worker passes straight into the SDK call (`openai_completions_llm_worker.py:149` for text, `:234` for the instructor path). That is a working, per-request, payload-carried header seam that exists today for tracing.
+
+So the decision seam is: **the caller stamps a credential reference onto the job payload; the worker resolves it in `make_extras`-time and emits it as an auth header or a per-request client option.** This is payload-first and needs no ContextVars.
+
+The one thing that must not happen: putting the secret *itself* on `JobMetadata`. `JobMetadata` is explicitly designed to cross the Temporal serialization boundary (its own comments say so), which means anything on it lands in workflow history in plaintext. Carry a **reference** (an org id, a profile id, a key id) and resolve it to a secret inside the worker process; never carry the material.
+
+## 3. How do we get it?
+
+`SecretsProviderAbstract` (`pipelex/tools/secrets/secrets_provider_abstract.py`) is already the right shape and is already pluggable through a registry. What it lacks is a *scope*: every method takes only `secret_id`, so "the OpenAI key" is a single global fact. A per-request design needs one of:
+
+- a provider whose `get_secret` is given the caller scope alongside the secret id; or
+- a per-request resolver object built once per request from the payload reference and handed to the workers.
+
+Either way, the resolution result should be cached for the life of one run — the workers make several SDK calls per pipe, and a KMS/Secrets-Manager round trip per LLM call is not acceptable.
+
+## 4. SDK survey — can the key be overridden per request?
+
+| SDK (pinned version) | Per-request key override | Mechanism |
+|---|---|---|
+| `openai` 2.34.0 | **Yes, two ways** | `extra_headers={"Authorization": f"Bearer {key}"}` on the call; or `client.with_options(api_key=…)` which reuses the same httpx pool |
+| `openai` Azure variant 2.34.0 | **Yes** | Same, but the header is `api-key`, not `Authorization` |
+| `anthropic` 0.99.0 | **Yes, two ways** | `extra_headers={"X-Api-Key": key}`; or `client.with_options(api_key=…)`, also pool-reusing |
+| `portkey-ai` 2.3.0 | **Yes** | `client.with_options(api_key=…)` — and the codebase already calls `with_options(config=…)` on this client |
+| Gateway / Portkey via `openai` | **Yes, trivially** | The credential is already just the `x-portkey-api-key` header, and an `extra_headers` dict is already threaded per request |
+| `mistralai` 1.12.0 | **Yes, two ways** | `http_headers={"Authorization": f"Bearer {key}"}` on every operation; or construct the client with a **callable** `api_key`, re-invoked per request |
+| `google-genai` 1.75.0 | **Yes on the native path, no through `instructor`** | `config=GenerateContentConfig(http_options=HttpOptions(headers={"x-goog-api-key": key}))` — the structured path is blocked, see the note under the table |
+| `fal-client` 1.0.0 | **Yes** | `submit`/`run`/`subscribe` all take `headers=`, and httpx request headers override the client's `Authorization` |
+| `huggingface_hub` 1.16.1 | **No** | `token` is constructor-only; `text_to_image` exposes no header or token parameter |
+| `linkup-sdk` 0.13.0 | **No** | `api_key` is constructor-only; no operation takes headers |
+| `boto3` / `aioboto3` (Bedrock) | **No** | Credentials belong to the session/client; needs a fresh client per credential set |
+| `azure_rest` img-gen (our own httpx code) | **Yes** | We build the `Api-Key` header ourselves (`azure_img_gen_worker.py:150`) |
+| `docling`, `pypdfium2` | N/A | Local, no credential |
+
+### Details worth knowing
+
+**`openai` — `with_options` is cheap.** `AsyncOpenAI.copy()` (aliased as `with_options`) ends with `http_client = http_client or self._client`, so a per-key clone shares the connection pool and only re-wraps the options. This is the clean route for the instructor-wrapped paths, where `extra_headers` is available but a per-key `instructor` wrapper would still need rebuilding.
+
+**`openai` also accepts a callable key provider — do not use it as-is.** Since 2.x, `api_key` may be a `Callable[[], Awaitable[str]]`, invoked from `_prepare_options` before every request. But `_refresh_api_key` assigns to `self.api_key` on the *shared* client, and the header is built afterwards in `_build_request`, with an `await` in between. Two concurrent requests wanting different keys on the same client instance will race, and the loser sends the wrong tenant's key. In a concurrent runtime this is a silent cross-tenant credential leak, not a flaky test. `with_options` has no such window because each clone owns its own `api_key` attribute.
+
+**`mistralai`'s callable is safe, unlike openai's.** `Mistral(api_key=callable)` wraps it as `lambda: Security(api_key=api_key())` and the generated request builder calls it fresh per request into a local variable — no shared mutation (`sdk.py:115`, `basesdk.py:181`). Alternatively `http_headers` is applied *last* in the header merge (`basesdk.py:209`), so it cleanly overrides the security header.
+
+**`fal` per-request headers really do win.** The client-level `Authorization` sits on the httpx client; httpx merges request headers over client headers with replacement semantics, verified empirically. So `headers={"Authorization": f"Key {key}"}` on `submit` overrides it. Our Fal worker does not currently pass `headers` (`fal_img_gen_worker.py:59`), so this is an added argument, not a redesign.
+
+**`google-genai` — the native path can, the structured path cannot.** `generate_content(config=…)` accepts `http_options`, and per-call headers are merged over the client's defaults with the patch winning (`_api_client.patch_http_options`), so overriding `x-goog-api-key` per request works on `_gen_text`. The structured path goes through `instructor`'s genai adapter, whose kwarg mapping copies only a whitelist of OpenAI-named fields into the config it builds — `http_options` is not in it, and nothing outside the whitelist survives. So Gemini structured generation needs a per-credential `genai.Client` and therefore a per-credential `from_genai` wrapper. That same mapping is the subject of a separate defect: see `wip/google-structured-config-dropped-and-vertex-token-stale.md`.
+
+**The three that cannot do it** — HuggingFace, Linkup, Bedrock — all need a **client per credential**, which means the `SdkClientRegistry` cache key has to grow a credential dimension for them regardless. Bedrock is the heaviest: `BedrockClientBoto3` builds a boto3 client in `__init__`, and `BedrockClientAioboto3` holds an `aioboto3.Session`. Neither is expensive enough to worry about at per-org granularity, but both are far too expensive per request, so the credential-scoped cache is mandatory rather than optional there.
+
+## 5. What this suggests
+
+Two mechanisms cover everything, and the split is not per-SDK, it is per-*capability*:
+
+- **Header/option override on the request** for openai, Azure OpenAI, anthropic, mistral, portkey, gateway, fal, azure_rest. Nothing is cached per credential; the existing single client stays. For the Gateway path specifically this is close to a one-line change, since `make_extras` already returns the header dict that gets sent.
+- **A credential-scoped client cache** for HuggingFace, Linkup, Bedrock, and the Google structured-output path. Concretely: extend `ModelHandle.sdk_handle` (or the registry key) with a credential fingerprint, so `get_or_create` builds one client per (model handle, credential) pair. Fingerprint, never the key itself, so the cache key is not a secret.
+
+Whichever seam a given provider uses, the *decision* is the same and stays payload-first: reference on the job → resolved to material in-process → handed to the worker.
+
+## 6. Open questions
+
+1. **What is the reference we put on the payload?** An org id (server resolves to that org's stored key), a profile id (the BYOK inference-profile design), or a key id? This determines the shape of the secrets-provider scope change.
+2. **Do we support per-request keys for all backends or only the Gateway?** Gateway-only is dramatically cheaper — one header, no cache changes, no per-SDK work — and covers the hosted product. All-backends is what BYOK-with-your-own-provider-keys requires.
+3. **Where does resolution happen relative to Temporal?** If the worker resolves the reference, the secret never enters workflow history. If the dispatcher resolves it, it does. The first is the only safe answer, and it constrains where the secrets provider must be reachable.
+4. **Does `InferenceBackend` stay a boot-time singleton?** If a per-request key can also imply a per-request *endpoint* (self-hosted, regional, Azure resource), then the override is a backend override, not a key override, and the design is meaningfully larger.

--- a/wip/api_keys/sdk-per-request-key-survey.md
+++ b/wip/api_keys/sdk-per-request-key-survey.md
@@ -1,6 +1,6 @@
 # Per-request API keys: where the key is bound today, and what each SDK lets us override
 
-Survey for `feature/API-key-per-request`. Two questions are in scope: **how do we decide to change the key, and how do we get it**, and **do the SDKs we ship let us override the key on the request rather than on the client**. Everything below about SDK behaviour was verified by reading and executing the versions actually pinned in `.venv` — versions are named at each claim, because several of these answers changed within the last few releases.
+Survey for `feature/API-key-per-request`. The narrowed Gateway-only, Temporal-only design lives beside this file in `gateway-per-request-key-under-temporal.md`. Two questions are in scope: **how do we decide to change the key, and how do we get it**, and **do the SDKs we ship let us override the key on the request rather than on the client**. Everything below about SDK behaviour was verified by reading and executing the versions actually pinned in `.venv` — versions are named at each claim, because several of these answers changed within the last few releases.
 
 ## 1. Where the key is bound today
 

--- a/wip/api_keys/sdk-per-request-key-survey.md
+++ b/wip/api_keys/sdk-per-request-key-survey.md
@@ -28,7 +28,7 @@ Every worker call receives an `InferenceJobAbstract`, which carries `job_metadat
 
 So the decision seam is: **the caller stamps a credential reference onto the job payload; the worker resolves it in `make_extras`-time and emits it as an auth header or a per-request client option.** This is payload-first and needs no ContextVars.
 
-The one thing that must not happen: putting the secret *itself* on `JobMetadata`. `JobMetadata` is explicitly designed to cross the Temporal serialization boundary (its own comments say so), which means anything on it lands in workflow history in plaintext. Carry a **reference** (an org id, a profile id, a key id) and resolve it to a secret inside the worker process; never carry the material.
+The one thing that must not happen: putting the secret *itself* on `JobMetadata`. `JobMetadata` is explicitly designed to cross the Temporal serialization boundary (its own comments say so), which means anything on it lands in workflow history in plaintext. Carry a **reference** (an org id, a profile id, a key id) and resolve it to a secret inside the worker process; never carry the material. The payload codec does not soften this: `StoragePayloadCodec` is a size-threshold *offload*, not encryption — payloads below `size_threshold` (1 MB by default) pass through untouched, and it ships disabled (`is_enabled = false`). A short credential string sits far below that threshold, so it would ride into workflow history in cleartext even with the codec switched on.
 
 ## 3. How do we get it?
 
@@ -37,7 +37,19 @@ The one thing that must not happen: putting the secret *itself* on `JobMetadata`
 - a provider whose `get_secret` is given the caller scope alongside the secret id; or
 - a per-request resolver object built once per request from the payload reference and handed to the workers.
 
-Either way, the resolution result should be cached for the life of one run — the workers make several SDK calls per pipe, and a KMS/Secrets-Manager round trip per LLM call is not acceptable.
+### The resolution has to be cached, and the cache scope is the process, not the run
+
+A KMS or Secrets-Manager round trip per LLM call is not acceptable, so the resolution result must be cached somewhere. The intuitive scope — "for the life of one run" — is the wrong one, because under distributed execution that scope does not exist in any process.
+
+Under our Temporal plugin the activity granularity is **one LLM call**, not one run: `act_llm_gen_text(llm_assignment: LLMAssignment)` is the entire activity body (`act_llm_generate.py`), and so are `act_llm_gen_object` and `act_llm_gen_object_list`. Each call is an independent activity task, taken off a single shared queue (`default_task_queue`, with `activity_queues` empty) by whichever worker in the pool polls it first. Retries are configured at `maximum_attempts = 3`, and a second attempt may well execute on a different worker than the first. The worker itself boots Pipelex once at process start and then polls forever (`worker_cmd.py`), which is why the three caches named in §1 are already process-lifetime and shared across tenants there.
+
+A run-scoped credential cache under those conditions can only be one of two things, and neither is what we want. Built per activity invocation, it is a fresh empty dictionary every time, which is precisely the per-call round trip it was introduced to prevent. Held instead in a process-wide `dict[run_id, secret]`, it becomes N independent copies across N workers, and nothing ever evicts a finished run's entry, because no single worker is guaranteed to observe that run's last activity. The second form accumulates tenant secrets in worker memory indefinitely while presenting itself as run-bounded.
+
+The scope that genuinely exists is the **process**, and moving to it is an improvement rather than a concession:
+
+- Key the cache on the **credential reference** (org id, profile id, key id) and never on the run. It then hits across every run of the same tenant that lands on that worker, which is a considerably better hit rate than run scoping could have reached.
+- Bound it and give it a TTL. Because the process outlives every run, revocation latency turns into an explicit design parameter: with no TTL, a rotated or revoked credential stays usable until the worker restarts. Run scoping concealed that question; process scoping forces us to answer it.
+- Direct in-process execution gets exactly the same cache with the same semantics, so this is one mechanism rather than one per orchestrator.
 
 ## 4. SDK survey — can the key be overridden per request?
 
@@ -76,7 +88,7 @@ Either way, the resolution result should be cached for the life of one run — t
 Two mechanisms cover everything, and the split is not per-SDK, it is per-*capability*:
 
 - **Header/option override on the request** for openai, Azure OpenAI, anthropic, mistral, portkey, gateway, fal, azure_rest. Nothing is cached per credential; the existing single client stays. For the Gateway path specifically this is close to a one-line change, since `make_extras` already returns the header dict that gets sent.
-- **A credential-scoped client cache** for HuggingFace, Linkup, Bedrock, and the Google structured-output path. Concretely: extend `ModelHandle.sdk_handle` (or the registry key) with a credential fingerprint, so `get_or_create` builds one client per (model handle, credential) pair. Fingerprint, never the key itself, so the cache key is not a secret.
+- **A credential-scoped client cache** for HuggingFace, Linkup, Bedrock, and the Google structured-output path. Concretely: extend `ModelHandle.sdk_handle` (or the registry key) with a credential fingerprint, so `get_or_create` builds one client per (model handle, credential) pair. Fingerprint, never the key itself, so the cache key is not a secret. This cache inherits the lifetime argument from §3, with heavier objects at stake: on a Temporal worker the `SdkClientRegistry` lives for the life of the process, so adding a credential dimension multiplies a long-lived cache of boto3 clients, `aioboto3` sessions and httpx pools by the number of tenants that worker has served. It needs a bound and idle eviction, not merely a wider key.
 
 Whichever seam a given provider uses, the *decision* is the same and stays payload-first: reference on the job → resolved to material in-process → handed to the worker.
 
@@ -84,5 +96,6 @@ Whichever seam a given provider uses, the *decision* is the same and stays paylo
 
 1. **What is the reference we put on the payload?** An org id (server resolves to that org's stored key), a profile id (the BYOK inference-profile design), or a key id? This determines the shape of the secrets-provider scope change.
 2. **Do we support per-request keys for all backends or only the Gateway?** Gateway-only is dramatically cheaper — one header, no cache changes, no per-SDK work — and covers the hosted product. All-backends is what BYOK-with-your-own-provider-keys requires.
-3. **Where does resolution happen relative to Temporal?** If the worker resolves the reference, the secret never enters workflow history. If the dispatcher resolves it, it does. The first is the only safe answer, and it constrains where the secrets provider must be reachable.
-4. **Does `InferenceBackend` stay a boot-time singleton?** If a per-request key can also imply a per-request *endpoint* (self-hosted, regional, Azure resource), then the override is a backend override, not a key override, and the design is meaningfully larger.
+3. **Where does resolution happen relative to Temporal?** If the worker resolves the reference, the secret never enters workflow history. If the dispatcher resolves it, it does. The first is the only safe answer, and the seam already supports it: `job_metadata` is a field of `LLMAssignment`, so the reference reaches the activity intact. The constraint it imposes is worth stating plainly, because it is a blast-radius one — the worker fleet polls a single shared queue on behalf of every tenant, so every worker needs secrets-read reachability for every tenant it might serve.
+4. **What revocation latency do we accept?** §3 makes the credential cache process-scoped, which turns its TTL into the revocation SLA. A short TTL costs one secrets-provider round trip per tenant per TTL window per worker; a long one keeps a revoked credential usable for that long. This needs an agreed number rather than a default.
+5. **Does `InferenceBackend` stay a boot-time singleton?** If a per-request key can also imply a per-request *endpoint* (self-hosted, regional, Azure resource), then the override is a backend override, not a key override, and the design is meaningfully larger.

--- a/wip/google-structured-config-dropped-and-vertex-token-stale.md
+++ b/wip/google-structured-config-dropped-and-vertex-token-stale.md
@@ -1,0 +1,37 @@
+# Two inference-provider bugs found while surveying per-request API keys
+
+Found on 2026-08-18 while surveying the SDK credential paths for `feature/API-key-per-request` (see `wip/api_keys/sdk-per-request-key-survey.md`). Neither is in that feature's scope, so they are filed here instead. **Both are recorded from the survey only — whoever fixes them still has to do the research.** In particular, no fix has been designed, no test has been written, and the blast radius of each has not been mapped beyond what is stated below.
+
+## Bug 1 — the Google structured-output path silently discards its whole generation config
+
+**What we observed.** `GoogleLLMWorker._gen_object` (`pipelex/providers/google/google_llm_worker.py:255-274`) builds a `genai_types.GenerateContentConfig` carrying `system_instruction`, `temperature`, `max_output_tokens` and `candidate_count`, then hands it to instructor as the `generation_config=` kwarg on `create_with_completion`.
+
+Instructor's genai adapter (`instructor/providers/gemini/utils.py`, `update_genai_kwargs`, around line 275) pops that value and then tests each field with `if openai_key in generation_config`. Our value is a **pydantic object**, not a dict. Pydantic's `BaseModel.__iter__` yields `(key, value)` tuples, so `"temperature" in some_config` compares a string against tuples and is never true. Every field is skipped, and the adapter goes on to build `types.GenerateContentConfig(**generation_config)` from its own `base_config` alone.
+
+**Verified by execution** against the pinned versions (`google-genai` 1.75.0, `instructor` 1.15.1):
+
+```python
+from google.genai import types as t
+from instructor.providers.gemini.utils import update_genai_kwargs
+
+cfg = t.GenerateContentConfig(temperature=0.3, max_output_tokens=999, system_instruction="SYS")
+print('temperature' in cfg)        # -> False
+out = update_genai_kwargs({"generation_config": cfg}, {"response_mime_type": "application/json"})
+print(list(out.keys()))            # -> ['response_mime_type', 'safety_settings']
+```
+
+**Impact.** Every structured Gemini generation runs at Google's default temperature, with no max-token cap, and with no system instruction. The non-structured path is unaffected — `_gen_text` calls `generate_content(config=…)` on the client directly (`google_llm_worker.py:217`) and does not go through instructor.
+
+**Notes for whoever fixes it.** Passing a plain dict instead of the pydantic object would recover the whitelisted fields (`max_tokens`, `temperature`, `n`, `top_p`, `stop`, `seed`, `presence_penalty`, `frequency_penalty` — mapped via `OPENAI_TO_GEMINI_MAP`), but `system_instruction` is set by instructor itself from the message list, and anything outside the whitelist — including `http_options` — is dropped either way. So a dict is a partial recovery, not a full one; bypassing instructor's kwarg mapping, or fixing it upstream, may be the real answer. Worth checking whether the other instructor-wrapped workers (openai, anthropic, mistral) have an analogous silent-drop, since they were not examined for this.
+
+**Why the API-key survey cares.** This is also the reason the Google structured path has no per-request key seam: `http_options` cannot be threaded through instructor's mapping, so a per-request Gemini key needs a per-credential `genai.Client` and therefore a per-credential `from_genai` wrapper.
+
+## Bug 2 — the Vertex AI access token is minted once at boot and never refreshed
+
+**What we observed.** `InferenceBackendFactory.make_inference_backend` has a special case for the `vertexai` backend that calls `VertexAIFactory.make_endpoint_and_api_key(extra_config=…)` (`pipelex/cogt/model_backends/backend_factory.py`). That in turn calls `_make_api_key(...)` (`pipelex/providers/openai/vertexai_factory.py:42`), which loads a GCP service-account credentials file and mints an **OAuth access token**, returning it as the backend's `api_key`.
+
+That string is then frozen onto `InferenceBackend.api_key` for the life of the process, and baked into the cached `openai.AsyncOpenAI` client at first use.
+
+**Impact.** GCP OAuth access tokens are short-lived (on the order of an hour). Any process that outlives the token — every server, every Temporal worker, any long-running CLI session — will start failing Vertex calls with 401s, with no path to recovery short of a restart. Short-lived processes (a one-shot CLI run) never see it, which is presumably why it has not surfaced.
+
+**Notes for whoever fixes it.** The credential is structurally a *refreshable* token, not a static API key, so the fix is a resolution seam rather than a longer expiry — `google.auth`'s `Credentials` object knows how to refresh itself, and the current code throws that object away after reading `.token` once. This overlaps directly with the per-request-key work: a design that resolves the credential at request time rather than at boot fixes this as a side effect. Not verified: the exact token lifetime in our GCP configuration, and whether any deployed environment actually has the `vertexai` backend enabled today.


### PR DESCRIPTION
## Summary

Docs-only PR under `wip/api_keys/`. No code changes. It captures the study and design for giving each hosted run its own Portkey gateway key, and the handoff spec for the `pipelex-server` half of that work.

- **`sdk-per-request-key-survey.md`** — where the API key is bound today (TOML placeholder → secrets provider → `InferenceBackend` → cached SDK client) and, per SDK we ship, whether the key can be overridden on the request rather than the client. Verified by executing the pinned versions against a recording `httpx.MockTransport`.
- **`gateway-per-request-key-under-temporal.md`** — the narrowed design: Gateway-only, holds under our Temporal plugin. Reference (never material) rides on `JobMetadata`; a `GatewayKeyResolver` seam in the gateway plugin, defaulting to today's behaviour; the `AsyncOpenAI` vs `AsyncPortkey` override mechanics, including the `post(headers=…)` trap on the Portkey client that would pass review while sending the boot key.
- **`pipelex-server-per-request-gateway-key-handoff.md`** — spec for the hosted plane: the runtime contract, what to build where (platform stamps the reference on both runner hops, a new resolver plugin member, provisioning, config/IAM/deploy), tests, and the open decisions. Corrects two design assumptions after checking `pipelex-server` `dev`: the runner never sees `X-Org-Id` (the platform fronts every `/v1/*` route and dispatches itself), and per-user Portkey keys already exist and now carry paid top-up credit.
- **`…handoff.html`** — a skimmable HTML version of the handoff that points at the `.md` for details.
- **`wip/google-structured-config-dropped-and-vertex-token-stale.md`** — two unrelated inference-provider bugs noticed during the survey, filed for later; not designed or fixed here.

## Test plan

- [ ] Docs only; nothing to run. Review is a read of the design and the handoff decisions (§6 of the handoff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q3napiozmUbwpQBF7U6r53

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents the design for per-request Portkey Gateway keys under Temporal and a `pipelex-server` handoff; no code changes. Today all hosted runs share one Gateway key; the design moves to a per-request key resolved from a reference on `JobMetadata` to enable per-tenant attribution, budgets, and limits.

- Adds `sdk-per-request-key-survey.md`: where keys bind today and per-SDK override seams. Key trap: `AsyncPortkey.post(headers=…)` does not override auth; use `with_options(api_key=…)`. `openai` paths accept `extra_headers`.
- Adds `gateway-per-request-key-under-temporal.md`: narrow design. Introduces a `gateway_key_ref` on `JobMetadata` and a `GatewayKeyResolver` seam (default falls back to the boot key). All six Gateway handles override per request; retries re-resolve on any worker. No changes to `SdkClientRegistry`, `InferenceManager`, or `instructor`.
- Adds `pipelex-server-per-request-gateway-key-handoff.{md,html}`: hosted implementation. Platform stamps `gateway_key_ref` on run dispatch payloads and sets `X-Gateway-Key-Ref` on `/build/*`; runner threads it to `JobMetadata`. New resolver member installed in both `api-hosted` and `worker` reads the tenant’s key (DynamoDB), with a process TTL LRU cache. Config switch for missing-reference policy; IAM read grants (and optional KMS decrypt). Corrects two assumptions: the runner never sees `X-Org-Id`; per-user Portkey keys already exist and carry paid credit.
- Adds `wip/google-structured-config-dropped-and-vertex-token-stale.md`: files two unrelated defects found during the survey (Gemini structured config dropped via `instructor`, Vertex token minted once and never refreshed).

**Decisions for reviewers**
- Choose the v1 reference: user id (reuses existing per-user keys/credit) or org id (new per-org keys).
- Confirm where plaintext lives (row vs envelope encryption now).
- Set cache numbers: positive TTL (revocation SLA), negative TTL, entry cap.
- Policy: fail-closed on missing reference in hosted; keep fallback in local/dev.
- Optionally ship alongside the org-scoped storage change to avoid duplicate runner/worker rebuilds and `pipelex` bumps.

<sup>Written for commit eae7d76d79a4fc4b429a24c8db041bd99ea3d118. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Pipelex/pipelex/pull/1126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

